### PR TITLE
feat(rsc): add the React Server Components module graph and action registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "uf_project",
  "uf_rm",
  "uf_router",
+ "uf_rsc",
  "uf_runtime",
  "uf_test",
  "uf_tui",
@@ -1353,6 +1354,25 @@ dependencies = [
  "tempfile",
  "thiserror",
  "uf_config",
+ "walkdir",
+]
+
+[[package]]
+name = "uf_rsc"
+version = "0.1.0"
+dependencies = [
+ "camino",
+ "compact_str",
+ "criterion",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2",
+ "similar-asserts",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "uf_infra",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "crates/uf_project",
   "crates/uf_rm",
   "crates/uf_router",
+  "crates/uf_rsc",
   "crates/uf_runtime",
   "crates/uf_state",
   "crates/uf_story",

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -35,6 +35,7 @@ uf_prepare = { path = "../uf_prepare" }
 uf_project = { path = "../uf_project" }
 uf_rm = { path = "../uf_rm" }
 uf_router = { path = "../uf_router" }
+uf_rsc = { path = "../uf_rsc" }
 uf_runtime = { path = "../uf_runtime" }
 uf_test = { path = "../uf_test" }
 uf_tui = { path = "../uf_tui" }

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -21,6 +21,7 @@ use uf_prepare::default_plan;
 use uf_project::{CreateKind, CreateOptions, collect_source_files, create_project};
 use uf_rm::{RuntimeManagerPlan, RuntimeReference, RuntimeUsePlan, XdgEnv, XdgLayout};
 use uf_router::{discover_routes, write_router_manifest};
+use uf_rsc::{BuildId, ProjectScanOptions, analyze_project};
 use uf_runtime::RuntimeContract;
 use uf_test::{NativeTestRunnerPlan, discover_tests, merge_plans, run_tests};
 
@@ -240,6 +241,12 @@ fn build(cwd: &Utf8Path) -> Result<()> {
         },
     });
     write_json_file(&build_manifest, &payload)?;
+    let rsc = analyze_project(
+        &resolved.root,
+        &BuildId::from_env_or_generate(),
+        &ProjectScanOptions::default(),
+    )?;
+    let rsc_manifest = uf_rsc::write_manifest(&out_dir, &rsc.manifest())?;
     println!(
         "uf build: entries={} outDir={} sourcemap={} backend=uf-native/vite-compatible/rolldown-compatible manifest={}",
         resolved
@@ -253,6 +260,14 @@ fn build(cwd: &Utf8Path) -> Result<()> {
         resolved.config.build.out_dir,
         resolved.config.build.sourcemap,
         build_manifest
+    );
+    println!(
+        "uf build: rsc modules={} clientBoundaries={} serverActions={} diagnostics={} manifest={}",
+        rsc.graph.modules().len(),
+        rsc.graph.client_boundaries().len(),
+        rsc.callable_action_count(),
+        rsc.graph.diagnostics().len(),
+        rsc_manifest
     );
     if let Some(manifest) = manifest {
         println!("generated {}", manifest);

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -153,6 +153,20 @@ fn build_writes_native_manifest_and_router_types() {
             .unwrap()
             .contains("export type RoutePath")
     );
+
+    assert!(stdout.contains("uf-rsc-manifest.json"));
+    let rsc_manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(app.join("dist/uf-rsc-manifest.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        rsc_manifest["clientBundleRoots"],
+        serde_json::json!(["app/client/Counter.js"])
+    );
+    assert_eq!(
+        rsc_manifest["serverActions"][0]["module"],
+        serde_json::json!("server/actions.js")
+    );
+    assert_eq!(rsc_manifest["diagnostics"], serde_json::json!([]));
 }
 
 #[test]

--- a/crates/uf_rsc/Cargo.toml
+++ b/crates/uf_rsc/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "uf_rsc"
+description = "React Server Components module graph and server action registry for uniflowed."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+camino.workspace = true
+compact_str.workspace = true
+rayon.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+smallvec.workspace = true
+thiserror.workspace = true
+uf_infra = { path = "../uf_infra" }
+walkdir.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+similar-asserts.workspace = true
+tempfile.workspace = true
+
+[[bench]]
+name = "rsc"
+harness = false

--- a/crates/uf_rsc/benches/rsc.rs
+++ b/crates/uf_rsc/benches/rsc.rs
@@ -1,0 +1,100 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use uf_rsc::{
+    BuildId, EntryKind, RscGraphBuilder, RscManifest, ServerActionRegistry, module_environment,
+};
+
+const MODULES: usize = 5_000;
+
+/// One synthetic module per index: mostly Server Components, every eighth a
+/// Client Component, every twentieth a `"use server"` module.
+fn module_source(index: usize) -> String {
+    let mut source = String::with_capacity(256);
+    if index.is_multiple_of(20) {
+        source.push_str("\"use server\";\n");
+    } else if index.is_multiple_of(8) {
+        source.push_str("\"use client\";\n");
+    }
+    source.push_str("// @flow\n");
+    source.push_str("import * as React from \"@uniflowed/react\";\n");
+    if index + 1 < MODULES {
+        source.push_str(&format!("import next from \"./m{}.js\";\n", index + 1));
+    }
+    if index + 8 < MODULES {
+        source.push_str(&format!("import wide from \"./m{}.js\";\n", index + 8));
+    }
+    if index.is_multiple_of(20) {
+        source.push_str("export async function refresh() {}\n");
+    } else {
+        source.push_str("export default function Page() { return null; }\n");
+    }
+    source
+}
+
+fn sources() -> Vec<(String, String)> {
+    (0..MODULES)
+        .map(|index| (format!("app/m{index}.js"), module_source(index)))
+        .collect()
+}
+
+fn bench_rsc(criterion: &mut Criterion) {
+    let sources = sources();
+    let build_id = BuildId::new("uf-rsc-benchmark-build-id").expect("valid build id");
+
+    criterion.bench_function("module_environment over 5000 modules", |bencher| {
+        bencher.iter(|| {
+            let mut clients = 0usize;
+            for (_, source) in &sources {
+                clients +=
+                    usize::from(module_environment(source) == uf_rsc::ModuleEnvironment::Client);
+            }
+            black_box(clients)
+        });
+    });
+
+    criterion.bench_function("build a 5000 module graph", |bencher| {
+        bencher.iter(|| {
+            let mut builder = RscGraphBuilder::new();
+            for (path, source) in &sources {
+                builder.add_source(path.as_str(), source);
+            }
+            builder.add_entry("app/m0.js", EntryKind::Server);
+            black_box(builder.build())
+        });
+    });
+
+    let mut builder = RscGraphBuilder::new();
+    for (path, source) in &sources {
+        builder.add_source(path.as_str(), source);
+    }
+    builder.add_entry("app/m0.js", EntryKind::Server);
+    let graph = builder.build();
+
+    criterion.bench_function("register server actions for 5000 modules", |bencher| {
+        bencher.iter(|| black_box(ServerActionRegistry::from_graph(&graph, &build_id)));
+    });
+
+    let registry = ServerActionRegistry::from_graph(&graph, &build_id);
+    let known = registry
+        .callable_actions()
+        .next()
+        .map(|action| action.id.to_hex())
+        .unwrap_or_else(|| "0".repeat(64).into());
+    let unknown = "0".repeat(64);
+
+    criterion.bench_function("resolve a known action id", |bencher| {
+        bencher.iter(|| black_box(registry.resolve(&known).is_ok()));
+    });
+
+    criterion.bench_function("reject an unknown action id", |bencher| {
+        bencher.iter(|| black_box(registry.resolve(&unknown).is_err()));
+    });
+
+    criterion.bench_function("serialize the manifest", |bencher| {
+        bencher.iter(|| black_box(RscManifest::new(&graph, &registry).to_json()));
+    });
+}
+
+criterion_group!(benches, bench_rsc);
+criterion_main!(benches);

--- a/crates/uf_rsc/src/action.rs
+++ b/crates/uf_rsc/src/action.rs
@@ -1,0 +1,1066 @@
+//! Server action identity and the callable-endpoint registry.
+//!
+//! # Threat model
+//!
+//! A server action is a function the browser can invoke by id over the network.
+//! Everything about how that id is built is therefore security-relevant, and the
+//! failure modes below are the ones that have produced real CVEs in other React
+//! frameworks:
+//!
+//! * **Guessable ids.** If the id is the module path plus the export name, or a
+//!   plain hash of them, anyone who can read the source — an open-source app, a
+//!   published sourcemap — can compute the id of *any* function and call it,
+//!   including functions the UI never exposes. [`ActionId`] is therefore an
+//!   HMAC-SHA256 keyed with the per-build [`BuildId`]: without the build id, an
+//!   attacker cannot derive an id even with the whole repository in hand.
+//! * **Ids that survive a rebuild.** Reusing an id across builds lets an
+//!   attacker replay an id captured from an older, more permissive deployment.
+//!   A new build id changes every action id.
+//! * **Oracles in the error path.** Distinguishing "no such module" from "no
+//!   such export" from "that action exists but is not callable" turns the
+//!   endpoint into an enumeration oracle. [`ServerActionRegistry::resolve`]
+//!   answers every failure with the same [`UnknownAction`], and scans the whole
+//!   table with a constant-time comparison so the *timing* does not answer
+//!   either.
+//! * **Dead actions left dialable.** A `"use server"` export nothing reaches is
+//!   still an endpoint if it is registered. Actions that no client boundary can
+//!   reach are recorded as [`ActionExposure::UnreachableFromClient`] and are
+//!   never resolvable.
+//!
+//! # Id construction
+//!
+//! ```text
+//! id = HMAC-SHA256(
+//!         key     = build id bytes,
+//!         message = "uf-rsc-action-v1"
+//!                || u32be(len(module)) || module   // path relative to the project root
+//!                || u32be(len(export)) || export   // export name, or the closure's binding
+//!                || kind                           // 0x01 module export, 0x02 inline closure
+//!      )
+//! ```
+//!
+//! Every variable-length field is length-prefixed, so no two different tuples
+//! can produce the same message, and the domain-separation prefix keeps these
+//! digests distinct from any other HMAC the toolchain computes with the same key.
+
+use std::collections::hash_map::RandomState;
+use std::fmt;
+use std::hash::BuildHasher;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use camino::Utf8PathBuf;
+use compact_str::CompactString;
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::directive::ModuleEnvironment;
+use crate::graph::RscGraph;
+use crate::scan::ExportKind;
+
+/// Domain separation prefix for action digests.
+const ACTION_DOMAIN: &[u8] = b"uf-rsc-action-v1";
+
+/// Domain separation prefix for the manifest fingerprint.
+const FINGERPRINT_DOMAIN: &[u8] = b"uf-rsc-manifest-fingerprint-v1";
+
+/// Shortest accepted build id, in bytes.
+///
+/// A one-character build id is not a key; it is a formality. Anything shorter
+/// than this is rejected rather than silently accepted as a weak HMAC key.
+pub const MIN_BUILD_ID_BYTES: usize = 8;
+
+/// Longest accepted build id, in bytes.
+pub const MAX_BUILD_ID_BYTES: usize = 256;
+
+/// Length of an action id in hexadecimal characters.
+pub const ACTION_ID_HEX_LEN: usize = 64;
+
+/// Why a build id was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum BuildIdError {
+    /// The build id is too short to be used as an HMAC key.
+    #[error("build id must be at least {MIN_BUILD_ID_BYTES} bytes, got {len}")]
+    TooShort {
+        /// Length that was supplied.
+        len: usize,
+    },
+    /// The build id is longer than [`MAX_BUILD_ID_BYTES`].
+    #[error("build id must be at most {MAX_BUILD_ID_BYTES} bytes, got {len}")]
+    TooLong {
+        /// Length that was supplied.
+        len: usize,
+    },
+}
+
+/// Why an action id string was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum ActionIdError {
+    /// The string is not exactly [`ACTION_ID_HEX_LEN`] characters.
+    #[error("action id must be {ACTION_ID_HEX_LEN} hex characters, got {len}")]
+    InvalidLength {
+        /// Length that was supplied.
+        len: usize,
+    },
+    /// The string contains something other than lowercase hexadecimal.
+    #[error("action id must be lowercase hexadecimal")]
+    InvalidCharacter,
+}
+
+/// The single error every failed action lookup produces.
+///
+/// It deliberately carries nothing: no id, no module, no reason. Any detail here
+/// would be an enumeration oracle for whoever is probing the endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Error)]
+#[error("unknown server action")]
+pub struct UnknownAction;
+
+/// The per-build secret that keys every action id.
+///
+/// Treat it like a signing key: it must not be written into the manifest, logged,
+/// or shipped to the browser. [`ServerActionRegistry`] keeps only a fingerprint
+/// of it once the ids are computed.
+#[derive(Clone, PartialEq, Eq)]
+pub struct BuildId {
+    value: CompactString,
+}
+
+impl BuildId {
+    /// Accept a caller-supplied build id.
+    pub fn new(value: impl Into<CompactString>) -> Result<Self, BuildIdError> {
+        let value = value.into();
+        let len = value.len();
+        if len < MIN_BUILD_ID_BYTES {
+            return Err(BuildIdError::TooShort { len });
+        }
+        if len > MAX_BUILD_ID_BYTES {
+            return Err(BuildIdError::TooLong { len });
+        }
+        Ok(Self { value })
+    }
+
+    /// Generate a fresh build id from operating-system entropy.
+    ///
+    /// Falls back to mixing the process id, the wall clock and two
+    /// `RandomState` seeds when `/dev/urandom` is unavailable. Set `UF_BUILD_ID`
+    /// instead when a build must be reproducible; see
+    /// [`BuildId::from_env_or_generate`].
+    pub fn generate() -> Self {
+        let mut entropy = [0u8; 32];
+        if !os_entropy(&mut entropy) {
+            let mut hasher = Sha256::new();
+            hasher.update(b"uf-rsc-build-id-fallback");
+            hasher.update(std::process::id().to_le_bytes());
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|elapsed| elapsed.as_nanos())
+                .unwrap_or_default();
+            hasher.update(nanos.to_le_bytes());
+            hasher.update(RandomState::new().hash_one(0u64).to_le_bytes());
+            hasher.update(RandomState::new().hash_one(1u64).to_le_bytes());
+            entropy.copy_from_slice(&hasher.finalize());
+        }
+        Self {
+            value: hex(&entropy),
+        }
+    }
+
+    /// Read `UF_BUILD_ID` when it is set and usable, otherwise generate one.
+    pub fn from_env_or_generate() -> Self {
+        std::env::var("UF_BUILD_ID")
+            .ok()
+            .and_then(|value| Self::new(value).ok())
+            .unwrap_or_else(Self::generate)
+    }
+
+    /// The build id bytes, used as the HMAC key.
+    fn key(&self) -> &[u8] {
+        self.value.as_bytes()
+    }
+
+    /// A digest of the build id that is safe to publish.
+    pub fn fingerprint(&self) -> CompactString {
+        hex(&hmac_sha256(self.key(), FINGERPRINT_DOMAIN))
+    }
+}
+
+impl fmt::Debug for BuildId {
+    /// Redacted: a build id that reaches a log is a leaked key.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("BuildId(<redacted>)")
+    }
+}
+
+/// The public identifier of one server action.
+#[derive(Clone, Copy)]
+pub struct ActionId([u8; 32]);
+
+impl ActionId {
+    /// Derive the id of an action.
+    pub fn derive(build_id: &BuildId, module: &str, export: &str, kind: ServerActionKind) -> Self {
+        let mut message = Vec::with_capacity(ACTION_DOMAIN.len() + module.len() + export.len() + 9);
+        message.extend_from_slice(ACTION_DOMAIN);
+        message.extend_from_slice(&(module.len() as u32).to_be_bytes());
+        message.extend_from_slice(module.as_bytes());
+        message.extend_from_slice(&(export.len() as u32).to_be_bytes());
+        message.extend_from_slice(export.as_bytes());
+        message.push(kind.tag());
+        Self(hmac_sha256(build_id.key(), &message))
+    }
+
+    /// Parse the canonical lowercase hexadecimal form.
+    pub fn parse(text: &str) -> Result<Self, ActionIdError> {
+        // Length is checked before anything is allocated, so an oversized id
+        // cannot be used to force work or memory on the server.
+        if text.len() != ACTION_ID_HEX_LEN {
+            return Err(ActionIdError::InvalidLength { len: text.len() });
+        }
+        let mut bytes = [0u8; 32];
+        let (pairs, _) = text.as_bytes().as_chunks::<2>();
+        for (position, pair) in pairs.iter().enumerate() {
+            let high = hex_value(pair[0]).ok_or(ActionIdError::InvalidCharacter)?;
+            let low = hex_value(pair[1]).ok_or(ActionIdError::InvalidCharacter)?;
+            bytes[position] = (high << 4) | low;
+        }
+        Ok(Self(bytes))
+    }
+
+    /// The canonical lowercase hexadecimal form.
+    pub fn to_hex(self) -> CompactString {
+        hex(&self.0)
+    }
+
+    /// The raw digest.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl PartialEq for ActionId {
+    /// Constant-time: comparing action ids must not leak how much of a guess matched.
+    fn eq(&self, other: &Self) -> bool {
+        constant_time_eq(&self.0, &other.0) == 1
+    }
+}
+
+impl Eq for ActionId {}
+
+impl PartialOrd for ActionId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ActionId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl fmt::Debug for ActionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "ActionId({})", self.to_hex())
+    }
+}
+
+impl fmt::Display for ActionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.to_hex())
+    }
+}
+
+impl Serialize for ActionId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for ActionId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = CompactString::deserialize(deserializer)?;
+        Self::parse(&text).map_err(D::Error::custom)
+    }
+}
+
+/// Where a server action was declared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ServerActionKind {
+    /// An export of a file-level `"use server"` module.
+    ModuleExport,
+    /// A closure whose body starts with `"use server"`.
+    InlineClosure,
+}
+
+impl ServerActionKind {
+    /// Byte mixed into the action digest so the two kinds can never collide.
+    fn tag(self) -> u8 {
+        match self {
+            Self::ModuleExport => 0x01,
+            Self::InlineClosure => 0x02,
+        }
+    }
+}
+
+/// Whether an action can be called from the browser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ActionExposure {
+    /// Reachable from a client boundary; registered as a callable endpoint.
+    CallableEndpoint,
+    /// Nothing on the client can reach it, so it is never dialable.
+    UnreachableFromClient,
+}
+
+impl ActionExposure {
+    /// Whether the action is a callable endpoint.
+    pub fn is_callable(self) -> bool {
+        matches!(self, Self::CallableEndpoint)
+    }
+}
+
+/// One server action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerAction {
+    /// Keyed identifier the client uses to call it.
+    pub id: ActionId,
+    /// Declaring module, relative to the project root.
+    pub module: Utf8PathBuf,
+    /// Export name, or the binding of an inline closure.
+    pub export: CompactString,
+    /// Where the action was declared.
+    pub kind: ServerActionKind,
+    /// Whether the client can reach it.
+    pub exposure: ActionExposure,
+}
+
+/// Every server action of a build, and the lookup the runtime dials into.
+#[derive(Debug, Clone)]
+pub struct ServerActionRegistry {
+    actions: Vec<ServerAction>,
+    fingerprint: CompactString,
+}
+
+impl ServerActionRegistry {
+    /// Collect the actions of a resolved graph.
+    pub fn from_graph(graph: &RscGraph, build_id: &BuildId) -> Self {
+        let modules = graph.modules();
+        let hands_off = hands_off_to_client(graph);
+
+        let mut actions: Vec<ServerAction> = Vec::new();
+        for (position, module) in modules.iter().enumerate() {
+            let exposure = if hands_off[position] {
+                ActionExposure::CallableEndpoint
+            } else {
+                ActionExposure::UnreachableFromClient
+            };
+
+            if module.environment == ModuleEnvironment::ServerActions {
+                for export in &module.exports {
+                    // Only shapes React can actually invoke become endpoints;
+                    // anything else is reported by the graph and left out.
+                    if !matches!(
+                        export.kind,
+                        ExportKind::AsyncFunction | ExportKind::ReExport
+                    ) {
+                        continue;
+                    }
+                    actions.push(ServerAction {
+                        id: ActionId::derive(
+                            build_id,
+                            module.path.as_str(),
+                            &export.name,
+                            ServerActionKind::ModuleExport,
+                        ),
+                        module: module.path.clone(),
+                        export: export.name.clone(),
+                        kind: ServerActionKind::ModuleExport,
+                        exposure,
+                    });
+                }
+            }
+
+            for directive in &module.function_actions {
+                let export = CompactString::from(directive.owner.to_string());
+                actions.push(ServerAction {
+                    id: ActionId::derive(
+                        build_id,
+                        module.path.as_str(),
+                        &export,
+                        ServerActionKind::InlineClosure,
+                    ),
+                    module: module.path.clone(),
+                    export,
+                    kind: ServerActionKind::InlineClosure,
+                    exposure,
+                });
+            }
+        }
+
+        actions.sort_by(|left, right| {
+            left.module
+                .cmp(&right.module)
+                .then(left.kind.cmp(&right.kind))
+                .then(left.export.cmp(&right.export))
+        });
+        actions.dedup_by(|left, right| {
+            left.module == right.module && left.kind == right.kind && left.export == right.export
+        });
+
+        Self {
+            actions,
+            fingerprint: build_id.fingerprint(),
+        }
+    }
+
+    /// Every action, callable or not, ordered by module and name.
+    pub fn actions(&self) -> &[ServerAction] {
+        &self.actions
+    }
+
+    /// Only the actions that are callable endpoints.
+    pub fn callable_actions(&self) -> impl Iterator<Item = &ServerAction> {
+        self.actions
+            .iter()
+            .filter(|action| action.exposure.is_callable())
+    }
+
+    /// Number of registered actions.
+    pub fn len(&self) -> usize {
+        self.actions.len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.actions.is_empty()
+    }
+
+    /// A publishable digest of the build id.
+    pub fn build_fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    /// Resolve an id received from a client.
+    ///
+    /// Malformed, forged, unknown and unreachable ids are all
+    /// [`UnknownAction`]: the caller learns nothing beyond "no".
+    pub fn resolve(&self, raw_id: &str) -> Result<&ServerAction, UnknownAction> {
+        let id = ActionId::parse(raw_id).map_err(|_| UnknownAction)?;
+        self.lookup(&id)
+    }
+
+    /// Resolve a parsed id.
+    ///
+    /// The scan visits every entry whatever happens, and compares with
+    /// [`constant_time_eq`], so neither the running time nor the branch pattern
+    /// depends on which entry matched — or on whether one did.
+    pub fn lookup(&self, id: &ActionId) -> Result<&ServerAction, UnknownAction> {
+        let mut selected = 0u32;
+        let mut found = 0u8;
+
+        for (position, action) in self.actions.iter().enumerate() {
+            let matches = constant_time_eq(&action.id.0, &id.0)
+                & u8::from(action.exposure == ActionExposure::CallableEndpoint);
+            let mask = 0u32.wrapping_sub(u32::from(matches));
+            selected = (selected & !mask) | ((position as u32) & mask);
+            found |= matches;
+        }
+
+        if found == 1 {
+            self.actions.get(selected as usize).ok_or(UnknownAction)
+        } else {
+            Err(UnknownAction)
+        }
+    }
+}
+
+/// Which modules can hand a server action across a client boundary.
+///
+/// A module qualifies when the client graph already contains it, or when the
+/// server renders it *and* it reaches a `"use client"` import — that is the only
+/// way a closure defined there can end up as a prop on a Client Component. Every
+/// `"use server"` module such a module imports becomes callable with it.
+fn hands_off_to_client(graph: &RscGraph) -> Vec<bool> {
+    let modules = graph.modules();
+    let mut hands_off = vec![false; modules.len()];
+
+    for (position, module) in modules.iter().enumerate() {
+        hands_off[position] = module.reachability.is_client_reachable()
+            || (module.reachability.is_server_reachable() && module.proximity.reaches_boundary());
+    }
+
+    for (position, module) in modules.iter().enumerate() {
+        if !hands_off[position] {
+            continue;
+        }
+        for target in module.imports.iter().copied() {
+            if modules[target.index()].environment == ModuleEnvironment::ServerActions {
+                hands_off[target.index()] = true;
+            }
+        }
+    }
+
+    hands_off
+}
+
+/// HMAC-SHA256, RFC 2104.
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK_LEN: usize = 64;
+
+    let mut block = [0u8; BLOCK_LEN];
+    if key.len() > BLOCK_LEN {
+        block[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        block[..key.len()].copy_from_slice(key);
+    }
+
+    let mut inner_pad = [0x36u8; BLOCK_LEN];
+    let mut outer_pad = [0x5cu8; BLOCK_LEN];
+    for ((inner, outer), key_byte) in inner_pad
+        .iter_mut()
+        .zip(outer_pad.iter_mut())
+        .zip(block.iter())
+    {
+        *inner ^= key_byte;
+        *outer ^= key_byte;
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(message);
+    let inner = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner);
+    outer.finalize().into()
+}
+
+/// Returns 1 when the two digests are equal, without an early exit.
+fn constant_time_eq(left: &[u8; 32], right: &[u8; 32]) -> u8 {
+    let mut difference = 0u8;
+    for (left_byte, right_byte) in left.iter().zip(right.iter()) {
+        difference |= left_byte ^ right_byte;
+    }
+    (((difference as u32).wrapping_sub(1)) >> 31) as u8
+}
+
+fn hex(bytes: &[u8]) -> CompactString {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut text = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        text.push(DIGITS[(byte >> 4) as usize] as char);
+        text.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    CompactString::from(text)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
+}
+
+fn os_entropy(buffer: &mut [u8]) -> bool {
+    use std::io::Read;
+
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(buffer))
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::directive::FunctionOwner;
+    use crate::graph::{EntryKind, RscGraphBuilder, RscModuleInput};
+
+    fn build_id() -> BuildId {
+        BuildId::new("build-id-for-tests").expect("valid build id")
+    }
+
+    fn graph_with_reachable_action() -> RscGraph {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "app/page.js",
+            "import Counter from \"./Counter.js\";\nimport { refresh } from \"../server/actions.js\";\n",
+        );
+        builder.add_source("app/Counter.js", "\"use client\";\n");
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport async function refresh() {}\n",
+        );
+        builder.add_entry("app/page.js", EntryKind::Server);
+        builder.build()
+    }
+
+    #[test]
+    fn hmac_matches_rfc_4231_test_case_1() {
+        let mac = hmac_sha256(&[0x0b; 20], b"Hi There");
+        assert_eq!(
+            hex(&mac),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+    }
+
+    #[test]
+    fn hmac_matches_rfc_4231_test_case_2() {
+        let mac = hmac_sha256(b"Jefe", b"what do ya want for nothing?");
+        assert_eq!(
+            hex(&mac),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
+
+    #[test]
+    fn hmac_matches_rfc_4231_test_case_6_with_an_oversized_key() {
+        let mac = hmac_sha256(
+            &[0xaa; 131],
+            b"Test Using Larger Than Block-Size Key - Hash Key First",
+        );
+        assert_eq!(
+            hex(&mac),
+            "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54"
+        );
+    }
+
+    #[test]
+    fn a_short_build_id_is_rejected() {
+        assert_eq!(
+            BuildId::new("short"),
+            Err(BuildIdError::TooShort { len: 5 })
+        );
+    }
+
+    #[test]
+    fn an_empty_build_id_is_rejected() {
+        assert_eq!(BuildId::new(""), Err(BuildIdError::TooShort { len: 0 }));
+    }
+
+    #[test]
+    fn an_oversized_build_id_is_rejected() {
+        let value = "x".repeat(MAX_BUILD_ID_BYTES + 1);
+        assert_eq!(
+            BuildId::new(value),
+            Err(BuildIdError::TooLong {
+                len: MAX_BUILD_ID_BYTES + 1
+            })
+        );
+    }
+
+    #[test]
+    fn a_generated_build_id_is_long_and_unique() {
+        let first = BuildId::generate();
+        let second = BuildId::generate();
+        assert!(first.value.len() >= MIN_BUILD_ID_BYTES);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn a_build_id_never_prints_itself() {
+        let formatted = format!("{:?}", build_id());
+        assert_eq!(formatted, "BuildId(<redacted>)");
+        assert!(!formatted.contains("build-id-for-tests"));
+    }
+
+    #[test]
+    fn action_ids_are_stable_across_runs() {
+        let first = ActionId::derive(
+            &build_id(),
+            "server/actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        let second = ActionId::derive(
+            &build_id(),
+            "server/actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn action_ids_change_with_the_build_id() {
+        let first = ActionId::derive(
+            &BuildId::new("build-id-one").unwrap(),
+            "server/actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        let second = ActionId::derive(
+            &BuildId::new("build-id-two").unwrap(),
+            "server/actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn action_ids_change_with_the_module_path() {
+        let first = ActionId::derive(
+            &build_id(),
+            "server/a.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        let second = ActionId::derive(
+            &build_id(),
+            "server/b.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn action_ids_change_with_the_export_name() {
+        let first = ActionId::derive(
+            &build_id(),
+            "server/a.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        let second = ActionId::derive(
+            &build_id(),
+            "server/a.js",
+            "reload",
+            ServerActionKind::ModuleExport,
+        );
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn action_ids_change_with_the_declaration_kind() {
+        let first = ActionId::derive(
+            &build_id(),
+            "server/a.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        let second = ActionId::derive(
+            &build_id(),
+            "server/a.js",
+            "refresh",
+            ServerActionKind::InlineClosure,
+        );
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn length_prefixing_stops_field_boundaries_from_sliding() {
+        let first = ActionId::derive(&build_id(), "ab", "cd", ServerActionKind::ModuleExport);
+        let second = ActionId::derive(&build_id(), "a", "bcd", ServerActionKind::ModuleExport);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn an_action_id_never_contains_the_module_path() {
+        let id = ActionId::derive(
+            &build_id(),
+            "server/secret-actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        assert!(!id.to_hex().contains("secret"));
+        assert_eq!(id.to_hex().len(), ACTION_ID_HEX_LEN);
+    }
+
+    #[test]
+    fn action_ids_round_trip_through_hex() {
+        let id = ActionId::derive(
+            &build_id(),
+            "server/actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        assert_eq!(ActionId::parse(&id.to_hex()).unwrap(), id);
+    }
+
+    #[test]
+    fn a_truncated_action_id_is_rejected() {
+        let id = ActionId::derive(
+            &build_id(),
+            "server/actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        let hex = id.to_hex();
+        assert_eq!(
+            ActionId::parse(&hex[..hex.len() - 1]),
+            Err(ActionIdError::InvalidLength { len: 63 })
+        );
+    }
+
+    #[test]
+    fn an_oversized_action_id_is_rejected_before_any_allocation() {
+        let oversized = "a".repeat(1_000_000);
+        assert_eq!(
+            ActionId::parse(&oversized),
+            Err(ActionIdError::InvalidLength { len: 1_000_000 })
+        );
+    }
+
+    #[test]
+    fn an_empty_action_id_is_rejected() {
+        assert_eq!(
+            ActionId::parse(""),
+            Err(ActionIdError::InvalidLength { len: 0 })
+        );
+    }
+
+    #[test]
+    fn a_non_hex_action_id_is_rejected() {
+        let text = "z".repeat(ACTION_ID_HEX_LEN);
+        assert_eq!(ActionId::parse(&text), Err(ActionIdError::InvalidCharacter));
+    }
+
+    #[test]
+    fn an_uppercase_action_id_is_rejected() {
+        let id = ActionId::derive(
+            &build_id(),
+            "server/actions.js",
+            "refresh",
+            ServerActionKind::ModuleExport,
+        );
+        let upper = id.to_hex().to_uppercase();
+        assert!(ActionId::parse(&upper).is_err());
+    }
+
+    #[test]
+    fn constant_time_comparison_agrees_with_equality() {
+        let left = [7u8; 32];
+        let mut right = [7u8; 32];
+        assert_eq!(constant_time_eq(&left, &right), 1);
+        right[31] = 8;
+        assert_eq!(constant_time_eq(&left, &right), 0);
+        right[31] = 7;
+        right[0] = 8;
+        assert_eq!(constant_time_eq(&left, &right), 0);
+    }
+
+    #[test]
+    fn a_reachable_module_export_is_registered_as_an_endpoint() {
+        let graph = graph_with_reachable_action();
+        let registry = ServerActionRegistry::from_graph(&graph, &build_id());
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.actions()[0].export, "refresh");
+        assert_eq!(
+            registry.actions()[0].exposure,
+            ActionExposure::CallableEndpoint
+        );
+        assert_eq!(registry.callable_actions().count(), 1);
+    }
+
+    #[test]
+    fn a_registered_endpoint_resolves_by_its_id() {
+        let graph = graph_with_reachable_action();
+        let registry = ServerActionRegistry::from_graph(&graph, &build_id());
+        let id = registry.actions()[0].id.to_hex();
+        assert_eq!(registry.resolve(&id).unwrap().export, "refresh");
+    }
+
+    #[test]
+    fn an_unreachable_action_is_never_resolvable() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/orphan.js",
+            "\"use server\";\nexport async function drop() {}\n",
+        );
+        let graph = builder.build();
+        let registry = ServerActionRegistry::from_graph(&graph, &build_id());
+
+        assert_eq!(registry.len(), 1);
+        assert_eq!(
+            registry.actions()[0].exposure,
+            ActionExposure::UnreachableFromClient
+        );
+        assert_eq!(registry.callable_actions().count(), 0);
+
+        let id = registry.actions()[0].id.to_hex();
+        assert_eq!(registry.resolve(&id), Err(UnknownAction));
+    }
+
+    #[test]
+    fn an_action_reached_only_from_a_server_module_without_a_boundary_is_not_callable() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source("app/page.js", "import \"../server/actions.js\";\n");
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport async function refresh() {}\n",
+        );
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let registry = ServerActionRegistry::from_graph(&builder.build(), &build_id());
+        assert_eq!(
+            registry.actions()[0].exposure,
+            ActionExposure::UnreachableFromClient
+        );
+    }
+
+    #[test]
+    fn an_action_imported_by_a_client_module_is_callable() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source("app/page.js", "import Form from \"./Form.js\";\n");
+        builder.add_source(
+            "app/Form.js",
+            "\"use client\";\nimport { save } from \"../server/actions.js\";\n",
+        );
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport async function save() {}\n",
+        );
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let registry = ServerActionRegistry::from_graph(&builder.build(), &build_id());
+        assert_eq!(
+            registry.actions()[0].exposure,
+            ActionExposure::CallableEndpoint
+        );
+    }
+
+    #[test]
+    fn an_inline_closure_action_is_registered_separately() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "app/page.js",
+            "import Form from \"./Form.js\";\nexport default function Page() {\n const save = async () => {\n  \"use server\";\n };\n return save;\n}\n",
+        );
+        builder.add_source("app/Form.js", "\"use client\";\n");
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let registry = ServerActionRegistry::from_graph(&builder.build(), &build_id());
+
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.actions()[0].kind, ServerActionKind::InlineClosure);
+        assert_eq!(registry.actions()[0].export, "save");
+        assert_eq!(
+            registry.actions()[0].exposure,
+            ActionExposure::CallableEndpoint
+        );
+    }
+
+    #[test]
+    fn a_sync_export_of_a_server_actions_module_is_not_registered() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport function refresh() {}\n",
+        );
+        let registry = ServerActionRegistry::from_graph(&builder.build(), &build_id());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn a_non_function_export_of_a_server_actions_module_is_not_registered() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport const n = 1;\n",
+        );
+        assert!(ServerActionRegistry::from_graph(&builder.build(), &build_id()).is_empty());
+    }
+
+    #[test]
+    fn a_forged_id_is_rejected_with_the_same_error_as_an_unknown_one() {
+        let graph = graph_with_reachable_action();
+        let registry = ServerActionRegistry::from_graph(&graph, &build_id());
+
+        let forged = "0".repeat(ACTION_ID_HEX_LEN);
+        let malformed = "not-an-id";
+        assert_eq!(registry.resolve(&forged), Err(UnknownAction));
+        assert_eq!(registry.resolve(malformed), Err(UnknownAction));
+        assert_eq!(
+            registry.resolve(&forged).unwrap_err().to_string(),
+            registry.resolve(malformed).unwrap_err().to_string()
+        );
+    }
+
+    #[test]
+    fn an_id_from_another_build_does_not_resolve() {
+        let graph = graph_with_reachable_action();
+        let current = ServerActionRegistry::from_graph(&graph, &build_id());
+        let previous =
+            ServerActionRegistry::from_graph(&graph, &BuildId::new("previous-build-id").unwrap());
+        let stale = previous.actions()[0].id.to_hex();
+        assert_eq!(current.resolve(&stale), Err(UnknownAction));
+    }
+
+    #[test]
+    fn the_unknown_action_error_says_nothing_about_the_registry() {
+        let message = UnknownAction.to_string();
+        assert_eq!(message, "unknown server action");
+    }
+
+    #[test]
+    fn ids_are_unique_across_a_large_registry() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source("app/page.js", "import \"./Counter.js\";\n");
+        builder.add_source("app/Counter.js", "\"use client\";\n");
+        for index in 0..2_000 {
+            builder.add_module(
+                RscModuleInput::new(
+                    format!("server/actions{index}.js"),
+                    ModuleEnvironment::ServerActions,
+                )
+                .with_export("refresh", ExportKind::AsyncFunction)
+                .with_export("reload", ExportKind::AsyncFunction),
+            );
+        }
+        let registry = ServerActionRegistry::from_graph(&builder.build(), &build_id());
+        assert_eq!(registry.len(), 4_000);
+
+        let mut ids: Vec<_> = registry
+            .actions()
+            .iter()
+            .map(|action| action.id.to_hex())
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), 4_000);
+    }
+
+    #[test]
+    fn duplicate_declarations_collapse_to_one_action() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(
+            RscModuleInput::new("server/actions.js", ModuleEnvironment::ServerActions)
+                .with_export("refresh", ExportKind::AsyncFunction)
+                .with_export("refresh", ExportKind::AsyncFunction),
+        );
+        let registry = ServerActionRegistry::from_graph(&builder.build(), &build_id());
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn the_build_fingerprint_is_derived_and_not_the_build_id() {
+        let registry =
+            ServerActionRegistry::from_graph(&graph_with_reachable_action(), &build_id());
+        assert_eq!(registry.build_fingerprint().len(), ACTION_ID_HEX_LEN);
+        assert!(!registry.build_fingerprint().contains("build-id-for-tests"));
+        assert_eq!(registry.build_fingerprint(), build_id().fingerprint());
+    }
+
+    #[test]
+    fn registries_built_twice_from_the_same_input_are_identical() {
+        let graph = graph_with_reachable_action();
+        let first = ServerActionRegistry::from_graph(&graph, &build_id());
+        let second = ServerActionRegistry::from_graph(&graph, &build_id());
+        assert_eq!(first.actions(), second.actions());
+    }
+
+    #[test]
+    fn inline_closures_in_the_same_module_get_distinct_ids() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(
+            RscModuleInput::new("app/page.js", ModuleEnvironment::Server)
+                .with_function_action(FunctionOwner::Anonymous { ordinal: 0 })
+                .with_function_action(FunctionOwner::Anonymous { ordinal: 1 }),
+        );
+        let registry = ServerActionRegistry::from_graph(&builder.build(), &build_id());
+        assert_eq!(registry.len(), 2);
+        assert_ne!(registry.actions()[0].id, registry.actions()[1].id);
+    }
+}

--- a/crates/uf_rsc/src/directive.rs
+++ b/crates/uf_rsc/src/directive.rs
@@ -1,0 +1,1014 @@
+//! Directive detection for React Server Components.
+//!
+//! Every module in a `uf` app runs on the server unless it opts out. A module
+//! joins the client bundle with a file-level `"use client"` directive, and a
+//! module exposes server actions with a file-level `"use server"` directive.
+//!
+//! # What counts as a directive
+//!
+//! The rules follow the ECMAScript *directive prologue*, because that is what
+//! React and the bundlers implement:
+//!
+//! * a UTF-8 BOM, a `#!` hashbang line, comments and blank lines may precede it;
+//! * it must be a plain single- or double-quoted string literal;
+//! * it must be terminated by `;`, by a line break (ASI), by `}`, or by the end
+//!   of the file;
+//! * the string content is compared to the *raw* source text, so
+//!   `"use  client"` (two spaces) and `"use client"` are not directives —
+//!   exactly as `"use strict"` behaves in the language;
+//! * it may only appear in the prologue. `"use client"` further down the file,
+//!   built by concatenation, or written as a template literal is rejected with a
+//!   typed [`DirectiveIssue`] instead of being silently ignored.
+//!
+//! Silently ignoring one of those cases is how a module that its author believed
+//! was a Client Component ends up rendered on the server (or the reverse), which
+//! is the bug class this module exists to prevent.
+//!
+//! A `"use server"` directive at the top of a *function body* is a different,
+//! supported construct: it marks that single closure as a server action rather
+//! than changing the module environment. Those are collected separately in
+//! [`DirectiveScan::function_directives`].
+
+use std::fmt;
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uf_infra::{InlineVec, LineIndex};
+
+use crate::scan::{Token, TokenKind, clamp_u32, matching_open, starts_statement, tokenize};
+
+/// Inline list of function-level directives found in one module.
+pub type FunctionDirectiveList = InlineVec<FunctionDirective, 4>;
+
+/// Inline list of directive issues found in one module.
+pub type DirectiveIssueList = InlineVec<DirectiveIssue, 2>;
+
+/// Which environment a module executes in.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModuleEnvironment {
+    /// The default: a Server Component, never shipped to the browser.
+    #[default]
+    Server,
+    /// A Client Component: a `"use client"` module and a client bundle root.
+    Client,
+    /// A `"use server"` module: every export is a server action.
+    ServerActions,
+}
+
+impl ModuleEnvironment {
+    /// Environment implied by a file-level directive, if any.
+    pub fn from_file_directive(directive: Option<DirectiveKind>) -> Self {
+        match directive {
+            None => Self::Server,
+            Some(DirectiveKind::UseClient) => Self::Client,
+            Some(DirectiveKind::UseServer) => Self::ServerActions,
+        }
+    }
+
+    /// Whether the module executes on the server.
+    pub fn runs_on_server(self) -> bool {
+        matches!(self, Self::Server | Self::ServerActions)
+    }
+
+    /// Whether the module is bundled for the browser.
+    pub fn runs_on_client(self) -> bool {
+        matches!(self, Self::Client)
+    }
+}
+
+/// The two RSC directives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DirectiveKind {
+    /// `"use client"`.
+    UseClient,
+    /// `"use server"`.
+    UseServer,
+}
+
+impl DirectiveKind {
+    /// Match the raw text between the quotes against the two directives.
+    ///
+    /// The comparison is byte-exact on the *source* text, which is what makes
+    /// `"use  client"` and `"use client"` ordinary string statements.
+    pub fn from_content(content: &str) -> Option<Self> {
+        match content {
+            "use client" => Some(Self::UseClient),
+            "use server" => Some(Self::UseServer),
+            _ => None,
+        }
+    }
+
+    /// The directive text without quotes.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UseClient => "use client",
+            Self::UseServer => "use server",
+        }
+    }
+}
+
+impl fmt::Display for DirectiveKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// The accepted file-level directive of a module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileDirective {
+    /// Which directive was found.
+    pub kind: DirectiveKind,
+    /// 1-based line of the directive.
+    pub line: u32,
+    /// 1-based column of the directive.
+    pub column: u32,
+}
+
+/// The function a function-level `"use server"` directive belongs to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FunctionOwner {
+    /// A binding the scanner could name.
+    Named(CompactString),
+    /// An inline closure, identified by its source order within the module.
+    Anonymous {
+        /// 0-based index among the anonymous inline actions of this module.
+        ordinal: u32,
+    },
+}
+
+impl fmt::Display for FunctionOwner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Named(name) => formatter.write_str(name),
+            Self::Anonymous { ordinal } => write!(formatter, "<anonymous#{ordinal}>"),
+        }
+    }
+}
+
+/// A `"use server"` directive at the top of a function body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FunctionDirective {
+    /// The function the directive applies to.
+    pub owner: FunctionOwner,
+    /// 1-based line of the directive.
+    pub line: u32,
+    /// 1-based column of the directive.
+    pub column: u32,
+}
+
+/// A directive-shaped construct that is not a valid directive.
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "issue")]
+pub enum DirectiveIssue {
+    /// A `"use client"` or `"use server"` string outside the module prologue.
+    #[error("`{kind}` at line {line}:{column} is not the first statement of the module")]
+    NotInPrologue {
+        /// Which directive was written.
+        kind: DirectiveKind,
+        /// 1-based line.
+        line: u32,
+        /// 1-based column.
+        column: u32,
+    },
+    /// A directive built from a template literal or a concatenation.
+    #[error("`{kind}` at line {line}:{column} must be a plain string literal")]
+    NotAStringLiteral {
+        /// Which directive was intended.
+        kind: DirectiveKind,
+        /// 1-based line.
+        line: u32,
+        /// 1-based column.
+        column: u32,
+    },
+    /// A module declaring both `"use client"` and `"use server"`.
+    #[error("conflicting `use client` and `use server` directives at line {line}:{column}")]
+    Conflicting {
+        /// 1-based line of the second directive.
+        line: u32,
+        /// 1-based column of the second directive.
+        column: u32,
+    },
+    /// A `"use client"` directive inside a function body, which React does not support.
+    #[error("`use client` at line {line}:{column} is only valid at the top of a module")]
+    ClientDirectiveInFunction {
+        /// 1-based line.
+        line: u32,
+        /// 1-based column.
+        column: u32,
+    },
+}
+
+impl DirectiveIssue {
+    /// Stable rule identifier for reporting.
+    pub fn rule(&self) -> &'static str {
+        match self {
+            Self::NotInPrologue { .. } => "rsc/directive-not-in-prologue",
+            Self::NotAStringLiteral { .. } => "rsc/directive-not-a-string-literal",
+            Self::Conflicting { .. } => "rsc/conflicting-directives",
+            Self::ClientDirectiveInFunction { .. } => "rsc/client-directive-in-function",
+        }
+    }
+
+    /// 1-based line the issue was found on.
+    pub fn line(&self) -> u32 {
+        match self {
+            Self::NotInPrologue { line, .. }
+            | Self::NotAStringLiteral { line, .. }
+            | Self::Conflicting { line, .. }
+            | Self::ClientDirectiveInFunction { line, .. } => *line,
+        }
+    }
+}
+
+/// Everything the directive pass learned about one module.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DirectiveScan {
+    /// Environment the module executes in.
+    pub environment: ModuleEnvironment,
+    /// The accepted file-level directive, when the module has one.
+    pub file_directive: Option<FileDirective>,
+    /// Function-level `"use server"` closures, in source order.
+    pub function_directives: FunctionDirectiveList,
+    /// Rejected directive-shaped constructs.
+    pub issues: DirectiveIssueList,
+}
+
+/// Classify a module by its file-level directive.
+///
+/// Modules without a valid file-level directive are [`ModuleEnvironment::Server`],
+/// which is the `uf` default.
+pub fn module_environment(source: &str) -> ModuleEnvironment {
+    scan_directives(source).environment
+}
+
+/// Run the full directive pass over a module.
+pub fn scan_directives(source: &str) -> DirectiveScan {
+    let tokens = tokenize(source);
+    let index = LineIndex::new(source);
+    scan_directive_tokens(source, &tokens, &index)
+}
+
+pub(crate) fn scan_directive_tokens(
+    source: &str,
+    tokens: &[Token],
+    index: &LineIndex,
+) -> DirectiveScan {
+    let mut scan = DirectiveScan::default();
+    let mut consumed = vec![false; tokens.len()];
+
+    let prologue_end = scan_prologue(source, tokens, index, &mut consumed, &mut scan);
+    scan_function_directives(source, tokens, index, &mut consumed, &mut scan);
+    scan_misplaced_directives(source, tokens, index, &consumed, prologue_end, &mut scan);
+
+    scan.environment =
+        ModuleEnvironment::from_file_directive(scan.file_directive.map(|found| found.kind));
+    scan
+}
+
+/// Walk the directive prologue, returning the token index it ends at.
+fn scan_prologue(
+    source: &str,
+    tokens: &[Token],
+    index: &LineIndex,
+    consumed: &mut [bool],
+    scan: &mut DirectiveScan,
+) -> usize {
+    let mut position = 0usize;
+
+    while let Some(token) = tokens.get(position) {
+        if token.kind != TokenKind::String {
+            break;
+        }
+        let directive = DirectiveKind::from_content(token.quoted_content(source));
+        let (line, column) = line_column(index, token);
+
+        if !terminates_statement(tokens, position) {
+            // `"use client" + ""` is an expression, not a directive. Report it so
+            // the author is not left believing the module is a Client Component.
+            if let Some(kind) = directive {
+                consumed[position] = true;
+                scan.issues
+                    .push(DirectiveIssue::NotAStringLiteral { kind, line, column });
+            }
+            break;
+        }
+
+        consumed[position] = true;
+        if let Some(kind) = directive {
+            match scan.file_directive {
+                None => scan.file_directive = Some(FileDirective { kind, line, column }),
+                Some(existing) if existing.kind != kind => {
+                    scan.issues
+                        .push(DirectiveIssue::Conflicting { line, column });
+                }
+                Some(_) => {}
+            }
+        }
+
+        position += 1;
+        if tokens.get(position).is_some_and(|next| next.is_punct(b';')) {
+            consumed[position] = true;
+            position += 1;
+        }
+    }
+
+    position
+}
+
+/// Collect `"use server"` directives at the top of function bodies.
+fn scan_function_directives(
+    source: &str,
+    tokens: &[Token],
+    index: &LineIndex,
+    consumed: &mut [bool],
+    scan: &mut DirectiveScan,
+) {
+    let mut anonymous = 0u32;
+
+    for position in 0..tokens.len() {
+        if !tokens[position].is_punct(b'{') {
+            continue;
+        }
+        let Some(head) = function_head(source, tokens, position) else {
+            continue;
+        };
+        let body = position + 1;
+        let Some(token) = tokens.get(body) else {
+            continue;
+        };
+        if token.kind != TokenKind::String {
+            continue;
+        }
+        let Some(kind) = DirectiveKind::from_content(token.quoted_content(source)) else {
+            continue;
+        };
+        let (line, column) = line_column(index, token);
+
+        if !terminates_statement(tokens, body) {
+            consumed[body] = true;
+            scan.issues
+                .push(DirectiveIssue::NotAStringLiteral { kind, line, column });
+            continue;
+        }
+
+        consumed[body] = true;
+        match kind {
+            DirectiveKind::UseServer => {
+                let owner = function_owner(source, tokens, head, &mut anonymous);
+                scan.function_directives.push(FunctionDirective {
+                    owner,
+                    line,
+                    column,
+                });
+            }
+            DirectiveKind::UseClient => {
+                scan.issues
+                    .push(DirectiveIssue::ClientDirectiveInFunction { line, column });
+            }
+        }
+    }
+}
+
+/// Report directive-shaped constructs that the two passes above did not accept.
+fn scan_misplaced_directives(
+    source: &str,
+    tokens: &[Token],
+    index: &LineIndex,
+    consumed: &[bool],
+    prologue_end: usize,
+    scan: &mut DirectiveScan,
+) {
+    for (position, token) in tokens.iter().enumerate() {
+        if consumed[position] {
+            continue;
+        }
+        let content = match token.kind {
+            TokenKind::String | TokenKind::Template => token.quoted_content(source),
+            _ => continue,
+        };
+        let Some(kind) = DirectiveKind::from_content(content) else {
+            continue;
+        };
+        if !starts_statement(tokens, position) {
+            continue;
+        }
+        let (line, column) = line_column(index, token);
+
+        if token.kind == TokenKind::Template || !terminates_statement(tokens, position) {
+            scan.issues
+                .push(DirectiveIssue::NotAStringLiteral { kind, line, column });
+        } else if position >= prologue_end {
+            scan.issues
+                .push(DirectiveIssue::NotInPrologue { kind, line, column });
+        }
+    }
+}
+
+fn line_column(index: &LineIndex, token: &Token) -> (u32, u32) {
+    let position = index.line_col(token.start);
+    (clamp_u32(position.line), clamp_u32(position.column))
+}
+
+/// Whether the statement starting at `position` ends there.
+///
+/// A directive ends at `;`, at a line break, at the `}` closing its block, or at
+/// the end of the file. It does *not* end when the next token can continue the
+/// expression, which is what makes `"use client" + ""` an ordinary statement.
+fn terminates_statement(tokens: &[Token], position: usize) -> bool {
+    let Some(next) = tokens.get(position + 1) else {
+        return true;
+    };
+    if next.is_punct(b';') || next.is_punct(b'}') {
+        return true;
+    }
+    if continues_expression(next) {
+        return false;
+    }
+    next.newline_before
+}
+
+/// Whether a token can continue the expression started by the previous token.
+///
+/// Automatic semicolon insertion does not fire before these, so a line break in
+/// front of one of them does not end the statement either.
+fn continues_expression(token: &Token) -> bool {
+    match token.kind {
+        TokenKind::Arrow | TokenKind::Template => true,
+        TokenKind::Punct(byte) => matches!(
+            byte,
+            b'+' | b'-'
+                | b'*'
+                | b'/'
+                | b'%'
+                | b','
+                | b'.'
+                | b'?'
+                | b':'
+                | b'='
+                | b'('
+                | b'['
+                | b'<'
+                | b'>'
+                | b'&'
+                | b'|'
+                | b'^'
+        ),
+        _ => false,
+    }
+}
+
+/// Where the head of a function whose body opens at `brace` sits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FunctionHead {
+    /// Token index of the `=>` of an arrow function.
+    Arrow(usize),
+    /// Token index of the `)` closing the parameter list.
+    Params(usize),
+}
+
+/// Decide whether the `{` at `brace` opens a function body.
+///
+/// This is the one place the lexer has to reason about syntax. The walk goes
+/// backwards from the brace, skipping a Flow return-type annotation, and stops
+/// at the first token that decides the question:
+///
+/// * `=>` — an arrow function body;
+/// * `)`  — a parameter list, unless the token before its `(` is a control-flow
+///   keyword, which is what separates `function f() {` from `if (c) {`;
+/// * anything else — a block, an object literal, or a class body.
+fn function_head(source: &str, tokens: &[Token], brace: usize) -> Option<FunctionHead> {
+    const MAX_TYPE_TOKENS: usize = 128;
+
+    let mut at = brace.checked_sub(1)?;
+    for _ in 0..MAX_TYPE_TOKENS {
+        let token = tokens.get(at)?;
+        match token.kind {
+            TokenKind::Arrow => return Some(FunctionHead::Arrow(at)),
+            TokenKind::Punct(b')') => {
+                let open = matching_open(tokens, at, b'(', b')')?;
+                let previous = open.checked_sub(1)?;
+                let head = tokens.get(previous)?;
+                if head.kind == TokenKind::Ident
+                    && matches!(
+                        head.text(source),
+                        "if" | "for" | "while" | "switch" | "catch" | "with"
+                    )
+                {
+                    return None;
+                }
+                return Some(FunctionHead::Params(at));
+            }
+            // Tokens a Flow return-type annotation is made of.
+            TokenKind::Ident
+            | TokenKind::String
+            | TokenKind::Number
+            | TokenKind::Punct(
+                b':' | b'<' | b'>' | b'|' | b'&' | b'?' | b'.' | b'[' | b']' | b'+',
+            ) => {
+                if token.kind == TokenKind::Ident
+                    && matches!(token.text(source), "else" | "try" | "do" | "finally")
+                {
+                    return None;
+                }
+                at = at.checked_sub(1)?;
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Best-effort name for the function whose head is at `head`.
+fn function_owner(
+    source: &str,
+    tokens: &[Token],
+    head: FunctionHead,
+    anonymous: &mut u32,
+) -> FunctionOwner {
+    let params_start = match head {
+        FunctionHead::Arrow(arrow) => arrow
+            .checked_sub(1)
+            .map(|before| {
+                if tokens[before].is_punct(b')') {
+                    matching_open(tokens, before, b'(', b')').unwrap_or(before)
+                } else {
+                    before
+                }
+            })
+            .unwrap_or(arrow),
+        FunctionHead::Params(close) => matching_open(tokens, close, b'(', b')').unwrap_or(close),
+    };
+
+    if let Some(name) = binding_name(source, tokens, params_start) {
+        return FunctionOwner::Named(name);
+    }
+
+    let ordinal = *anonymous;
+    *anonymous = anonymous.saturating_add(1);
+    FunctionOwner::Anonymous { ordinal }
+}
+
+/// Walk backwards from the parameter list to whatever names the function.
+fn binding_name(source: &str, tokens: &[Token], params_start: usize) -> Option<CompactString> {
+    const MAX_HEAD_TOKENS: usize = 16;
+
+    let mut at = params_start;
+    for _ in 0..MAX_HEAD_TOKENS {
+        let previous = at.checked_sub(1)?;
+        let token = tokens.get(previous)?;
+        match token.kind {
+            TokenKind::Ident => {
+                let text = token.text(source);
+                if matches!(text, "function" | "async" | "hook" | "component") {
+                    at = previous;
+                    continue;
+                }
+                return Some(CompactString::from(text));
+            }
+            TokenKind::Punct(b'*') => {
+                at = previous;
+                continue;
+            }
+            // Generic parameter list of a method or function.
+            TokenKind::Punct(b'>') => {
+                at = matching_open(tokens, previous, b'<', b'>')?;
+                continue;
+            }
+            TokenKind::Punct(b'=' | b':') => {
+                let name = tokens.get(previous.checked_sub(1)?)?;
+                return match name.kind {
+                    TokenKind::Ident => Some(CompactString::from(name.text(source))),
+                    TokenKind::String => Some(CompactString::from(name.quoted_content(source))),
+                    _ => None,
+                };
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_module_without_a_directive_is_a_server_component() {
+        assert_eq!(
+            module_environment("// @flow\nexport default function Page() {}\n"),
+            ModuleEnvironment::Server
+        );
+    }
+
+    #[test]
+    fn an_empty_module_is_a_server_component() {
+        assert_eq!(module_environment(""), ModuleEnvironment::Server);
+    }
+
+    #[test]
+    fn double_quoted_use_client_is_a_client_module() {
+        assert_eq!(
+            module_environment("\"use client\";\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn single_quoted_use_client_is_a_client_module() {
+        assert_eq!(
+            module_environment("'use client';\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn use_server_marks_a_server_actions_module() {
+        assert_eq!(
+            module_environment("\"use server\";\n"),
+            ModuleEnvironment::ServerActions
+        );
+    }
+
+    #[test]
+    fn a_directive_without_a_semicolon_is_accepted() {
+        assert_eq!(
+            module_environment("\"use client\"\nexport const a = 1;\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn a_directive_at_the_end_of_file_without_a_terminator_is_accepted() {
+        assert_eq!(
+            module_environment("'use client'"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn a_byte_order_mark_does_not_hide_the_directive() {
+        assert_eq!(
+            module_environment("\u{feff}\"use client\";\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn a_shebang_does_not_hide_the_directive() {
+        assert_eq!(
+            module_environment("#!/usr/bin/env uf\n\"use client\";\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn a_byte_order_mark_and_a_shebang_together_do_not_hide_the_directive() {
+        assert_eq!(
+            module_environment("\u{feff}#!/usr/bin/env uf\n'use server'\n"),
+            ModuleEnvironment::ServerActions
+        );
+    }
+
+    #[test]
+    fn a_line_comment_may_precede_the_directive() {
+        assert_eq!(
+            module_environment("// @flow\n\"use client\";\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn a_block_comment_may_precede_the_directive_on_the_same_line() {
+        assert_eq!(
+            module_environment("/* c */ \"use client\";\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn a_multiline_block_comment_may_precede_the_directive() {
+        assert_eq!(
+            module_environment("/*\n * @flow\n */\n'use client';\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn blank_lines_and_odd_whitespace_may_precede_the_directive() {
+        assert_eq!(
+            module_environment("\n\n\t   'use client'   ;\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn crlf_line_endings_do_not_hide_the_directive() {
+        assert_eq!(
+            module_environment("// @flow\r\n\"use client\";\r\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn use_strict_before_the_directive_is_allowed() {
+        assert_eq!(
+            module_environment("\"use strict\";\n\"use client\";\n"),
+            ModuleEnvironment::Client
+        );
+    }
+
+    #[test]
+    fn two_spaces_inside_the_directive_is_not_a_directive() {
+        let scan = scan_directives("\"use  client\";\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert!(scan.issues.is_empty());
+    }
+
+    #[test]
+    fn a_unicode_escape_inside_the_directive_is_not_a_directive() {
+        assert_eq!(
+            module_environment("\"use\\u0020client\";\n"),
+            ModuleEnvironment::Server
+        );
+    }
+
+    #[test]
+    fn padding_inside_the_quotes_is_not_a_directive() {
+        assert_eq!(
+            module_environment("\" use client \";\n"),
+            ModuleEnvironment::Server
+        );
+    }
+
+    #[test]
+    fn uppercase_directives_are_not_directives() {
+        assert_eq!(
+            module_environment("\"USE CLIENT\";\n"),
+            ModuleEnvironment::Server
+        );
+    }
+
+    #[test]
+    fn a_concatenated_directive_is_rejected_with_an_issue() {
+        let scan = scan_directives("\"use client\" + \"\";\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert_eq!(
+            scan.issues.as_slice(),
+            &[DirectiveIssue::NotAStringLiteral {
+                kind: DirectiveKind::UseClient,
+                line: 1,
+                column: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_concatenated_directive_split_over_lines_is_rejected() {
+        let scan = scan_directives("\"use client\"\n  + \"\";\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert_eq!(scan.issues.len(), 1);
+        assert_eq!(scan.issues[0].rule(), "rsc/directive-not-a-string-literal");
+    }
+
+    #[test]
+    fn a_template_literal_directive_is_rejected() {
+        let scan = scan_directives("`use client`;\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert_eq!(
+            scan.issues.as_slice(),
+            &[DirectiveIssue::NotAStringLiteral {
+                kind: DirectiveKind::UseClient,
+                line: 1,
+                column: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_directive_after_a_statement_is_rejected() {
+        let scan = scan_directives("const a = 1;\n\"use client\";\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert_eq!(
+            scan.issues.as_slice(),
+            &[DirectiveIssue::NotInPrologue {
+                kind: DirectiveKind::UseClient,
+                line: 2,
+                column: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_directive_after_an_import_is_rejected() {
+        let scan = scan_directives("import \"./a.js\";\n\"use client\";\n");
+        assert_eq!(scan.issues.len(), 1);
+        assert_eq!(scan.issues[0].line(), 2);
+    }
+
+    #[test]
+    fn a_directive_inside_a_string_value_is_not_a_directive() {
+        let scan = scan_directives("const marker = \"use client\";\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert!(scan.issues.is_empty());
+    }
+
+    #[test]
+    fn a_directive_inside_a_comment_is_not_a_directive() {
+        let scan = scan_directives("// \"use client\";\nconst a = 1;\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert!(scan.issues.is_empty());
+    }
+
+    #[test]
+    fn a_directive_passed_as_an_argument_is_not_a_directive() {
+        let scan = scan_directives("register(\"use server\");\n");
+        assert!(scan.issues.is_empty());
+        assert!(scan.function_directives.is_empty());
+    }
+
+    #[test]
+    fn conflicting_directives_keep_the_first_and_report() {
+        let scan = scan_directives("\"use client\";\n\"use server\";\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Client);
+        assert_eq!(
+            scan.issues.as_slice(),
+            &[DirectiveIssue::Conflicting { line: 2, column: 1 }]
+        );
+    }
+
+    #[test]
+    fn a_repeated_identical_directive_is_not_a_conflict() {
+        let scan = scan_directives("\"use client\";\n\"use client\";\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Client);
+        assert!(scan.issues.is_empty());
+    }
+
+    #[test]
+    fn a_function_level_use_server_is_collected_not_rejected() {
+        let scan = scan_directives(
+            "export async function refresh() {\n  \"use server\";\n  return 1;\n}\n",
+        );
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert!(scan.issues.is_empty());
+        assert_eq!(scan.function_directives.len(), 1);
+        assert_eq!(
+            scan.function_directives[0].owner,
+            FunctionOwner::Named(CompactString::const_new("refresh"))
+        );
+    }
+
+    #[test]
+    fn a_function_level_use_server_in_an_arrow_is_named_after_its_binding() {
+        let scan = scan_directives("const save = async () => {\n  \"use server\";\n};\n");
+        assert_eq!(
+            scan.function_directives[0].owner,
+            FunctionOwner::Named(CompactString::const_new("save"))
+        );
+    }
+
+    #[test]
+    fn an_inline_closure_action_gets_a_stable_ordinal() {
+        let scan = scan_directives(
+            "register(async () => {\n \"use server\";\n});\nregister(async () => {\n \"use server\";\n});\n",
+        );
+        assert_eq!(scan.function_directives.len(), 2);
+        assert_eq!(
+            scan.function_directives[0].owner,
+            FunctionOwner::Anonymous { ordinal: 0 }
+        );
+        assert_eq!(
+            scan.function_directives[1].owner,
+            FunctionOwner::Anonymous { ordinal: 1 }
+        );
+    }
+
+    #[test]
+    fn a_flow_return_type_does_not_hide_a_function_level_action() {
+        let scan =
+            scan_directives("async function refresh(): Promise<string> {\n \"use server\";\n}\n");
+        assert_eq!(scan.function_directives.len(), 1);
+        assert_eq!(
+            scan.function_directives[0].owner,
+            FunctionOwner::Named(CompactString::const_new("refresh"))
+        );
+    }
+
+    #[test]
+    fn a_default_exported_function_action_is_named_default() {
+        let scan = scan_directives("export default async function () {\n \"use server\";\n}\n");
+        assert_eq!(
+            scan.function_directives[0].owner,
+            FunctionOwner::Named(CompactString::const_new("default"))
+        );
+    }
+
+    #[test]
+    fn a_method_level_action_is_named_after_the_method() {
+        let scan = scan_directives("const api = {\n async save() {\n \"use server\";\n }\n};\n");
+        assert_eq!(
+            scan.function_directives[0].owner,
+            FunctionOwner::Named(CompactString::const_new("save"))
+        );
+    }
+
+    #[test]
+    fn a_directive_at_the_top_of_an_if_block_is_not_a_function_action() {
+        let scan = scan_directives("if (ready) {\n \"use server\";\n}\n");
+        assert!(scan.function_directives.is_empty());
+        assert_eq!(scan.issues.len(), 1);
+        assert_eq!(scan.issues[0].rule(), "rsc/directive-not-in-prologue");
+    }
+
+    #[test]
+    fn a_directive_at_the_top_of_a_for_block_is_not_a_function_action() {
+        let scan = scan_directives("for (const x of xs) {\n \"use server\";\n}\n");
+        assert!(scan.function_directives.is_empty());
+        assert_eq!(scan.issues.len(), 1);
+    }
+
+    #[test]
+    fn a_client_directive_inside_a_function_is_rejected() {
+        let scan = scan_directives("function Widget() {\n \"use client\";\n}\n");
+        assert!(scan.function_directives.is_empty());
+        assert_eq!(
+            scan.issues.as_slice(),
+            &[DirectiveIssue::ClientDirectiveInFunction { line: 2, column: 2 }]
+        );
+    }
+
+    #[test]
+    fn a_function_level_action_after_a_file_directive_is_still_collected() {
+        let scan = scan_directives(
+            "\"use client\";\nexport function Form() {\n const save = async () => {\n  \"use server\";\n };\n}\n",
+        );
+        assert_eq!(scan.environment, ModuleEnvironment::Client);
+        assert_eq!(scan.function_directives.len(), 1);
+    }
+
+    #[test]
+    fn a_single_line_function_action_terminated_by_a_brace_is_collected() {
+        let scan = scan_directives("const save = async () => { \"use server\" };\n");
+        assert_eq!(scan.function_directives.len(), 1);
+    }
+
+    #[test]
+    fn a_directive_in_a_regular_expression_is_not_a_directive() {
+        let scan = scan_directives("const re = /\"use client\";/;\n");
+        assert_eq!(scan.environment, ModuleEnvironment::Server);
+        assert!(scan.issues.is_empty());
+    }
+
+    #[test]
+    fn a_non_ascii_module_keeps_correct_positions() {
+        let scan = scan_directives("// 日本語のコメント\nconst a = 1;\n\"use client\";\n");
+        assert_eq!(scan.issues.len(), 1);
+        assert_eq!(scan.issues[0].line(), 3);
+    }
+
+    #[test]
+    fn an_unterminated_string_is_not_a_directive() {
+        assert_eq!(
+            module_environment("\"use client\nconst a = 1;\n"),
+            ModuleEnvironment::Server
+        );
+    }
+
+    #[test]
+    fn directive_kind_round_trips_through_its_text() {
+        for kind in [DirectiveKind::UseClient, DirectiveKind::UseServer] {
+            assert_eq!(DirectiveKind::from_content(kind.as_str()), Some(kind));
+            assert_eq!(kind.to_string(), kind.as_str());
+        }
+    }
+
+    #[test]
+    fn environments_report_where_they_run() {
+        assert!(ModuleEnvironment::Server.runs_on_server());
+        assert!(ModuleEnvironment::ServerActions.runs_on_server());
+        assert!(!ModuleEnvironment::Client.runs_on_server());
+        assert!(ModuleEnvironment::Client.runs_on_client());
+    }
+
+    #[test]
+    fn scanning_is_idempotent() {
+        let source = "\"use client\";\nexport const a = 1;\n";
+        assert_eq!(scan_directives(source), scan_directives(source));
+    }
+
+    #[test]
+    fn a_very_large_module_still_finds_its_directive() {
+        let mut source = String::from("\"use client\";\n");
+        for index in 0..20_000 {
+            source.push_str(&format!("const value{index} = {index};\n"));
+        }
+        assert_eq!(module_environment(&source), ModuleEnvironment::Client);
+    }
+}

--- a/crates/uf_rsc/src/graph.rs
+++ b/crates/uf_rsc/src/graph.rs
@@ -1,0 +1,1567 @@
+//! The React Server Components module graph.
+//!
+//! [`RscGraph`] answers the three questions `uf build` and `uf dev` need before
+//! they can emit anything:
+//!
+//! 1. which environment does each module execute in;
+//! 2. which modules are reachable from a server entry, from a client entry, or
+//!    from both;
+//! 3. where does the server graph hand off to the client — the *client
+//!    boundaries*, whose targets become client-bundle roots.
+//!
+//! # Termination
+//!
+//! Import graphs contain cycles, and a graph walk that recurses on them either
+//! overflows the stack or never finishes. Propagation here is an explicit
+//! worklist over `(module, colour)` pairs with a seen-set per colour, so every
+//! pair is processed at most once and the walk is `O(V + E)` on any input,
+//! cyclic or not. There is no recursion anywhere in this module.
+
+use std::borrow::Cow;
+use std::collections::VecDeque;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uf_infra::{FxHashMap, InlineVec, LineIndex};
+
+use crate::directive::{
+    DirectiveIssue, DirectiveIssueList, FunctionDirective, FunctionDirectiveList, FunctionOwner,
+    ModuleEnvironment, scan_directive_tokens,
+};
+use crate::scan::{
+    ClientApiUseList, ExportKind, ExportList, ImportKind, ImportList, ImportSpecifier,
+    ModuleExport, client_api_uses_from_tokens, exports_from_tokens, imports_from_tokens, tokenize,
+};
+
+/// Packages whose code must never reach the browser.
+///
+/// Importing one of these from the client graph is the "server code leaked into
+/// the client bundle" class: database handles, secrets and privileged helpers
+/// end up served to every visitor. Sorted for binary search.
+pub const SERVER_ONLY_PACKAGES: &[&str] = &["@uniflowed/db", "@uniflowed/server", "server-only"];
+
+/// Suffix marking a module as server-only by file name.
+pub const SERVER_ONLY_SUFFIX: &str = ".server.js";
+
+/// Identifier of a module inside one [`RscGraph`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModuleId(u32);
+
+impl ModuleId {
+    /// Index of the module in [`RscGraph::modules`].
+    pub fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Why a module is an entry point of the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EntryKind {
+    /// Rendered by the server: a page, a layout, middleware.
+    Server,
+    /// Loaded by the browser: a client bundle entry.
+    Client,
+}
+
+/// Which halves of the app a module is reachable from.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModuleReachability {
+    /// No entry reaches this module; it is dead code.
+    #[default]
+    Unreachable,
+    /// Reachable only while rendering on the server.
+    ServerOnly,
+    /// Reachable only from the client bundle.
+    ClientOnly,
+    /// Reachable from both halves; the module is shared code.
+    ServerAndClient,
+}
+
+impl ModuleReachability {
+    /// Build a reachability from the two propagation colours.
+    pub fn from_colours(server: bool, client: bool) -> Self {
+        match (server, client) {
+            (false, false) => Self::Unreachable,
+            (true, false) => Self::ServerOnly,
+            (false, true) => Self::ClientOnly,
+            (true, true) => Self::ServerAndClient,
+        }
+    }
+
+    /// Whether a server entry reaches this module.
+    pub fn is_server_reachable(self) -> bool {
+        matches!(self, Self::ServerOnly | Self::ServerAndClient)
+    }
+
+    /// Whether a client entry or a client boundary reaches this module.
+    pub fn is_client_reachable(self) -> bool {
+        matches!(self, Self::ClientOnly | Self::ServerAndClient)
+    }
+
+    /// Whether any entry reaches this module.
+    pub fn is_reachable(self) -> bool {
+        !matches!(self, Self::Unreachable)
+    }
+
+    /// Stable identifier used in the manifest.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unreachable => "unreachable",
+            Self::ServerOnly => "server-only",
+            Self::ClientOnly => "client-only",
+            Self::ServerAndClient => "server-and-client",
+        }
+    }
+}
+
+/// Whether a module can hand a server action to the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum ClientBoundaryProximity {
+    /// Neither this module nor anything it imports crosses a client boundary.
+    #[default]
+    Isolated,
+    /// This module, or a module it transitively imports, imports a `"use client"`
+    /// module, so a closure defined here can be passed across the boundary.
+    ReachesBoundary,
+}
+
+impl ClientBoundaryProximity {
+    /// Whether the module reaches a client boundary.
+    pub fn reaches_boundary(self) -> bool {
+        matches!(self, Self::ReachesBoundary)
+    }
+}
+
+/// A server module importing a `"use client"` module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClientBoundary {
+    /// The server module that owns the import.
+    pub importer: ModuleId,
+    /// The `"use client"` module, which becomes a client bundle root.
+    pub client_module: ModuleId,
+}
+
+/// How serious a diagnostic is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RscSeverity {
+    /// Worth fixing, but the build can continue.
+    Warn,
+    /// Breaks the RSC contract.
+    Error,
+}
+
+impl RscSeverity {
+    /// Stable identifier used in the manifest.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// A violation of the React Server Components contract.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RscDiagnostic {
+    /// A module in the client graph imports server-only code.
+    #[error("client module `{module}` imports server-only `{specifier}` at line {line}")]
+    ServerOnlyImportInClientModule {
+        /// Importing module, relative to the project root.
+        module: Utf8PathBuf,
+        /// The specifier as written.
+        specifier: CompactString,
+        /// 1-based line of the import.
+        line: u32,
+    },
+    /// A Server Component reaches for an API that only exists in the browser.
+    #[error("server module `{module}` uses client-only `{api}` at line {line}:{column}")]
+    ClientOnlyApiInServerModule {
+        /// The server module.
+        module: Utf8PathBuf,
+        /// Name of the client-only API.
+        api: &'static str,
+        /// 1-based line.
+        line: u32,
+        /// 1-based column.
+        column: u32,
+    },
+    /// A `"use server"` export that React cannot call.
+    #[error("server action `{export}` in `{module}` must be an async function")]
+    ServerActionNotAsync {
+        /// The `"use server"` module.
+        module: Utf8PathBuf,
+        /// Exported name.
+        export: CompactString,
+        /// 1-based line of the export.
+        line: u32,
+    },
+    /// A `"use server"` module exporting something that is not a function at all.
+    #[error("`use server` module `{module}` exports non-function `{export}`")]
+    ServerActionNotFunction {
+        /// The `"use server"` module.
+        module: Utf8PathBuf,
+        /// Exported name.
+        export: CompactString,
+        /// 1-based line of the export.
+        line: u32,
+    },
+    /// An import specifier that resolves outside the project root.
+    #[error("module `{module}` imports `{specifier}` from outside the project root")]
+    ImportEscapesProjectRoot {
+        /// The importing module.
+        module: Utf8PathBuf,
+        /// The specifier as written.
+        specifier: CompactString,
+        /// 1-based line of the import.
+        line: u32,
+    },
+    /// A module whose own path is not inside the project root.
+    #[error("module path `{module}` is not inside the project root")]
+    ModulePathOutsideProject {
+        /// The offending path, as supplied.
+        module: Utf8PathBuf,
+    },
+    /// A rejected directive, lifted from the directive pass.
+    #[error("in `{module}`: {issue}")]
+    Directive {
+        /// The module the directive was written in.
+        module: Utf8PathBuf,
+        /// What was wrong with it.
+        issue: DirectiveIssue,
+    },
+}
+
+impl RscDiagnostic {
+    /// Stable rule identifier.
+    pub fn rule(&self) -> &'static str {
+        match self {
+            Self::ServerOnlyImportInClientModule { .. } => "rsc/server-only-import-in-client",
+            Self::ClientOnlyApiInServerModule { .. } => "rsc/client-only-api-in-server",
+            Self::ServerActionNotAsync { .. } => "rsc/server-action-not-async",
+            Self::ServerActionNotFunction { .. } => "rsc/server-action-not-a-function",
+            Self::ImportEscapesProjectRoot { .. } => "rsc/import-escapes-project-root",
+            Self::ModulePathOutsideProject { .. } => "rsc/module-outside-project-root",
+            Self::Directive { issue, .. } => issue.rule(),
+        }
+    }
+
+    /// Severity of the diagnostic. Every RSC contract violation is an error.
+    pub fn severity(&self) -> RscSeverity {
+        RscSeverity::Error
+    }
+
+    /// Module the diagnostic belongs to.
+    pub fn module(&self) -> &Utf8Path {
+        match self {
+            Self::ServerOnlyImportInClientModule { module, .. }
+            | Self::ClientOnlyApiInServerModule { module, .. }
+            | Self::ServerActionNotAsync { module, .. }
+            | Self::ServerActionNotFunction { module, .. }
+            | Self::ImportEscapesProjectRoot { module, .. }
+            | Self::ModulePathOutsideProject { module }
+            | Self::Directive { module, .. } => module,
+        }
+    }
+
+    /// 1-based line the diagnostic points at, when there is one.
+    pub fn line(&self) -> u32 {
+        match self {
+            Self::ServerOnlyImportInClientModule { line, .. }
+            | Self::ClientOnlyApiInServerModule { line, .. }
+            | Self::ServerActionNotAsync { line, .. }
+            | Self::ServerActionNotFunction { line, .. }
+            | Self::ImportEscapesProjectRoot { line, .. } => *line,
+            Self::ModulePathOutsideProject { .. } => 0,
+            Self::Directive { issue, .. } => issue.line(),
+        }
+    }
+}
+
+/// One module as it is fed into [`RscGraphBuilder`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RscModuleInput {
+    /// Path relative to the project root, with forward slashes.
+    pub path: Utf8PathBuf,
+    /// Environment the module executes in.
+    pub environment: ModuleEnvironment,
+    /// Import specifiers exactly as written.
+    pub imports: ImportList,
+    /// Exported bindings.
+    pub exports: ExportList,
+    /// Function-level `"use server"` closures.
+    pub function_actions: FunctionDirectiveList,
+    /// Client-only APIs the module reaches for.
+    pub client_api_uses: ClientApiUseList,
+    /// Rejected directives found while scanning the module.
+    pub directive_issues: DirectiveIssueList,
+}
+
+impl RscModuleInput {
+    /// An empty module at `path` with an explicit environment.
+    pub fn new(path: impl Into<Utf8PathBuf>, environment: ModuleEnvironment) -> Self {
+        Self {
+            path: normalize_module_path(&path.into()),
+            environment,
+            imports: ImportList::new(),
+            exports: ExportList::new(),
+            function_actions: FunctionDirectiveList::new(),
+            client_api_uses: ClientApiUseList::new(),
+            directive_issues: DirectiveIssueList::new(),
+        }
+    }
+
+    /// Scan a module from its source text, in one pass over the tokens.
+    pub fn from_source(path: impl Into<Utf8PathBuf>, source: &str) -> Self {
+        let tokens = tokenize(source);
+        let index = LineIndex::new(source);
+        let directives = scan_directive_tokens(source, &tokens, &index);
+
+        Self {
+            path: normalize_module_path(&path.into()),
+            environment: directives.environment,
+            imports: imports_from_tokens(source, &tokens, &index),
+            exports: exports_from_tokens(source, &tokens, &index),
+            function_actions: directives.function_directives,
+            client_api_uses: client_api_uses_from_tokens(source, &tokens, &index),
+            directive_issues: directives.issues,
+        }
+    }
+
+    /// Add a static import specifier.
+    pub fn with_import(mut self, specifier: impl Into<CompactString>) -> Self {
+        self.imports.push(ImportSpecifier {
+            specifier: specifier.into(),
+            kind: ImportKind::Static,
+            line: 1,
+        });
+        self
+    }
+
+    /// Add an export.
+    pub fn with_export(mut self, name: impl Into<CompactString>, kind: ExportKind) -> Self {
+        self.exports.push(ModuleExport {
+            name: name.into(),
+            kind,
+            line: 1,
+        });
+        self
+    }
+
+    /// Add a function-level `"use server"` closure.
+    pub fn with_function_action(mut self, owner: FunctionOwner) -> Self {
+        self.function_actions.push(FunctionDirective {
+            owner,
+            line: 1,
+            column: 1,
+        });
+        self
+    }
+}
+
+/// A module after the graph has been resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RscModule {
+    /// Path relative to the project root.
+    pub path: Utf8PathBuf,
+    /// Environment the module executes in.
+    pub environment: ModuleEnvironment,
+    /// Which halves of the app reach this module.
+    pub reachability: ModuleReachability,
+    /// Whether a closure defined here can cross into the client.
+    pub proximity: ClientBoundaryProximity,
+    /// Modules imported from this one, sorted and deduplicated.
+    pub imports: InlineVec<ModuleId, 8>,
+    /// Import specifiers that do not resolve to a module of this graph.
+    pub external_imports: InlineVec<CompactString, 4>,
+    /// Exported bindings.
+    pub exports: ExportList,
+    /// Function-level `"use server"` closures.
+    pub function_actions: FunctionDirectiveList,
+}
+
+/// Collects modules and entries, then resolves them into an [`RscGraph`].
+#[derive(Debug, Clone, Default)]
+pub struct RscGraphBuilder {
+    modules: Vec<RscModuleInput>,
+    entries: Vec<(Utf8PathBuf, EntryKind)>,
+}
+
+impl RscGraphBuilder {
+    /// An empty builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a module. The first registration of a path wins.
+    pub fn add_module(&mut self, module: RscModuleInput) -> &mut Self {
+        self.modules.push(module);
+        self
+    }
+
+    /// Register a module from its source text.
+    pub fn add_source(&mut self, path: impl Into<Utf8PathBuf>, source: &str) -> &mut Self {
+        self.add_module(RscModuleInput::from_source(path, source))
+    }
+
+    /// Mark a module path as an entry point.
+    ///
+    /// Modules that no entry reaches are reported as
+    /// [`ModuleReachability::Unreachable`] and their actions are never
+    /// registered as callable endpoints.
+    pub fn add_entry(&mut self, path: impl Into<Utf8PathBuf>, kind: EntryKind) -> &mut Self {
+        self.entries
+            .push((normalize_module_path(&path.into()), kind));
+        self
+    }
+
+    /// Resolve imports, propagate reachability and collect diagnostics.
+    pub fn build(self) -> RscGraph {
+        let Self {
+            mut modules,
+            entries,
+        } = self;
+
+        let mut diagnostics = Vec::new();
+
+        // Deterministic module ids: sort by path, keep the first of any duplicate.
+        modules.sort_by(|left, right| left.path.cmp(&right.path));
+        modules.dedup_by(|left, right| left.path == right.path);
+        modules.retain(|module| {
+            if is_inside_project(&module.path) {
+                true
+            } else {
+                diagnostics.push(RscDiagnostic::ModulePathOutsideProject {
+                    module: module.path.clone(),
+                });
+                false
+            }
+        });
+
+        let mut index: FxHashMap<Utf8PathBuf, ModuleId> = FxHashMap::default();
+        index.reserve(modules.len());
+        for (position, module) in modules.iter().enumerate() {
+            index.insert(module.path.clone(), ModuleId(position as u32));
+        }
+
+        let resolved = resolve_edges(&modules, &index, &mut diagnostics);
+        let environments: Vec<ModuleEnvironment> =
+            modules.iter().map(|module| module.environment).collect();
+
+        let (server_seen, client_seen) = propagate(&resolved, &environments, &entries, &index);
+        let boundaries = collect_boundaries(&resolved, &environments, &server_seen);
+        let proximity = compute_proximity(&resolved, &boundaries);
+        let bundle_roots = collect_bundle_roots(&boundaries, &entries, &index, &environments);
+
+        let mut graph_modules = Vec::with_capacity(modules.len());
+        for (position, module) in modules.into_iter().enumerate() {
+            let reachability =
+                ModuleReachability::from_colours(server_seen[position], client_seen[position]);
+            report_module_diagnostics(
+                &module,
+                reachability,
+                &resolved[position].external,
+                &mut diagnostics,
+            );
+            graph_modules.push(RscModule {
+                path: module.path,
+                environment: module.environment,
+                reachability,
+                proximity: proximity[position],
+                imports: resolved[position].imports.clone(),
+                external_imports: resolved[position]
+                    .external
+                    .iter()
+                    .map(|import| import.specifier.clone())
+                    .collect(),
+                exports: module.exports,
+                function_actions: module.function_actions,
+            });
+        }
+
+        report_client_graph_leaks(&graph_modules, &resolved, &mut diagnostics);
+
+        diagnostics.sort_by(|left, right| {
+            left.module()
+                .cmp(right.module())
+                .then(left.line().cmp(&right.line()))
+                .then(left.rule().cmp(right.rule()))
+                .then(left.to_string().cmp(&right.to_string()))
+        });
+        diagnostics.dedup();
+
+        RscGraph {
+            modules: graph_modules,
+            index,
+            boundaries,
+            bundle_roots,
+            diagnostics,
+        }
+    }
+}
+
+/// The resolved React Server Components graph of a project.
+#[derive(Debug, Clone)]
+pub struct RscGraph {
+    modules: Vec<RscModule>,
+    index: FxHashMap<Utf8PathBuf, ModuleId>,
+    boundaries: Vec<ClientBoundary>,
+    bundle_roots: Vec<ModuleId>,
+    diagnostics: Vec<RscDiagnostic>,
+}
+
+impl RscGraph {
+    /// Every module, ordered by path.
+    pub fn modules(&self) -> &[RscModule] {
+        &self.modules
+    }
+
+    /// Look up a module by its project-relative path.
+    pub fn module(&self, path: impl AsRef<str>) -> Option<&RscModule> {
+        let path = normalize_module_path(Utf8Path::new(path.as_ref()));
+        self.index.get(&path).map(|id| &self.modules[id.index()])
+    }
+
+    /// Look up a module by id.
+    pub fn module_by_id(&self, id: ModuleId) -> Option<&RscModule> {
+        self.modules.get(id.index())
+    }
+
+    /// Server-to-client import edges, ordered.
+    pub fn client_boundaries(&self) -> &[ClientBoundary] {
+        &self.boundaries
+    }
+
+    /// Client bundle roots, ordered.
+    pub fn client_bundle_roots(&self) -> &[ModuleId] {
+        &self.bundle_roots
+    }
+
+    /// Contract violations found while building the graph, ordered.
+    pub fn diagnostics(&self) -> &[RscDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Whether any diagnostic is an error.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.severity() == RscSeverity::Error)
+    }
+}
+
+/// Resolved edges of one module.
+#[derive(Debug, Clone, Default)]
+struct ResolvedImports {
+    imports: InlineVec<ModuleId, 8>,
+    external: Vec<ImportSpecifier>,
+}
+
+fn resolve_edges(
+    modules: &[RscModuleInput],
+    index: &FxHashMap<Utf8PathBuf, ModuleId>,
+    diagnostics: &mut Vec<RscDiagnostic>,
+) -> Vec<ResolvedImports> {
+    let mut resolved = Vec::with_capacity(modules.len());
+
+    for module in modules {
+        let mut edges = ResolvedImports::default();
+        for import in &module.imports {
+            match resolve_specifier(&module.path, &import.specifier) {
+                SpecifierResolution::Relative(candidate) => {
+                    match resolve_candidates(&candidate, index) {
+                        Some(id) => {
+                            if !edges.imports.contains(&id) {
+                                edges.imports.push(id);
+                            }
+                        }
+                        None => edges.external.push(import.clone()),
+                    }
+                }
+                SpecifierResolution::Bare => edges.external.push(import.clone()),
+                // Path traversal guard: a specifier that climbs out of the
+                // project root must never be resolved or read.
+                SpecifierResolution::Escapes => {
+                    diagnostics.push(RscDiagnostic::ImportEscapesProjectRoot {
+                        module: module.path.clone(),
+                        specifier: import.specifier.clone(),
+                        line: import.line,
+                    });
+                    edges.external.push(import.clone());
+                }
+            }
+        }
+        edges.imports.sort_unstable();
+        resolved.push(edges);
+    }
+
+    resolved
+}
+
+/// Walk the graph with an explicit worklist, once per `(module, colour)` pair.
+fn propagate(
+    resolved: &[ResolvedImports],
+    environments: &[ModuleEnvironment],
+    entries: &[(Utf8PathBuf, EntryKind)],
+    index: &FxHashMap<Utf8PathBuf, ModuleId>,
+) -> (Vec<bool>, Vec<bool>) {
+    let mut server_seen = vec![false; resolved.len()];
+    let mut client_seen = vec![false; resolved.len()];
+    let mut work: VecDeque<(usize, EntryKind)> = VecDeque::new();
+
+    for (path, kind) in entries {
+        let Some(id) = index.get(path) else {
+            continue;
+        };
+        let colour = match (kind, environments[id.index()]) {
+            // A `"use client"` module declared as a server entry is still a
+            // client module: it is referenced, never executed, by the server.
+            (EntryKind::Server, ModuleEnvironment::Client) => EntryKind::Client,
+            (kind, _) => *kind,
+        };
+        enqueue(
+            id.index(),
+            colour,
+            &mut server_seen,
+            &mut client_seen,
+            &mut work,
+        );
+    }
+
+    while let Some((position, colour)) = work.pop_front() {
+        for target in resolved[position].imports.iter().copied() {
+            let next = match colour {
+                EntryKind::Server => match environments[target.index()] {
+                    // The server never executes a client module; it emits a
+                    // reference, and the client module becomes a bundle root.
+                    ModuleEnvironment::Client => EntryKind::Client,
+                    _ => EntryKind::Server,
+                },
+                EntryKind::Client => EntryKind::Client,
+            };
+            enqueue(
+                target.index(),
+                next,
+                &mut server_seen,
+                &mut client_seen,
+                &mut work,
+            );
+        }
+    }
+
+    (server_seen, client_seen)
+}
+
+fn enqueue(
+    position: usize,
+    colour: EntryKind,
+    server_seen: &mut [bool],
+    client_seen: &mut [bool],
+    work: &mut VecDeque<(usize, EntryKind)>,
+) {
+    let seen = match colour {
+        EntryKind::Server => &mut server_seen[position],
+        EntryKind::Client => &mut client_seen[position],
+    };
+    if !*seen {
+        *seen = true;
+        work.push_back((position, colour));
+    }
+}
+
+fn collect_boundaries(
+    resolved: &[ResolvedImports],
+    environments: &[ModuleEnvironment],
+    server_seen: &[bool],
+) -> Vec<ClientBoundary> {
+    let mut boundaries = Vec::new();
+    for (position, edges) in resolved.iter().enumerate() {
+        if !server_seen[position] || environments[position] == ModuleEnvironment::Client {
+            continue;
+        }
+        for target in edges.imports.iter().copied() {
+            if environments[target.index()] == ModuleEnvironment::Client {
+                boundaries.push(ClientBoundary {
+                    importer: ModuleId(position as u32),
+                    client_module: target,
+                });
+            }
+        }
+    }
+    boundaries.sort_unstable();
+    boundaries.dedup();
+    boundaries
+}
+
+/// Reverse walk from the boundary importers, again with an explicit worklist.
+fn compute_proximity(
+    resolved: &[ResolvedImports],
+    boundaries: &[ClientBoundary],
+) -> Vec<ClientBoundaryProximity> {
+    let mut reverse: Vec<Vec<u32>> = vec![Vec::new(); resolved.len()];
+    for (position, edges) in resolved.iter().enumerate() {
+        for target in edges.imports.iter().copied() {
+            reverse[target.index()].push(position as u32);
+        }
+    }
+
+    let mut proximity = vec![ClientBoundaryProximity::Isolated; resolved.len()];
+    let mut work: VecDeque<usize> = VecDeque::new();
+    for boundary in boundaries {
+        let position = boundary.importer.index();
+        if proximity[position] == ClientBoundaryProximity::Isolated {
+            proximity[position] = ClientBoundaryProximity::ReachesBoundary;
+            work.push_back(position);
+        }
+    }
+
+    while let Some(position) = work.pop_front() {
+        for importer in reverse[position].iter().copied() {
+            let importer = importer as usize;
+            if proximity[importer] == ClientBoundaryProximity::Isolated {
+                proximity[importer] = ClientBoundaryProximity::ReachesBoundary;
+                work.push_back(importer);
+            }
+        }
+    }
+
+    proximity
+}
+
+fn collect_bundle_roots(
+    boundaries: &[ClientBoundary],
+    entries: &[(Utf8PathBuf, EntryKind)],
+    index: &FxHashMap<Utf8PathBuf, ModuleId>,
+    environments: &[ModuleEnvironment],
+) -> Vec<ModuleId> {
+    let mut roots: Vec<ModuleId> = boundaries
+        .iter()
+        .map(|boundary| boundary.client_module)
+        .collect();
+    for (path, kind) in entries {
+        if *kind != EntryKind::Client {
+            continue;
+        }
+        if let Some(id) = index.get(path)
+            && environments[id.index()] == ModuleEnvironment::Client
+        {
+            roots.push(*id);
+        }
+    }
+    roots.sort_unstable();
+    roots.dedup();
+    roots
+}
+
+fn report_module_diagnostics(
+    module: &RscModuleInput,
+    reachability: ModuleReachability,
+    external: &[ImportSpecifier],
+    diagnostics: &mut Vec<RscDiagnostic>,
+) {
+    for issue in &module.directive_issues {
+        diagnostics.push(RscDiagnostic::Directive {
+            module: module.path.clone(),
+            issue: issue.clone(),
+        });
+    }
+
+    if module.environment == ModuleEnvironment::ServerActions {
+        for export in &module.exports {
+            match export.kind {
+                ExportKind::AsyncFunction | ExportKind::ReExport => {}
+                ExportKind::SyncFunction => {
+                    diagnostics.push(RscDiagnostic::ServerActionNotAsync {
+                        module: module.path.clone(),
+                        export: export.name.clone(),
+                        line: export.line,
+                    });
+                }
+                ExportKind::Class | ExportKind::Value => {
+                    diagnostics.push(RscDiagnostic::ServerActionNotFunction {
+                        module: module.path.clone(),
+                        export: export.name.clone(),
+                        line: export.line,
+                    });
+                }
+            }
+        }
+    }
+
+    // Client-only APIs only matter for code the server actually executes. A
+    // module without a directive that is reached solely from the client graph is
+    // bundled for the browser, where the hooks it calls are legal.
+    if module.environment.runs_on_server() && reachability.is_server_reachable() {
+        for use_site in &module.client_api_uses {
+            diagnostics.push(RscDiagnostic::ClientOnlyApiInServerModule {
+                module: module.path.clone(),
+                api: use_site.api,
+                line: use_site.line,
+                column: use_site.column,
+            });
+        }
+    }
+
+    if module.environment == ModuleEnvironment::Client || reachability.is_client_reachable() {
+        for import in external {
+            if is_server_only_specifier(&import.specifier) {
+                diagnostics.push(RscDiagnostic::ServerOnlyImportInClientModule {
+                    module: module.path.clone(),
+                    specifier: import.specifier.clone(),
+                    line: import.line,
+                });
+            }
+        }
+    }
+}
+
+/// Report `*.server.js` modules that the client graph resolved to.
+fn report_client_graph_leaks(
+    modules: &[RscModule],
+    resolved: &[ResolvedImports],
+    diagnostics: &mut Vec<RscDiagnostic>,
+) {
+    for (position, module) in modules.iter().enumerate() {
+        if module.environment != ModuleEnvironment::Client
+            && !module.reachability.is_client_reachable()
+        {
+            continue;
+        }
+        for target in resolved[position].imports.iter().copied() {
+            let imported = &modules[target.index()];
+            if is_server_only_path(imported.path.as_str()) {
+                diagnostics.push(RscDiagnostic::ServerOnlyImportInClientModule {
+                    module: module.path.clone(),
+                    specifier: CompactString::from(imported.path.as_str()),
+                    line: 0,
+                });
+            }
+        }
+    }
+}
+
+/// Whether an import specifier names server-only code.
+pub fn is_server_only_specifier(specifier: &str) -> bool {
+    if SERVER_ONLY_PACKAGES.binary_search(&specifier).is_ok() {
+        return true;
+    }
+    if SERVER_ONLY_PACKAGES.iter().any(|package| {
+        specifier
+            .strip_prefix(package)
+            .is_some_and(|rest| rest.starts_with('/'))
+    }) {
+        return true;
+    }
+    is_server_only_path(specifier)
+}
+
+fn is_server_only_path(path: &str) -> bool {
+    path.rsplit('/').next().is_some_and(|name| {
+        name.len() > SERVER_ONLY_SUFFIX.len() && name.ends_with(SERVER_ONLY_SUFFIX)
+    })
+}
+
+enum SpecifierResolution {
+    Relative(Utf8PathBuf),
+    Bare,
+    Escapes,
+}
+
+fn resolve_specifier(importer: &Utf8Path, specifier: &str) -> SpecifierResolution {
+    let specifier = if specifier.contains('\\') {
+        Cow::Owned(specifier.replace('\\', "/"))
+    } else {
+        Cow::Borrowed(specifier)
+    };
+    if !(specifier.starts_with("./") || specifier.starts_with("../") || specifier == ".") {
+        return SpecifierResolution::Bare;
+    }
+    let base = importer.parent().unwrap_or(Utf8Path::new(""));
+    match normalize_relative(base, &specifier) {
+        Some(path) => SpecifierResolution::Relative(path),
+        None => SpecifierResolution::Escapes,
+    }
+}
+
+/// Join and normalize without touching the file system.
+///
+/// `..` segments are resolved textually and a specifier that climbs above the
+/// project root returns `None` rather than a path outside it. This is the
+/// path-traversal guard for the graph: no analysis, and no bundler consuming the
+/// manifest, is ever handed a path that leaves the project.
+fn normalize_relative(base: &Utf8Path, specifier: &str) -> Option<Utf8PathBuf> {
+    let mut segments: Vec<&str> = base
+        .as_str()
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect();
+
+    for segment in specifier.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop()?;
+            }
+            other => segments.push(other),
+        }
+    }
+
+    let mut path = String::with_capacity(specifier.len() + base.as_str().len());
+    for (position, segment) in segments.iter().enumerate() {
+        if position > 0 {
+            path.push('/');
+        }
+        path.push_str(segment);
+    }
+    Some(Utf8PathBuf::from(path))
+}
+
+/// Try the resolved path, then the `.js` and `/index.js` forms.
+fn resolve_candidates(
+    candidate: &Utf8Path,
+    index: &FxHashMap<Utf8PathBuf, ModuleId>,
+) -> Option<ModuleId> {
+    if let Some(id) = index.get(candidate) {
+        return Some(*id);
+    }
+    let with_extension = Utf8PathBuf::from(format!("{candidate}.js"));
+    if let Some(id) = index.get(&with_extension) {
+        return Some(*id);
+    }
+    let with_index = candidate.join("index.js");
+    index.get(&with_index).copied()
+}
+
+/// Normalize a module path to the project-relative, forward-slash form.
+///
+/// A `..` that cannot be resolved is kept so [`is_inside_project`] can reject the
+/// path instead of silently rewriting an escape into a plausible-looking module.
+fn normalize_module_path(path: &Utf8Path) -> Utf8PathBuf {
+    let text = path.as_str().replace('\\', "/");
+    let mut segments: Vec<&str> = Vec::new();
+
+    for segment in text.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if segments.last().is_some_and(|last| *last != "..") {
+                    segments.pop();
+                } else {
+                    segments.push("..");
+                }
+            }
+            other => segments.push(other),
+        }
+    }
+
+    let mut normalized = String::with_capacity(text.len());
+    if text.starts_with('/') {
+        normalized.push('/');
+    }
+    for (position, segment) in segments.iter().enumerate() {
+        if position > 0 {
+            normalized.push('/');
+        }
+        normalized.push_str(segment);
+    }
+    Utf8PathBuf::from(normalized)
+}
+
+/// Whether a normalized module path stays inside the project root.
+fn is_inside_project(path: &Utf8Path) -> bool {
+    let text = path.as_str();
+    !text.is_empty()
+        && !text.starts_with('/')
+        && !text.starts_with("../")
+        && text != ".."
+        && !text.contains(':')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(path: impl Into<Utf8PathBuf>) -> RscModuleInput {
+        RscModuleInput::new(path, ModuleEnvironment::Client)
+    }
+
+    fn server(path: impl Into<Utf8PathBuf>) -> RscModuleInput {
+        RscModuleInput::new(path, ModuleEnvironment::Server)
+    }
+
+    fn actions(path: impl Into<Utf8PathBuf>) -> RscModuleInput {
+        RscModuleInput::new(path, ModuleEnvironment::ServerActions)
+    }
+
+    #[test]
+    fn an_empty_graph_has_no_modules_or_diagnostics() {
+        let graph = RscGraphBuilder::new().build();
+        assert!(graph.modules().is_empty());
+        assert!(graph.diagnostics().is_empty());
+        assert!(!graph.has_errors());
+    }
+
+    #[test]
+    fn modules_are_ordered_by_path() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("z.js"));
+        builder.add_module(server("a.js"));
+        builder.add_module(server("m.js"));
+        let graph = builder.build();
+        let paths: Vec<_> = graph
+            .modules()
+            .iter()
+            .map(|module| module.path.as_str())
+            .collect();
+        assert_eq!(paths, vec!["a.js", "m.js", "z.js"]);
+    }
+
+    #[test]
+    fn duplicate_module_paths_are_collapsed() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("a.js"));
+        builder.add_module(server("a.js"));
+        assert_eq!(builder.build().modules().len(), 1);
+    }
+
+    #[test]
+    fn relative_imports_resolve_to_modules() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./widget.js"));
+        builder.add_module(server("app/widget.js"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+        let page = graph.module("app/page.js").unwrap();
+        assert_eq!(page.imports.len(), 1);
+        assert_eq!(
+            graph.module_by_id(page.imports[0]).unwrap().path,
+            "app/widget.js"
+        );
+    }
+
+    #[test]
+    fn extensionless_imports_resolve_to_the_js_file() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./widget"));
+        builder.add_module(server("app/widget.js"));
+        let graph = builder.build();
+        assert_eq!(graph.module("app/page.js").unwrap().imports.len(), 1);
+    }
+
+    #[test]
+    fn directory_imports_resolve_to_index_js() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./widget"));
+        builder.add_module(server("app/widget/index.js"));
+        let graph = builder.build();
+        assert_eq!(graph.module("app/page.js").unwrap().imports.len(), 1);
+    }
+
+    #[test]
+    fn parent_relative_imports_resolve() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("../server/actions.js"));
+        builder.add_module(actions("server/actions.js"));
+        let graph = builder.build();
+        assert_eq!(graph.module("app/page.js").unwrap().imports.len(), 1);
+    }
+
+    #[test]
+    fn bare_specifiers_are_external() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("@uniflowed/react"));
+        let graph = builder.build();
+        let page = graph.module("app/page.js").unwrap();
+        assert!(page.imports.is_empty());
+        assert_eq!(page.external_imports.as_slice(), &["@uniflowed/react"]);
+    }
+
+    #[test]
+    fn an_import_climbing_out_of_the_project_is_rejected() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("../../../../etc/passwd"));
+        let graph = builder.build();
+        assert_eq!(
+            graph.diagnostics()[0].rule(),
+            "rsc/import-escapes-project-root"
+        );
+    }
+
+    #[test]
+    fn a_module_path_outside_the_project_is_dropped() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("../outside.js"));
+        let graph = builder.build();
+        assert!(graph.modules().is_empty());
+        assert_eq!(
+            graph.diagnostics()[0].rule(),
+            "rsc/module-outside-project-root"
+        );
+    }
+
+    #[test]
+    fn an_absolute_module_path_is_dropped() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("/etc/passwd"));
+        assert!(builder.build().modules().is_empty());
+    }
+
+    #[test]
+    fn without_entries_every_module_is_unreachable() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js"));
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("app/page.js").unwrap().reachability,
+            ModuleReachability::Unreachable
+        );
+    }
+
+    #[test]
+    fn a_server_entry_makes_its_imports_server_reachable() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./data.js"));
+        builder.add_module(server("app/data.js"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("app/data.js").unwrap().reachability,
+            ModuleReachability::ServerOnly
+        );
+    }
+
+    #[test]
+    fn a_client_module_imported_by_a_server_module_is_a_boundary() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./Counter.js"));
+        builder.add_module(client("app/Counter.js"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+
+        assert_eq!(graph.client_boundaries().len(), 1);
+        let boundary = graph.client_boundaries()[0];
+        assert_eq!(
+            graph.module_by_id(boundary.importer).unwrap().path,
+            "app/page.js"
+        );
+        assert_eq!(
+            graph.module_by_id(boundary.client_module).unwrap().path,
+            "app/Counter.js"
+        );
+        assert_eq!(graph.client_bundle_roots().len(), 1);
+        assert_eq!(
+            graph.module("app/Counter.js").unwrap().reachability,
+            ModuleReachability::ClientOnly
+        );
+    }
+
+    #[test]
+    fn code_below_a_client_boundary_is_client_reachable() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./Counter.js"));
+        builder.add_module(client("app/Counter.js").with_import("./format.js"));
+        builder.add_module(server("app/format.js"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("app/format.js").unwrap().reachability,
+            ModuleReachability::ClientOnly
+        );
+    }
+
+    #[test]
+    fn shared_code_is_reachable_from_both_halves() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(
+            server("app/page.js")
+                .with_import("./Counter.js")
+                .with_import("./format.js"),
+        );
+        builder.add_module(client("app/Counter.js").with_import("./format.js"));
+        builder.add_module(server("app/format.js"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("app/format.js").unwrap().reachability,
+            ModuleReachability::ServerAndClient
+        );
+    }
+
+    #[test]
+    fn a_client_entry_marks_its_module_a_bundle_root() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(client("app/entry.js"));
+        builder.add_entry("app/entry.js", EntryKind::Client);
+        let graph = builder.build();
+        assert_eq!(graph.client_bundle_roots().len(), 1);
+    }
+
+    #[test]
+    fn a_client_module_named_as_a_server_entry_is_still_a_client_module() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(client("app/entry.js"));
+        builder.add_entry("app/entry.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("app/entry.js").unwrap().reachability,
+            ModuleReachability::ClientOnly
+        );
+    }
+
+    #[test]
+    fn a_two_module_cycle_terminates() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("a.js").with_import("./b.js"));
+        builder.add_module(server("b.js").with_import("./a.js"));
+        builder.add_entry("a.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("b.js").unwrap().reachability,
+            ModuleReachability::ServerOnly
+        );
+    }
+
+    #[test]
+    fn a_self_import_terminates() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("a.js").with_import("./a.js"));
+        builder.add_entry("a.js", EntryKind::Server);
+        assert_eq!(
+            builder.build().module("a.js").unwrap().reachability,
+            ModuleReachability::ServerOnly
+        );
+    }
+
+    #[test]
+    fn a_cycle_crossing_a_client_boundary_terminates() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("a.js").with_import("./b.js"));
+        builder.add_module(client("b.js").with_import("./c.js"));
+        builder.add_module(server("c.js").with_import("./a.js"));
+        builder.add_entry("a.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("a.js").unwrap().reachability,
+            ModuleReachability::ServerAndClient
+        );
+        assert_eq!(graph.client_boundaries().len(), 1);
+    }
+
+    #[test]
+    fn a_long_cycle_terminates() {
+        let mut builder = RscGraphBuilder::new();
+        let size = 5_000usize;
+        for position in 0..size {
+            let next = (position + 1) % size;
+            builder
+                .add_module(server(format!("m{position}.js")).with_import(format!("./m{next}.js")));
+        }
+        builder.add_entry("m0.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(graph.modules().len(), size);
+        assert!(
+            graph
+                .modules()
+                .iter()
+                .all(|module| module.reachability == ModuleReachability::ServerOnly)
+        );
+    }
+
+    #[test]
+    fn a_ten_thousand_module_graph_builds() {
+        let mut builder = RscGraphBuilder::new();
+        let size = 10_000usize;
+        for position in 0..size {
+            let mut module = server(format!("m{position}.js"));
+            if position + 1 < size {
+                module = module.with_import(format!("./m{}.js", position + 1));
+            }
+            if position + 7 < size {
+                module = module.with_import(format!("./m{}.js", position + 7));
+            }
+            builder.add_module(module);
+        }
+        builder.add_entry("m0.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(graph.modules().len(), size);
+        assert!(
+            graph
+                .modules()
+                .iter()
+                .all(|module| module.reachability.is_server_reachable())
+        );
+    }
+
+    #[test]
+    fn a_client_module_importing_a_server_only_package_is_an_error() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(client("app/Counter.js").with_import("@uniflowed/server"));
+        let graph = builder.build();
+        assert_eq!(
+            graph.diagnostics()[0].rule(),
+            "rsc/server-only-import-in-client"
+        );
+        assert!(graph.has_errors());
+    }
+
+    #[test]
+    fn a_client_module_importing_a_server_only_subpath_is_an_error() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(client("app/Counter.js").with_import("@uniflowed/server/db"));
+        assert_eq!(builder.build().diagnostics().len(), 1);
+    }
+
+    #[test]
+    fn a_client_module_importing_a_dot_server_file_is_an_error() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(client("app/Counter.js").with_import("./secrets.server.js"));
+        builder.add_module(server("app/secrets.server.js"));
+        builder.add_entry("app/Counter.js", EntryKind::Client);
+        let graph = builder.build();
+        assert!(
+            graph
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.rule() == "rsc/server-only-import-in-client")
+        );
+    }
+
+    #[test]
+    fn a_module_pulled_into_the_client_graph_may_not_import_server_only_code() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./Counter.js"));
+        builder.add_module(client("app/Counter.js").with_import("./shared.js"));
+        builder.add_module(server("app/shared.js").with_import("@uniflowed/server"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+        assert!(
+            graph
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.rule() == "rsc/server-only-import-in-client")
+        );
+    }
+
+    #[test]
+    fn a_server_module_may_import_server_only_code() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("@uniflowed/server"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        assert!(builder.build().diagnostics().is_empty());
+    }
+
+    #[test]
+    fn a_server_module_calling_a_client_only_api_is_an_error() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "app/page.js",
+            "export default function Page() {\n const [a] = useState(1);\n return a;\n}\n",
+        );
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+        assert_eq!(
+            graph.diagnostics()[0].rule(),
+            "rsc/client-only-api-in-server"
+        );
+    }
+
+    #[test]
+    fn a_client_module_calling_a_client_only_api_is_fine() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "app/Counter.js",
+            "\"use client\";\nexport default function Counter() {\n const [a] = useState(1);\n return a;\n}\n",
+        );
+        builder.add_entry("app/Counter.js", EntryKind::Client);
+        assert!(builder.build().diagnostics().is_empty());
+    }
+
+    #[test]
+    fn a_shared_module_reached_only_from_the_client_may_use_hooks() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source("app/page.js", "import Counter from \"./Counter.js\";\n");
+        builder.add_source(
+            "app/Counter.js",
+            "\"use client\";\nimport { useCounter } from \"./useCounter.js\";\n",
+        );
+        builder.add_source(
+            "app/useCounter.js",
+            "export function useCounter() {\n return useState(0);\n}\n",
+        );
+        builder.add_entry("app/page.js", EntryKind::Server);
+        assert!(builder.build().diagnostics().is_empty());
+    }
+
+    #[test]
+    fn an_unreachable_server_module_using_hooks_is_not_reported() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source("app/orphan.js", "const a = useState(1);\n");
+        assert!(builder.build().diagnostics().is_empty());
+    }
+
+    #[test]
+    fn a_sync_server_action_export_is_an_error() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport function refresh() {}\n",
+        );
+        let graph = builder.build();
+        assert_eq!(graph.diagnostics()[0].rule(), "rsc/server-action-not-async");
+    }
+
+    #[test]
+    fn a_non_function_server_action_export_is_an_error() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport const limit = 5;\n",
+        );
+        let graph = builder.build();
+        assert_eq!(
+            graph.diagnostics()[0].rule(),
+            "rsc/server-action-not-a-function"
+        );
+    }
+
+    #[test]
+    fn an_exported_class_in_a_server_actions_module_is_an_error() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source("server/actions.js", "\"use server\";\nexport class Db {}\n");
+        assert_eq!(
+            builder.build().diagnostics()[0].rule(),
+            "rsc/server-action-not-a-function"
+        );
+    }
+
+    #[test]
+    fn an_async_server_action_export_is_accepted() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport async function refresh() {}\n",
+        );
+        assert!(builder.build().diagnostics().is_empty());
+    }
+
+    #[test]
+    fn a_server_action_factory_export_is_accepted() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport const refresh = serverAction(async () => {});\n",
+        );
+        assert!(builder.build().diagnostics().is_empty());
+    }
+
+    #[test]
+    fn directive_issues_are_lifted_into_graph_diagnostics() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source("app/page.js", "const a = 1;\n\"use client\";\n");
+        let graph = builder.build();
+        assert_eq!(
+            graph.diagnostics()[0].rule(),
+            "rsc/directive-not-in-prologue"
+        );
+    }
+
+    #[test]
+    fn proximity_marks_modules_that_can_hand_a_closure_to_the_client() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app/page.js").with_import("./section.js"));
+        builder.add_module(server("app/section.js").with_import("./Counter.js"));
+        builder.add_module(client("app/Counter.js"));
+        builder.add_module(server("app/lonely.js"));
+        builder.add_entry("app/page.js", EntryKind::Server);
+        let graph = builder.build();
+
+        assert_eq!(
+            graph.module("app/page.js").unwrap().proximity,
+            ClientBoundaryProximity::ReachesBoundary
+        );
+        assert_eq!(
+            graph.module("app/section.js").unwrap().proximity,
+            ClientBoundaryProximity::ReachesBoundary
+        );
+        assert_eq!(
+            graph.module("app/lonely.js").unwrap().proximity,
+            ClientBoundaryProximity::Isolated
+        );
+    }
+
+    #[test]
+    fn diagnostics_are_ordered_deterministically() {
+        let build = || {
+            let mut builder = RscGraphBuilder::new();
+            builder.add_source("b.js", "\"use client\";\nimport \"@uniflowed/server\";\n");
+            builder.add_source("a.js", "\"use client\";\nimport \"server-only\";\n");
+            builder.build()
+        };
+        let first: Vec<_> = build()
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.to_string())
+            .collect();
+        let second: Vec<_> = build()
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.to_string())
+            .collect();
+        assert_eq!(first, second);
+        assert!(first[0].contains("a.js"));
+    }
+
+    #[test]
+    fn function_level_actions_survive_into_the_graph() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(
+            server("app/page.js")
+                .with_function_action(FunctionOwner::Named(CompactString::const_new("save"))),
+        );
+        let graph = builder.build();
+        assert_eq!(
+            graph.module("app/page.js").unwrap().function_actions.len(),
+            1
+        );
+    }
+
+    #[test]
+    fn server_only_specifier_detection_covers_packages_and_files() {
+        assert!(is_server_only_specifier("@uniflowed/server"));
+        assert!(is_server_only_specifier("@uniflowed/server/db"));
+        assert!(is_server_only_specifier("server-only"));
+        assert!(is_server_only_specifier("./secrets.server.js"));
+        assert!(!is_server_only_specifier("@uniflowed/react"));
+        assert!(!is_server_only_specifier("./server.js"));
+        assert!(!is_server_only_specifier("@uniflowed/serverless"));
+    }
+
+    #[test]
+    fn windows_style_paths_are_normalized() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_module(server("app\\page.js").with_import(".\\widget.js"));
+        builder.add_module(server("app/widget.js"));
+        let graph = builder.build();
+        assert_eq!(graph.module("app/page.js").unwrap().imports.len(), 1);
+    }
+
+    #[test]
+    fn building_the_same_input_twice_gives_the_same_graph() {
+        let build = || {
+            let mut builder = RscGraphBuilder::new();
+            builder.add_module(server("app/page.js").with_import("./Counter.js"));
+            builder.add_module(client("app/Counter.js"));
+            builder.add_entry("app/page.js", EntryKind::Server);
+            builder.build()
+        };
+        let first = build();
+        let second = build();
+        assert_eq!(first.modules(), second.modules());
+        assert_eq!(first.client_boundaries(), second.client_boundaries());
+    }
+}

--- a/crates/uf_rsc/src/lib.rs
+++ b/crates/uf_rsc/src/lib.rs
@@ -1,0 +1,167 @@
+#![deny(missing_docs)]
+//! React Server Components analysis for uniflowed.
+//!
+//! `uf` renders every module on the server by default. A module opts into the
+//! client bundle with `"use client";` and into the server action protocol with
+//! `"use server";`. This crate turns those directives into the three artefacts
+//! the rest of the toolchain needs:
+//!
+//! * [`module_environment`] — where a single module runs, with the directive
+//!   rules pinned down in [`directive`];
+//! * [`RscGraph`] — the resolved module graph: reachability, client boundaries,
+//!   client-bundle roots, and typed [`RscDiagnostic`]s for every way an app can
+//!   break the RSC contract;
+//! * [`ServerActionRegistry`] — every server action behind a keyed, unguessable
+//!   [`ActionId`], with a lookup that refuses to be used as an enumeration
+//!   oracle.
+//!
+//! [`analyze_project`] runs all three over a project directory, and
+//! [`RscManifest`] serializes the result to `dist/uf-rsc-manifest.json`.
+//!
+//! ```
+//! use uf_rsc::{EntryKind, ModuleEnvironment, RscGraphBuilder, module_environment};
+//!
+//! assert_eq!(module_environment("\"use client\";\n"), ModuleEnvironment::Client);
+//!
+//! let mut builder = RscGraphBuilder::new();
+//! builder.add_source("app/page.js", "import Counter from \"./Counter.js\";\n");
+//! builder.add_source("app/Counter.js", "\"use client\";\n");
+//! builder.add_entry("app/page.js", EntryKind::Server);
+//!
+//! let graph = builder.build();
+//! assert_eq!(graph.client_boundaries().len(), 1);
+//! ```
+
+use camino::Utf8PathBuf;
+use thiserror::Error;
+
+pub mod action;
+pub mod directive;
+pub mod graph;
+pub mod manifest;
+pub mod project;
+pub mod scan;
+
+pub use action::{
+    ACTION_ID_HEX_LEN, ActionExposure, ActionId, ActionIdError, BuildId, BuildIdError,
+    MAX_BUILD_ID_BYTES, MIN_BUILD_ID_BYTES, ServerAction, ServerActionKind, ServerActionRegistry,
+    UnknownAction,
+};
+pub use directive::{
+    DirectiveIssue, DirectiveKind, DirectiveScan, FileDirective, FunctionDirective, FunctionOwner,
+    ModuleEnvironment, module_environment, scan_directives,
+};
+pub use graph::{
+    ClientBoundary, ClientBoundaryProximity, EntryKind, ModuleId, ModuleReachability,
+    RscDiagnostic, RscGraph, RscGraphBuilder, RscModule, RscModuleInput, RscSeverity,
+    SERVER_ONLY_PACKAGES, SERVER_ONLY_SUFFIX, is_server_only_specifier,
+};
+pub use manifest::{
+    RSC_MANIFEST_FILE_NAME, RSC_MANIFEST_VERSION, RscManifest, RscManifestAction,
+    RscManifestBoundary, RscManifestDiagnostic, RscManifestModule, write_manifest,
+};
+pub use project::{
+    IGNORED_DIRECTORIES, NON_APP_SUFFIXES, ProjectScanOptions, ROUTER_ENTRY_FILES, RscAnalysis,
+    analyze_project,
+};
+pub use scan::{
+    CLIENT_ONLY_APIS, CLIENT_ONLY_GLOBALS, ClientApiUse, ExportKind, ImportKind, ImportSpecifier,
+    MAX_SOURCE_BYTES, ModuleExport, scan_client_api_uses, scan_exports, scan_imports,
+};
+
+/// Anything that can go wrong outside the analyses themselves.
+///
+/// Violations of the RSC contract are [`RscDiagnostic`]s, not errors: a build
+/// collects all of them instead of stopping at the first.
+#[derive(Debug, Error)]
+pub enum RscError {
+    /// A module could not be read.
+    #[error("failed to read {path}: {source}")]
+    Read {
+        /// Module path, relative to the project root.
+        path: Utf8PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The manifest could not be written.
+    #[error("failed to write {path}: {source}")]
+    Write {
+        /// Path that was being written.
+        path: Utf8PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The project tree could not be walked.
+    #[error("failed to walk {path}: {source}")]
+    Walk {
+        /// Directory that was being walked.
+        path: Utf8PathBuf,
+        /// Underlying walk error.
+        #[source]
+        source: walkdir::Error,
+    },
+    /// The manifest could not be serialized.
+    #[error("failed to serialize the RSC manifest: {source}")]
+    Serialize {
+        /// Underlying serialization error.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// A path in the project is not valid UTF-8.
+    #[error("path is not UTF-8: {0}")]
+    NonUtf8Path(String),
+    /// A module is not valid UTF-8.
+    #[error("module {path} is not valid UTF-8")]
+    NonUtf8Source {
+        /// Module path, relative to the project root.
+        path: Utf8PathBuf,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_crate_reexports_the_public_surface() {
+        assert_eq!(module_environment(""), ModuleEnvironment::Server);
+        assert_eq!(RSC_MANIFEST_FILE_NAME, "uf-rsc-manifest.json");
+        assert_eq!(RSC_MANIFEST_VERSION, 1);
+        assert_eq!(ACTION_ID_HEX_LEN, 64);
+    }
+
+    #[test]
+    fn errors_render_with_their_path() {
+        let error = RscError::NonUtf8Source {
+            path: Utf8PathBuf::from("app/page.js"),
+        };
+        assert_eq!(error.to_string(), "module app/page.js is not valid UTF-8");
+    }
+
+    #[test]
+    fn a_full_analysis_flows_from_sources_to_a_manifest() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "app/_uf.page.js",
+            "import Counter from \"./Counter.js\";\nimport { save } from \"../server/actions.js\";\n",
+        );
+        builder.add_source("app/Counter.js", "\"use client\";\n");
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\nexport async function save() {}\n",
+        );
+        builder.add_entry("app/_uf.page.js", EntryKind::Server);
+
+        let graph = builder.build();
+        let build_id = BuildId::new("lib-test-build-id").unwrap();
+        let registry = ServerActionRegistry::from_graph(&graph, &build_id);
+        let manifest = RscManifest::new(&graph, &registry);
+
+        assert_eq!(manifest.modules.len(), 3);
+        assert_eq!(manifest.client_boundaries.len(), 1);
+        assert_eq!(manifest.server_actions.len(), 1);
+        assert!(manifest.diagnostics.is_empty());
+    }
+}

--- a/crates/uf_rsc/src/manifest.rs
+++ b/crates/uf_rsc/src/manifest.rs
@@ -1,0 +1,393 @@
+//! The `dist/uf-rsc-manifest.json` build artefact.
+//!
+//! The manifest is what `uf build` hands to the bundler and what `uf dev` reads
+//! back, so it is deterministic by construction: every collection is sorted, and
+//! two builds of the same sources with the same build id produce byte-identical
+//! JSON.
+//!
+//! Two things are deliberately absent:
+//!
+//! * the build id, which is the HMAC key behind every action id — only a
+//!   [`BuildId::fingerprint`] derived from it is published;
+//! * actions no client boundary can reach, which are tracked in the registry but
+//!   never written here, so nothing downstream can turn one into an endpoint.
+
+use std::fs;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+use crate::RscError;
+use crate::action::{ActionId, ServerActionKind, ServerActionRegistry};
+use crate::directive::ModuleEnvironment;
+use crate::graph::{ModuleReachability, RscGraph, RscSeverity};
+
+/// File name of the manifest inside the build output directory.
+pub const RSC_MANIFEST_FILE_NAME: &str = "uf-rsc-manifest.json";
+
+/// Schema version of the manifest.
+pub const RSC_MANIFEST_VERSION: u32 = 1;
+
+/// The serialized React Server Components manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RscManifest {
+    /// Schema version.
+    pub version: u32,
+    /// Engine that produced the manifest.
+    pub engine: CompactString,
+    /// Digest of the build id; the build id itself is never published.
+    pub build_fingerprint: CompactString,
+    /// Every module of the graph, ordered by path.
+    pub modules: Vec<RscManifestModule>,
+    /// Server-to-client import edges, ordered.
+    pub client_boundaries: Vec<RscManifestBoundary>,
+    /// Client bundle roots, ordered.
+    pub client_bundle_roots: Vec<Utf8PathBuf>,
+    /// Callable server actions, ordered by id.
+    pub server_actions: Vec<RscManifestAction>,
+    /// Contract violations, ordered.
+    pub diagnostics: Vec<RscManifestDiagnostic>,
+}
+
+/// One module in the manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RscManifestModule {
+    /// Path relative to the project root.
+    pub path: Utf8PathBuf,
+    /// Environment the module executes in.
+    pub environment: ModuleEnvironment,
+    /// Which halves of the app reach it.
+    pub reachability: ModuleReachability,
+    /// Resolved internal imports, ordered.
+    pub imports: Vec<Utf8PathBuf>,
+    /// Unresolved specifiers, ordered.
+    pub external_imports: Vec<CompactString>,
+    /// Exported names, ordered.
+    pub exports: Vec<CompactString>,
+}
+
+/// One server-to-client import edge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RscManifestBoundary {
+    /// The server module that owns the import.
+    pub importer: Utf8PathBuf,
+    /// The `"use client"` module it imports.
+    pub module: Utf8PathBuf,
+}
+
+/// One callable server action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RscManifestAction {
+    /// Keyed action id.
+    pub id: ActionId,
+    /// Declaring module.
+    pub module: Utf8PathBuf,
+    /// Export name or closure binding.
+    pub export: CompactString,
+    /// Where the action was declared.
+    pub kind: ServerActionKind,
+}
+
+/// One reported contract violation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RscManifestDiagnostic {
+    /// Stable rule identifier.
+    pub rule: CompactString,
+    /// How serious it is.
+    pub severity: RscSeverity,
+    /// Module the violation belongs to.
+    pub module: Utf8PathBuf,
+    /// 1-based line, or 0 when the violation is not tied to one.
+    pub line: u32,
+    /// Human-readable rendering of the typed diagnostic.
+    pub message: CompactString,
+}
+
+impl RscManifest {
+    /// Build the manifest from a resolved graph and its action registry.
+    pub fn new(graph: &RscGraph, registry: &ServerActionRegistry) -> Self {
+        let modules = graph
+            .modules()
+            .iter()
+            .map(|module| {
+                let mut imports: Vec<Utf8PathBuf> = module
+                    .imports
+                    .iter()
+                    .filter_map(|id| graph.module_by_id(*id))
+                    .map(|imported| imported.path.clone())
+                    .collect();
+                imports.sort();
+                imports.dedup();
+
+                let mut external_imports: Vec<CompactString> =
+                    module.external_imports.iter().cloned().collect();
+                external_imports.sort();
+                external_imports.dedup();
+
+                let mut exports: Vec<CompactString> = module
+                    .exports
+                    .iter()
+                    .map(|export| export.name.clone())
+                    .collect();
+                exports.sort();
+                exports.dedup();
+
+                RscManifestModule {
+                    path: module.path.clone(),
+                    environment: module.environment,
+                    reachability: module.reachability,
+                    imports,
+                    external_imports,
+                    exports,
+                }
+            })
+            .collect();
+
+        let mut client_boundaries: Vec<RscManifestBoundary> = graph
+            .client_boundaries()
+            .iter()
+            .filter_map(|boundary| {
+                Some(RscManifestBoundary {
+                    importer: graph.module_by_id(boundary.importer)?.path.clone(),
+                    module: graph.module_by_id(boundary.client_module)?.path.clone(),
+                })
+            })
+            .collect();
+        client_boundaries.sort_by(|left, right| {
+            left.importer
+                .cmp(&right.importer)
+                .then(left.module.cmp(&right.module))
+        });
+        client_boundaries.dedup();
+
+        let mut client_bundle_roots: Vec<Utf8PathBuf> = graph
+            .client_bundle_roots()
+            .iter()
+            .filter_map(|id| graph.module_by_id(*id))
+            .map(|module| module.path.clone())
+            .collect();
+        client_bundle_roots.sort();
+        client_bundle_roots.dedup();
+
+        let mut server_actions: Vec<RscManifestAction> = registry
+            .callable_actions()
+            .map(|action| RscManifestAction {
+                id: action.id,
+                module: action.module.clone(),
+                export: action.export.clone(),
+                kind: action.kind,
+            })
+            .collect();
+        server_actions.sort_by_key(|action| action.id);
+
+        let mut diagnostics: Vec<RscManifestDiagnostic> = graph
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| RscManifestDiagnostic {
+                rule: CompactString::from(diagnostic.rule()),
+                severity: diagnostic.severity(),
+                module: diagnostic.module().to_path_buf(),
+                line: diagnostic.line(),
+                message: CompactString::from(diagnostic.to_string()),
+            })
+            .collect();
+        diagnostics.sort_by(|left, right| {
+            left.module
+                .cmp(&right.module)
+                .then(left.line.cmp(&right.line))
+                .then(left.rule.cmp(&right.rule))
+                .then(left.message.cmp(&right.message))
+        });
+        diagnostics.dedup();
+
+        Self {
+            version: RSC_MANIFEST_VERSION,
+            engine: CompactString::const_new("uf-native"),
+            build_fingerprint: CompactString::from(registry.build_fingerprint()),
+            modules,
+            client_boundaries,
+            client_bundle_roots,
+            server_actions,
+            diagnostics,
+        }
+    }
+
+    /// Render the manifest exactly as it is written to disk.
+    pub fn to_json(&self) -> Result<String, RscError> {
+        let mut json =
+            serde_json::to_string_pretty(self).map_err(|source| RscError::Serialize { source })?;
+        json.push('\n');
+        Ok(json)
+    }
+}
+
+/// Write `uf-rsc-manifest.json` into the build output directory.
+pub fn write_manifest(out_dir: &Utf8Path, manifest: &RscManifest) -> Result<Utf8PathBuf, RscError> {
+    fs::create_dir_all(out_dir).map_err(|source| RscError::Write {
+        path: out_dir.to_path_buf(),
+        source,
+    })?;
+    let path = out_dir.join(RSC_MANIFEST_FILE_NAME);
+    fs::write(&path, manifest.to_json()?).map_err(|source| RscError::Write {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::action::BuildId;
+    use crate::graph::{EntryKind, RscGraphBuilder};
+
+    fn fixture() -> (RscGraph, ServerActionRegistry) {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "app/_uf.page.js",
+            "// @flow\nimport Counter from \"./client/Counter.js\";\nimport { refresh } from \"../server/actions.js\";\nexport default function Page() {}\n",
+        );
+        builder.add_source(
+            "app/client/Counter.js",
+            "\"use client\";\n// @flow\nimport { useState } from \"@uniflowed/react\";\nexport default function Counter() {\n const [n] = useState(0);\n return n;\n}\n",
+        );
+        builder.add_source(
+            "server/actions.js",
+            "\"use server\";\n// @flow\nexport async function refresh() {}\n",
+        );
+        builder.add_entry("app/_uf.page.js", EntryKind::Server);
+        let graph = builder.build();
+        let build_id = BuildId::new("fixture-build-id").expect("valid build id");
+        let registry = ServerActionRegistry::from_graph(&graph, &build_id);
+        (graph, registry)
+    }
+
+    #[test]
+    fn the_manifest_matches_its_snapshot() {
+        let (graph, registry) = fixture();
+        let manifest = RscManifest::new(&graph, &registry);
+        similar_asserts::assert_eq!(
+            manifest.to_json().unwrap(),
+            include_str!("../tests/fixtures/uf-rsc-manifest.json")
+        );
+    }
+
+    #[test]
+    fn the_manifest_is_byte_identical_across_builds() {
+        let (first_graph, first_registry) = fixture();
+        let (second_graph, second_registry) = fixture();
+        assert_eq!(
+            RscManifest::new(&first_graph, &first_registry)
+                .to_json()
+                .unwrap(),
+            RscManifest::new(&second_graph, &second_registry)
+                .to_json()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn the_manifest_never_contains_the_build_id() {
+        let (graph, registry) = fixture();
+        let json = RscManifest::new(&graph, &registry).to_json().unwrap();
+        assert!(!json.contains("fixture-build-id"));
+        assert!(json.contains("buildFingerprint"));
+    }
+
+    #[test]
+    fn unreachable_actions_are_not_written_to_the_manifest() {
+        let mut builder = RscGraphBuilder::new();
+        builder.add_source(
+            "server/orphan.js",
+            "\"use server\";\nexport async function drop() {}\n",
+        );
+        let graph = builder.build();
+        let registry =
+            ServerActionRegistry::from_graph(&graph, &BuildId::new("fixture-build-id").unwrap());
+        let manifest = RscManifest::new(&graph, &registry);
+        assert_eq!(registry.len(), 1);
+        assert!(manifest.server_actions.is_empty());
+    }
+
+    #[test]
+    fn the_manifest_round_trips_through_serde() {
+        let (graph, registry) = fixture();
+        let manifest = RscManifest::new(&graph, &registry);
+        let json = manifest.to_json().unwrap();
+        let parsed: RscManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, manifest);
+    }
+
+    #[test]
+    fn collections_are_sorted() {
+        let (graph, registry) = fixture();
+        let manifest = RscManifest::new(&graph, &registry);
+        assert!(
+            manifest
+                .modules
+                .windows(2)
+                .all(|pair| pair[0].path <= pair[1].path)
+        );
+        assert!(
+            manifest
+                .client_bundle_roots
+                .windows(2)
+                .all(|pair| pair[0] <= pair[1])
+        );
+        assert!(
+            manifest
+                .server_actions
+                .windows(2)
+                .all(|pair| pair[0].id <= pair[1].id)
+        );
+    }
+
+    #[test]
+    fn writing_the_manifest_creates_the_output_directory() {
+        let (graph, registry) = fixture();
+        let manifest = RscManifest::new(&graph, &registry);
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = Utf8PathBuf::from_path_buf(dir.path().join("dist/nested")).unwrap();
+
+        let path = write_manifest(&out_dir, &manifest).unwrap();
+        assert_eq!(path.file_name(), Some(RSC_MANIFEST_FILE_NAME));
+        let written = fs::read_to_string(&path).unwrap();
+        assert_eq!(written, manifest.to_json().unwrap());
+        assert!(written.ends_with('\n'));
+    }
+
+    #[test]
+    fn writing_the_manifest_twice_is_idempotent() {
+        let (graph, registry) = fixture();
+        let manifest = RscManifest::new(&graph, &registry);
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+
+        let first = write_manifest(&out_dir, &manifest).unwrap();
+        let second = write_manifest(&out_dir, &manifest).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(
+            fs::read_to_string(&first).unwrap(),
+            fs::read_to_string(&second).unwrap()
+        );
+    }
+
+    #[test]
+    fn an_empty_graph_produces_an_empty_manifest() {
+        let graph = RscGraphBuilder::new().build();
+        let registry =
+            ServerActionRegistry::from_graph(&graph, &BuildId::new("fixture-build-id").unwrap());
+        let manifest = RscManifest::new(&graph, &registry);
+        assert!(manifest.modules.is_empty());
+        assert!(manifest.client_boundaries.is_empty());
+        assert!(manifest.server_actions.is_empty());
+        assert!(manifest.diagnostics.is_empty());
+        assert_eq!(manifest.version, RSC_MANIFEST_VERSION);
+    }
+}

--- a/crates/uf_rsc/src/project.rs
+++ b/crates/uf_rsc/src/project.rs
@@ -1,0 +1,338 @@
+//! Scanning a whole project into an [`RscAnalysis`].
+//!
+//! This is the entry point `uf build` and `uf dev` call. It walks the project,
+//! scans every `.js` module once, resolves the graph and derives the action
+//! registry.
+//!
+//! # Guards
+//!
+//! * symbolic links are never followed, so a link pointing outside the project
+//!   cannot pull foreign files into the graph;
+//! * files above [`ProjectScanOptions::max_file_bytes`] are skipped rather than
+//!   read into memory;
+//! * generated and vendored directories are skipped by name.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use rayon::prelude::*;
+use walkdir::WalkDir;
+
+use crate::RscError;
+use crate::action::{BuildId, ServerActionRegistry};
+use crate::graph::{EntryKind, RscGraph, RscGraphBuilder, RscModuleInput};
+use crate::manifest::RscManifest;
+use crate::scan::MAX_SOURCE_BYTES;
+
+/// Directory names that never contain application modules.
+pub const IGNORED_DIRECTORIES: &[&str] =
+    &[".git", ".uf", "coverage", "dist", "node_modules", "target"];
+
+/// File-name suffixes that are not part of the application graph.
+pub const NON_APP_SUFFIXES: &[&str] = &[".bench.js", ".spec.js", ".stories.js", ".test.js"];
+
+/// Reserved router files that act as server entries.
+pub const ROUTER_ENTRY_FILES: &[&str] = &["_uf.layout.js", "_uf.middleware.js", "_uf.page.js"];
+
+/// How [`analyze_project`] walks a project.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectScanOptions {
+    /// Directory names never descended into.
+    pub ignored_directories: Vec<CompactString>,
+    /// File names that make a module a server entry.
+    pub server_entry_files: Vec<CompactString>,
+    /// Extra entry points, relative to the project root.
+    pub extra_entries: Vec<(Utf8PathBuf, EntryKind)>,
+    /// Largest module that will be read.
+    pub max_file_bytes: usize,
+}
+
+impl Default for ProjectScanOptions {
+    fn default() -> Self {
+        Self {
+            ignored_directories: IGNORED_DIRECTORIES
+                .iter()
+                .map(|name| CompactString::from(*name))
+                .collect(),
+            server_entry_files: ROUTER_ENTRY_FILES
+                .iter()
+                .map(|name| CompactString::from(*name))
+                .collect(),
+            extra_entries: Vec::new(),
+            max_file_bytes: MAX_SOURCE_BYTES,
+        }
+    }
+}
+
+/// The resolved graph of a project and the actions it declares.
+#[derive(Debug, Clone)]
+pub struct RscAnalysis {
+    /// The module graph.
+    pub graph: RscGraph,
+    /// The server action registry.
+    pub registry: ServerActionRegistry,
+}
+
+impl RscAnalysis {
+    /// Render the manifest for this analysis.
+    pub fn manifest(&self) -> RscManifest {
+        RscManifest::new(&self.graph, &self.registry)
+    }
+
+    /// Number of modules that end up in the client bundle as roots.
+    pub fn client_bundle_root_count(&self) -> usize {
+        self.graph.client_bundle_roots().len()
+    }
+
+    /// Number of actions that are callable endpoints.
+    pub fn callable_action_count(&self) -> usize {
+        self.registry.callable_actions().count()
+    }
+}
+
+/// Scan a project rooted at `root` and resolve its RSC graph.
+pub fn analyze_project(
+    root: &Utf8Path,
+    build_id: &BuildId,
+    options: &ProjectScanOptions,
+) -> Result<RscAnalysis, RscError> {
+    let paths = collect_module_paths(root, options)?;
+
+    let modules = paths
+        .par_iter()
+        .map(|(absolute, relative)| {
+            let bytes = std::fs::read(absolute).map_err(|source| RscError::Read {
+                path: relative.clone(),
+                source,
+            })?;
+            let source = uf_infra::validate_utf8(&bytes).map_err(|_| RscError::NonUtf8Source {
+                path: relative.clone(),
+            })?;
+            Ok(RscModuleInput::from_source(relative.clone(), source))
+        })
+        .collect::<Result<Vec<_>, RscError>>()?;
+
+    let mut builder = RscGraphBuilder::new();
+    for module in modules {
+        let is_entry = module
+            .path
+            .file_name()
+            .is_some_and(|name| options.server_entry_files.iter().any(|entry| entry == name));
+        if is_entry {
+            builder.add_entry(module.path.clone(), EntryKind::Server);
+        }
+        builder.add_module(module);
+    }
+    for (path, kind) in &options.extra_entries {
+        builder.add_entry(path.clone(), *kind);
+    }
+
+    let graph = builder.build();
+    let registry = ServerActionRegistry::from_graph(&graph, build_id);
+    Ok(RscAnalysis { graph, registry })
+}
+
+/// Collect `(absolute, project-relative)` paths of every scannable module.
+fn collect_module_paths(
+    root: &Utf8Path,
+    options: &ProjectScanOptions,
+) -> Result<Vec<(Utf8PathBuf, Utf8PathBuf)>, RscError> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut paths = Vec::new();
+    // `WalkDir` does not follow symbolic links by default, which is what keeps a
+    // link inside the project from pulling in files outside it.
+    let walk = WalkDir::new(root).into_iter().filter_entry(|entry| {
+        entry.depth() == 0
+            || !options
+                .ignored_directories
+                .iter()
+                .any(|ignored| ignored.as_str() == entry.file_name().to_string_lossy())
+    });
+
+    for entry in walk {
+        let entry = entry.map_err(|source| RscError::Walk {
+            path: root.to_path_buf(),
+            source,
+        })?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let absolute = Utf8PathBuf::from_path_buf(entry.path().to_path_buf())
+            .map_err(|path| RscError::NonUtf8Path(path.display().to_string()))?;
+        let Some(name) = absolute.file_name() else {
+            continue;
+        };
+        if !name.ends_with(".js") || NON_APP_SUFFIXES.iter().any(|suffix| name.ends_with(suffix)) {
+            continue;
+        }
+        if entry
+            .metadata()
+            .map(|metadata| metadata.len() as usize > options.max_file_bytes)
+            .unwrap_or(true)
+        {
+            continue;
+        }
+
+        let relative = absolute
+            .strip_prefix(root)
+            .unwrap_or(&absolute)
+            .to_path_buf();
+        paths.push((absolute, relative));
+    }
+
+    paths.sort();
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn project(files: &[(&str, &str)]) -> (tempfile::TempDir, Utf8PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf8 root");
+        for (path, contents) in files {
+            let target = root.join(path);
+            fs::create_dir_all(target.parent().expect("parent")).expect("dirs");
+            fs::write(&target, contents).expect("write");
+        }
+        (dir, root)
+    }
+
+    fn build_id() -> BuildId {
+        BuildId::new("project-test-build-id").expect("valid build id")
+    }
+
+    #[test]
+    fn a_missing_root_analyses_to_nothing() {
+        let analysis = analyze_project(
+            Utf8Path::new("/nonexistent/uf/project"),
+            &build_id(),
+            &ProjectScanOptions::default(),
+        )
+        .unwrap();
+        assert!(analysis.graph.modules().is_empty());
+    }
+
+    #[test]
+    fn a_scaffold_shaped_project_resolves_its_boundary_and_action() {
+        let (_dir, root) = project(&[
+            (
+                "app/_uf.page.js",
+                "// @flow\nimport Counter from \"./client/Counter.js\";\nimport { refreshGreeting } from \"../server/actions.js\";\n",
+            ),
+            (
+                "app/client/Counter.js",
+                "\"use client\";\n// @flow\nimport { useCounter } from \"./useCounter.js\";\n",
+            ),
+            (
+                "app/client/useCounter.js",
+                "\"use client\";\n// @flow\nimport { useState } from \"@uniflowed/react\";\n",
+            ),
+            (
+                "server/actions.js",
+                "\"use server\";\n// @flow\nexport const refreshGreeting = serverAction(async () => {});\n",
+            ),
+        ]);
+
+        let analysis = analyze_project(&root, &build_id(), &ProjectScanOptions::default()).unwrap();
+
+        assert_eq!(analysis.graph.modules().len(), 4);
+        assert_eq!(analysis.graph.client_boundaries().len(), 1);
+        assert_eq!(analysis.client_bundle_root_count(), 1);
+        assert_eq!(analysis.callable_action_count(), 1);
+        assert!(analysis.graph.diagnostics().is_empty());
+    }
+
+    #[test]
+    fn ignored_directories_are_not_scanned() {
+        let (_dir, root) = project(&[
+            ("app/_uf.page.js", "// @flow\n"),
+            ("node_modules/pkg/index.js", "\"use client\";\n"),
+            ("dist/bundle.js", "\"use client\";\n"),
+        ]);
+        let analysis = analyze_project(&root, &build_id(), &ProjectScanOptions::default()).unwrap();
+        assert_eq!(analysis.graph.modules().len(), 1);
+    }
+
+    #[test]
+    fn test_files_are_not_part_of_the_app_graph() {
+        let (_dir, root) = project(&[
+            ("app/_uf.page.js", "// @flow\n"),
+            ("app/_uf.page.test.js", "// @flow\n"),
+        ]);
+        let analysis = analyze_project(&root, &build_id(), &ProjectScanOptions::default()).unwrap();
+        assert_eq!(analysis.graph.modules().len(), 1);
+    }
+
+    #[test]
+    fn oversized_modules_are_skipped_rather_than_read() {
+        let (_dir, root) = project(&[("app/_uf.page.js", "// @flow\nconst a = 1;\n")]);
+        let options = ProjectScanOptions {
+            max_file_bytes: 4,
+            ..ProjectScanOptions::default()
+        };
+        let analysis = analyze_project(&root, &build_id(), &options).unwrap();
+        assert!(analysis.graph.modules().is_empty());
+    }
+
+    #[test]
+    fn router_files_become_server_entries() {
+        let (_dir, root) = project(&[
+            ("app/_uf.page.js", "import \"./data.js\";\n"),
+            ("app/data.js", "// @flow\n"),
+        ]);
+        let analysis = analyze_project(&root, &build_id(), &ProjectScanOptions::default()).unwrap();
+        assert!(
+            analysis
+                .graph
+                .module("app/data.js")
+                .unwrap()
+                .reachability
+                .is_reachable()
+        );
+    }
+
+    #[test]
+    fn extra_entries_are_honoured() {
+        let (_dir, root) = project(&[("app/entry.js", "\"use client\";\n")]);
+        let options = ProjectScanOptions {
+            extra_entries: vec![(Utf8PathBuf::from("app/entry.js"), EntryKind::Client)],
+            ..ProjectScanOptions::default()
+        };
+        let analysis = analyze_project(&root, &build_id(), &options).unwrap();
+        assert_eq!(analysis.client_bundle_root_count(), 1);
+    }
+
+    #[test]
+    fn analysing_the_same_project_twice_gives_the_same_manifest() {
+        let (_dir, root) = project(&[
+            ("app/_uf.page.js", "import \"./client/Counter.js\";\n"),
+            ("app/client/Counter.js", "\"use client\";\n"),
+        ]);
+        let first = analyze_project(&root, &build_id(), &ProjectScanOptions::default())
+            .unwrap()
+            .manifest()
+            .to_json()
+            .unwrap();
+        let second = analyze_project(&root, &build_id(), &ProjectScanOptions::default())
+            .unwrap()
+            .manifest()
+            .to_json()
+            .unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn a_non_utf8_module_is_reported_not_ignored() {
+        let (_dir, root) = project(&[("app/_uf.page.js", "// @flow\n")]);
+        fs::write(root.join("app/broken.js"), [0xff, 0xfe, 0xfd]).unwrap();
+        let error = analyze_project(&root, &build_id(), &ProjectScanOptions::default())
+            .expect_err("invalid utf-8 must be reported");
+        assert!(matches!(error, RscError::NonUtf8Source { .. }));
+    }
+}

--- a/crates/uf_rsc/src/scan.rs
+++ b/crates/uf_rsc/src/scan.rs
@@ -1,0 +1,1260 @@
+//! Single-pass token scanning for `.js` sources.
+//!
+//! The RSC analyses need four things out of a module: its directive prologue,
+//! its import specifiers, its exported bindings, and whether a server module
+//! reaches for a client-only API. All four are answered from one token vector
+//! produced by [`tokenize`], so a module is scanned exactly once.
+//!
+//! The scanner is deliberately a lexer and not a parser: it understands string,
+//! template, regular-expression and comment boundaries (so a `"use client"`
+//! inside a comment or a string is never mistaken for a directive) but it does
+//! not build an AST. Every place where that costs precision is documented at the
+//! function that pays the cost.
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+use uf_infra::{InlineVec, LineIndex};
+
+/// Inline list of import specifiers belonging to one module.
+pub type ImportList = InlineVec<ImportSpecifier, 8>;
+
+/// Inline list of exported bindings belonging to one module.
+pub type ExportList = InlineVec<ModuleExport, 8>;
+
+/// Inline list of client-only API uses found in one module.
+pub type ClientApiUseList = InlineVec<ClientApiUse, 4>;
+
+/// Longest source accepted by the scanner, in bytes.
+///
+/// Guards against unbounded allocation when a hostile or generated file is fed
+/// to `uf build`; larger files are reported as unscannable rather than parsed.
+pub const MAX_SOURCE_BYTES: usize = 8 * 1024 * 1024;
+
+/// React APIs that only exist inside the client bundle.
+///
+/// A Server Component that calls one of these fails at render time, which is the
+/// error class Next.js surfaces as "This React hook only works in a client
+/// component". The list is sorted so lookups can binary search it.
+pub const CLIENT_ONLY_APIS: &[&str] = &[
+    "createContext",
+    "useActionState",
+    "useCallback",
+    "useContext",
+    "useDebugValue",
+    "useDeferredValue",
+    "useEffect",
+    "useFormStatus",
+    "useImperativeHandle",
+    "useInsertionEffect",
+    "useLayoutEffect",
+    "useMemo",
+    "useOptimistic",
+    "useReducer",
+    "useRef",
+    "useState",
+    "useSyncExternalStore",
+    "useTransition",
+];
+
+/// Browser globals that only exist inside the client bundle.
+///
+/// Sorted for binary search.
+pub const CLIENT_ONLY_GLOBALS: &[&str] = &[
+    "alert",
+    "document",
+    "localStorage",
+    "navigator",
+    "sessionStorage",
+    "window",
+];
+
+/// How a module reached another module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ImportKind {
+    /// `import x from "..."` or a bare `import "..."`.
+    Static,
+    /// `export { x } from "..."` or `export * from "..."`.
+    ReExport,
+    /// `import("...")`.
+    Dynamic,
+    /// `require("...")`.
+    Require,
+}
+
+/// One import specifier as written in the source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportSpecifier {
+    /// The specifier text exactly as written, without quotes.
+    pub specifier: CompactString,
+    /// Syntactic form the specifier appeared in.
+    pub kind: ImportKind,
+    /// 1-based line the specifier appeared on.
+    pub line: u32,
+}
+
+/// Shape of an exported binding, as far as a lexer can tell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExportKind {
+    /// `export async function f()`, `export const f = async () => {}`.
+    AsyncFunction,
+    /// `export function f()`, `export const f = () => {}`, `export hook useF()`.
+    SyncFunction,
+    /// `export class C {}`.
+    Class,
+    /// Any other initializer: a literal, an object, a call result.
+    Value,
+    /// `export { x } from "./other.js"`, where the shape lives in another module.
+    ReExport,
+}
+
+impl ExportKind {
+    /// Whether the export is callable at all.
+    pub fn is_function(self) -> bool {
+        matches!(self, Self::AsyncFunction | Self::SyncFunction)
+    }
+}
+
+/// One exported binding of a module.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModuleExport {
+    /// Exported name; `default` for a default export.
+    pub name: CompactString,
+    /// Shape of the exported binding.
+    pub kind: ExportKind,
+    /// 1-based line the export was declared on.
+    pub line: u32,
+}
+
+/// One use of a client-only API inside a module.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientApiUse {
+    /// The API name, borrowed from [`CLIENT_ONLY_APIS`] or [`CLIENT_ONLY_GLOBALS`].
+    pub api: &'static str,
+    /// 1-based line of the use.
+    pub line: u32,
+    /// 1-based column of the use.
+    pub column: u32,
+}
+
+/// Collect the import specifiers of a module.
+pub fn scan_imports(source: &str) -> ImportList {
+    let tokens = tokenize(source);
+    let index = LineIndex::new(source);
+    imports_from_tokens(source, &tokens, &index)
+}
+
+/// Collect the exported bindings of a module.
+pub fn scan_exports(source: &str) -> ExportList {
+    let tokens = tokenize(source);
+    let index = LineIndex::new(source);
+    exports_from_tokens(source, &tokens, &index)
+}
+
+/// Collect client-only API uses inside a module.
+pub fn scan_client_api_uses(source: &str) -> ClientApiUseList {
+    let tokens = tokenize(source);
+    let index = LineIndex::new(source);
+    client_api_uses_from_tokens(source, &tokens, &index)
+}
+
+/// Clamp a `usize` position into the `u32` used by diagnostics.
+pub(crate) fn clamp_u32(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TokenKind {
+    Ident,
+    String,
+    Template,
+    Number,
+    Regex,
+    /// `=>`, lexed as one token so it is never confused with `=` followed by `>`.
+    Arrow,
+    /// A single punctuation byte.
+    Punct(u8),
+    /// An unterminated string, template or comment.
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Token {
+    pub kind: TokenKind,
+    pub start: usize,
+    pub end: usize,
+    /// Whether a line terminator separates this token from the previous one.
+    pub newline_before: bool,
+}
+
+impl Token {
+    pub(crate) fn text<'a>(&self, source: &'a str) -> &'a str {
+        source.get(self.start..self.end).unwrap_or_default()
+    }
+
+    /// Content of a string or template token, without the surrounding quotes.
+    pub(crate) fn quoted_content<'a>(&self, source: &'a str) -> &'a str {
+        if self.end < self.start + 2 {
+            return "";
+        }
+        source.get(self.start + 1..self.end - 1).unwrap_or_default()
+    }
+
+    pub(crate) fn is_punct(&self, byte: u8) -> bool {
+        self.kind == TokenKind::Punct(byte)
+    }
+}
+
+/// Tokenize a module, skipping a BOM and a leading `#!` line.
+pub(crate) fn tokenize(source: &str) -> Vec<Token> {
+    let bytes = source.as_bytes();
+    if bytes.len() > MAX_SOURCE_BYTES {
+        return Vec::new();
+    }
+
+    let mut tokens: Vec<Token> = Vec::with_capacity(bytes.len() / 6 + 8);
+    let mut cursor = skip_bom(bytes);
+    let mut newline_before = false;
+
+    if bytes[cursor..].starts_with(b"#!") {
+        cursor = line_end(bytes, cursor);
+    }
+
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+
+        if let Some(next) = line_terminator_width(bytes, cursor) {
+            newline_before = true;
+            cursor += next;
+            continue;
+        }
+        if let Some(width) = whitespace_width(bytes, cursor) {
+            cursor += width;
+            continue;
+        }
+        if byte == b'/' && bytes.get(cursor + 1) == Some(&b'/') {
+            cursor = line_end(bytes, cursor);
+            continue;
+        }
+        if byte == b'/' && bytes.get(cursor + 1) == Some(&b'*') {
+            let (end, saw_newline) = block_comment_end(bytes, cursor);
+            newline_before |= saw_newline;
+            cursor = end;
+            continue;
+        }
+
+        let start = cursor;
+        let kind = lex_token(bytes, &mut cursor, tokens.last(), source);
+        tokens.push(Token {
+            kind,
+            start,
+            end: cursor,
+            newline_before,
+        });
+        newline_before = false;
+    }
+
+    tokens
+}
+
+fn skip_bom(bytes: &[u8]) -> usize {
+    if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
+        3
+    } else {
+        0
+    }
+}
+
+/// Width in bytes of a line terminator at `at`, if there is one.
+///
+/// Handles LF, CR, CRLF and the two non-ASCII terminators U+2028 and U+2029.
+fn line_terminator_width(bytes: &[u8], at: usize) -> Option<usize> {
+    match bytes[at] {
+        b'\n' => Some(1),
+        b'\r' => {
+            if bytes.get(at + 1) == Some(&b'\n') {
+                Some(2)
+            } else {
+                Some(1)
+            }
+        }
+        0xe2 if bytes.get(at + 1) == Some(&0x80)
+            && matches!(bytes.get(at + 2), Some(0xa8 | 0xa9)) =>
+        {
+            Some(3)
+        }
+        _ => None,
+    }
+}
+
+/// Width in bytes of non-line-terminator whitespace at `at`, if there is any.
+fn whitespace_width(bytes: &[u8], at: usize) -> Option<usize> {
+    match bytes[at] {
+        b' ' | b'\t' | 0x0b | 0x0c => Some(1),
+        // U+00A0 NO-BREAK SPACE.
+        0xc2 if bytes.get(at + 1) == Some(&0xa0) => Some(2),
+        // U+FEFF ZERO WIDTH NO-BREAK SPACE, legal whitespace away from the BOM.
+        0xef if bytes.get(at + 1) == Some(&0xbb) && bytes.get(at + 2) == Some(&0xbf) => Some(3),
+        _ => None,
+    }
+}
+
+fn line_end(bytes: &[u8], from: usize) -> usize {
+    let mut cursor = from;
+    while cursor < bytes.len() && line_terminator_width(bytes, cursor).is_none() {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn block_comment_end(bytes: &[u8], from: usize) -> (usize, bool) {
+    let mut cursor = from + 2;
+    let mut saw_newline = false;
+    while cursor < bytes.len() {
+        if line_terminator_width(bytes, cursor).is_some() {
+            saw_newline = true;
+        }
+        if bytes[cursor] == b'*' && bytes.get(cursor + 1) == Some(&b'/') {
+            return (cursor + 2, saw_newline);
+        }
+        cursor += 1;
+    }
+    (bytes.len(), saw_newline)
+}
+
+fn lex_token(bytes: &[u8], cursor: &mut usize, prev: Option<&Token>, source: &str) -> TokenKind {
+    let byte = bytes[*cursor];
+    match byte {
+        b'"' | b'\'' => lex_quoted(bytes, cursor, byte),
+        b'`' => lex_template(bytes, cursor),
+        b'0'..=b'9' => {
+            lex_number(bytes, cursor);
+            TokenKind::Number
+        }
+        b'.' if matches!(bytes.get(*cursor + 1), Some(b'0'..=b'9')) => {
+            lex_number(bytes, cursor);
+            TokenKind::Number
+        }
+        b'/' if regex_allowed(prev, source) => match lex_regex(bytes, cursor) {
+            true => TokenKind::Regex,
+            false => {
+                *cursor += 1;
+                TokenKind::Punct(b'/')
+            }
+        },
+        b'=' if bytes.get(*cursor + 1) == Some(&b'>') => {
+            *cursor += 2;
+            TokenKind::Arrow
+        }
+        _ if is_ident_start(byte) => {
+            *cursor += 1;
+            while *cursor < bytes.len() && is_ident_part(bytes[*cursor]) {
+                *cursor += 1;
+            }
+            TokenKind::Ident
+        }
+        _ => {
+            *cursor += 1;
+            TokenKind::Punct(byte)
+        }
+    }
+}
+
+fn lex_quoted(bytes: &[u8], cursor: &mut usize, quote: u8) -> TokenKind {
+    let mut at = *cursor + 1;
+    while at < bytes.len() {
+        let byte = bytes[at];
+        if byte == b'\\' {
+            at += 2;
+            continue;
+        }
+        if byte == quote {
+            *cursor = at + 1;
+            return TokenKind::String;
+        }
+        if line_terminator_width(bytes, at).is_some() {
+            break;
+        }
+        at += 1;
+    }
+    *cursor = at.min(bytes.len());
+    TokenKind::Invalid
+}
+
+fn lex_template(bytes: &[u8], cursor: &mut usize) -> TokenKind {
+    let mut at = *cursor + 1;
+    let mut depth = 0usize;
+    while at < bytes.len() {
+        let byte = bytes[at];
+        if byte == b'\\' {
+            at += 2;
+            continue;
+        }
+        if depth == 0 && byte == b'`' {
+            *cursor = at + 1;
+            return TokenKind::Template;
+        }
+        if byte == b'$' && bytes.get(at + 1) == Some(&b'{') {
+            depth += 1;
+            at += 2;
+            continue;
+        }
+        if depth > 0 && byte == b'}' {
+            depth -= 1;
+        }
+        at += 1;
+    }
+    *cursor = bytes.len();
+    TokenKind::Invalid
+}
+
+fn lex_number(bytes: &[u8], cursor: &mut usize) {
+    let mut at = *cursor;
+    while at < bytes.len() {
+        let byte = bytes[at];
+        if byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'.' {
+            at += 1;
+            continue;
+        }
+        if (byte == b'+' || byte == b'-') && at > *cursor {
+            let previous = bytes[at - 1];
+            if previous == b'e' || previous == b'E' {
+                at += 1;
+                continue;
+            }
+        }
+        break;
+    }
+    *cursor = at;
+}
+
+/// Consume a regular-expression literal, returning whether one was found.
+fn lex_regex(bytes: &[u8], cursor: &mut usize) -> bool {
+    let mut at = *cursor + 1;
+    let mut in_class = false;
+    while at < bytes.len() {
+        let byte = bytes[at];
+        if byte == b'\\' {
+            at += 2;
+            continue;
+        }
+        if line_terminator_width(bytes, at).is_some() {
+            return false;
+        }
+        match byte {
+            b'[' => in_class = true,
+            b']' => in_class = false,
+            b'/' if !in_class => {
+                at += 1;
+                while at < bytes.len() && is_ident_part(bytes[at]) {
+                    at += 1;
+                }
+                *cursor = at;
+                return true;
+            }
+            _ => {}
+        }
+        at += 1;
+    }
+    false
+}
+
+/// Whether a `/` at this position starts a regular expression rather than a division.
+fn regex_allowed(prev: Option<&Token>, source: &str) -> bool {
+    let Some(prev) = prev else {
+        return true;
+    };
+    match prev.kind {
+        TokenKind::Arrow => true,
+        TokenKind::Ident => matches!(
+            prev.text(source),
+            "await"
+                | "case"
+                | "delete"
+                | "do"
+                | "else"
+                | "in"
+                | "instanceof"
+                | "new"
+                | "of"
+                | "return"
+                | "throw"
+                | "typeof"
+                | "void"
+                | "yield"
+        ),
+        TokenKind::Punct(byte) => !matches!(byte, b')' | b']' | b'}'),
+        _ => false,
+    }
+}
+
+fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$' || byte >= 0x80
+}
+
+fn is_ident_part(byte: u8) -> bool {
+    is_ident_start(byte) || byte.is_ascii_digit()
+}
+
+pub(crate) fn imports_from_tokens(source: &str, tokens: &[Token], index: &LineIndex) -> ImportList {
+    let mut imports = ImportList::new();
+
+    for (position, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::Ident {
+            continue;
+        }
+        match token.text(source) {
+            "import" => {
+                if !starts_statement(tokens, position) && !is_dynamic_import(tokens, position) {
+                    continue;
+                }
+                if let Some(next) = tokens.get(position + 1) {
+                    if next.kind == TokenKind::String {
+                        push_specifier(&mut imports, source, next, ImportKind::Static, index);
+                        continue;
+                    }
+                    if next.is_punct(b'(') {
+                        if let Some(literal) = tokens.get(position + 2)
+                            && literal.kind == TokenKind::String
+                        {
+                            push_specifier(
+                                &mut imports,
+                                source,
+                                literal,
+                                ImportKind::Dynamic,
+                                index,
+                            );
+                        }
+                        continue;
+                    }
+                }
+                if let Some(literal) = find_from_clause(source, tokens, position) {
+                    push_specifier(&mut imports, source, literal, ImportKind::Static, index);
+                }
+            }
+            "export" => {
+                if !starts_statement(tokens, position) {
+                    continue;
+                }
+                if let Some(literal) = find_from_clause(source, tokens, position) {
+                    push_specifier(&mut imports, source, literal, ImportKind::ReExport, index);
+                }
+            }
+            "require" => {
+                let Some(open) = tokens.get(position + 1) else {
+                    continue;
+                };
+                if !open.is_punct(b'(') {
+                    continue;
+                }
+                if let Some(literal) = tokens.get(position + 2)
+                    && literal.kind == TokenKind::String
+                {
+                    push_specifier(&mut imports, source, literal, ImportKind::Require, index);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    imports
+}
+
+fn push_specifier(
+    imports: &mut ImportList,
+    source: &str,
+    literal: &Token,
+    kind: ImportKind,
+    index: &LineIndex,
+) {
+    let position = index.line_col(literal.start);
+    imports.push(ImportSpecifier {
+        specifier: CompactString::from(literal.quoted_content(source)),
+        kind,
+        line: clamp_u32(position.line),
+    });
+}
+
+/// Find the string literal of a `from "..."` clause started at `position`.
+fn find_from_clause<'a>(source: &str, tokens: &'a [Token], position: usize) -> Option<&'a Token> {
+    let mut at = position + 1;
+    let limit = (position + 512).min(tokens.len());
+    while at < limit {
+        let token = &tokens[at];
+        if token.is_punct(b';') {
+            return None;
+        }
+        if token.kind == TokenKind::Ident && token.text(source) == "from" {
+            let literal = tokens.get(at + 1)?;
+            return (literal.kind == TokenKind::String).then_some(literal);
+        }
+        at += 1;
+    }
+    None
+}
+
+fn is_dynamic_import(tokens: &[Token], position: usize) -> bool {
+    tokens
+        .get(position + 1)
+        .is_some_and(|token| token.is_punct(b'('))
+}
+
+/// Whether the token at `position` begins a statement.
+pub(crate) fn starts_statement(tokens: &[Token], position: usize) -> bool {
+    match position.checked_sub(1) {
+        None => true,
+        Some(previous) => {
+            let token = &tokens[previous];
+            token.is_punct(b';') || token.is_punct(b'{') || token.is_punct(b'}')
+        }
+    }
+}
+
+pub(crate) fn exports_from_tokens(source: &str, tokens: &[Token], index: &LineIndex) -> ExportList {
+    let mut exports = ExportList::new();
+    let locals = local_bindings(source, tokens);
+
+    for (position, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::Ident || token.text(source) != "export" {
+            continue;
+        }
+        if !starts_statement(tokens, position) {
+            continue;
+        }
+        let line = clamp_u32(index.line_col(token.start).line);
+        collect_export(source, tokens, position, line, &locals, &mut exports);
+    }
+
+    exports
+}
+
+fn collect_export(
+    source: &str,
+    tokens: &[Token],
+    position: usize,
+    line: u32,
+    locals: &[(CompactString, ExportKind)],
+    exports: &mut ExportList,
+) {
+    let Some(next) = tokens.get(position + 1) else {
+        return;
+    };
+
+    if next.is_punct(b'*') {
+        return;
+    }
+
+    if next.is_punct(b'{') {
+        let re_export = find_from_clause(source, tokens, position).is_some();
+        let mut at = position + 2;
+        let mut pending: Option<&Token> = None;
+        while at < tokens.len() && !tokens[at].is_punct(b'}') {
+            let token = &tokens[at];
+            if token.kind == TokenKind::Ident {
+                if token.text(source) == "as" {
+                    pending = None;
+                    at += 1;
+                    continue;
+                }
+                pending = Some(token);
+            }
+            if token.is_punct(b',')
+                && let Some(name) = pending.take()
+            {
+                push_named_export(source, name, line, re_export, locals, exports);
+            }
+            at += 1;
+        }
+        if let Some(name) = pending.take() {
+            push_named_export(source, name, line, re_export, locals, exports);
+        }
+        return;
+    }
+
+    if next.kind != TokenKind::Ident {
+        return;
+    }
+
+    match next.text(source) {
+        "default" => {
+            let kind = initializer_kind(source, tokens, position + 2);
+            exports.push(ModuleExport {
+                name: CompactString::const_new("default"),
+                kind,
+                line,
+            });
+        }
+        "type" | "interface" | "opaque" | "declare" | "enum" => {}
+        "async" => {
+            if let Some(name) = declaration_name(source, tokens, position + 3) {
+                exports.push(ModuleExport {
+                    name,
+                    kind: ExportKind::AsyncFunction,
+                    line,
+                });
+            }
+        }
+        "function" | "hook" | "component" => {
+            if let Some(name) = declaration_name(source, tokens, position + 2) {
+                exports.push(ModuleExport {
+                    name,
+                    kind: ExportKind::SyncFunction,
+                    line,
+                });
+            }
+        }
+        "class" => {
+            if let Some(name) = declaration_name(source, tokens, position + 2) {
+                exports.push(ModuleExport {
+                    name,
+                    kind: ExportKind::Class,
+                    line,
+                });
+            }
+        }
+        "const" | "let" | "var" => {
+            collect_declarators(source, tokens, position + 2, line, exports);
+        }
+        _ => {}
+    }
+}
+
+fn push_named_export(
+    source: &str,
+    name: &Token,
+    line: u32,
+    re_export: bool,
+    locals: &[(CompactString, ExportKind)],
+    exports: &mut ExportList,
+) {
+    let text = name.text(source);
+    let kind = if re_export {
+        ExportKind::ReExport
+    } else {
+        locals
+            .iter()
+            .find(|(local, _)| local == text)
+            .map_or(ExportKind::Value, |(_, kind)| *kind)
+    };
+    exports.push(ModuleExport {
+        name: CompactString::from(text),
+        kind,
+        line,
+    });
+}
+
+fn declaration_name(source: &str, tokens: &[Token], position: usize) -> Option<CompactString> {
+    let token = tokens.get(position)?;
+    (token.kind == TokenKind::Ident).then(|| CompactString::from(token.text(source)))
+}
+
+/// Walk the declarators of a `const a = 1, b = 2;` statement.
+///
+/// Destructuring patterns bind names the lexer cannot attribute to an
+/// initializer, so they are skipped rather than guessed at.
+fn collect_declarators(
+    source: &str,
+    tokens: &[Token],
+    position: usize,
+    line: u32,
+    exports: &mut ExportList,
+) {
+    let mut at = position;
+    loop {
+        let Some(name_token) = tokens.get(at) else {
+            return;
+        };
+        if name_token.kind != TokenKind::Ident {
+            return;
+        }
+        let name = CompactString::from(name_token.text(source));
+
+        let mut cursor = at + 1;
+        let mut depth = 0usize;
+        let mut kind = ExportKind::Value;
+        let mut assigned = false;
+        while cursor < tokens.len() {
+            let token = &tokens[cursor];
+            match token.kind {
+                TokenKind::Punct(b'(' | b'[' | b'{') => depth += 1,
+                TokenKind::Punct(b')' | b']' | b'}') => {
+                    if depth == 0 {
+                        break;
+                    }
+                    depth -= 1;
+                }
+                TokenKind::Punct(b'=') if depth == 0 && !assigned => {
+                    assigned = true;
+                    kind = initializer_kind(source, tokens, cursor + 1);
+                }
+                TokenKind::Punct(b',' | b';') if depth == 0 => break,
+                _ => {}
+            }
+            cursor += 1;
+        }
+
+        exports.push(ModuleExport { name, kind, line });
+
+        match tokens.get(cursor) {
+            Some(token) if token.is_punct(b',') => at = cursor + 1,
+            _ => return,
+        }
+    }
+}
+
+/// Classify the initializer expression starting at `position`.
+///
+/// Server-action factories are transparent: `serverAction(async () => {})` is an
+/// async function for the purposes of the React server-action contract, so a
+/// call expression is classified by its first argument.
+fn initializer_kind(source: &str, tokens: &[Token], position: usize) -> ExportKind {
+    initializer_kind_inner(source, tokens, position, 0)
+}
+
+fn initializer_kind_inner(
+    source: &str,
+    tokens: &[Token],
+    position: usize,
+    depth: u32,
+) -> ExportKind {
+    if depth > 4 {
+        return ExportKind::Value;
+    }
+    let Some(token) = tokens.get(position) else {
+        return ExportKind::Value;
+    };
+
+    if token.kind == TokenKind::Ident {
+        match token.text(source) {
+            "async" => {
+                return ExportKind::AsyncFunction;
+            }
+            "function" | "hook" | "component" => return ExportKind::SyncFunction,
+            "class" => return ExportKind::Class,
+            _ => {}
+        }
+        if tokens
+            .get(position + 1)
+            .is_some_and(|next| next.is_punct(b'('))
+        {
+            return initializer_kind_inner(source, tokens, position + 2, depth + 1);
+        }
+        if tokens
+            .get(position + 1)
+            .is_some_and(|next| next.kind == TokenKind::Arrow)
+        {
+            return ExportKind::SyncFunction;
+        }
+        return ExportKind::Value;
+    }
+
+    if token.is_punct(b'(')
+        && let Some(close) = matching_close(tokens, position, b'(', b')')
+    {
+        // A Flow return type may sit between `)` and `=>`.
+        let mut at = close + 1;
+        let limit = (close + 64).min(tokens.len());
+        while at < limit {
+            if tokens[at].kind == TokenKind::Arrow {
+                return ExportKind::SyncFunction;
+            }
+            if tokens[at].is_punct(b';') || tokens[at].is_punct(b',') {
+                break;
+            }
+            at += 1;
+        }
+    }
+
+    ExportKind::Value
+}
+
+/// Index of the token closing the group opened at `position`.
+pub(crate) fn matching_close(
+    tokens: &[Token],
+    position: usize,
+    open: u8,
+    close: u8,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    for (at, token) in tokens.iter().enumerate().skip(position) {
+        if token.is_punct(open) {
+            depth += 1;
+        } else if token.is_punct(close) {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(at);
+            }
+        }
+    }
+    None
+}
+
+/// Index of the token opening the group closed at `position`.
+pub(crate) fn matching_open(
+    tokens: &[Token],
+    position: usize,
+    open: u8,
+    close: u8,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut at = position;
+    loop {
+        let token = tokens.get(at)?;
+        if token.is_punct(close) {
+            depth += 1;
+        } else if token.is_punct(open) {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(at);
+            }
+        }
+        at = at.checked_sub(1)?;
+    }
+}
+
+/// Collect top-level `function`/`class`/`const` bindings so `export { foo }` can
+/// be classified without a second pass over the source.
+fn local_bindings(source: &str, tokens: &[Token]) -> Vec<(CompactString, ExportKind)> {
+    let mut locals = Vec::new();
+    for (position, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::Ident || !starts_statement(tokens, position) {
+            continue;
+        }
+        match token.text(source) {
+            "async" => {
+                if tokens
+                    .get(position + 1)
+                    .is_some_and(|next| next.kind == TokenKind::Ident)
+                    && let Some(name) = declaration_name(source, tokens, position + 2)
+                {
+                    locals.push((name, ExportKind::AsyncFunction));
+                }
+            }
+            "function" | "hook" | "component" => {
+                if let Some(name) = declaration_name(source, tokens, position + 1) {
+                    locals.push((name, ExportKind::SyncFunction));
+                }
+            }
+            "class" => {
+                if let Some(name) = declaration_name(source, tokens, position + 1) {
+                    locals.push((name, ExportKind::Class));
+                }
+            }
+            "const" | "let" | "var" => {
+                let mut declarators = ExportList::new();
+                collect_declarators(source, tokens, position + 1, 0, &mut declarators);
+                locals.extend(
+                    declarators
+                        .into_iter()
+                        .map(|export| (export.name, export.kind)),
+                );
+            }
+            _ => {}
+        }
+    }
+    locals
+}
+
+pub(crate) fn client_api_uses_from_tokens(
+    source: &str,
+    tokens: &[Token],
+    index: &LineIndex,
+) -> ClientApiUseList {
+    let mut uses = ClientApiUseList::new();
+    for (position, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::Ident {
+            continue;
+        }
+        let text = token.text(source);
+        if is_declaration_site(source, tokens, position) {
+            continue;
+        }
+
+        let matched = if tokens
+            .get(position + 1)
+            .is_some_and(|next| next.is_punct(b'('))
+        {
+            CLIENT_ONLY_APIS
+                .binary_search(&text)
+                .ok()
+                .map(|found| CLIENT_ONLY_APIS[found])
+        } else {
+            None
+        };
+
+        let matched = matched.or_else(|| {
+            if position
+                .checked_sub(1)
+                .is_some_and(|previous| tokens[previous].is_punct(b'.'))
+            {
+                return None;
+            }
+            CLIENT_ONLY_GLOBALS
+                .binary_search(&text)
+                .ok()
+                .map(|found| CLIENT_ONLY_GLOBALS[found])
+        });
+
+        if let Some(api) = matched {
+            let position = index.line_col(token.start);
+            uses.push(ClientApiUse {
+                api,
+                line: clamp_u32(position.line),
+                column: clamp_u32(position.column),
+            });
+        }
+    }
+    uses
+}
+
+/// Whether the identifier at `position` is being declared rather than used.
+fn is_declaration_site(source: &str, tokens: &[Token], position: usize) -> bool {
+    let Some(previous) = position.checked_sub(1) else {
+        return false;
+    };
+    let token = &tokens[previous];
+    token.kind == TokenKind::Ident
+        && matches!(
+            token.text(source),
+            "function" | "hook" | "component" | "class" | "const" | "let" | "var" | "import"
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(source: &str) -> Vec<TokenKind> {
+        tokenize(source)
+            .into_iter()
+            .map(|token| token.kind)
+            .collect()
+    }
+
+    #[test]
+    fn tokenizes_identifiers_and_punctuation() {
+        assert_eq!(
+            kinds("const a = 1;"),
+            vec![
+                TokenKind::Ident,
+                TokenKind::Ident,
+                TokenKind::Punct(b'='),
+                TokenKind::Number,
+                TokenKind::Punct(b';'),
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_a_byte_order_mark_before_the_first_token() {
+        let tokens = tokenize("\u{feff}\"use client\";");
+        assert_eq!(tokens[0].kind, TokenKind::String);
+        assert_eq!(
+            tokens[0].quoted_content("\u{feff}\"use client\";"),
+            "use client"
+        );
+    }
+
+    #[test]
+    fn skips_a_shebang_line() {
+        let source = "#!/usr/bin/env uf\n\"use client\";";
+        let tokens = tokenize(source);
+        assert_eq!(tokens[0].kind, TokenKind::String);
+        assert!(tokens[0].newline_before);
+    }
+
+    #[test]
+    fn lexes_arrow_as_one_token() {
+        assert_eq!(
+            kinds("() => 1"),
+            vec![
+                TokenKind::Punct(b'('),
+                TokenKind::Punct(b')'),
+                TokenKind::Arrow,
+                TokenKind::Number,
+            ]
+        );
+    }
+
+    #[test]
+    fn does_not_see_directives_inside_comments() {
+        let source = "/* \"use client\"; */ const a = 1;";
+        assert!(!kinds(source).contains(&TokenKind::String));
+    }
+
+    #[test]
+    fn treats_unterminated_strings_as_invalid() {
+        assert_eq!(kinds("\"use client\n"), vec![TokenKind::Invalid]);
+    }
+
+    #[test]
+    fn lexes_regex_literals_without_swallowing_quotes() {
+        let source = "const re = /[\"']/; const a = 1;";
+        let tokens = tokenize(source);
+        assert!(tokens.iter().any(|token| token.kind == TokenKind::Regex));
+        assert!(!tokens.iter().any(|token| token.kind == TokenKind::String));
+    }
+
+    #[test]
+    fn handles_crlf_line_endings() {
+        let source = "\"use client\";\r\nconst a = 1;\r\n";
+        let tokens = tokenize(source);
+        assert_eq!(tokens[0].quoted_content(source), "use client");
+        assert!(tokens[2].newline_before);
+    }
+
+    #[test]
+    fn handles_template_literals_with_substitutions() {
+        let source = "const a = `x${ y }z`;";
+        assert!(kinds(source).contains(&TokenKind::Template));
+    }
+
+    #[test]
+    fn returns_no_tokens_for_oversized_sources() {
+        let source = "a".repeat(MAX_SOURCE_BYTES + 1);
+        assert!(tokenize(&source).is_empty());
+    }
+
+    #[test]
+    fn scans_static_dynamic_and_require_imports() {
+        let source = r#"
+import Counter from "./client/Counter.js";
+import "./side-effect.js";
+export { a } from "./re-export.js";
+const lazy = import("./lazy.js");
+const legacy = require("./legacy.js");
+"#;
+        let imports = scan_imports(source);
+        let specifiers: Vec<_> = imports
+            .iter()
+            .map(|import| (import.specifier.as_str(), import.kind))
+            .collect();
+        assert_eq!(
+            specifiers,
+            vec![
+                ("./client/Counter.js", ImportKind::Static),
+                ("./side-effect.js", ImportKind::Static),
+                ("./re-export.js", ImportKind::ReExport),
+                ("./lazy.js", ImportKind::Dynamic),
+                ("./legacy.js", ImportKind::Require),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_import_like_text_inside_strings() {
+        let imports = scan_imports("const doc = \"import x from './a.js'\";");
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn scans_export_shapes() {
+        let source = r#"
+export async function refresh() {}
+export function render() {}
+export const value = 1;
+export const handler = async () => {};
+export const wrapped = serverAction(async () => {});
+export class Widget {}
+export default async function () {}
+"#;
+        let exports = scan_exports(source);
+        let shapes: Vec<_> = exports
+            .iter()
+            .map(|export| (export.name.as_str(), export.kind))
+            .collect();
+        assert_eq!(
+            shapes,
+            vec![
+                ("refresh", ExportKind::AsyncFunction),
+                ("render", ExportKind::SyncFunction),
+                ("value", ExportKind::Value),
+                ("handler", ExportKind::AsyncFunction),
+                ("wrapped", ExportKind::AsyncFunction),
+                ("Widget", ExportKind::Class),
+                ("default", ExportKind::AsyncFunction),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolves_named_exports_through_local_declarations() {
+        let source =
+            "async function refresh() {}\nfunction render() {}\nexport { refresh, render };";
+        let exports = scan_exports(source);
+        assert_eq!(
+            exports
+                .iter()
+                .map(|export| (export.name.as_str(), export.kind))
+                .collect::<Vec<_>>(),
+            vec![
+                ("refresh", ExportKind::AsyncFunction),
+                ("render", ExportKind::SyncFunction),
+            ]
+        );
+    }
+
+    #[test]
+    fn named_re_exports_are_marked_as_re_exports() {
+        let exports = scan_exports("export { refresh } from \"./actions.js\";");
+        assert_eq!(exports[0].kind, ExportKind::ReExport);
+    }
+
+    #[test]
+    fn export_star_declares_no_named_binding() {
+        assert!(scan_exports("export * from \"./actions.js\";").is_empty());
+    }
+
+    #[test]
+    fn flow_type_exports_are_not_runtime_exports() {
+        assert!(scan_exports("export type Props = { a: number };").is_empty());
+    }
+
+    #[test]
+    fn flow_annotated_const_exports_keep_their_shape() {
+        let exports = scan_exports("export const run: () => Promise<void> = async () => {};");
+        assert_eq!(exports[0].kind, ExportKind::AsyncFunction);
+    }
+
+    #[test]
+    fn finds_client_only_hooks_and_globals() {
+        let source = "function Page() { const [a] = useState(1); window.scrollTo(0); }";
+        let uses = scan_client_api_uses(source);
+        let names: Vec<_> = uses.iter().map(|use_site| use_site.api).collect();
+        assert_eq!(names, vec!["useState", "window"]);
+    }
+
+    #[test]
+    fn does_not_flag_client_apis_in_comments_or_strings() {
+        let source = "// useState(1)\nconst doc = \"useState(1)\";";
+        assert!(scan_client_api_uses(source).is_empty());
+    }
+
+    #[test]
+    fn does_not_flag_a_local_declaration_named_like_a_hook() {
+        assert!(scan_client_api_uses("function useState() {}").is_empty());
+    }
+
+    #[test]
+    fn client_only_lists_are_sorted_for_binary_search() {
+        let mut sorted = CLIENT_ONLY_APIS.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(sorted, CLIENT_ONLY_APIS.to_vec());
+
+        let mut globals = CLIENT_ONLY_GLOBALS.to_vec();
+        globals.sort_unstable();
+        assert_eq!(globals, CLIENT_ONLY_GLOBALS.to_vec());
+    }
+
+    #[test]
+    fn empty_source_scans_cleanly() {
+        assert!(tokenize("").is_empty());
+        assert!(scan_imports("").is_empty());
+        assert!(scan_exports("").is_empty());
+        assert!(scan_client_api_uses("").is_empty());
+    }
+}

--- a/crates/uf_rsc/tests/fixtures/uf-rsc-manifest.json
+++ b/crates/uf_rsc/tests/fixtures/uf-rsc-manifest.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "engine": "uf-native",
+  "buildFingerprint": "71527ae95b8871ca4467cfe1c007937a061888fad13c7da20eb669bacb59fb0b",
+  "modules": [
+    {
+      "path": "app/_uf.page.js",
+      "environment": "server",
+      "reachability": "server-only",
+      "imports": [
+        "app/client/Counter.js",
+        "server/actions.js"
+      ],
+      "externalImports": [],
+      "exports": [
+        "default"
+      ]
+    },
+    {
+      "path": "app/client/Counter.js",
+      "environment": "client",
+      "reachability": "client-only",
+      "imports": [],
+      "externalImports": [
+        "@uniflowed/react"
+      ],
+      "exports": [
+        "default"
+      ]
+    },
+    {
+      "path": "server/actions.js",
+      "environment": "server-actions",
+      "reachability": "server-only",
+      "imports": [],
+      "externalImports": [],
+      "exports": [
+        "refresh"
+      ]
+    }
+  ],
+  "clientBoundaries": [
+    {
+      "importer": "app/_uf.page.js",
+      "module": "app/client/Counter.js"
+    }
+  ],
+  "clientBundleRoots": [
+    "app/client/Counter.js"
+  ],
+  "serverActions": [
+    {
+      "id": "8d7c75b4efb3c7d0fa4a9e14bffc1f04a65049708a390873e494523aaaf3a496",
+      "module": "server/actions.js",
+      "export": "refresh",
+      "kind": "module-export"
+    }
+  ],
+  "diagnostics": []
+}


### PR DESCRIPTION
`uf` renders every module on the server by default, but nothing computed the
RSC boundary. `uf_rsc` does, and `uf build` now emits
`dist/uf-rsc-manifest.json` alongside the existing build manifest.

Directive detection follows the ECMAScript directive prologue: a BOM, a `#!`
line, comments and blank lines may precede it; it must be a plain string
literal terminated by `;`, a line break, `}` or EOF; and the content is matched
against the raw source, so `"use  client"`, `"use client"` and
`"use client" + ""` are not directives. Each of those, plus a directive below
the prologue or written as a template literal, is reported as a typed
`DirectiveIssue` rather than silently ignored. A `"use server"` at the top of a
function body is modelled separately as a supported inline action.

The graph propagates server and client reachability with an explicit worklist
over `(module, colour)` pairs — no recursion, so cycles terminate — and reports
server-only imports reaching the client graph, client-only APIs called from
server modules, non-async and non-function `"use server"` exports, and imports
that climb out of the project root.

Action ids are HMAC-SHA256 keyed with the per-build id over a length-prefixed
`(module, export, kind)` message, so they cannot be derived from the source
alone and change with every build. Lookup scans the whole table with a
constant-time comparison and answers every failure — malformed, forged, unknown
or unreachable — with the same `UnknownAction`. The build id is never written to
the manifest; only a fingerprint derived from it is, and actions no client
boundary reaches are left out entirely.

174 tests, plus a criterion bench over a synthetic 5,000 module graph.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790916570&installation_model_id=422833&pr_number=10&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F10&signature=8555ccbde02283be885438879fe003f81c4e79a88729a0958aa4aff46b497242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->