### PR TITLE
ci: detect provers before running why3

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -21,4 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      # why3 only knows about provers listed in ~/.why3.conf, which does not
+      # exist on a fresh runner, so z3 has to be detected before proving.
+      - run: nix develop ./tools/nix --command why3 config detect
       - run: nix develop ./tools/nix --command why3 prove tools/formal/std_contract.mlw -P z3 -a split_vc


### PR DESCRIPTION
## Summary

With the action pin fixed in #6, the `Why3 Z3` job now reaches its prove step for
the first time — and fails:

```
No prover in /home/runner/.why3.conf corresponds to "z3"
```

why3 only dispatches to provers recorded in `~/.why3.conf`, and a fresh runner
has no such file. Run `why3 config detect` first so it finds the z3 that the
dev shell already provides.

## Verification

- [ ] `Why3 Z3` completes on this PR — `formal.yml` is in its own path filter, so
      this workflow-only change triggers the job and is its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790915645&installation_model_id=422833&pr_number=8&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F8&signature=dece9ef19841b731675c571223c5c0d436e91687bd5026c647f057eea70aff9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->