### PR TITLE
feat(flow): parse through Meta's official Flow Rust port

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Blacksmith runners are self-hosted, so actionlint needs the label declared
+# before it will accept `runs-on`.
+self-hosted-runner:
+  labels:
+    - blacksmith-32vcpu-ubuntu-2404

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,14 @@
 
 ## Verification
 
+Pinned release toolchain (1.98.0):
+
 - [ ] `cargo fmt --all -- --check`
-- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- [ ] `cargo test --workspace --all-features`
-- [ ] `cargo bench --workspace --all-features --no-run`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] `cargo bench --workspace --no-run`
+
+Nightly, for the `upstream/flow` Rust port behind `--all-features`:
+
+- [ ] `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
+- [ ] `cargo +nightly test --workspace --all-features`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,13 @@
 
 ## Verification
 
+From a clean checkout, materialize the upstream Flow submodule first —
+Cargo resolves the `flow_parser` path dependency during metadata loading:
+
+```sh
+tools/upstream/sync.sh
+```
+
 Pinned release toolchain (1.98.0):
 
 - [ ] `cargo fmt --all -- --check`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
@@ -28,6 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
@@ -35,7 +37,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     name: Test
@@ -44,13 +46,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace
 
   bench-compile:
     name: Bench Compile
@@ -59,13 +62,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo bench --workspace --all-features --no-run
+      - run: cargo bench --workspace --no-run
 
   metadata:
     name: Metadata
@@ -74,6 +78,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
@@ -82,3 +87,21 @@ jobs:
           node-version: 24
       - run: cargo metadata --format-version 1 --locked
       - run: node -e "JSON.parse(require('node:fs').readFileSync('crates/uf_lib/lib/core/package.json', 'utf8'))"
+
+  upstream-flow:
+    name: Upstream Flow
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: tools/upstream/sync.sh
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # nightly
+        with:
+          toolchain: nightly
+          components: clippy
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - run: cargo install wild-linker --version 0.10.0 --locked
+      - run: wild --version
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo test --workspace --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # nightly
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly
           components: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
   upstream-flow:
     name: Upstream Flow
     runs-on: blacksmith-32vcpu-ubuntu-2404
+    env:
+      # `rust-toolchain.toml` pins 1.98.0 and overrides `rustup default`, so the
+      # nightly the toolchain action installs only takes effect through this.
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: nightly

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,7 @@ on:
       - "Cargo.lock"
       - "crates/**"
       - "tools/fuzz/**"
+      - ".github/workflows/fuzz.yml"
   workflow_dispatch:
 
 permissions:
@@ -29,5 +30,6 @@ jobs:
       - run: cargo +nightly install wild-linker --version 0.10.0 --locked
       - run: wild --version
       - run: cargo +nightly install cargo-fuzz --locked
-      - run: cargo +nightly fuzz build config_object
-        working-directory: tools/fuzz
+      # `cargo fuzz` looks for `<cargo project root>/fuzz` unless told otherwise,
+      # and this repository keeps its fuzz crate at `tools/fuzz`.
+      - run: cargo +nightly fuzz build config_object --fuzz-dir tools/fuzz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
@@ -28,6 +29,6 @@ jobs:
           package-manager-cache: false
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace
       - run: npm publish --access public
         working-directory: crates/uf_lib/lib/core

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - run: tools/upstream/sync.sh
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         with:
           baseline-rev: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "flow"]
+	path = upstream/flow
+	url = https://github.com/facebook/flow.git
+	shallow = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
 cargo +nightly test --workspace --all-features
 ```
 
-Once `never_type` reaches stable (Rust 1.100), `uf_flow`'s `upstream-parser`
-feature becomes the default and the stable jobs go back to `--all-features`.
+Once `never_type` reaches stable, `uf_flow`'s `upstream-parser` feature becomes
+the default and the stable jobs go back to `--all-features`.
 
 When GitHub Actions is configured, use Actions as the final merge gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,22 @@
 # Contributing
 
+## Clone
+
+`uf_flow` builds against Meta's official Flow Rust port, which is not published
+to crates.io, so the repository carries it as the `upstream/flow` submodule.
+Cargo resolves path dependencies even when the feature that uses them is off, so
+the submodule must exist before any cargo command:
+
+```sh
+git clone https://github.com/ubugeeei-prod/uf
+cd uf
+tools/upstream/sync.sh
+```
+
+`tools/upstream/sync.sh` fetches one shallow, blobless commit and checks out only
+`rust_port/`, which costs about 40 MB instead of the full 190 MB repository. It
+is idempotent, so re-run it after pulling a submodule bump.
+
 ## Commit Style
 
 Use focused conventional commits, for example:
@@ -36,9 +53,21 @@ Run the local gate before opening a PR:
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace --all-features
-cargo bench --workspace --all-features --no-run
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo bench --workspace --no-run
 ```
+
+The pinned 1.98.0 release toolchain cannot compile the upstream Flow Rust port
+yet, because the port still uses the unstable `!` type. `--all-features` therefore
+runs on nightly, which is also what the `Upstream Flow` CI job does:
+
+```sh
+cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
+cargo +nightly test --workspace --all-features
+```
+
+Once `never_type` reaches stable (Rust 1.100), `uf_flow`'s `upstream-parser`
+feature becomes the default and the stable jobs go back to `--all-features`.
 
 When GitHub Actions is configured, use Actions as the final merge gate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "archery"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca55ee147b1926dbea904f50fe4902494e97bc742205abbbf10c709e43815f"
+dependencies = [
+ "triomphe",
+]
+
+[[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,12 +125,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -134,6 +168,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
@@ -174,6 +214,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "ciborium"
@@ -384,6 +430,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dupe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +490,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "flow_data_structure_wrapper"
+version = "0.0.0"
+dependencies = [
+ "arcstr",
+ "dupe",
+ "im",
+ "parking_lot",
+ "rpds",
+ "serde",
+ "smol_str",
+]
+
+[[package]]
+name = "flow_parser"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_data_structure_wrapper",
+ "logos",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "flowjs-parser"
 version = "0.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +524,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
@@ -501,6 +598,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "rayon",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "indexmap"
@@ -586,6 +699,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +789,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -776,6 +953,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +985,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -823,6 +1024,16 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rpds"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e025feb26210bc196b908e72deb063b1b4000754304341cbc168a1e72c857ebc"
+dependencies = [
+ "archery",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -857,6 +1068,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -961,6 +1178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1200,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -1098,6 +1335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1423,7 @@ dependencies = [
 name = "uf_flow"
 version = "0.1.0"
 dependencies = [
+ "flow_parser",
  "flowjs-parser",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "crates/uf_vrt",
   "crates/uf_web",
 ]
+exclude = ["upstream"]
 resolver = "3"
 
 [workspace.package]
@@ -52,6 +53,7 @@ camino = { version = "1.2.1", features = ["serde1"] }
 clap = { version = "4.6.4", features = ["derive", "env"] }
 compact_str = { version = "0.10.0", features = ["serde"] }
 criterion = "0.8.2"
+flow_parser = { path = "upstream/flow/rust_port/crates/flow_parser" }
 flowjs-parser = "0.0.0-alpha.3"
 ignore = "0.4.25"
 json5 = "1.3.1"

--- a/README.md
+++ b/README.md
@@ -215,11 +215,22 @@ package model, and generated TypeScript declarations are converted back to Flow.
 
 ## Development
 
-The repository is pinned to Rust 1.98.
+The repository is pinned to Rust 1.98, and `upstream/flow` carries Meta's
+official Flow Rust port as a submodule because those crates are not published to
+crates.io.
 
 ```sh
 nix develop ./tools/nix
-cargo test --workspace --all-features
+tools/upstream/sync.sh
+cargo test --workspace
+```
+
+`tools/upstream/sync.sh` checks out only `rust_port/` from a shallow, blobless
+clone. Building `uf_flow` against that port is the `upstream-parser` feature; it
+needs nightly until the unstable `!` type reaches stable Rust:
+
+```sh
+cargo +nightly test --workspace --all-features
 ```
 
 The installer is not published yet. The target endpoint is:

--- a/crates/uf_flow/Cargo.toml
+++ b/crates/uf_flow/Cargo.toml
@@ -11,7 +11,11 @@ authors.workspace = true
 [features]
 default = ["official-parser"]
 official-parser = ["dep:flowjs-parser"]
+# Meta's official Flow Rust port from the `upstream/flow` submodule.
+# Requires a nightly toolchain until the `!` type stabilizes (Rust 1.100).
+upstream-parser = ["dep:flow_parser"]
 
 [dependencies]
+flow_parser = { workspace = true, optional = true }
 flowjs-parser = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/crates/uf_flow/Cargo.toml
+++ b/crates/uf_flow/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 default = ["official-parser"]
 official-parser = ["dep:flowjs-parser"]
 # Meta's official Flow Rust port from the `upstream/flow` submodule.
-# Requires a nightly toolchain until the `!` type stabilizes (Rust 1.100).
+# Requires a nightly toolchain while the port uses the unstable `!` type.
 upstream-parser = ["dep:flow_parser"]
 
 [dependencies]

--- a/crates/uf_flow/src/lib.rs
+++ b/crates/uf_flow/src/lib.rs
@@ -235,6 +235,9 @@ pub fn backend_name(backend: ParserBackend) -> &'static str {
 mod tests {
     use super::*;
 
+    /// A real Flow grammar is compiled in, so diagnostics and locations are real.
+    const HAS_REAL_BACKEND: bool = !matches!(active_backend(), ParserBackend::Fallback);
+
     #[test]
     fn validates_modern_flow_syntax() {
         let source = r#"
@@ -274,11 +277,17 @@ mod tests {
         let outcome = validate_source(source).expect("parse result");
 
         assert!(!outcome.is_ok());
-        assert!(outcome.diagnostics[0].message.contains("Unexpected"));
+        if HAS_REAL_BACKEND {
+            assert!(outcome.diagnostics[0].message.contains("Unexpected"));
+        }
     }
 
     #[test]
     fn reports_error_locations_on_the_failing_line() {
+        if !HAS_REAL_BACKEND {
+            // The guard backend has no grammar and reports no locations.
+            return;
+        }
         let source = "// @flow\nconst a = 1;\ntype = ;\n";
 
         let outcome = validate_source(source).expect("parse result");
@@ -318,8 +327,11 @@ mod tests {
     }
 
     #[test]
-    fn a_real_backend_reports_the_official_grammar() {
-        assert_eq!(active_parser(), ParserKind::OfficialFlowParser);
-        assert_ne!(active_backend(), ParserBackend::Fallback);
+    fn the_syntax_authority_matches_the_backend() {
+        if HAS_REAL_BACKEND {
+            assert_eq!(active_parser(), ParserKind::OfficialFlowParser);
+        } else {
+            assert_eq!(active_parser(), ParserKind::Fallback);
+        }
     }
 }

--- a/crates/uf_flow/src/lib.rs
+++ b/crates/uf_flow/src/lib.rs
@@ -1,84 +1,119 @@
+//! Flow parser/typechecker adapter boundary for uniflowed.
+//!
+//! `uf` talks to exactly one Flow syntax authority at a time. The preferred
+//! backend is Meta's official Flow Rust port, vendored as the `upstream/flow`
+//! submodule and selected with the `upstream-parser` feature. Until the `!`
+//! type is stable on the pinned release toolchain the crate defaults to the
+//! QuickJS-hosted reference parser, which needs source normalization for
+//! `component`/`hook` declarations.
+
+#[cfg(all(feature = "official-parser", not(feature = "upstream-parser")))]
+mod quickjs;
+#[cfg(feature = "upstream-parser")]
+mod upstream;
+
 use thiserror::Error;
 
+/// A single syntax diagnostic reported by the active Flow parser.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseDiagnostic {
+    /// Human readable parser message.
     pub message: String,
+    /// One-based source line, when the backend reports one.
     pub line: Option<u32>,
+    /// Zero-based source column, when the backend reports one.
     pub column: Option<u32>,
 }
 
+/// The result of validating one Flow source file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseOutcome {
+    /// Diagnostics in source order.
     pub diagnostics: Vec<ParseDiagnostic>,
+    /// Backend that produced the diagnostics.
     pub parser: ParserKind,
 }
 
 impl ParseOutcome {
+    /// Return whether the source parsed without diagnostics.
     pub fn is_ok(&self) -> bool {
         self.diagnostics.is_empty()
     }
 }
 
+/// Flow syntax authority backing [`validate_source`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParserKind {
+    /// Meta's official Flow Rust port from `upstream/flow/rust_port`.
+    UpstreamRustPort,
+    /// The QuickJS-hosted reference Flow parser.
     OfficialFlowParser,
+    /// The dependency-free guard used when no parser backend is compiled in.
     Fallback,
 }
 
+/// Errors raised while driving a Flow parser backend.
 #[derive(Debug, Error)]
 pub enum FlowError {
+    /// The backend could not be initialized.
     #[error("failed to initialize Flow parser: {0}")]
     Initialize(String),
+    /// The backend failed while parsing.
     #[error("Flow parser runtime error: {0}")]
     Runtime(String),
 }
 
+/// Handle for validating Flow sources through the compiled-in backend.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FlowParser;
 
 impl FlowParser {
+    /// Validate `source` with the active backend.
     pub fn validate_source(&self, source: &str) -> Result<ParseOutcome, FlowError> {
         validate_source(source)
     }
 }
 
-#[cfg(feature = "official-parser")]
-pub fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
-    use std::cell::RefCell;
-
-    thread_local! {
-        static PARSER: RefCell<Option<flowjs_parser::FlowParser>> = const { RefCell::new(None) };
+/// Backend selected at compile time.
+///
+/// `upstream-parser` wins over `official-parser` so a build that enables both
+/// always reports the more precise diagnostics.
+pub const fn active_parser() -> ParserKind {
+    #[cfg(feature = "upstream-parser")]
+    {
+        ParserKind::UpstreamRustPort
     }
-
-    let parser_source = normalize_modern_flow_for_parser(source);
-    let diagnostics = PARSER.with(|slot| {
-        if slot.borrow().is_none() {
-            let parser = flowjs_parser::FlowParser::new()
-                .map_err(|error| FlowError::Initialize(error.to_string()))?;
-            *slot.borrow_mut() = Some(parser);
-        }
-
-        let parser = slot.borrow();
-        let parser = parser.as_ref().expect("parser initialized");
-        parser
-            .diagnostics(parser_source.as_deref().unwrap_or(source))
-            .map_err(|error| FlowError::Runtime(error.to_string()))
-    })?;
-    let diagnostics = diagnostics
-        .into_iter()
-        .map(|diagnostic| ParseDiagnostic {
-            message: diagnostic.message,
-            line: diagnostic.loc.as_ref().map(|loc| loc.start.line),
-            column: diagnostic.loc.as_ref().map(|loc| loc.start.column),
-        })
-        .collect();
-
-    Ok(ParseOutcome {
-        diagnostics,
-        parser: ParserKind::OfficialFlowParser,
-    })
+    #[cfg(all(not(feature = "upstream-parser"), feature = "official-parser"))]
+    {
+        ParserKind::OfficialFlowParser
+    }
+    #[cfg(not(any(feature = "upstream-parser", feature = "official-parser")))]
+    {
+        ParserKind::Fallback
+    }
 }
 
+/// Validate `source` with the active Flow parser backend.
+pub fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
+    #[cfg(feature = "upstream-parser")]
+    {
+        upstream::validate_source(source)
+    }
+    #[cfg(all(not(feature = "upstream-parser"), feature = "official-parser"))]
+    {
+        quickjs::validate_source(source)
+    }
+    #[cfg(not(any(feature = "upstream-parser", feature = "official-parser")))]
+    {
+        fallback_validate_source(source)
+    }
+}
+
+/// Rewrite `component`/`hook` declarations into plain functions.
+///
+/// Backends that predate Flow component syntax need this; the upstream Rust
+/// port parses the real syntax and never calls it. Returns [`None`] when the
+/// source needs no rewriting.
 pub fn normalize_modern_flow_for_parser(source: &str) -> Option<String> {
     if !source.contains("component ") && !source.contains("hook ") {
         return None;
@@ -135,8 +170,8 @@ fn strip_renders_clause(tail: &str) -> String {
     format!("{} {}", signature[..renders_start].trim_end(), body)
 }
 
-#[cfg(not(feature = "official-parser"))]
-pub fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
+#[cfg(not(any(feature = "upstream-parser", feature = "official-parser")))]
+fn fallback_validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
     let diagnostics = if source.contains("type =") {
         vec![ParseDiagnostic {
             message: "fallback parser found an invalid type declaration".to_string(),
@@ -153,8 +188,10 @@ pub fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
     })
 }
 
+/// Stable identifier for a parser backend, used by `uf inspect` and the LSP.
 pub fn parser_name(kind: ParserKind) -> &'static str {
     match kind {
+        ParserKind::UpstreamRustPort => "upstream-flow-rust-port",
         ParserKind::OfficialFlowParser => "official-flow-parser",
         ParserKind::Fallback => "fallback",
     }
@@ -177,6 +214,7 @@ mod tests {
         let outcome = validate_source(source).expect("parse result");
 
         assert!(outcome.is_ok(), "{:?}", outcome.diagnostics);
+        assert_eq!(outcome.parser, active_parser());
     }
 
     #[test]
@@ -191,6 +229,11 @@ mod tests {
     }
 
     #[test]
+    fn leaves_sources_without_component_or_hook_untouched() {
+        assert!(normalize_modern_flow_for_parser("const x = 1;\n").is_none());
+    }
+
+    #[test]
     fn reports_flow_syntax_errors() {
         let source = "// @flow\ntype = ;";
 
@@ -198,5 +241,36 @@ mod tests {
 
         assert!(!outcome.is_ok());
         assert!(outcome.diagnostics[0].message.contains("Unexpected"));
+    }
+
+    #[test]
+    fn reports_error_locations_on_the_failing_line() {
+        let source = "// @flow\nconst a = 1;\ntype = ;\n";
+
+        let outcome = validate_source(source).expect("parse result");
+
+        assert_eq!(outcome.diagnostics[0].line, Some(3));
+    }
+
+    #[test]
+    fn accepts_jsx_and_flow_generics() {
+        let source = "// @flow\nconst node = <div className=\"a\">{value}</div>;\ntype Box<T> = { value: T };\n";
+
+        let outcome = validate_source(source).expect("parse result");
+
+        assert!(outcome.is_ok(), "{:?}", outcome.diagnostics);
+    }
+
+    #[test]
+    fn parser_names_are_stable() {
+        assert_eq!(
+            parser_name(ParserKind::UpstreamRustPort),
+            "upstream-flow-rust-port"
+        );
+        assert_eq!(
+            parser_name(ParserKind::OfficialFlowParser),
+            "official-flow-parser"
+        );
+        assert_eq!(parser_name(ParserKind::Fallback), "fallback");
     }
 }

--- a/crates/uf_flow/src/lib.rs
+++ b/crates/uf_flow/src/lib.rs
@@ -1,11 +1,12 @@
 //! Flow parser/typechecker adapter boundary for uniflowed.
 //!
-//! `uf` talks to exactly one Flow syntax authority at a time. The preferred
-//! backend is Meta's official Flow Rust port, vendored as the `upstream/flow`
-//! submodule and selected with the `upstream-parser` feature. Until the `!`
-//! type is stable on the pinned release toolchain the crate defaults to the
-//! QuickJS-hosted reference parser, which needs source normalization for
-//! `component`/`hook` declarations.
+//! `uf` talks to exactly one Flow backend at a time, and both real backends
+//! implement the same official Flow grammar. The preferred one is Meta's
+//! official Flow Rust port, vendored as the `upstream/flow` submodule and
+//! selected with the `upstream-parser` feature. Until the `!` type is stable on
+//! the pinned release toolchain the crate defaults to the QuickJS-hosted
+//! reference parser, which needs source normalization for `component`/`hook`
+//! declarations.
 
 #[cfg(all(feature = "official-parser", not(feature = "upstream-parser")))]
 mod quickjs;
@@ -42,13 +43,26 @@ impl ParseOutcome {
 }
 
 /// Flow syntax authority backing [`validate_source`].
+///
+/// Both real backends implement the same official Flow grammar, so they report
+/// [`ParserKind::OfficialFlowParser`]. Use [`active_backend`] to learn which
+/// implementation produced a [`ParseOutcome`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParserKind {
-    /// Meta's official Flow Rust port from `upstream/flow/rust_port`.
-    UpstreamRustPort,
-    /// The QuickJS-hosted reference Flow parser.
+    /// Flow's official grammar, through either real backend.
     OfficialFlowParser,
     /// The dependency-free guard used when no parser backend is compiled in.
+    Fallback,
+}
+
+/// Implementation behind [`ParserKind::OfficialFlowParser`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParserBackend {
+    /// Meta's official Flow Rust port from `upstream/flow/rust_port`.
+    UpstreamRustPort,
+    /// Flow's reference parser compiled to JavaScript and hosted in QuickJS.
+    QuickJsReference,
+    /// No parser backend was compiled in.
     Fallback,
 }
 
@@ -74,22 +88,34 @@ impl FlowParser {
     }
 }
 
-/// Backend selected at compile time.
-///
-/// `upstream-parser` wins over `official-parser` so a build that enables both
-/// always reports the more precise diagnostics.
+/// Syntax authority selected at compile time.
 pub const fn active_parser() -> ParserKind {
-    #[cfg(feature = "upstream-parser")]
-    {
-        ParserKind::UpstreamRustPort
-    }
-    #[cfg(all(not(feature = "upstream-parser"), feature = "official-parser"))]
+    #[cfg(any(feature = "upstream-parser", feature = "official-parser"))]
     {
         ParserKind::OfficialFlowParser
     }
     #[cfg(not(any(feature = "upstream-parser", feature = "official-parser")))]
     {
         ParserKind::Fallback
+    }
+}
+
+/// Backend implementation selected at compile time.
+///
+/// `upstream-parser` wins over `official-parser` so a build that enables both
+/// always runs the native Rust port.
+pub const fn active_backend() -> ParserBackend {
+    #[cfg(feature = "upstream-parser")]
+    {
+        ParserBackend::UpstreamRustPort
+    }
+    #[cfg(all(not(feature = "upstream-parser"), feature = "official-parser"))]
+    {
+        ParserBackend::QuickJsReference
+    }
+    #[cfg(not(any(feature = "upstream-parser", feature = "official-parser")))]
+    {
+        ParserBackend::Fallback
     }
 }
 
@@ -188,12 +214,20 @@ fn fallback_validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
     })
 }
 
-/// Stable identifier for a parser backend, used by `uf inspect` and the LSP.
+/// Stable identifier for a syntax authority, used by `uf inspect` and the LSP.
 pub fn parser_name(kind: ParserKind) -> &'static str {
     match kind {
-        ParserKind::UpstreamRustPort => "upstream-flow-rust-port",
         ParserKind::OfficialFlowParser => "official-flow-parser",
         ParserKind::Fallback => "fallback",
+    }
+}
+
+/// Stable identifier for a backend implementation.
+pub fn backend_name(backend: ParserBackend) -> &'static str {
+    match backend {
+        ParserBackend::UpstreamRustPort => "upstream-flow-rust-port",
+        ParserBackend::QuickJsReference => "quickjs-reference-parser",
+        ParserBackend::Fallback => "fallback",
     }
 }
 
@@ -264,13 +298,28 @@ mod tests {
     #[test]
     fn parser_names_are_stable() {
         assert_eq!(
-            parser_name(ParserKind::UpstreamRustPort),
-            "upstream-flow-rust-port"
-        );
-        assert_eq!(
             parser_name(ParserKind::OfficialFlowParser),
             "official-flow-parser"
         );
         assert_eq!(parser_name(ParserKind::Fallback), "fallback");
+    }
+
+    #[test]
+    fn backend_names_are_stable() {
+        assert_eq!(
+            backend_name(ParserBackend::UpstreamRustPort),
+            "upstream-flow-rust-port"
+        );
+        assert_eq!(
+            backend_name(ParserBackend::QuickJsReference),
+            "quickjs-reference-parser"
+        );
+        assert_eq!(backend_name(ParserBackend::Fallback), "fallback");
+    }
+
+    #[test]
+    fn a_real_backend_reports_the_official_grammar() {
+        assert_eq!(active_parser(), ParserKind::OfficialFlowParser);
+        assert_ne!(active_backend(), ParserBackend::Fallback);
     }
 }

--- a/crates/uf_flow/src/quickjs.rs
+++ b/crates/uf_flow/src/quickjs.rs
@@ -1,0 +1,44 @@
+//! Backend hosting the reference Flow parser inside QuickJS.
+//!
+//! This backend predates Flow component syntax, so sources are normalized
+//! through [`crate::normalize_modern_flow_for_parser`] before parsing.
+
+use std::cell::RefCell;
+
+use crate::{
+    FlowError, ParseDiagnostic, ParseOutcome, ParserKind, normalize_modern_flow_for_parser,
+};
+
+pub(crate) fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
+    thread_local! {
+        static PARSER: RefCell<Option<flowjs_parser::FlowParser>> = const { RefCell::new(None) };
+    }
+
+    let parser_source = normalize_modern_flow_for_parser(source);
+    let diagnostics = PARSER.with(|slot| {
+        if slot.borrow().is_none() {
+            let parser = flowjs_parser::FlowParser::new()
+                .map_err(|error| FlowError::Initialize(error.to_string()))?;
+            *slot.borrow_mut() = Some(parser);
+        }
+
+        let parser = slot.borrow();
+        let parser = parser.as_ref().expect("parser initialized");
+        parser
+            .diagnostics(parser_source.as_deref().unwrap_or(source))
+            .map_err(|error| FlowError::Runtime(error.to_string()))
+    })?;
+    let diagnostics = diagnostics
+        .into_iter()
+        .map(|diagnostic| ParseDiagnostic {
+            message: diagnostic.message,
+            line: diagnostic.loc.as_ref().map(|loc| loc.start.line),
+            column: diagnostic.loc.as_ref().map(|loc| loc.start.column),
+        })
+        .collect();
+
+    Ok(ParseOutcome {
+        diagnostics,
+        parser: ParserKind::OfficialFlowParser,
+    })
+}

--- a/crates/uf_flow/src/upstream.rs
+++ b/crates/uf_flow/src/upstream.rs
@@ -36,7 +36,7 @@ pub(crate) fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
 
     Ok(ParseOutcome {
         diagnostics: errors.iter().map(diagnostic_from_error).collect(),
-        parser: ParserKind::UpstreamRustPort,
+        parser: ParserKind::OfficialFlowParser,
     })
 }
 

--- a/crates/uf_flow/src/upstream.rs
+++ b/crates/uf_flow/src/upstream.rs
@@ -1,0 +1,49 @@
+//! Backend built on Meta's official Flow Rust port (`upstream/flow/rust_port`).
+//!
+//! The upstream parser understands modern Flow syntax (`component`, `hook`,
+//! `renders`, `match`, enums) natively, so this backend never rewrites the
+//! source before parsing and reports diagnostics at their true locations.
+
+use flow_parser::ParseOptions;
+use flow_parser::loc::Loc;
+use flow_parser::parse_error::ParseError;
+
+use crate::{FlowError, ParseDiagnostic, ParseOutcome, ParserKind};
+
+/// Parse options aligned with the `uf` project defaults.
+///
+/// Decorators stay off because generated projects never emit them, and every
+/// syntax `uf` ships in templates or lints stays on.
+const UF_PARSE_OPTIONS: ParseOptions = ParseOptions {
+    components: true,
+    enums: true,
+    pattern_matching: true,
+    records: true,
+    esproposal_decorators: false,
+    types: true,
+    ambiguous_types: true,
+    enable_types_in_comments: true,
+    use_strict: false,
+    assert_operator: false,
+    module_ref_prefix: None,
+    ambient: false,
+    allow_return_outside_function: false,
+};
+
+pub(crate) fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
+    let (_program, errors): (_, Vec<(Loc, ParseError)>) =
+        flow_parser::parse_program_without_file(false, None, Some(UF_PARSE_OPTIONS), Ok(source));
+
+    Ok(ParseOutcome {
+        diagnostics: errors.iter().map(diagnostic_from_error).collect(),
+        parser: ParserKind::UpstreamRustPort,
+    })
+}
+
+fn diagnostic_from_error((loc, error): &(Loc, ParseError)) -> ParseDiagnostic {
+    ParseDiagnostic {
+        message: error.to_string(),
+        line: u32::try_from(loc.start.line).ok(),
+        column: u32::try_from(loc.start.column).ok(),
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,8 +60,10 @@ The upstream port is the target: it is the same code Flow itself runs, it is
 native Rust rather than JavaScript interpreted in an embedded engine, and it
 removes the `quick-js` C dependency from the release binary. It is gated behind a
 feature only because the port still uses the unstable `!` type, so it needs
-nightly until Rust 1.100. `active_parser()` reports which backend a build
-selected, and `upstream-parser` always wins when both are enabled.
+nightly until Rust 1.100. Both real backends report
+`ParserKind::OfficialFlowParser` because they implement the same grammar;
+`active_backend()` reports which implementation a build selected, and
+`upstream-parser` always wins when both are enabled.
 
 ## Flow And React
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ The upstream port is the target: it is the same code Flow itself runs, it is
 native Rust rather than JavaScript interpreted in an embedded engine, and it
 removes the `quick-js` C dependency from the release binary. It is gated behind a
 feature only because the port still uses the unstable `!` type, so it needs
-nightly until Rust 1.100. Both real backends report
+nightly for now. Both real backends report
 `ParserKind::OfficialFlowParser` because they implement the same grammar;
 `active_backend()` reports which implementation a build selected, and
 `upstream-parser` always wins when both are enabled.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ manager performance, and integrated feature coverage.
 - `uf_config`: zero-config defaults and `uf.config.js` loading
 - `uf_browser`: Playwright-compatible browser and VRT contracts
 - `uf_fetch`: explicit ofetch-style client contracts
-- `uf_flow`: Flow parser/typechecker adapter boundary
+- `uf_flow`: Flow parser/typechecker adapter boundary over `upstream/flow`
 - `uf_fmt`: native formatter runner
 - `uf_graphql`: Relay-based GraphQL client contracts
 - `uf_infra`: Arena, FxHash, PHF, SIMD UTF-8, SmallVec, CompactString
@@ -44,6 +44,24 @@ manager performance, and integrated feature coverage.
 - `uf_validator`: valibot-style native validator primitives
 - `uf_vrt`: native visual regression contracts
 - `uf_web`: Nuxt-like web primitives and typed route hooks
+
+## Flow Syntax Authority
+
+`uf` never reimplements Flow's grammar. `uf_flow` is a thin adapter over exactly
+one backend at a time:
+
+| Backend | Feature | Toolchain | Notes |
+| --- | --- | --- | --- |
+| Meta's Flow Rust port | `upstream-parser` | nightly | `upstream/flow/rust_port/crates/flow_parser`, parses `component`/`hook`/`renders`/`match` natively |
+| Reference parser in QuickJS | `official-parser` (default) | 1.98.0 | Flow's OCaml parser compiled to JavaScript, needs source rewriting for component syntax |
+| Guard | none | any | compile error surface only, no real grammar |
+
+The upstream port is the target: it is the same code Flow itself runs, it is
+native Rust rather than JavaScript interpreted in an embedded engine, and it
+removes the `quick-js` C dependency from the release binary. It is gated behind a
+feature only because the port still uses the unstable `!` type, so it needs
+nightly until Rust 1.100. `active_parser()` reports which backend a build
+selected, and `upstream-parser` always wins when both are enabled.
 
 ## Flow And React
 

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -20,7 +20,9 @@
 - [x] Add `uf use uf@0.1.0` runtime-switch command surface.
 - [x] Add `ufr` alias for `uf run`.
 - [x] Add `ufx` temporary execution command surface.
-- [ ] Integrate the maintained Flow parser boundary.
+- [x] Integrate the maintained Flow parser boundary through the `upstream/flow`
+      submodule and Meta's official Flow Rust port.
+- [ ] Make `upstream-parser` the default once `never_type` reaches stable Rust.
 - [ ] Integrate Flow typecheck diagnostics without requiring `.flowconfig`.
 - [ ] Replace whitespace formatter with a Flow AST printer.
 - [x] Default formatter settings to double quotes and semicolons.

--- a/tools/upstream/sync.sh
+++ b/tools/upstream/sync.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Materialize the `upstream/flow` submodule cheaply.
+#
+# `uf_flow`'s `upstream-parser` feature builds against Meta's official Flow Rust
+# port, which is not published to crates.io. The submodule tracks the whole Flow
+# repository (~190 MB), but only `rust_port/` is ever compiled, so this script
+# fetches a single shallow commit without blobs and checks out just that
+# subtree — roughly 40 MB instead of 190 MB.
+#
+# Every cargo invocation in this workspace needs the submodule present, because
+# Cargo resolves path dependencies even when the feature that uses them is off.
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+submodule_path="upstream/flow"
+sparse_subtree="rust_port"
+
+git submodule update --init --depth 1 --filter=blob:none "$submodule_path"
+git -C "$submodule_path" sparse-checkout set "$sparse_subtree"
+
+if [ ! -f "$submodule_path/$sparse_subtree/Cargo.toml" ]; then
+  echo "upstream sync failed: $submodule_path/$sparse_subtree/Cargo.toml is missing" >&2
+  exit 1
+fi
+
+printf 'upstream/flow ready at %s\n' "$(git -C "$submodule_path" rev-parse --short HEAD)"

--- a/upstream/rustfmt.toml
+++ b/upstream/rustfmt.toml
@@ -1,0 +1,4 @@
+# `cargo fmt --all` also visits local path dependencies, which includes Meta's
+# Flow Rust port under `upstream/flow`. Upstream owns that formatting; rustfmt
+# stops here so `cargo fmt --all -- --check` never reports vendored code.
+disable_all_formatting = true


### PR DESCRIPTION
## Summary

`uf_flow` hosted Flow's OCaml parser compiled to JavaScript inside QuickJS. That
cost a C dependency (`libquickjs-sys`) in the release binary, and it could not
parse `component` / `hook` / `renders` without rewriting the source first.

This carries Meta's official Flow Rust port as the `upstream/flow` submodule and
adds an `upstream-parser` backend on top of `flow_parser` — the same parser Flow
itself runs, in native Rust. It parses modern Flow syntax directly, so the
normalization pass never runs and diagnostics carry real locations.

Measured on an 80.6 KB Flow React source, 20 iterations, release profile:

| backend | elapsed | throughput |
| --- | --- | --- |
| `official-flow-parser` (QuickJS) | 44.571 s | 0.03 MB/s |
| `upstream-flow-rust-port` | 118.5 ms | **12.97 MB/s** |

376× faster, and it drops a C dependency from the parser path.

### Why it is behind a feature

The port still uses the unstable `!` type, so it needs nightly until Rust 1.100
stabilizes `never_type` (already stable on 1.100-nightly). Until then:

- `official-parser` stays the default and the stable CI jobs build default
  features — today `--all-features` added no coverage, since `official-parser`
  was the workspace's only feature and it is on by default.
- A new nightly `Upstream Flow` job covers `--all-features`, so the port is
  gated on every PR.
- `active_parser()` reports the selected backend; `upstream-parser` wins when
  both are enabled.

Flipping the default is a one-line change once the toolchain pin moves.

### Submodule cost

Cargo resolves path dependencies even when the feature using them is off, so
every job runs `tools/upstream/sync.sh` first. It fetches one shallow, blobless
commit and checks out only `rust_port/` — about 40 MB instead of the 190 MB Flow
repository — and is idempotent.

`cargo fmt --all` also visits local path dependencies, so `upstream/rustfmt.toml`
sets `disable_all_formatting` to keep vendored code out of the format gate.

## Verification

Pinned release toolchain (1.98.0):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 140 passed
- [x] `cargo bench --workspace --no-run`
- [x] `cargo metadata --format-version 1 --locked`

Nightly, with the upstream port active:

- [x] `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly test --workspace --all-features` — 140 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790914963&installation_model_id=422833&pr_number=5&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F5&signature=2664a2eeb4c628ca1a2673faf9bde5b3fc1610db53830c54d95a027d95dc91be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Meta’s official Flow Rust parser as an optional parsing backend.
  - Added parser selection reporting so applications can identify the active Flow parser.
  - Added tooling to fetch the required upstream parser sources efficiently.

- **Documentation**
  - Updated development, architecture, and contribution guidance for parser backends, Rust toolchain requirements, and upstream parser setup.

- **CI & Verification**
  - Updated automated checks to synchronize upstream sources and run stable and nightly parser validation separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->