### PR TITLE
ci: repin nix-installer-action to a commit that exists

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@28cf3ba74de6f3163b6e6d410c10569e74b6cae8 # v20
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - run: nix develop ./tools/nix --command why3 prove tools/formal/std_contract.mlw -P z3 -a split_vc


### PR DESCRIPTION
## Summary

The `Why3 Z3` job has been failing on every pull request — including on `main`'s
own dependabot branches — with:

```
Unable to resolve action `determinatesystems/nix-installer-action@28cf3ba74de6f3163b6e6d410c10569e74b6cae8`, unable to find version `28cf3ba74de6f3163b6e6d410c10569e74b6cae8`
```

That SHA is not a commit in `DeterminateSystems/nix-installer-action` (the API
returns `422 No commit found for SHA`), so the action never resolves and the
formal-verification gate has never actually run.

Repinned to the real `v22` tag commit `ef8a148080ab6020fd15196c2084a2eea5ff2d25`.

## Verification

- [x] `gh api repos/DeterminateSystems/nix-installer-action/tags` confirms `v22` → `ef8a148080ab6020fd15196c2084a2eea5ff2d25`
- [x] The old SHA returns `422 No commit found for SHA`
- [ ] `Why3 Z3` runs to completion on this PR (this is the first time it can)

Workflow-only change; no Rust code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790915135&installation_model_id=422833&pr_number=6&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F6&signature=f94dce2c77897c59288403c8362223a8bfde053c034750afa86d2e54537ccd64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->