### PR TITLE
docs: add the security threat model

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,6 +9,11 @@
 - Keep Vite-compatible plugin semantics and Rolldown as internal engines where
   they help, but make `uf` the only user-facing interface.
 
+The threat model that every one of these must satisfy is in
+[docs/security.md](security.md): each row names a published CVE in an
+incumbent tool and the structural decision that makes the same bug impossible
+in `uf`.
+
 ## P0: Toolchain Spine
 
 - Keep the first executable native slice green: `uf create`, `uf build`,

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,112 @@
+# Security
+
+`uf` replaces a toolchain whose parts have shipped real, exploited
+vulnerabilities. The goal is not to react to our own CVEs quickly; it is to be
+structurally incapable of most of them, and to hold a regression test for every
+class we have studied.
+
+This document is the threat model. Every row names a published failure in an
+incumbent tool, the structural decision that makes the same bug impossible or
+loud in `uf`, and where the regression test lives. A row whose test does not
+exist on `main` yet is marked `todo`; that row is a work item, not a claim.
+Land the guard, then update the row in the same change.
+
+Every CVE identifier below was verified against the NVD API before being cited.
+
+## Rules
+
+1. **Untrusted input is named.** Source text, file paths, HTTP requests, archive
+   entries, registry metadata, and `package.json` fields are attacker-controlled
+   in the threat model, even in a "local dev" tool. A developer machine running
+   `uf install` on a cloned repository is a remote-code-execution target.
+2. **Decide on the canonical form.** Never authorize against a raw request
+   string, a pre-normalization path, or a partially decoded URL. Resolve first,
+   then check, then use the value you checked — no re-derivation afterwards.
+3. **Deny by default, allow by table.** Program names, adapters, hosts, and
+   loaders come from fixed `&'static str` tables. Untrusted text never reaches a
+   position where it can name a program, a path root, or a host.
+4. **No unbounded anything.** Every parse, every cache, every recursion, and
+   every read has an explicit bound and a typed error above it.
+5. **No regex on untrusted input** unless the engine is proven non-backtracking.
+   Hand-written single-pass parsers are cheaper than a ReDoS advisory.
+6. **Every guard has a test that fails without it.** A guard with no failing
+   test is a comment.
+
+## Dev server and file serving
+
+The Vite dev server has been bypassed four separate ways in one year, all
+variations on "the deny check ran against a string that was not the path that
+was eventually opened."
+
+| Past failure | Structural decision in `uf` | Test |
+| --- | --- | --- |
+| [CVE-2025-30208](https://github.com/advisories/GHSA-x574-m823-4x7w) — `?raw??` and `?import&raw??` bypass `server.fs.deny` | Query suffixes are stripped and the request is canonicalized to an absolute path *before* any access decision; the decision is made on the resolved path only | todo |
+| [CVE-2025-31125](https://nvd.nist.gov/vuln/detail/CVE-2025-31125) — `?import` / `?inline` / `?raw` traversal | Loader selection is a table lookup over a closed enum, not a string suffix match | todo |
+| [CVE-2025-32395](https://nvd.nist.gov/vuln/detail/CVE-2025-32395) — invalid `request-target` bypass | Requests whose target is not a valid origin-form path are rejected before routing, not normalized into one | todo |
+| [CVE-2025-62522](https://nvd.nist.gov/vuln/detail/CVE-2025-62522) — Windows trailing backslash bypass | `\` is treated as a path separator on every platform when deciding access, never only on Windows | todo |
+
+The dev server binds loopback by default. Exposing it requires an explicit
+opt-in, and that opt-in must also require an allowed-origin list rather than
+defaulting to `*`.
+
+## Framework, RSC, and server actions
+
+| Past failure | Structural decision in `uf` | Test |
+| --- | --- | --- |
+| [CVE-2025-29927](https://nvd.nist.gov/vuln/detail/CVE-2025-29927) — spoofing `x-middleware-subrequest` skips middleware, bypassing auth | No inbound request header participates in middleware dispatch. Recursion control is internal state, never a header a client can send | todo |
+| Server Action endpoint IDs globally disclosed | Action ids are keyed hashes of (module path, export name, build id), so they are neither guessable nor stable across builds; an action not reachable from a client boundary is never registered as an endpoint | todo |
+| RSC cache poisoning when a shared cache does not partition response variants ([CVE-2026-44576](https://nvd.nist.gov/vuln/detail/CVE-2026-44576)) | Route, fetch, action, and data caches are **off by default**. When enabled, the RSC variant is part of the cache key, and the response carries the matching `Vary` | todo |
+| Server-code leak: a `"use client"` module importing server-only code | The RSC graph rejects the edge at build time as an error, not a warning | todo |
+| Directive parsing bugs — `"use client"` accepted when not the first statement, or built from a template literal | The directive is only recognized as a plain string literal in leading directive position; everything else is a typed diagnostic | todo |
+| `"use server"` export that is not an async function | Rejected at build time; React's calling convention makes this a correctness *and* a safety issue | todo |
+| SSRF via WebSocket upgrade ([CVE-2026-44578](https://nvd.nist.gov/vuln/detail/CVE-2026-44578)) | Upgrade targets are resolved against an allowlist; no request-derived value selects an upstream host | todo |
+| Image optimizer: unbounded disk cache, CPU exhaustion from remote images, cache deception | Image caching is opt-in, remote sources require an explicit host allowlist, decode work is bounded by pixel budget, and the cache has a size ceiling | todo |
+| XSS via CSP nonce handling and `beforeInteractive` scripts | Nonces are generated per response and never reused across a cached response; script injection points are typed, not string-concatenated | todo |
+
+## Package manager
+
+`uf install` runs on a freshly cloned, untrusted repository. Everything in
+`package.json` and every registry response is hostile input.
+
+| Past failure | Structural decision in `uf` | Test |
+| --- | --- | --- |
+| [pnpm GHSA-6x96-7vc8-cm3p](https://github.com/pnpm/pnpm/security/advisories/GHSA-6x96-7vc8-cm3p) / CVE-2026-23889 — Windows backslash tarball path traversal | Archive entry names are validated as a closed grammar on all platforms; `\`, `..`, absolute paths, and drive-relative paths are rejected before any join | todo |
+| [CVE-2026-82393](https://nvd.nist.gov/vuln/detail/CVE-2026-82393) — scoped path traversal through a tarball manifest `name`, overwriting arbitrary paths **even with `--ignore-scripts`** | The manifest `name` never becomes a filesystem path. Store layout is content-addressed by integrity hash, so the extraction path does not depend on attacker text at all | todo |
+| Transitive dependency alias containing traversal segments, used as a link path | Aliases are validated with the same grammar as names, and links are created inside the store root with the root re-checked after resolution | todo |
+| Tarballs from `codeload.github.com` not hash-pinned in the lockfile | Every resolved artifact carries an integrity hash in `uf.lock`; a source without one is a hard error, not a warning | todo |
+| Binary planting through the `bin` field | `bin` targets are validated as single path segments inside the package, and shims are written only into the store's own bin directory | todo |
+| Lifecycle scripts as an RCE vector | npm scripts are **forbidden by default** — `uf install` fails on a manifest that declares them. Project automation lives in `uf.config.js` tasks | `crates/uf_pm` |
+| Shell injection through the `packageManager` field | Parsed by a hand-written single-pass parser with no regex (ReDoS), and `Invocation.program` comes only from a fixed program table, so no manifest text can name a program or inject an argument | todo |
+| Prototype-pollution keys in manifest JSON | `__proto__`, `constructor`, and `prototype` are reported and dropped wherever manifest JSON becomes a map | todo |
+
+## Parser, formatter, linter, and test runner
+
+These read attacker-authored source text. The failure mode is denial of service
+on a CI machine, or a formatter silently changing program meaning.
+
+| Risk | Structural decision in `uf` | Test |
+| --- | --- | --- |
+| Stack overflow on deeply nested input | Depth is tracked on an explicit stack, never the call stack, and bounded | todo |
+| Quadratic or exponential scanning | Single-pass lexing with byte scanning; no backtracking regex on source text | todo |
+| A formatter that changes the token stream | Formatting is verified token-preserving: the lexer output of input and output must match, ignoring trivia | todo |
+| Unbounded memory on a hostile file | File size caps with typed errors | todo |
+| Non-UTF-8 and lone-surrogate input | Rejected at the boundary with a typed error; never sliced blindly | todo |
+
+## Supply chain of `uf` itself
+
+- Every GitHub Action is pinned to a commit SHA whose version comment resolves
+  to a real Git ref, and `zizmor` runs at `pedantic` with `min-severity: low` on
+  every pull request.
+- `persist-credentials: false` on every checkout, so a compromised build step
+  cannot reuse the workflow token.
+- Publishing is tokenless OIDC trusted publishing on a `uf@*` tag push; the
+  first publish is local and manual.
+- `upstream/flow` is pinned to a specific commit and is subject to the same
+  review as any other dependency bump.
+- `cargo-fuzz` builds on every pull request that touches the workspace, and
+  `tools/legal` tracks the license of every built-in dependency.
+
+## Reporting
+
+Security reports go to the repository's private vulnerability reporting. Do not
+open a public issue for a suspected vulnerability.


### PR DESCRIPTION
## Summary

`uf` replaces a toolchain whose parts have shipped exploited vulnerabilities, so
"we patch quickly" is not the bar. `docs/security.md` writes down the classes we
have studied, the structural decision that makes each one impossible or loud in
`uf`, and where the regression test lives.

Studied and mapped:

- **Dev server** — the four Vite `server.fs.deny` bypasses of the last year
  (`?raw??`, `?import`/`?inline`/`?raw` traversal, invalid `request-target`,
  Windows trailing backslash). All four are the same bug: the deny check ran
  against a string that was not the path eventually opened.
- **Framework / RSC** — the `x-middleware-subrequest` auth bypass, RSC cache
  poisoning from unpartitioned response variants, server-action id disclosure,
  server-code leak across the client boundary, WebSocket-upgrade SSRF, and
  image-optimizer resource exhaustion.
- **Package manager** — the pnpm tarball path-traversal family (including the
  scoped-name variant that overwrites arbitrary paths *even with
  `--ignore-scripts`*), unhashed tarball sources, binary planting via `bin`, and
  lifecycle scripts as an RCE vector.
- **Parser / formatter / linter** — stack overflow on nested input, ReDoS,
  unbounded allocation, and a formatter silently changing program meaning.

Rows whose test does not exist on `main` yet are marked `todo`, so the table
stays a checklist rather than a claim. Landing a guard means updating its row in
the same change.

## Verification

- [x] Every CVE identifier cited was verified to exist via the NVD API
      (`services.nvd.nist.gov/rest/json/cves/2.0?cveId=…`, `totalResults: 1` for
      all nine).
- [x] The three descriptions I paraphrased most tightly (CVE-2026-44576,
      CVE-2026-82393, CVE-2025-62522) were read back from NVD and match.
- [x] Documentation only — no Rust code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790916336&installation_model_id=422833&pr_number=9&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F9&signature=396a8d3739212f959ba583934b05f9c54a3ae6932eca1ab09f3f7d137bf62cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->