### PR TITLE
feat(lint): union Flow's built-in lints with uf's own rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,9 @@ name = "uf_lint"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "phf",
  "rayon",
+ "serde",
  "thiserror",
  "uf_config",
  "uf_flow",

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -633,6 +633,14 @@ fn inspect(cwd: &Utf8Path, as_json: bool) -> Result<()> {
         println!("ui components: {}", ui_components().len());
         println!("tui components: {}", tui_contract().components.len());
         println!("hooks: {}", hook_descriptors().len());
+        println!(
+            "lint rules: {} ({} need the type checker)",
+            uf_lint::rules().len(),
+            uf_lint::rules()
+                .iter()
+                .filter(|descriptor| !descriptor.requirement.is_available())
+                .count()
+        );
     }
     Ok(())
 }
@@ -671,6 +679,7 @@ fn inspect_payload(resolved: &ResolvedConfig) -> Result<serde_json::Value> {
         "tui": tui_contract(),
         "vrt": vrt_plan(),
         "hooks": hook_descriptors(),
+        "lintRules": uf_lint::rules(),
         "ui": ui_components(),
         "engines": {
             "parser": "official-flow-parser",
@@ -903,10 +912,23 @@ fn print_lint_report(report: &uf_lint::LintReport) {
             diagnostic.message
         );
     }
+    if !report.unavailable.is_empty() {
+        let names = report
+            .unavailable
+            .iter()
+            .map(|unavailable| unavailable.rule)
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!(
+            "note: {} enabled rule(s) need Flow type inference, which uf does not implement yet: {names}",
+            report.unavailable.len()
+        );
+    }
     println!(
-        "uf lint: checked {} file(s), {} diagnostic(s)",
+        "uf lint: checked {} file(s), {} diagnostic(s), {} rule(s) not yet available",
         report.files_checked,
-        report.diagnostics.len()
+        report.diagnostics.len(),
+        report.unavailable.len()
     );
 }
 

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -1111,58 +1111,124 @@ pub struct LintConfig {
     pub rules: BTreeMap<CompactString, RuleLevel>,
 }
 
+/// Every lint rule `uf lint` ships, with the level uf applies out of the box.
+///
+/// `uf lint` is the union of Flow's built-in lint set (the `flow/` namespace) and
+/// uf's own framework rules, so this table has to name both. Flow itself defaults
+/// every built-in lint to `off`; uf does not, because a linter nobody switches on
+/// catches nothing. The policy, applied per row below:
+///
+/// - `error` when the pattern is a bug, an unsound escape hatch, or a rule whose
+///   fix is mechanical — the things a large Flow codebase cannot let accumulate.
+/// - `warn` when the pattern is only suspicious, is legitimate in some code, or
+///   when uf's current check covers a syntactic subset of what Flow checks.
+/// - `off` only where leaving a rule on would report the same violation twice.
+///
+/// Each rule's full rationale, category, and one-line description live on its
+/// `uf_lint::RuleDescriptor`; `uf_lint` has a test asserting this table and that
+/// catalogue agree exactly, in both directions, so the two cannot drift apart.
+const DEFAULT_LINT_RULES: [(&str, RuleLevel); 53] = [
+    // --- Flow built-in lints ------------------------------------------------
+    // Exactness must be stated, not inferred from a config flag.
+    ("flow/ambiguous-object-type", RuleLevel::Error),
+    // Reading named exports off a default import is a CommonJS interop bug.
+    ("flow/default-import-access", RuleLevel::Error),
+    // `bool` is a legacy alias for `boolean`; mechanical fix.
+    ("flow/deprecated-type", RuleLevel::Error),
+    // Legal, just confusing.
+    ("flow/export-renamed-default", RuleLevel::Warn),
+    // Flow's internal types are unstable across releases.
+    ("flow/internal-type", RuleLevel::Error),
+    // A namespace object is not a value.
+    ("flow/invalid-import-star-use", RuleLevel::Error),
+    // Rebinding a method to a foreign receiver is unsound.
+    ("flow/invalid-this-arg", RuleLevel::Error),
+    // Shadowing a builtin libdef breaks every consumer at once.
+    ("flow/libdef-override", RuleLevel::Error),
+    // uf ships ESM; mixing module systems defeats static analysis.
+    ("flow/mixed-import-and-require", RuleLevel::Error),
+    // A nested component remounts its whole subtree every render.
+    ("flow/nested-component", RuleLevel::Error),
+    // A nested hook gets a new identity every render.
+    ("flow/nested-hook", RuleLevel::Error),
+    // A mutable export is a live binding consumers cannot reason about.
+    ("flow/non-const-var-export", RuleLevel::Error),
+    // Only actionable mid-migration, so it must not block one.
+    ("flow/nonstrict-import", RuleLevel::Warn),
+    // Shadowing `div`/`span` silently changes what JSX means.
+    ("flow/react-intrinsic-overlap", RuleLevel::Error),
+    // The explicit form is verbose; the implicit form is not itself a bug.
+    ("flow/require-explicit-enum-checks", RuleLevel::Warn),
+    ("flow/require-explicit-enum-switch-cases", RuleLevel::Warn),
+    // The most common Flow-catchable production bug: `if (count)` skipping 0.
+    ("flow/sketchy-null", RuleLevel::Error),
+    // The typed variants stay off so one violation is not reported twice.
+    ("flow/sketchy-null-bigint", RuleLevel::Off),
+    ("flow/sketchy-null-bool", RuleLevel::Off),
+    ("flow/sketchy-null-mixed", RuleLevel::Off),
+    ("flow/sketchy-null-number", RuleLevel::Off),
+    ("flow/sketchy-null-string", RuleLevel::Off),
+    // `{count && <List />}` renders a literal `0`; user-visible bug.
+    ("flow/sketchy-number", RuleLevel::Error),
+    // Legal in methods, so warn rather than block.
+    ("flow/this-in-exported-function", RuleLevel::Warn),
+    // `any`/`Object`/`Function` switch the type checker off.
+    ("flow/unclear-type", RuleLevel::Error),
+    // Reading a field before the constructor finishes yields `undefined`.
+    ("flow/uninitialized-instance-property", RuleLevel::Error),
+    // Dead code, not a bug.
+    ("flow/unnecessary-invariant", RuleLevel::Warn),
+    // uf only sees the syntactic subset today.
+    ("flow/unnecessary-optional-chain", RuleLevel::Warn),
+    // Accessors hide side effects, but are legitimate in some UI code.
+    ("flow/unsafe-getters-setters", RuleLevel::Warn),
+    // `Object.assign` mutates its target and is unsound in Flow.
+    ("flow/unsafe-object-assign", RuleLevel::Error),
+    // An untyped dependency turns everything it exports into `any`.
+    ("flow/untyped-import", RuleLevel::Error),
+    ("flow/untyped-type-import", RuleLevel::Error),
+    // A floating promise swallows rejections and loses ordering.
+    ("flow/unused-promise", RuleLevel::Error),
+    // --- uf's own rules -----------------------------------------------------
+    // A file that does not parse cannot be checked at all.
+    ("flow/syntax", RuleLevel::Error),
+    ("uniflowed/no-tabs", RuleLevel::Error),
+    ("uniflowed/no-trailing-whitespace", RuleLevel::Error),
+    // Tasks belong in uf.config.js, never in a shelled-out package manager.
+    ("uniflowed/no-npm-script-invocation", RuleLevel::Error),
+    // A typo'd suppression silently stops enforcing a rule.
+    ("uniflowed/unknown-lint-suppression", RuleLevel::Error),
+    // Style preferences during the migration to Flow component/hook syntax.
+    ("react/component-syntax", RuleLevel::Warn),
+    ("react/hook-syntax", RuleLevel::Warn),
+    // Breaking the rules of hooks corrupts React's hook state.
+    ("react/hooks-rules", RuleLevel::Error),
+    // Framework routes are wired by name; `warn` while the scaffold migrates.
+    ("react/no-default-export-component", RuleLevel::Warn),
+    // Non-idempotent render breaks streaming SSR and hydration.
+    ("react/no-render-side-effects", RuleLevel::Error),
+    // Platform branches are a preference, not a correctness problem.
+    ("react-native/platform-split", RuleLevel::Warn),
+    // Leaking a secret into a client bundle is unrecoverable.
+    ("server/no-client-secret", RuleLevel::Error),
+    ("server/no-server-only-import-in-client", RuleLevel::Error),
+    // A misplaced directive is silently ignored; Next.js has shipped this bug.
+    ("server/use-client-directive-position", RuleLevel::Error),
+    ("server/use-server-actions", RuleLevel::Error),
+    ("router/reserved-files", RuleLevel::Error),
+    ("package/no-npm-scripts", RuleLevel::Error),
+    ("fetch/no-global-override", RuleLevel::Error),
+    // XSS and arbitrary code execution: never a warning.
+    ("security/no-dangerously-set-inner-html", RuleLevel::Error),
+    ("security/no-eval", RuleLevel::Error),
+];
+
 impl Default for LintConfig {
     fn default() -> Self {
         let mut rules = BTreeMap::new();
-        rules.insert(CompactString::const_new("flow/syntax"), RuleLevel::Error);
-        rules.insert(
-            CompactString::const_new("flow/type-aware/no-explicit-any"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("uniflowed/no-tabs"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("uniflowed/no-trailing-whitespace"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("react/component-syntax"),
-            RuleLevel::Warn,
-        );
-        rules.insert(
-            CompactString::const_new("react/hook-syntax"),
-            RuleLevel::Warn,
-        );
-        rules.insert(
-            CompactString::const_new("react-native/platform-split"),
-            RuleLevel::Warn,
-        );
-        rules.insert(
-            CompactString::const_new("react/no-render-side-effects"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("server/no-client-secret"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("server/use-server-actions"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("router/reserved-files"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("package/no-npm-scripts"),
-            RuleLevel::Error,
-        );
-        rules.insert(
-            CompactString::const_new("fetch/no-global-override"),
-            RuleLevel::Error,
-        );
+        for (rule, level) in DEFAULT_LINT_RULES {
+            rules.insert(CompactString::const_new(rule), level);
+        }
 
         Self {
             files: vec![

--- a/crates/uf_lint/Cargo.toml
+++ b/crates/uf_lint/Cargo.toml
@@ -12,7 +12,9 @@ authors.workspace = true
 uf_config = { path = "../uf_config" }
 uf_flow = { path = "../uf_flow" }
 uf_infra = { path = "../uf_infra" }
+phf.workspace = true
 rayon.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/uf_lint/benches/lint.rs
+++ b/crates/uf_lint/benches/lint.rs
@@ -1,22 +1,155 @@
 use std::hint::black_box;
 
-use criterion::{Criterion, criterion_group, criterion_main};
-use uf_config::UniflowedConfig;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use uf_config::{RuleLevel, UniflowedConfig};
+use uf_infra::CompactString;
 use uf_lint::{SourceFile, lint_sources};
 
-fn bench_lint_scan(c: &mut Criterion) {
-    let config = UniflowedConfig::default();
-    let files = (0..1_000)
+/// A module that touches every source-text rule in the catalogue, so the scan
+/// benchmark measures the real rule set rather than a happy-path fast exit.
+const RULE_HEAVY_MODULE: &str = r#"// @flow
+'use client';
+import { format } from '@uniflowed/intl';
+import { renderMarkdown } from '@uniflowed/markdown';
+
+type Props = {| +id: string, +title: string |};
+type Meta = { +tags: Array<string>, ... };
+
+opaque type Token = string;
+
+hook useTitle(props: Props): string {
+  const [title, setTitle] = useState(props.title);
+  useEffect(() => {
+    setTitle(format(props.title));
+  });
+  return title;
+}
+
+export component Article(props: Props) {
+  const title = useTitle(props);
+  const body = renderMarkdown(props.id);
+  return (
+    <article>
+      <h1>{title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: body }} />
+    </article>
+  );
+}
+
+export const helpers = {
+  merge(base: Meta, patch: Meta): Meta {
+    return { ...base, ...patch };
+  },
+};
+"#;
+
+/// The same module with a violation of most source-text rules, so the benchmark
+/// also measures the diagnostic-building path.
+const VIOLATING_MODULE: &str = r#"// @flow
+import { a } from './a.js';
+'use client';
+
+type Props = { id: any };
+
+export let counter = 0;
+
+const div = 1;
+
+class Box {
+  get value(): bool { return true; }
+}
+
+component Outer() {
+  component Inner() { return null; }
+  if (counter) {
+    const [x] = useState(0);
+  }
+  return <Inner />;
+}
+
+export default Outer;
+
+const merged = Object.assign({}, a);
+const legacy = require('./legacy.js');
+eval('boom');
+spawn('npm run build');
+"#;
+
+/// The default rule set with `flow/syntax` switched off.
+///
+/// `flow/syntax` hands the file to the official Flow parser (a QuickJS runtime
+/// inside `uf_flow`), which is a different subsystem with its own cost and its
+/// own scaling behaviour — at the time of writing it exhausts the JS stack when
+/// rayon fans a few hundred files across worker threads in an optimized build.
+/// Every other rule in the catalogue stays on, so these benchmarks measure the
+/// native scan on the real rule set rather than the embedded parser.
+fn scan_only_config() -> UniflowedConfig {
+    let mut config = UniflowedConfig::default();
+    config
+        .lint
+        .rules
+        .insert(CompactString::const_new("flow/syntax"), RuleLevel::Off);
+    config
+}
+
+fn corpus(module: &str, files: usize) -> Vec<SourceFile> {
+    (0..files)
         .map(|index| SourceFile {
             path: format!("app/route{index}/_uf.page.js"),
-            source: "// @flow\ncomponent Page() { return <main />; }\n".to_string(),
+            source: module.to_string(),
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+fn bench_lint_scan(c: &mut Criterion) {
+    let config = scan_only_config();
+    let files = corpus("// @flow\ncomponent Page() { return <main />; }\n", 1_000);
 
     c.bench_function("lint 1000 flow route files", |b| {
         b.iter(|| black_box(lint_sources(&files, &config).expect("lint")));
     });
 }
 
-criterion_group!(benches, bench_lint_scan);
+fn bench_rule_set_throughput(c: &mut Criterion) {
+    let config = scan_only_config();
+    let mut group = c.benchmark_group("lint_rule_set");
+
+    for (name, module) in [
+        ("clean", RULE_HEAVY_MODULE),
+        ("violating", VIOLATING_MODULE),
+    ] {
+        let files = corpus(module, 1_000);
+        let bytes = files.iter().map(|file| file.source.len() as u64).sum();
+        group.throughput(Throughput::Bytes(bytes));
+        group.bench_function(name, |b| {
+            b.iter(|| black_box(lint_sources(&files, &config).expect("lint")));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_suppression_scan(c: &mut Criterion) {
+    let config = scan_only_config();
+    let module = format!(
+        "// @flow\n// uf-lint-disable flow/unclear-type\n{}// uf-lint-enable flow/unclear-type\n",
+        "type A = any;\n".repeat(200)
+    );
+    let files = corpus(&module, 200);
+    let bytes = files.iter().map(|file| file.source.len() as u64).sum();
+
+    let mut group = c.benchmark_group("lint_suppressions");
+    group.throughput(Throughput::Bytes(bytes));
+    group.bench_function("block suppressed", |b| {
+        b.iter(|| black_box(lint_sources(&files, &config).expect("lint")));
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_lint_scan,
+    bench_rule_set_throughput,
+    bench_suppression_scan
+);
 criterion_main!(benches);

--- a/crates/uf_lint/src/flow_builtin.rs
+++ b/crates/uf_lint/src/flow_builtin.rs
@@ -1,0 +1,557 @@
+//! Flow's built-in lint set, mapped into uf's `flow/` rule-id namespace.
+//!
+//! # Where this list comes from
+//!
+//! The authoritative set is Flow's own `flow_lint_settings` crate — specifically
+//! `LintKind::as_str` (canonical spellings) and `LintKind::parse_from_str` (every
+//! spelling accepted in a `.flowconfig` `[lints]` section):
+//! <https://github.com/facebook/flow/blob/main/rust_port/crates/flow_lint_settings/src/lints.rs>
+//!
+//! It was cross-checked against the user-facing reference at
+//! <https://flow.org/en/docs/linting/rule-reference/>. Both were read on
+//! 2026-09-02; the two agree on every name below.
+//!
+//! Four names that circulate in older Flow write-ups are deliberately **absent**
+//! because current Flow does not accept them, and inventing them here would make
+//! `uf lint` reject configs Flow itself accepts (and vice versa):
+//!
+//! - `implicit-inexact-object` — removed when Flow moved to exact-by-default;
+//!   the surviving check is [`FlowBuiltinLint::AmbiguousObjectType`].
+//! - `unused-promise-in-async-scope` — renamed to `unused-promise`.
+//! - `require-explicit-import-type` — never a Flow lint.
+//! - `deprecated-class-static-blocks` — never a Flow lint.
+//!
+//! # Umbrella names
+//!
+//! Flow lets one configured name cover several reportable lints. `sketchy-null`
+//! is the only such umbrella that survives here (see
+//! [`FlowBuiltinLint::members`]). `sketchy-number` and `deprecated-type` each
+//! have exactly one member in Flow (`sketchy-number-and`, `deprecated-type-bool`),
+//! so uf keeps the short documented spelling as canonical and accepts the long
+//! one as an alias in [`FlowBuiltinLint::from_str`].
+
+use std::str::FromStr;
+
+use thiserror::Error;
+use uf_infra::CompactString;
+
+/// A single Flow built-in lint, identified by the name Flow accepts in `[lints]`.
+///
+/// Variants are ordered alphabetically by lint name, and that order is load
+/// bearing: [`LINTS`] is indexed by `self as usize`, which is what keeps
+/// [`FlowBuiltinLint::as_rule_id`] allocation free and branch free.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum FlowBuiltinLint {
+    /// `ambiguous-object-type`
+    AmbiguousObjectType,
+    /// `default-import-access`
+    DefaultImportAccess,
+    /// `deprecated-type`
+    DeprecatedType,
+    /// `export-renamed-default`
+    ExportRenamedDefault,
+    /// `internal-type`
+    InternalType,
+    /// `invalid-import-star-use`
+    InvalidImportStarUse,
+    /// `invalid-this-arg`
+    InvalidThisArg,
+    /// `libdef-override`
+    LibdefOverride,
+    /// `mixed-import-and-require`
+    MixedImportAndRequire,
+    /// `nested-component`
+    NestedComponent,
+    /// `nested-hook`
+    NestedHook,
+    /// `non-const-var-export`
+    NonConstVarExport,
+    /// `nonstrict-import`
+    NonstrictImport,
+    /// `react-intrinsic-overlap`
+    ReactIntrinsicOverlap,
+    /// `require-explicit-enum-checks`
+    RequireExplicitEnumChecks,
+    /// `require-explicit-enum-switch-cases`
+    RequireExplicitEnumSwitchCases,
+    /// `sketchy-null` — umbrella over the five typed variants.
+    SketchyNull,
+    /// `sketchy-null-bigint`
+    SketchyNullBigInt,
+    /// `sketchy-null-bool`
+    SketchyNullBool,
+    /// `sketchy-null-mixed`
+    SketchyNullMixed,
+    /// `sketchy-null-number`
+    SketchyNullNumber,
+    /// `sketchy-null-string`
+    SketchyNullString,
+    /// `sketchy-number` — Flow spells the single member `sketchy-number-and`.
+    SketchyNumber,
+    /// `this-in-exported-function`
+    ThisInExportedFunction,
+    /// `unclear-type`
+    UnclearType,
+    /// `uninitialized-instance-property`
+    UninitializedInstanceProperty,
+    /// `unnecessary-invariant`
+    UnnecessaryInvariant,
+    /// `unnecessary-optional-chain`
+    UnnecessaryOptionalChain,
+    /// `unsafe-getters-setters`
+    UnsafeGettersSetters,
+    /// `unsafe-object-assign`
+    UnsafeObjectAssign,
+    /// `untyped-import`
+    UntypedImport,
+    /// `untyped-type-import`
+    UntypedTypeImport,
+    /// `unused-promise`
+    UnusedPromise,
+}
+
+/// One row of the name/id table backing [`FlowBuiltinLint`].
+#[derive(Debug, Clone, Copy)]
+struct LintEntry {
+    lint: FlowBuiltinLint,
+    name: &'static str,
+    rule_id: &'static str,
+    members: &'static [FlowBuiltinLint],
+}
+
+const fn leaf(lint: FlowBuiltinLint, name: &'static str, rule_id: &'static str) -> LintEntry {
+    LintEntry {
+        lint,
+        name,
+        rule_id,
+        members: &[],
+    }
+}
+
+/// Members of the `sketchy-null` umbrella, in the order Flow expands them.
+const SKETCHY_NULL_MEMBERS: &[FlowBuiltinLint] = &[
+    FlowBuiltinLint::SketchyNullBool,
+    FlowBuiltinLint::SketchyNullString,
+    FlowBuiltinLint::SketchyNullNumber,
+    FlowBuiltinLint::SketchyNullBigInt,
+    FlowBuiltinLint::SketchyNullMixed,
+];
+
+/// The single source of truth for Flow lint name ↔ uf rule id.
+///
+/// Indexed by `FlowBuiltinLint as usize`; `lint_table_is_indexed_by_discriminant`
+/// pins that invariant down.
+const LINTS: [LintEntry; FlowBuiltinLint::COUNT] = [
+    leaf(
+        FlowBuiltinLint::AmbiguousObjectType,
+        "ambiguous-object-type",
+        "flow/ambiguous-object-type",
+    ),
+    leaf(
+        FlowBuiltinLint::DefaultImportAccess,
+        "default-import-access",
+        "flow/default-import-access",
+    ),
+    leaf(
+        FlowBuiltinLint::DeprecatedType,
+        "deprecated-type",
+        "flow/deprecated-type",
+    ),
+    leaf(
+        FlowBuiltinLint::ExportRenamedDefault,
+        "export-renamed-default",
+        "flow/export-renamed-default",
+    ),
+    leaf(
+        FlowBuiltinLint::InternalType,
+        "internal-type",
+        "flow/internal-type",
+    ),
+    leaf(
+        FlowBuiltinLint::InvalidImportStarUse,
+        "invalid-import-star-use",
+        "flow/invalid-import-star-use",
+    ),
+    leaf(
+        FlowBuiltinLint::InvalidThisArg,
+        "invalid-this-arg",
+        "flow/invalid-this-arg",
+    ),
+    leaf(
+        FlowBuiltinLint::LibdefOverride,
+        "libdef-override",
+        "flow/libdef-override",
+    ),
+    leaf(
+        FlowBuiltinLint::MixedImportAndRequire,
+        "mixed-import-and-require",
+        "flow/mixed-import-and-require",
+    ),
+    leaf(
+        FlowBuiltinLint::NestedComponent,
+        "nested-component",
+        "flow/nested-component",
+    ),
+    leaf(
+        FlowBuiltinLint::NestedHook,
+        "nested-hook",
+        "flow/nested-hook",
+    ),
+    leaf(
+        FlowBuiltinLint::NonConstVarExport,
+        "non-const-var-export",
+        "flow/non-const-var-export",
+    ),
+    leaf(
+        FlowBuiltinLint::NonstrictImport,
+        "nonstrict-import",
+        "flow/nonstrict-import",
+    ),
+    leaf(
+        FlowBuiltinLint::ReactIntrinsicOverlap,
+        "react-intrinsic-overlap",
+        "flow/react-intrinsic-overlap",
+    ),
+    leaf(
+        FlowBuiltinLint::RequireExplicitEnumChecks,
+        "require-explicit-enum-checks",
+        "flow/require-explicit-enum-checks",
+    ),
+    leaf(
+        FlowBuiltinLint::RequireExplicitEnumSwitchCases,
+        "require-explicit-enum-switch-cases",
+        "flow/require-explicit-enum-switch-cases",
+    ),
+    LintEntry {
+        lint: FlowBuiltinLint::SketchyNull,
+        name: "sketchy-null",
+        rule_id: "flow/sketchy-null",
+        members: SKETCHY_NULL_MEMBERS,
+    },
+    leaf(
+        FlowBuiltinLint::SketchyNullBigInt,
+        "sketchy-null-bigint",
+        "flow/sketchy-null-bigint",
+    ),
+    leaf(
+        FlowBuiltinLint::SketchyNullBool,
+        "sketchy-null-bool",
+        "flow/sketchy-null-bool",
+    ),
+    leaf(
+        FlowBuiltinLint::SketchyNullMixed,
+        "sketchy-null-mixed",
+        "flow/sketchy-null-mixed",
+    ),
+    leaf(
+        FlowBuiltinLint::SketchyNullNumber,
+        "sketchy-null-number",
+        "flow/sketchy-null-number",
+    ),
+    leaf(
+        FlowBuiltinLint::SketchyNullString,
+        "sketchy-null-string",
+        "flow/sketchy-null-string",
+    ),
+    leaf(
+        FlowBuiltinLint::SketchyNumber,
+        "sketchy-number",
+        "flow/sketchy-number",
+    ),
+    leaf(
+        FlowBuiltinLint::ThisInExportedFunction,
+        "this-in-exported-function",
+        "flow/this-in-exported-function",
+    ),
+    leaf(
+        FlowBuiltinLint::UnclearType,
+        "unclear-type",
+        "flow/unclear-type",
+    ),
+    leaf(
+        FlowBuiltinLint::UninitializedInstanceProperty,
+        "uninitialized-instance-property",
+        "flow/uninitialized-instance-property",
+    ),
+    leaf(
+        FlowBuiltinLint::UnnecessaryInvariant,
+        "unnecessary-invariant",
+        "flow/unnecessary-invariant",
+    ),
+    leaf(
+        FlowBuiltinLint::UnnecessaryOptionalChain,
+        "unnecessary-optional-chain",
+        "flow/unnecessary-optional-chain",
+    ),
+    leaf(
+        FlowBuiltinLint::UnsafeGettersSetters,
+        "unsafe-getters-setters",
+        "flow/unsafe-getters-setters",
+    ),
+    leaf(
+        FlowBuiltinLint::UnsafeObjectAssign,
+        "unsafe-object-assign",
+        "flow/unsafe-object-assign",
+    ),
+    leaf(
+        FlowBuiltinLint::UntypedImport,
+        "untyped-import",
+        "flow/untyped-import",
+    ),
+    leaf(
+        FlowBuiltinLint::UntypedTypeImport,
+        "untyped-type-import",
+        "flow/untyped-type-import",
+    ),
+    leaf(
+        FlowBuiltinLint::UnusedPromise,
+        "unused-promise",
+        "flow/unused-promise",
+    ),
+];
+
+/// Name → lint lookup, including the two long spellings Flow also accepts.
+///
+/// A perfect hash keeps config resolution and suppression-comment parsing free
+/// of both allocation and linear scans.
+static BY_NAME: phf::Map<&'static str, FlowBuiltinLint> = phf::phf_map! {
+    "ambiguous-object-type" => FlowBuiltinLint::AmbiguousObjectType,
+    "default-import-access" => FlowBuiltinLint::DefaultImportAccess,
+    "deprecated-type" => FlowBuiltinLint::DeprecatedType,
+    "deprecated-type-bool" => FlowBuiltinLint::DeprecatedType,
+    "export-renamed-default" => FlowBuiltinLint::ExportRenamedDefault,
+    "internal-type" => FlowBuiltinLint::InternalType,
+    "invalid-import-star-use" => FlowBuiltinLint::InvalidImportStarUse,
+    "invalid-this-arg" => FlowBuiltinLint::InvalidThisArg,
+    "libdef-override" => FlowBuiltinLint::LibdefOverride,
+    "mixed-import-and-require" => FlowBuiltinLint::MixedImportAndRequire,
+    "nested-component" => FlowBuiltinLint::NestedComponent,
+    "nested-hook" => FlowBuiltinLint::NestedHook,
+    "non-const-var-export" => FlowBuiltinLint::NonConstVarExport,
+    "nonstrict-import" => FlowBuiltinLint::NonstrictImport,
+    "react-intrinsic-overlap" => FlowBuiltinLint::ReactIntrinsicOverlap,
+    "require-explicit-enum-checks" => FlowBuiltinLint::RequireExplicitEnumChecks,
+    "require-explicit-enum-switch-cases" => FlowBuiltinLint::RequireExplicitEnumSwitchCases,
+    "sketchy-null" => FlowBuiltinLint::SketchyNull,
+    "sketchy-null-bigint" => FlowBuiltinLint::SketchyNullBigInt,
+    "sketchy-null-bool" => FlowBuiltinLint::SketchyNullBool,
+    "sketchy-null-mixed" => FlowBuiltinLint::SketchyNullMixed,
+    "sketchy-null-number" => FlowBuiltinLint::SketchyNullNumber,
+    "sketchy-null-string" => FlowBuiltinLint::SketchyNullString,
+    "sketchy-number" => FlowBuiltinLint::SketchyNumber,
+    "sketchy-number-and" => FlowBuiltinLint::SketchyNumber,
+    "this-in-exported-function" => FlowBuiltinLint::ThisInExportedFunction,
+    "unclear-type" => FlowBuiltinLint::UnclearType,
+    "uninitialized-instance-property" => FlowBuiltinLint::UninitializedInstanceProperty,
+    "unnecessary-invariant" => FlowBuiltinLint::UnnecessaryInvariant,
+    "unnecessary-optional-chain" => FlowBuiltinLint::UnnecessaryOptionalChain,
+    "unsafe-getters-setters" => FlowBuiltinLint::UnsafeGettersSetters,
+    "unsafe-object-assign" => FlowBuiltinLint::UnsafeObjectAssign,
+    "untyped-import" => FlowBuiltinLint::UntypedImport,
+    "untyped-type-import" => FlowBuiltinLint::UntypedTypeImport,
+    "unused-promise" => FlowBuiltinLint::UnusedPromise,
+};
+
+/// The `flow/` prefix every Flow built-in rule id carries.
+pub const FLOW_NAMESPACE: &str = "flow/";
+
+impl FlowBuiltinLint {
+    /// Number of Flow built-in lints uf models.
+    pub const COUNT: usize = 33;
+
+    /// Every Flow built-in lint, in ascending lint-name order.
+    pub fn all() -> impl ExactSizeIterator<Item = FlowBuiltinLint> {
+        LINTS.iter().map(|entry| entry.lint)
+    }
+
+    /// The bare Flow lint name, e.g. `"sketchy-null"`.
+    #[inline]
+    pub fn as_name(self) -> &'static str {
+        LINTS[self as usize].name
+    }
+
+    /// The uf rule id, e.g. `"flow/sketchy-null"`.
+    #[inline]
+    pub fn as_rule_id(self) -> &'static str {
+        LINTS[self as usize].rule_id
+    }
+
+    /// Lints this name expands to when Flow reports a violation.
+    ///
+    /// Empty for every leaf lint; only `sketchy-null` has members.
+    #[inline]
+    pub fn members(self) -> &'static [FlowBuiltinLint] {
+        LINTS[self as usize].members
+    }
+
+    /// Whether this name only exists to configure other lints in bulk.
+    #[inline]
+    pub fn is_umbrella(self) -> bool {
+        !self.members().is_empty()
+    }
+
+    /// Resolve a bare Flow lint name (no `flow/` prefix).
+    #[inline]
+    pub fn from_lint_name(name: &str) -> Option<Self> {
+        BY_NAME.get(name).copied()
+    }
+
+    /// Resolve a fully qualified uf rule id such as `"flow/unclear-type"`.
+    #[inline]
+    pub fn from_rule_id(rule_id: &str) -> Option<Self> {
+        rule_id
+            .strip_prefix(FLOW_NAMESPACE)
+            .and_then(Self::from_lint_name)
+    }
+}
+
+/// Failure to resolve a Flow built-in lint name.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum FlowLintParseError {
+    /// The name is not one Flow accepts in a `[lints]` section.
+    #[error("`{name}` is not a Flow built-in lint")]
+    UnknownLint {
+        /// The rejected spelling, as written by the user.
+        name: CompactString,
+    },
+}
+
+impl FromStr for FlowBuiltinLint {
+    type Err = FlowLintParseError;
+
+    /// Accepts both `"unclear-type"` and `"flow/unclear-type"`.
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::from_rule_id(value)
+            .or_else(|| Self::from_lint_name(value))
+            .ok_or_else(|| FlowLintParseError::UnknownLint {
+                name: CompactString::from(value),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lint_table_is_indexed_by_discriminant() {
+        for (index, entry) in LINTS.iter().enumerate() {
+            assert_eq!(
+                entry.lint as usize, index,
+                "{} is stored at the wrong index",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn every_lint_is_reachable_from_all() {
+        assert_eq!(FlowBuiltinLint::all().len(), FlowBuiltinLint::COUNT);
+        assert_eq!(LINTS.len(), FlowBuiltinLint::COUNT);
+    }
+
+    #[test]
+    fn rule_ids_are_the_namespaced_lint_names() {
+        for lint in FlowBuiltinLint::all() {
+            assert_eq!(
+                lint.as_rule_id(),
+                format!("{FLOW_NAMESPACE}{}", lint.as_name()),
+                "{} has a mismatched rule id",
+                lint.as_name()
+            );
+        }
+    }
+
+    #[test]
+    fn lint_names_are_sorted_and_unique() {
+        let names = LINTS.iter().map(|entry| entry.name).collect::<Vec<_>>();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn name_table_round_trips_through_the_perfect_hash() {
+        for lint in FlowBuiltinLint::all() {
+            assert_eq!(FlowBuiltinLint::from_lint_name(lint.as_name()), Some(lint));
+            assert_eq!(FlowBuiltinLint::from_rule_id(lint.as_rule_id()), Some(lint));
+        }
+    }
+
+    #[test]
+    fn perfect_hash_only_adds_the_two_flow_long_spellings() {
+        assert_eq!(BY_NAME.len(), FlowBuiltinLint::COUNT + 2);
+        assert_eq!(
+            FlowBuiltinLint::from_lint_name("sketchy-number-and"),
+            Some(FlowBuiltinLint::SketchyNumber)
+        );
+        assert_eq!(
+            FlowBuiltinLint::from_lint_name("deprecated-type-bool"),
+            Some(FlowBuiltinLint::DeprecatedType)
+        );
+    }
+
+    #[test]
+    fn sketchy_null_is_the_only_umbrella() {
+        let umbrellas = FlowBuiltinLint::all()
+            .filter(|lint| lint.is_umbrella())
+            .collect::<Vec<_>>();
+        assert_eq!(umbrellas, vec![FlowBuiltinLint::SketchyNull]);
+        assert_eq!(FlowBuiltinLint::SketchyNull.members().len(), 5);
+    }
+
+    #[test]
+    fn umbrella_members_are_themselves_leaves() {
+        for member in FlowBuiltinLint::SketchyNull.members() {
+            assert!(!member.is_umbrella());
+            assert!(member.as_name().starts_with("sketchy-null-"));
+        }
+    }
+
+    #[test]
+    fn from_str_accepts_bare_names_and_rule_ids() {
+        assert_eq!(
+            "unclear-type".parse::<FlowBuiltinLint>(),
+            Ok(FlowBuiltinLint::UnclearType)
+        );
+        assert_eq!(
+            "flow/unclear-type".parse::<FlowBuiltinLint>(),
+            Ok(FlowBuiltinLint::UnclearType)
+        );
+    }
+
+    #[test]
+    fn from_str_rejects_names_flow_does_not_ship() {
+        for name in [
+            "implicit-inexact-object",
+            "unused-promise-in-async-scope",
+            "require-explicit-import-type",
+            "deprecated-class-static-blocks",
+            "",
+            "flow/",
+            "sketchy",
+            "FLOW/UNCLEAR-TYPE",
+        ] {
+            assert_eq!(
+                name.parse::<FlowBuiltinLint>(),
+                Err(FlowLintParseError::UnknownLint {
+                    name: CompactString::from(name),
+                }),
+                "{name} should not resolve"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_error_message_names_the_offending_spelling() {
+        let error = "implicit-inexact-object"
+            .parse::<FlowBuiltinLint>()
+            .expect_err("unknown lint");
+        assert_eq!(
+            error.to_string(),
+            "`implicit-inexact-object` is not a Flow built-in lint"
+        );
+    }
+}

--- a/crates/uf_lint/src/lib.rs
+++ b/crates/uf_lint/src/lib.rs
@@ -1,38 +1,116 @@
+#![deny(missing_docs)]
+//! Native lint runner for Flow source files.
+//!
+//! `uf lint` is the **union** of two rule sets:
+//!
+//! 1. Flow's own built-in lints, under the `flow/` namespace — see
+//!    [`flow_builtin`] for where that list is sourced from.
+//! 2. uf's framework rules for the router, server/client boundary, React
+//!    component and hook syntax, package layout, and a small security set.
+//!
+//! [`rules`] enumerates every rule with its category, default level, one-line
+//! description, and whether it can run without a type checker. Rules that need
+//! type inference are declared with [`RuleRequirement::TypeChecker`]; because uf
+//! has no checker yet, enabling one of those puts it in
+//! [`LintReport::unavailable`] instead of silently passing.
+
+mod flow_builtin;
+mod rules;
+mod scan;
+mod suppression;
+
 use rayon::prelude::*;
 use thiserror::Error;
 use uf_config::{RuleLevel, UniflowedConfig};
 use uf_flow::FlowParser;
-use uf_infra::{LineIndex, memchr_iter};
+use uf_infra::memchr_iter;
 
+pub use crate::flow_builtin::{FLOW_NAMESPACE, FlowBuiltinLint, FlowLintParseError};
+pub use crate::rules::{
+    RuleCategory, RuleDescriptor, RuleRequirement, canonical_rule_id, rule, rules,
+};
+
+use crate::rules::deprecated_aliases_for;
+use crate::scan::{
+    FileScan, ends_word, find_all, find_words, identifier_len, is_hook_name, is_word_byte,
+    next_non_space, prev_non_space, previous_word, starts_word,
+};
+use crate::suppression::UNKNOWN_SUPPRESSION_RULE;
+
+/// How loudly a diagnostic is reported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
+    /// Reported, but does not fail the run.
     Warn,
+    /// Reported and fails the run.
     Error,
 }
 
+/// One rule violation at one place in one file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
+    /// Canonical rule id, e.g. `"flow/unclear-type"`.
     pub rule: &'static str,
+    /// Configured severity for the rule.
     pub severity: Severity,
+    /// Path of the offending file, when the source came from disk.
     pub path: Option<String>,
+    /// 1-based line number.
     pub line: usize,
+    /// 1-based **byte** column within the line, matching [`uf_infra::LineIndex`].
     pub column: usize,
+    /// Human-readable explanation.
     pub message: String,
 }
 
+/// A file handed to the linter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceFile {
+    /// Path used for path-sensitive rules and for reporting.
     pub path: String,
+    /// Full source text.
     pub source: String,
 }
 
+/// A rule that is enabled but cannot run yet.
+///
+/// This exists so that enabling, say, `flow/sketchy-null` is never a silent
+/// no-op: the report says out loud that the rule was skipped and why.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnavailableRule {
+    /// Canonical rule id.
+    pub rule: &'static str,
+    /// Level the config asked for.
+    pub level: RuleLevel,
+    /// What the rule is waiting on.
+    pub requirement: RuleRequirement,
+}
+
+impl UnavailableRule {
+    /// Why the rule did not run.
+    pub fn reason(&self) -> &'static str {
+        match self.requirement {
+            RuleRequirement::TypeChecker => {
+                "requires Flow type inference, which uf does not implement yet; the rule did not run"
+            }
+            RuleRequirement::SourceText => "available",
+        }
+    }
+}
+
+/// The outcome of a lint run.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LintReport {
+    /// Violations found, sorted by path, line, column, then rule id.
     pub diagnostics: Vec<Diagnostic>,
+    /// How many files were scanned.
     pub files_checked: usize,
+    /// Enabled rules that could not run; see [`UnavailableRule`].
+    pub unavailable: Vec<UnavailableRule>,
 }
 
 impl LintReport {
+    /// Whether any diagnostic is an error.
     pub fn has_errors(&self) -> bool {
         self.diagnostics
             .iter()
@@ -40,25 +118,65 @@ impl LintReport {
     }
 }
 
+/// Anything that can stop a lint run before it produces a report.
 #[derive(Debug, Error)]
 pub enum LintError {
+    /// The Flow parser failed to run.
     #[error(transparent)]
     Flow(#[from] uf_flow::FlowError),
 }
 
+/// Lint many files in parallel.
 pub fn lint_sources(
     files: &[SourceFile],
     config: &UniflowedConfig,
 ) -> Result<LintReport, LintError> {
-    let reports = files
+    let per_file = files
         .par_iter()
-        .map(|file| lint_source(file, config))
+        .map(|file| lint_file(file, config))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut diagnostics = reports
-        .into_iter()
-        .flat_map(|report| report.diagnostics)
-        .collect::<Vec<_>>();
+    let mut diagnostics = per_file.into_iter().flatten().collect::<Vec<_>>();
+    sort_diagnostics(&mut diagnostics);
+
+    Ok(LintReport {
+        diagnostics,
+        files_checked: files.len(),
+        unavailable: unavailable_rules(config),
+    })
+}
+
+/// Lint a single file.
+pub fn lint_source(file: &SourceFile, config: &UniflowedConfig) -> Result<LintReport, LintError> {
+    let mut diagnostics = lint_file(file, config)?;
+    sort_diagnostics(&mut diagnostics);
+
+    Ok(LintReport {
+        diagnostics,
+        files_checked: 1,
+        unavailable: unavailable_rules(config),
+    })
+}
+
+/// Every enabled rule that needs machinery uf has not built yet.
+///
+/// This is the single code path through which a rule is allowed to not run.
+pub fn unavailable_rules(config: &UniflowedConfig) -> Vec<UnavailableRule> {
+    rules()
+        .iter()
+        .filter(|descriptor| !descriptor.requirement.is_available())
+        .filter_map(|descriptor| {
+            let level = configured_level(config, descriptor.id)?;
+            level.is_enabled().then_some(UnavailableRule {
+                rule: descriptor.id,
+                level,
+                requirement: descriptor.requirement,
+            })
+        })
+        .collect()
+}
+
+fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
     diagnostics.sort_by(|a, b| {
         a.path
             .cmp(&b.path)
@@ -66,57 +184,85 @@ pub fn lint_sources(
             .then(a.column.cmp(&b.column))
             .then(a.rule.cmp(b.rule))
     });
-
-    Ok(LintReport {
-        diagnostics,
-        files_checked: files.len(),
-    })
 }
 
-pub fn lint_source(file: &SourceFile, config: &UniflowedConfig) -> Result<LintReport, LintError> {
+fn lint_file(file: &SourceFile, config: &UniflowedConfig) -> Result<Vec<Diagnostic>, LintError> {
+    let scan = FileScan::new(file);
     let mut diagnostics = Vec::new();
 
-    run_flow_syntax(file, config, &mut diagnostics)?;
-    run_flow_no_explicit_any(file, config, &mut diagnostics);
-    run_no_tabs(file, config, &mut diagnostics);
-    run_no_trailing_whitespace(file, config, &mut diagnostics);
-    run_react_component_syntax(file, config, &mut diagnostics);
-    run_react_hook_syntax(file, config, &mut diagnostics);
-    run_react_no_render_side_effects(file, config, &mut diagnostics);
-    run_react_native_platform_split(file, config, &mut diagnostics);
-    run_server_no_client_secret(file, config, &mut diagnostics);
-    run_server_use_server_actions(file, config, &mut diagnostics);
-    run_router_reserved_files(file, config, &mut diagnostics);
-    run_package_no_npm_scripts(file, config, &mut diagnostics);
-    run_fetch_no_global_override(file, config, &mut diagnostics);
+    let (suppressions, bad_suppressions) = suppression::collect(&scan);
+    if let Some(severity) = severity(config, UNKNOWN_SUPPRESSION_RULE) {
+        for bad in bad_suppressions {
+            push(
+                &mut diagnostics,
+                file,
+                UNKNOWN_SUPPRESSION_RULE,
+                severity,
+                bad.line,
+                bad.column,
+                bad.message,
+            );
+        }
+    }
 
-    Ok(LintReport {
-        diagnostics,
-        files_checked: 1,
+    run_flow_syntax(&scan, config, &mut diagnostics)?;
+    run_no_tabs(&scan, config, &mut diagnostics);
+    run_no_trailing_whitespace(&scan, config, &mut diagnostics);
+    run_no_npm_script_invocation(&scan, config, &mut diagnostics);
+
+    run_flow_unclear_type(&scan, config, &mut diagnostics);
+    run_flow_deprecated_type(&scan, config, &mut diagnostics);
+    run_flow_internal_type(&scan, config, &mut diagnostics);
+    run_flow_ambiguous_object_type(&scan, config, &mut diagnostics);
+    run_flow_unsafe_getters_setters(&scan, config, &mut diagnostics);
+    run_flow_unsafe_object_assign(&scan, config, &mut diagnostics);
+    run_flow_unnecessary_optional_chain(&scan, config, &mut diagnostics);
+    run_flow_mixed_import_and_require(&scan, config, &mut diagnostics);
+    run_flow_non_const_var_export(&scan, config, &mut diagnostics);
+    run_flow_export_renamed_default(&scan, config, &mut diagnostics);
+    run_flow_react_intrinsic_overlap(&scan, config, &mut diagnostics);
+
+    run_react_component_syntax(&scan, config, &mut diagnostics);
+    run_react_hook_syntax(&scan, config, &mut diagnostics);
+    run_react_no_default_export_component(&scan, config, &mut diagnostics);
+    run_react_no_render_side_effects(&scan, config, &mut diagnostics);
+    run_react_native_platform_split(&scan, config, &mut diagnostics);
+    run_structure_rules(&scan, config, &mut diagnostics);
+
+    run_server_no_client_secret(&scan, config, &mut diagnostics);
+    run_server_no_server_only_import_in_client(&scan, config, &mut diagnostics);
+    run_server_use_client_directive_position(&scan, config, &mut diagnostics);
+    run_server_use_server_actions(&scan, config, &mut diagnostics);
+
+    run_router_reserved_files(&scan, config, &mut diagnostics);
+    run_package_no_npm_scripts(&scan, config, &mut diagnostics);
+    run_fetch_no_global_override(&scan, config, &mut diagnostics);
+
+    run_security_no_dangerously_set_inner_html(&scan, config, &mut diagnostics);
+    run_security_no_eval(&scan, config, &mut diagnostics);
+
+    if !suppressions.is_empty() {
+        diagnostics
+            .retain(|diagnostic| !suppressions.is_suppressed(diagnostic.rule, diagnostic.line));
+    }
+
+    Ok(diagnostics)
+}
+
+/// Level configured for `rule`, honouring deprecated aliases.
+fn configured_level(config: &UniflowedConfig, rule: &str) -> Option<RuleLevel> {
+    config.lint.rules.get(rule).copied().or_else(|| {
+        // Only reached when the canonical id is absent, so the default config
+        // never pays for this lookup.
+        deprecated_aliases_for(rule).find_map(|alias| config.lint.rules.get(alias).copied())
     })
 }
 
 fn severity(config: &UniflowedConfig, rule: &'static str) -> Option<Severity> {
-    config
-        .lint
-        .rules
-        .get(rule)
-        .copied()
-        .unwrap_or(RuleLevel::Off)
-        .then_severity()
-}
-
-trait RuleLevelExt {
-    fn then_severity(self) -> Option<Severity>;
-}
-
-impl RuleLevelExt for RuleLevel {
-    fn then_severity(self) -> Option<Severity> {
-        match self {
-            RuleLevel::Off => None,
-            RuleLevel::Warn => Some(Severity::Warn),
-            RuleLevel::Error => Some(Severity::Error),
-        }
+    match configured_level(config, rule).unwrap_or(RuleLevel::Off) {
+        RuleLevel::Off => None,
+        RuleLevel::Warn => Some(Severity::Warn),
+        RuleLevel::Error => Some(Severity::Error),
     }
 }
 
@@ -139,24 +285,77 @@ fn push(
     });
 }
 
+/// Push a diagnostic addressed by zero-based line index and zero-based byte
+/// column within [`scan::Line::text`].
+///
+/// The 1-based position is resolved through the file's single [`uf_infra::LineIndex`],
+/// so every rule reports positions the same way.
+fn push_at(
+    diagnostics: &mut Vec<Diagnostic>,
+    scan: &FileScan<'_>,
+    rule: &'static str,
+    severity: Severity,
+    line_index: usize,
+    column_index: usize,
+    message: impl Into<String>,
+) {
+    let offset = scan.lines[line_index].offset + column_index;
+    let position = scan.index.line_col(offset);
+    push(
+        diagnostics,
+        scan.file,
+        rule,
+        severity,
+        position.line,
+        position.column,
+        message,
+    );
+}
+
+/// Push a diagnostic addressed by an offset inside [`scan::Line::code`].
+fn push_in_code(
+    diagnostics: &mut Vec<Diagnostic>,
+    scan: &FileScan<'_>,
+    rule: &'static str,
+    severity: Severity,
+    line_index: usize,
+    code_offset: usize,
+    message: impl Into<String>,
+) {
+    let column_index = scan.lines[line_index].code_offset() + code_offset;
+    push_at(
+        diagnostics,
+        scan,
+        rule,
+        severity,
+        line_index,
+        column_index,
+        message,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Flow parser
+// ---------------------------------------------------------------------------
+
 fn run_flow_syntax(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<(), LintError> {
     let Some(severity) = severity(config, "flow/syntax") else {
         return Ok(());
     };
-    if !is_flow_syntax_target(&file.path) {
+    if !is_flow_syntax_target(&scan.file.path) {
         return Ok(());
     }
 
     let parser = FlowParser;
-    let outcome = parser.validate_source(&file.source)?;
+    let outcome = parser.validate_source(&scan.file.source)?;
     for diagnostic in outcome.diagnostics {
         push(
             diagnostics,
-            file,
+            scan.file,
             "flow/syntax",
             severity,
             diagnostic.line.unwrap_or(1) as usize,
@@ -176,17 +375,20 @@ fn is_flow_syntax_target(path: &str) -> bool {
         || path.ends_with(".cjs")
 }
 
-fn run_no_tabs(file: &SourceFile, config: &UniflowedConfig, diagnostics: &mut Vec<Diagnostic>) {
+// ---------------------------------------------------------------------------
+// uniflowed/*
+// ---------------------------------------------------------------------------
+
+fn run_no_tabs(scan: &FileScan<'_>, config: &UniflowedConfig, diagnostics: &mut Vec<Diagnostic>) {
     let Some(severity) = severity(config, "uniflowed/no-tabs") else {
         return;
     };
 
-    let index = LineIndex::new(&file.source);
-    for offset in memchr_iter(b'\t', file.source.as_bytes()) {
-        let position = index.line_col(offset);
+    for offset in memchr_iter(b'\t', scan.file.source.as_bytes()) {
+        let position = scan.index.line_col(offset);
         push(
             diagnostics,
-            file,
+            scan.file,
             "uniflowed/no-tabs",
             severity,
             position.line,
@@ -196,41 +398,8 @@ fn run_no_tabs(file: &SourceFile, config: &UniflowedConfig, diagnostics: &mut Ve
     }
 }
 
-fn run_flow_no_explicit_any(
-    file: &SourceFile,
-    config: &UniflowedConfig,
-    diagnostics: &mut Vec<Diagnostic>,
-) {
-    let Some(severity) = severity(config, "flow/type-aware/no-explicit-any") else {
-        return;
-    };
-
-    for (line_index, line) in file.source.lines().enumerate() {
-        let Some(column) = line.find("any") else {
-            continue;
-        };
-        let before = line[..column].chars().next_back();
-        let after = line[column + 3..].chars().next();
-        if before.is_some_and(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-            || after.is_some_and(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-        {
-            continue;
-        }
-
-        push(
-            diagnostics,
-            file,
-            "flow/type-aware/no-explicit-any",
-            severity,
-            line_index + 1,
-            column + 1,
-            "avoid `any`; use `mixed`, opaque types, or generated router/action types",
-        );
-    }
-}
-
 fn run_no_trailing_whitespace(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -238,24 +407,615 @@ fn run_no_trailing_whitespace(
         return;
     };
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        let trimmed = line.trim_end_matches([' ', '\t']);
-        if trimmed.len() != line.len() {
-            push(
+    for (position, line) in scan.lines.iter().enumerate() {
+        // The final `split` element is the text after the last `\n`; an empty one
+        // is not a real line and must not be reported.
+        if position + 1 == scan.lines.len() && line.text.is_empty() {
+            continue;
+        }
+        let trimmed = line.text.trim_end_matches([' ', '\t']);
+        if trimmed.len() != line.text.len() {
+            push_at(
                 diagnostics,
-                file,
+                scan,
                 "uniflowed/no-trailing-whitespace",
                 severity,
-                line_index + 1,
-                trimmed.len() + 1,
+                position,
+                trimmed.len(),
                 "remove trailing whitespace",
             );
         }
     }
 }
 
+/// Package-manager invocations that belong in `uf.config.js` tasks instead.
+const PACKAGE_MANAGER_WORDS: [&str; 4] = ["yarn", "pnpm", "bunx", "npx"];
+
+fn run_no_npm_script_invocation(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(severity) = severity(config, "uniflowed/no-npm-script-invocation") else {
+        return;
+    };
+    // `package.json` has its own, more specific rule.
+    if scan.file.path.ends_with("package.json") {
+        return;
+    }
+
+    const MESSAGE: &str =
+        "declare the task in uf.config.js; uf projects do not shell out to npm/yarn/pnpm/bunx";
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for at in find_all(code, "npm run").filter(|&at| starts_word(code, at)) {
+            push_in_code(
+                diagnostics,
+                scan,
+                "uniflowed/no-npm-script-invocation",
+                severity,
+                position,
+                at,
+                MESSAGE,
+            );
+        }
+        for word in PACKAGE_MANAGER_WORDS {
+            for at in find_words(code, word) {
+                push_in_code(
+                    diagnostics,
+                    scan,
+                    "uniflowed/no-npm-script-invocation",
+                    severity,
+                    position,
+                    at,
+                    MESSAGE,
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// flow/* built-ins that are decidable from source text
+// ---------------------------------------------------------------------------
+
+/// Types Flow's `unclear-type` lint rejects, with the advice for each.
+const UNCLEAR_TYPES: [(&str, &str); 3] = [
+    (
+        "any",
+        "avoid `any`; use `mixed`, opaque types, or generated router/action types",
+    ),
+    ("Object", "avoid `Object`; describe the object's shape"),
+    ("Function", "avoid `Function`; describe the call signature"),
+];
+
+fn run_flow_unclear_type(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::UnclearType.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for (needle, message) in UNCLEAR_TYPES {
+            for at in find_words(code, needle) {
+                // `Object.keys(x)`, `x.any`, and `new Function(src)` are value
+                // positions, not type annotations.
+                if prev_non_space(code, at).is_some_and(|(_, byte)| byte == b'.') {
+                    continue;
+                }
+                if next_non_space(code, at + needle.len())
+                    .is_some_and(|(_, byte)| byte == b'.' || byte == b'(')
+                {
+                    continue;
+                }
+                push_in_code(diagnostics, scan, rule, severity, position, at, message);
+            }
+        }
+    }
+}
+
+fn run_flow_deprecated_type(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::DeprecatedType.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for at in find_words(code, "bool") {
+            if prev_non_space(code, at).is_some_and(|(_, byte)| byte == b'.') {
+                continue;
+            }
+            // `{ bool: true }` is a property name, not a type annotation.
+            if next_non_space(code, at + 4).is_some_and(|(_, byte)| byte == b':' || byte == b'(') {
+                continue;
+            }
+            push_in_code(
+                diagnostics,
+                scan,
+                rule,
+                severity,
+                position,
+                at,
+                "the `bool` type alias is deprecated; write `boolean`",
+            );
+        }
+    }
+}
+
+/// Flow types that exist only for the checker's own use.
+///
+/// Referencing them compiles today and breaks on the next Flow upgrade, which is
+/// exactly what Flow's `internal-type` lint is for.
+static INTERNAL_TYPES: phf::Set<&'static str> = phf::phf_set! {
+    "$Flow$EnumProto",
+    "$Flow$EnumValueRepresentationTypes",
+    "$Flow$ModuleRef",
+    "$TEMPORARY$array",
+    "$TEMPORARY$bigint",
+    "$TEMPORARY$number",
+    "$TEMPORARY$object",
+    "$TEMPORARY$string",
+    "React$AbstractComponent",
+    "React$Component",
+    "React$ComponentType",
+    "React$Context",
+    "React$Element",
+    "React$ElementConfig",
+    "React$ElementProps",
+    "React$ElementRef",
+    "React$ElementType",
+    "React$Key",
+    "React$MixedElement",
+    "React$Node",
+    "React$Portal",
+    "React$Ref",
+    "React$StatelessFunctionalComponent",
+};
+
+fn run_flow_internal_type(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::InternalType.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let mut at = 0usize;
+        while at < code.len() {
+            let len = identifier_len(code, at);
+            if len == 0 {
+                at += 1;
+                continue;
+            }
+            if starts_word(code, at) && INTERNAL_TYPES.contains(&code[at..at + len]) {
+                push_in_code(
+                    diagnostics,
+                    scan,
+                    rule,
+                    severity,
+                    position,
+                    at,
+                    "this is a Flow-internal type; use the public equivalent",
+                );
+            }
+            at += len;
+        }
+    }
+}
+
+fn run_flow_ambiguous_object_type(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::AmbiguousObjectType.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let Some(brace_at) = type_alias_object_start(line.code()) else {
+            continue;
+        };
+        report_ambiguous_object(scan, severity, rule, position, brace_at, diagnostics);
+    }
+}
+
+/// Offset of the `{` that opens a `type X = { ... }` right-hand side.
+///
+/// Deliberately narrow: only type-alias right-hand sides are recognised, because
+/// a bare `: {` is indistinguishable from an object literal or a ternary without
+/// a real parser, and a linter that guesses is worse than one that under-reports.
+fn type_alias_object_start(code: &str) -> Option<usize> {
+    let mut at = next_non_space(code, 0)?.0;
+    loop {
+        let len = identifier_len(code, at);
+        if len == 0 {
+            return None;
+        }
+        match &code[at..at + len] {
+            "export" | "declare" | "opaque" => at = next_non_space(code, at + len)?.0,
+            "type" => {
+                at += len;
+                break;
+            }
+            _ => return None,
+        }
+    }
+
+    let equals = at + code[at..].find('=')?;
+    let (brace_at, byte) = next_non_space(code, equals + 1)?;
+    (byte == b'{').then_some(brace_at)
+}
+
+/// Walk one object type from its opening `{` and report every nested object type
+/// that states neither exactness (`{| |}`) nor inexactness (`...`).
+fn report_ambiguous_object(
+    scan: &FileScan<'_>,
+    severity: Severity,
+    rule: &'static str,
+    start_line: usize,
+    start_in_code: usize,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    /// One open `{`: where it is, and what it has told us so far.
+    struct Open {
+        line: usize,
+        column: usize,
+        exact: bool,
+        spread: bool,
+    }
+
+    let mut stack: Vec<Open> = Vec::new();
+    for (position, line) in scan.lines.iter().enumerate().skip(start_line) {
+        let code = line.code();
+        let bytes = code.as_bytes();
+        let mut at = if position == start_line {
+            start_in_code
+        } else {
+            0
+        };
+        while at < bytes.len() {
+            match bytes[at] {
+                b'{' => {
+                    let exact = bytes.get(at + 1) == Some(&b'|');
+                    stack.push(Open {
+                        line: position,
+                        column: line.code_offset() + at,
+                        exact,
+                        spread: false,
+                    });
+                    at += if exact { 2 } else { 1 };
+                }
+                b'}' => {
+                    let Some(open) = stack.pop() else {
+                        return;
+                    };
+                    if !open.exact && !open.spread {
+                        push_at(
+                            diagnostics,
+                            scan,
+                            rule,
+                            severity,
+                            open.line,
+                            open.column,
+                            "object type is neither exact (`{| |}`) nor explicitly inexact (`...`)",
+                        );
+                    }
+                    if stack.is_empty() {
+                        return;
+                    }
+                    at += 1;
+                }
+                b'.' if bytes[at..].starts_with(b"...") => {
+                    if let Some(open) = stack.last_mut() {
+                        open.spread = true;
+                    }
+                    at += 3;
+                }
+                _ => at += 1,
+            }
+        }
+    }
+}
+
+fn run_flow_unsafe_getters_setters(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::UnsafeGettersSetters.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let Some((mut at, _)) = next_non_space(code, 0) else {
+            continue;
+        };
+        if code[at..].starts_with("static ") {
+            let Some((next, _)) = next_non_space(code, at + "static ".len()) else {
+                continue;
+            };
+            at = next;
+        }
+        let len = identifier_len(code, at);
+        if len == 0 || !matches!(&code[at..at + len], "get" | "set") {
+            continue;
+        }
+        let Some((name_at, _)) = next_non_space(code, at + len) else {
+            continue;
+        };
+        let name_len = identifier_len(code, name_at);
+        if name_len == 0 {
+            continue;
+        }
+        if !next_non_space(code, name_at + name_len).is_some_and(|(_, byte)| byte == b'(') {
+            continue;
+        }
+        push_in_code(
+            diagnostics,
+            scan,
+            rule,
+            severity,
+            position,
+            at,
+            "avoid getters and setters; they hide side effects behind property access",
+        );
+    }
+}
+
+fn run_flow_unsafe_object_assign(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::UnsafeObjectAssign.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for at in find_all(code, "Object.assign").filter(|&at| starts_word(code, at)) {
+            push_in_code(
+                diagnostics,
+                scan,
+                rule,
+                severity,
+                position,
+                at,
+                "prefer object spread over `Object.assign`, which mutates its target",
+            );
+        }
+    }
+}
+
+fn run_flow_unnecessary_optional_chain(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::UnnecessaryOptionalChain.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    // Only the syntactic subset is decidable without types: a base that is
+    // literally `this` can never be nullish.
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for at in find_all(code, "this?.").filter(|&at| starts_word(code, at)) {
+            push_in_code(
+                diagnostics,
+                scan,
+                rule,
+                severity,
+                position,
+                at,
+                "`this` is never nullish; drop the `?.`",
+            );
+        }
+    }
+}
+
+fn run_flow_mixed_import_and_require(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::MixedImportAndRequire.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+    if !scan.facts.has_esm_import {
+        return;
+    }
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for at in find_words(code, "require") {
+            if prev_non_space(code, at).is_some_and(|(_, byte)| byte == b'.') {
+                continue;
+            }
+            if !next_non_space(code, at + "require".len()).is_some_and(|(_, byte)| byte == b'(') {
+                continue;
+            }
+            push_in_code(
+                diagnostics,
+                scan,
+                rule,
+                severity,
+                position,
+                at,
+                "this module already uses `import`; do not mix in `require`",
+            );
+        }
+    }
+}
+
+fn run_flow_non_const_var_export(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::NonConstVarExport.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let Some((at, _)) = next_non_space(code, 0) else {
+            continue;
+        };
+        if identifier_len(code, at) != "export".len() || &code[at..at + 6] != "export" {
+            continue;
+        }
+        let Some((keyword_at, _)) = next_non_space(code, at + 6) else {
+            continue;
+        };
+        let len = identifier_len(code, keyword_at);
+        if len == 0 || !matches!(&code[keyword_at..keyword_at + len], "var" | "let") {
+            continue;
+        }
+        push_in_code(
+            diagnostics,
+            scan,
+            rule,
+            severity,
+            position,
+            keyword_at,
+            "exported bindings must be `const`; a mutable export is a live binding",
+        );
+    }
+}
+
+fn run_flow_export_renamed_default(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::ExportRenamedDefault.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for at in find_all(code, "as default")
+            .filter(|&at| starts_word(code, at) && ends_word(code, at + "as default".len()))
+        {
+            push_in_code(
+                diagnostics,
+                scan,
+                rule,
+                severity,
+                position,
+                at,
+                "renaming an export to `default` hides the real name; export it directly",
+            );
+        }
+    }
+}
+
+/// Lowercase JSX intrinsic element names, which local bindings must not shadow.
+static JSX_INTRINSICS: phf::Set<&'static str> = phf::phf_set! {
+    "a", "abbr", "address", "area", "article", "aside", "audio",
+    "b", "base", "bdi", "bdo", "big", "blockquote", "body", "br", "button",
+    "canvas", "caption", "circle", "cite", "clipPath", "code", "col", "colgroup",
+    "data", "datalist", "dd", "defs", "del", "details", "dfn", "dialog", "div",
+    "dl", "dt", "ellipse", "em", "embed", "fieldset", "figcaption", "figure",
+    "footer", "foreignObject", "form", "g", "h1", "h2", "h3", "h4", "h5", "h6",
+    "head", "header", "hgroup", "hr", "html", "i", "iframe", "image", "img",
+    "input", "ins", "kbd", "label", "legend", "li", "line", "linearGradient",
+    "link", "main", "map", "mark", "marker", "mask", "menu", "meta", "meter",
+    "nav", "noscript", "object", "ol", "optgroup", "option", "output", "p",
+    "param", "path", "pattern", "picture", "polygon", "polyline", "pre",
+    "progress", "q", "radialGradient", "rect", "rp", "rt", "ruby", "s", "samp",
+    "script", "search", "section", "select", "slot", "small", "source", "span",
+    "stop", "strong", "style", "sub", "summary", "sup", "svg", "table", "tbody",
+    "td", "template", "text", "textarea", "tfoot", "th", "thead", "time",
+    "title", "tr", "track", "tspan", "u", "ul", "use", "var", "video", "wbr",
+};
+
+/// Keywords that introduce a binding whose name follows.
+const BINDING_KEYWORDS: [&str; 7] = [
+    "const",
+    "let",
+    "var",
+    "function",
+    "component",
+    "hook",
+    "class",
+];
+
+fn run_flow_react_intrinsic_overlap(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let rule = FlowBuiltinLint::ReactIntrinsicOverlap.as_rule_id();
+    let Some(severity) = severity(config, rule) else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let Some((mut at, _)) = next_non_space(code, 0) else {
+            continue;
+        };
+        if code[at..].starts_with("export ") {
+            let Some((next, _)) = next_non_space(code, at + "export ".len()) else {
+                continue;
+            };
+            at = next;
+        }
+        let len = identifier_len(code, at);
+        if len == 0 || !BINDING_KEYWORDS.contains(&&code[at..at + len]) {
+            continue;
+        }
+        let Some((name_at, _)) = next_non_space(code, at + len) else {
+            continue;
+        };
+        let name_len = identifier_len(code, name_at);
+        if name_len == 0 || !JSX_INTRINSICS.contains(&code[name_at..name_at + name_len]) {
+            continue;
+        }
+        push_in_code(
+            diagnostics,
+            scan,
+            rule,
+            severity,
+            position,
+            name_at,
+            "this name shadows a JSX intrinsic element and silently changes what JSX means",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// react/*
+// ---------------------------------------------------------------------------
+
 fn run_react_component_syntax(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -263,16 +1023,17 @@ fn run_react_component_syntax(
         return;
     };
 
-    if !(file.path.ends_with(".jsx")
-        || file.path.ends_with(".tsx")
-        || file.source.contains("React"))
+    if !(scan.file.path.ends_with(".jsx")
+        || scan.file.path.ends_with(".tsx")
+        || scan.facts.mentions_react)
     {
         return;
     }
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        let trimmed = line.trim_start();
-        let leading = line.len() - trimmed.len();
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let trimmed = code.trim_start();
+        let leading = line.code_offset() + (code.len() - trimmed.len());
         let name = trimmed
             .strip_prefix("function ")
             .and_then(|tail| tail.split(['(', '<']).next())
@@ -289,13 +1050,13 @@ fn run_react_component_syntax(
             continue;
         };
         if first.is_ascii_uppercase() && !trimmed.starts_with("component ") {
-            push(
+            push_at(
                 diagnostics,
-                file,
+                scan,
                 "react/component-syntax",
                 severity,
-                line_index + 1,
-                leading + 1,
+                position,
+                leading,
                 "prefer Flow `component` syntax for React components",
             );
         }
@@ -303,7 +1064,7 @@ fn run_react_component_syntax(
 }
 
 fn run_react_hook_syntax(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -311,9 +1072,10 @@ fn run_react_hook_syntax(
         return;
     };
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        let trimmed = line.trim_start();
-        let leading = line.len() - trimmed.len();
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let trimmed = code.trim_start();
+        let leading = line.code_offset() + (code.len() - trimmed.len());
         let Some(name) = trimmed
             .strip_prefix("function ")
             .and_then(|tail| tail.split(['(', '<']).next())
@@ -321,95 +1083,96 @@ fn run_react_hook_syntax(
             continue;
         };
 
-        if name.starts_with("use")
-            && name
-                .chars()
-                .nth(3)
-                .is_some_and(|ch| ch.is_ascii_uppercase())
-        {
-            push(
+        if is_hook_name(name) {
+            push_at(
                 diagnostics,
-                file,
+                scan,
                 "react/hook-syntax",
                 severity,
-                line_index + 1,
-                leading + 1,
+                position,
+                leading,
                 "prefer Flow `hook` syntax for React hooks",
             );
         }
     }
 }
 
-fn run_server_no_client_secret(
-    file: &SourceFile,
+fn run_react_no_default_export_component(
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let Some(severity) = severity(config, "server/no-client-secret") else {
+    let Some(severity) = severity(config, "react/no-default-export-component") else {
         return;
     };
-
-    if !file.source.contains("\"use client\"") && !file.source.contains("'use client'") {
+    if !(scan.facts.declares_component || is_router_module(&scan.file.path)) {
         return;
     }
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        if line.contains("SECRET") || line.contains("PRIVATE_") {
-            push(
-                diagnostics,
-                file,
-                "server/no-client-secret",
-                severity,
-                line_index + 1,
-                line.find("SECRET")
-                    .or_else(|| line.find("PRIVATE_"))
-                    .map(|column| column + 1)
-                    .unwrap_or(1),
-                "client modules must not read private server secrets",
-            );
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let Some((at, _)) = next_non_space(code, 0) else {
+            continue;
+        };
+        if !code[at..].starts_with("export default") {
+            continue;
         }
+        push_in_code(
+            diagnostics,
+            scan,
+            "react/no-default-export-component",
+            severity,
+            position,
+            at,
+            "framework routes are wired by name; export components with a named export",
+        );
     }
 }
 
+fn is_router_module(path: &str) -> bool {
+    path.rsplit('/')
+        .next()
+        .is_some_and(|name| name.starts_with("_uf."))
+}
+
 fn run_react_no_render_side_effects(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let Some(severity) = severity(config, "react/no-render-side-effects") else {
         return;
     };
-
-    if !file.source.contains("component ") {
+    if !scan.facts.declares_component {
         return;
     }
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        let needle = [
-            "Date.now(",
-            "Math.random(",
-            "localStorage.",
-            "sessionStorage.",
-        ]
-        .into_iter()
-        .find(|needle| line.contains(needle));
-        let Some(needle) = needle else {
+    const NEEDLES: [&str; 4] = [
+        "Date.now(",
+        "Math.random(",
+        "localStorage.",
+        "sessionStorage.",
+    ];
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let Some(at) = NEEDLES.into_iter().find_map(|needle| code.find(needle)) else {
             continue;
         };
-        push(
+        push_in_code(
             diagnostics,
-            file,
+            scan,
             "react/no-render-side-effects",
             severity,
-            line_index + 1,
-            line.find(needle).map(|column| column + 1).unwrap_or(1),
+            position,
+            at,
             "keep React render idempotent; move unstable reads into actions, effects, or loaders",
         );
     }
 }
 
 fn run_react_native_platform_split(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -417,32 +1180,484 @@ fn run_react_native_platform_split(
         return;
     };
 
-    if !file.source.contains("react-native")
-        || !(file.source.contains("Platform.OS") || file.source.contains("Platform.select"))
-        || file.path.contains(".ios.")
-        || file.path.contains(".android.")
-        || file.path.contains(".native.")
+    if !scan.facts.mentions_react_native
+        || !(scan.file.source.contains("Platform.OS")
+            || scan.file.source.contains("Platform.select"))
+        || scan.file.path.contains(".ios.")
+        || scan.file.path.contains(".android.")
+        || scan.file.path.contains(".native.")
     {
         return;
     }
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        if let Some(column) = line.find("Platform.") {
-            push(
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        if let Some(at) = code.find("Platform.") {
+            push_in_code(
                 diagnostics,
-                file,
+                scan,
                 "react-native/platform-split",
                 severity,
-                line_index + 1,
-                column + 1,
+                position,
+                at,
                 "prefer platform-specific files for React Native platform branches",
             );
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// Structure rules: flow/nested-component, flow/nested-hook, react/hooks-rules
+// ---------------------------------------------------------------------------
+
+/// What kind of `{ ... }` a frame on the scope stack represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScopeKind {
+    /// A Flow `component` body.
+    Component,
+    /// A Flow `hook` body.
+    Hook,
+    /// A plain function whose name follows the `useSomething` convention.
+    UseFunction,
+    /// Any other function, class, or arrow body.
+    Function,
+    /// A JSX expression container, which does not nest hook scope.
+    Jsx,
+    /// A block, object literal, or anything else.
+    Block,
+}
+
+impl ScopeKind {
+    fn is_function(self) -> bool {
+        matches!(
+            self,
+            Self::Component | Self::Hook | Self::UseFunction | Self::Function
+        )
+    }
+
+    fn allows_hooks(self) -> bool {
+        matches!(self, Self::Component | Self::Hook | Self::UseFunction)
+    }
+}
+
+/// One open `{` during the structure walk.
+struct Frame {
+    kind: ScopeKind,
+    /// Hook nesting depth *inside* this frame.
+    hook_depth: u32,
+}
+
+const HOOK_SCOPE_MESSAGE: &str =
+    "call hooks only inside a `component`, a `hook`, or a `useX` function";
+const HOOK_TOP_LEVEL_MESSAGE: &str =
+    "call hooks at the top level; not inside conditions, loops, or callbacks";
+
+/// Walk the file once, tracking scopes, and report the three rules that need it.
+///
+/// Known limitation: a hook call inside a JSX expression container is only
+/// tolerated when the container opens on the same line as the `>` that precedes
+/// it, because that is as much JSX structure as a lexer-free scan can recover.
+fn run_structure_rules(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let nested_component_rule = FlowBuiltinLint::NestedComponent.as_rule_id();
+    let nested_hook_rule = FlowBuiltinLint::NestedHook.as_rule_id();
+    let nested_component = severity(config, nested_component_rule);
+    let nested_hook = severity(config, nested_hook_rule);
+    let hooks_rules = severity(config, "react/hooks-rules");
+    if nested_component.is_none() && nested_hook.is_none() && hooks_rules.is_none() {
+        return;
+    }
+
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut pending: Option<ScopeKind> = None;
+    let mut hook_depth: u32 = 0;
+    let mut paren_depth: u32 = 0;
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let bytes = code.as_bytes();
+        let mut previous: Option<&str> = None;
+        let mut at = 0usize;
+
+        while at < bytes.len() {
+            match bytes[at] {
+                b'(' => {
+                    paren_depth += 1;
+                    previous = None;
+                    at += 1;
+                }
+                b')' => {
+                    paren_depth = paren_depth.saturating_sub(1);
+                    previous = None;
+                    at += 1;
+                }
+                b'{' => {
+                    let kind = if paren_depth == 0 {
+                        pending.take().unwrap_or_else(|| classify_brace(code, at))
+                    } else {
+                        classify_brace(code, at)
+                    };
+                    if kind != ScopeKind::Jsx {
+                        hook_depth += 1;
+                    }
+                    stack.push(Frame { kind, hook_depth });
+                    previous = None;
+                    at += 1;
+                }
+                b'}' => {
+                    if let Some(frame) = stack.pop()
+                        && frame.kind != ScopeKind::Jsx
+                    {
+                        hook_depth = hook_depth.saturating_sub(1);
+                    }
+                    pending = None;
+                    previous = None;
+                    at += 1;
+                }
+                b';' => {
+                    pending = None;
+                    previous = None;
+                    at += 1;
+                }
+                b'=' if bytes.get(at + 1) == Some(&b'>') => {
+                    set_pending(&mut pending, ScopeKind::Function);
+                    previous = None;
+                    at += 2;
+                }
+                b'\'' | b'"' | b'`' => {
+                    // Strings are skipped so a `}` inside one cannot unbalance
+                    // the scope stack.
+                    let quote = bytes[at];
+                    at = skip_string(bytes, at + 1, quote);
+                    previous = None;
+                }
+                byte if is_word_byte(byte) => {
+                    let len = identifier_len(code, at);
+                    if len == 0 {
+                        at += 1;
+                        continue;
+                    }
+                    let word = &code[at..at + len];
+                    handle_structure_word(
+                        StructureWord {
+                            scan,
+                            position,
+                            code,
+                            at,
+                            word,
+                            previous,
+                        },
+                        &mut pending,
+                        &stack,
+                        hook_depth,
+                        (
+                            nested_component.map(|severity| (nested_component_rule, severity)),
+                            nested_hook.map(|severity| (nested_hook_rule, severity)),
+                            hooks_rules,
+                        ),
+                        diagnostics,
+                    );
+                    previous = Some(word);
+                    at += len;
+                }
+                _ => at += 1,
+            }
+        }
+    }
+}
+
+/// Everything `handle_structure_word` needs about the token it is looking at.
+struct StructureWord<'a, 'b> {
+    scan: &'a FileScan<'b>,
+    position: usize,
+    code: &'a str,
+    at: usize,
+    word: &'a str,
+    previous: Option<&'a str>,
+}
+
+type StructureSeverities = (
+    Option<(&'static str, Severity)>,
+    Option<(&'static str, Severity)>,
+    Option<Severity>,
+);
+
+fn handle_structure_word(
+    token: StructureWord<'_, '_>,
+    pending: &mut Option<ScopeKind>,
+    stack: &[Frame],
+    hook_depth: u32,
+    severities: StructureSeverities,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let StructureWord {
+        scan,
+        position,
+        code,
+        at,
+        word,
+        previous,
+    } = token;
+    let (nested_component, nested_hook, hooks_rules) = severities;
+
+    let declaration_context =
+        previous.is_none() || matches!(previous, Some("export" | "declare" | "default"));
+
+    match word {
+        "component" if declaration_context => {
+            set_pending(pending, ScopeKind::Component);
+            if let Some((rule, severity)) = nested_component
+                && stack.iter().any(|frame| frame.kind.allows_hooks())
+            {
+                push_in_code(
+                    diagnostics,
+                    scan,
+                    rule,
+                    severity,
+                    position,
+                    at,
+                    "declare this component at module scope; nesting it remounts its subtree every render",
+                );
+            }
+            return;
+        }
+        "hook" if declaration_context => {
+            set_pending(pending, ScopeKind::Hook);
+            if let Some((rule, severity)) = nested_hook
+                && stack.iter().any(|frame| frame.kind.allows_hooks())
+            {
+                push_in_code(
+                    diagnostics,
+                    scan,
+                    rule,
+                    severity,
+                    position,
+                    at,
+                    "declare this hook at module scope; a nested hook gets a new identity every render",
+                );
+            }
+            return;
+        }
+        "function" => {
+            set_pending(pending, ScopeKind::Function);
+            return;
+        }
+        "class" => {
+            set_pending(pending, ScopeKind::Function);
+            return;
+        }
+        _ => {}
+    }
+
+    let is_binding_name = matches!(
+        previous,
+        Some("function" | "const" | "let" | "var" | "component" | "hook")
+    );
+    if is_binding_name {
+        if is_hook_name(word) && matches!(previous, Some("function" | "const" | "let" | "var")) {
+            set_pending(pending, ScopeKind::UseFunction);
+        }
+        return;
+    }
+
+    let Some(severity) = hooks_rules else {
+        return;
+    };
+    if !is_hook_name(word) {
+        return;
+    }
+    if !next_non_space(code, at + word.len()).is_some_and(|(_, byte)| byte == b'(') {
+        return;
+    }
+    // `props.useThing` is a property read, not a hook call.
+    if prev_non_space(code, at).is_some_and(|(_, byte)| byte == b'.') {
+        return;
+    }
+
+    let message = match stack.iter().rev().find(|frame| frame.kind.is_function()) {
+        None => Some(HOOK_SCOPE_MESSAGE),
+        Some(frame) if !frame.kind.allows_hooks() => Some(HOOK_SCOPE_MESSAGE),
+        Some(frame) if frame.hook_depth != hook_depth => Some(HOOK_TOP_LEVEL_MESSAGE),
+        Some(_) => None,
+    };
+    if let Some(message) = message {
+        push_in_code(
+            diagnostics,
+            scan,
+            "react/hooks-rules",
+            severity,
+            position,
+            at,
+            message,
+        );
+    }
+}
+
+/// Remember what the next `{` opens, without letting a trailing `=>` downgrade a
+/// hook-eligible declaration.
+fn set_pending(pending: &mut Option<ScopeKind>, kind: ScopeKind) {
+    match (*pending, kind) {
+        (Some(existing), ScopeKind::Function) if existing.allows_hooks() => {}
+        _ => *pending = Some(kind),
+    }
+}
+
+/// Classify a `{` that no declaration head claimed.
+fn classify_brace(code: &str, at: usize) -> ScopeKind {
+    match prev_non_space(code, at) {
+        // `<div>{...}` is a JSX container; `=>` and `->` are not.
+        Some((position, b'>')) => {
+            let before = position.checked_sub(1).map(|index| code.as_bytes()[index]);
+            if matches!(before, Some(b'=') | Some(b'-')) {
+                ScopeKind::Block
+            } else {
+                ScopeKind::Jsx
+            }
+        }
+        _ => ScopeKind::Block,
+    }
+}
+
+/// Index just past the closing `quote`, or the end of the slice.
+fn skip_string(bytes: &[u8], from: usize, quote: u8) -> usize {
+    let mut at = from;
+    while at < bytes.len() {
+        match bytes[at] {
+            b'\\' => at += 2,
+            byte if byte == quote => return at + 1,
+            _ => at += 1,
+        }
+    }
+    bytes.len()
+}
+
+// ---------------------------------------------------------------------------
+// server/*
+// ---------------------------------------------------------------------------
+
+fn run_server_no_client_secret(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(severity) = severity(config, "server/no-client-secret") else {
+        return;
+    };
+    if !scan.facts.has_use_client {
+        return;
+    }
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let Some(at) = code.find("SECRET").or_else(|| code.find("PRIVATE_")) else {
+            continue;
+        };
+        push_in_code(
+            diagnostics,
+            scan,
+            "server/no-client-secret",
+            severity,
+            position,
+            at,
+            "client modules must not read private server secrets",
+        );
+    }
+}
+
+/// Module specifiers a `"use client"` module must never import.
+const SERVER_ONLY_SPECIFIERS: [&str; 3] = ["@uniflowed/server", ".server.js", ".server.flow"];
+
+fn run_server_no_server_only_import_in_client(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(severity) = severity(config, "server/no-server-only-import-in-client") else {
+        return;
+    };
+    if !scan.facts.has_use_client {
+        return;
+    }
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        if !(code.contains("import") || code.contains("require")) {
+            continue;
+        }
+        let Some(at) = SERVER_ONLY_SPECIFIERS
+            .into_iter()
+            .find_map(|specifier| code.find(specifier))
+        else {
+            continue;
+        };
+        push_in_code(
+            diagnostics,
+            scan,
+            "server/no-server-only-import-in-client",
+            severity,
+            position,
+            at,
+            "client modules must not import server-only modules; move the call behind a server action",
+        );
+    }
+}
+
+/// The directives that must lead a module.
+const BOUNDARY_DIRECTIVES: [&str; 4] = [
+    "\"use client\"",
+    "'use client'",
+    "\"use server\"",
+    "'use server'",
+];
+
+fn run_server_use_client_directive_position(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(severity) = severity(config, "server/use-client-directive-position") else {
+        return;
+    };
+    let Some(first_code_line) = scan.facts.first_code_line else {
+        return;
+    };
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        // A `"use server"` inside a function body is an inline server action, a
+        // different (valid) construct; only module-level directives are checked.
+        if line.depth_at_start != 0 {
+            continue;
+        }
+        let code = line.code();
+        let Some((at, _)) = next_non_space(code, 0) else {
+            continue;
+        };
+        if !BOUNDARY_DIRECTIVES
+            .into_iter()
+            .any(|directive| code[at..].starts_with(directive))
+        {
+            continue;
+        }
+        if position == first_code_line {
+            continue;
+        }
+        push_in_code(
+            diagnostics,
+            scan,
+            "server/use-client-directive-position",
+            severity,
+            position,
+            at,
+            "a boundary directive is only honoured as the module's first statement",
+        );
+    }
+}
+
 fn run_server_use_server_actions(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -450,27 +1665,24 @@ fn run_server_use_server_actions(
         return;
     };
 
-    if !(file.path.starts_with("server/")
-        || file.path.ends_with(".server.flow")
-        || file.path.ends_with(".server.js"))
-        || !file.source.contains("serverAction")
+    if !(scan.file.path.starts_with("server/")
+        || scan.file.path.ends_with(".server.flow")
+        || scan.file.path.ends_with(".server.js"))
+        || !scan.file.source.contains("serverAction")
     {
         return;
     }
 
-    let first_code_line = file
-        .source
-        .lines()
-        .find(|line| {
-            let trimmed = line.trim();
-            !trimmed.is_empty() && !trimmed.starts_with("//")
-        })
+    let first_code_line = scan
+        .facts
+        .first_code_line
+        .map(|position| scan.lines[position].code().trim())
         .unwrap_or("");
 
-    if first_code_line.trim() != r#""use server";"# && first_code_line.trim() != r#"'use server';"# {
+    if first_code_line != r#""use server";"# && first_code_line != r#"'use server';"# {
         push(
             diagnostics,
-            file,
+            scan.file,
             "server/use-server-actions",
             severity,
             1,
@@ -480,8 +1692,12 @@ fn run_server_use_server_actions(
     }
 }
 
+// ---------------------------------------------------------------------------
+// router/*, package/*, fetch/*
+// ---------------------------------------------------------------------------
+
 fn run_router_reserved_files(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -489,7 +1705,7 @@ fn run_router_reserved_files(
         return;
     };
 
-    let Some(file_name) = file.path.rsplit('/').next() else {
+    let Some(file_name) = scan.file.path.rsplit('/').next() else {
         return;
     };
     if !file_name.starts_with("_uf.") {
@@ -504,7 +1720,7 @@ fn run_router_reserved_files(
 
     push(
         diagnostics,
-        file,
+        scan.file,
         "router/reserved-files",
         severity,
         1,
@@ -514,26 +1730,26 @@ fn run_router_reserved_files(
 }
 
 fn run_package_no_npm_scripts(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let Some(severity) = severity(config, "package/no-npm-scripts") else {
         return;
     };
-    if !file.path.ends_with("package.json") {
+    if !scan.file.path.ends_with("package.json") {
         return;
     }
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        if let Some(column) = line.find(r#""scripts""#) {
-            push(
+    for (position, line) in scan.lines.iter().enumerate() {
+        if let Some(at) = line.text.find(r#""scripts""#) {
+            push_at(
                 diagnostics,
-                file,
+                scan,
                 "package/no-npm-scripts",
                 severity,
-                line_index + 1,
-                column + 1,
+                position,
+                at,
                 "declare tasks in uf.config.js; npm scripts are not part of the uf toolchain",
             );
         }
@@ -541,7 +1757,7 @@ fn run_package_no_npm_scripts(
 }
 
 fn run_fetch_no_global_override(
-    file: &SourceFile,
+    scan: &FileScan<'_>,
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -549,274 +1765,190 @@ fn run_fetch_no_global_override(
         return;
     };
 
-    for (line_index, line) in file.source.lines().enumerate() {
-        let column = line
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        let at = code
             .find("globalThis.fetch")
-            .or_else(|| line.find("window.fetch"))
-            .or_else(|| line.find("global.fetch"));
-        if let Some(column) = column {
-            push(
+            .or_else(|| code.find("window.fetch"))
+            .or_else(|| code.find("global.fetch"));
+        if let Some(at) = at {
+            push_in_code(
                 diagnostics,
-                file,
+                scan,
                 "fetch/no-global-override",
                 severity,
-                line_index + 1,
-                column + 1,
+                position,
+                at,
                 "do not override global fetch; use @uniflowed/fetch explicit clients",
             );
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use uf_config::{RuleLevel, UniflowedConfig};
-    use uf_infra::CompactString;
+// ---------------------------------------------------------------------------
+// security/*
+// ---------------------------------------------------------------------------
 
-    use super::*;
+/// The sanitizing package whose helpers may feed `dangerouslySetInnerHTML`.
+const MARKDOWN_PACKAGE: &str = "@uniflowed/markdown";
 
-    fn source(source: &str) -> SourceFile {
-        SourceFile {
-            path: "src/app/page.jsx".to_string(),
-            source: source.to_string(),
+/// Defends against the stored/reflected XSS class that React's
+/// `dangerouslySetInnerHTML` has produced repeatedly across the ecosystem
+/// (CVE-2018-6341 and the long tail of markdown-renderer XSS advisories):
+/// unsanitized HTML reaching the DOM. Only values produced by a
+/// `@uniflowed/markdown` helper — which sanitizes — are allowed through.
+fn run_security_no_dangerously_set_inner_html(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(severity) = severity(config, "security/no-dangerously-set-inner-html") else {
+        return;
+    };
+    if !scan.file.source.contains("dangerouslySetInnerHTML") {
+        return;
+    }
+
+    let sanitizers = markdown_sanitizers(scan);
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
+        for at in find_words(code, "dangerouslySetInnerHTML") {
+            // The `__html` value may wrap onto the next line, so both are checked.
+            let next = scan
+                .lines
+                .get(position + 1)
+                .map(|line| line.code())
+                .unwrap_or("");
+            if sanitizers
+                .iter()
+                .any(|&name| is_called_in(code, name) || is_called_in(next, name))
+            {
+                continue;
+            }
+            push_in_code(
+                diagnostics,
+                scan,
+                "security/no-dangerously-set-inner-html",
+                severity,
+                position,
+                at,
+                "unsanitized HTML is an XSS sink; render it through a @uniflowed/markdown helper",
+            );
         }
     }
+}
 
-    #[test]
-    fn reports_tabs_and_trailing_whitespace() {
-        let report = lint_source(
-            &source("// @flow\n\tconst x: number = 1;  \n"),
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(report.has_errors());
-        assert_eq!(report.diagnostics.len(), 2);
-        assert_eq!(report.diagnostics[0].rule, "uniflowed/no-tabs");
-        assert_eq!(
-            report.diagnostics[1].rule,
-            "uniflowed/no-trailing-whitespace"
-        );
+/// Names imported from `@uniflowed/markdown` in this file.
+fn markdown_sanitizers<'a>(scan: &FileScan<'a>) -> Vec<&'a str> {
+    let mut names = Vec::new();
+    for line in &scan.lines {
+        let code = line.code();
+        if !code.contains(MARKDOWN_PACKAGE) || !code.contains("import") {
+            continue;
+        }
+        let clause = code
+            .split_once(" from ")
+            .map(|(clause, _)| clause)
+            .unwrap_or(code);
+        let mut at = 0usize;
+        while at < clause.len() {
+            let len = identifier_len(clause, at);
+            if len == 0 {
+                at += 1;
+                continue;
+            }
+            let word = &clause[at..at + len];
+            if !matches!(word, "import" | "type" | "as" | "from") {
+                names.push(word);
+            }
+            at += len;
+        }
     }
+    names
+}
 
-    #[test]
-    fn rule_levels_can_disable_builtin_rules() {
-        let mut config = UniflowedConfig::default();
-        config.lint.rules.insert(
-            CompactString::const_new("uniflowed/no-tabs"),
-            RuleLevel::Off,
-        );
+/// Whether `name` is used as a call or a namespace member in `code`.
+fn is_called_in(code: &str, name: &str) -> bool {
+    find_words(code, name).any(|at| {
+        next_non_space(code, at + name.len()).is_some_and(|(_, byte)| byte == b'(' || byte == b'.')
+    })
+}
 
-        let report =
-            lint_source(&source("// @flow\n\tconst x: number = 1;\n"), &config).expect("lint");
+/// Timer APIs that accept a string body and `eval` it.
+const TIMER_FUNCTIONS: [&str; 2] = ["setTimeout", "setInterval"];
 
-        assert!(!report.has_errors());
-        assert!(report.diagnostics.is_empty());
-    }
+/// Defends against the arbitrary-code-execution class that comes from turning
+/// attacker-influenced strings into code (`eval`, `new Function`, and the
+/// string form of `setTimeout`/`setInterval`).
+fn run_security_no_eval(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(severity) = severity(config, "security/no-eval") else {
+        return;
+    };
 
-    #[test]
-    fn reports_flow_parse_errors() {
-        let report = lint_source(&source("// @flow\ntype = ;\n"), &UniflowedConfig::default())
-            .expect("lint");
+    for (position, line) in scan.lines.iter().enumerate() {
+        let code = line.code();
 
-        assert!(report.has_errors());
-        assert_eq!(report.diagnostics[0].rule, "flow/syntax");
-    }
+        for at in find_words(code, "eval") {
+            if !next_non_space(code, at + "eval".len()).is_some_and(|(_, byte)| byte == b'(') {
+                continue;
+            }
+            push_in_code(
+                diagnostics,
+                scan,
+                "security/no-eval",
+                severity,
+                position,
+                at,
+                "`eval` executes arbitrary code; parse the data instead",
+            );
+        }
 
-    #[test]
-    fn type_aware_rule_blocks_explicit_any() {
-        let report = lint_source(
-            &source("// @flow\ntype Props = { value: any };\n"),
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
+        for at in find_words(code, "Function") {
+            if !next_non_space(code, at + "Function".len()).is_some_and(|(_, byte)| byte == b'(') {
+                continue;
+            }
+            let Some((keyword_at, "new")) = previous_word(code, at) else {
+                continue;
+            };
+            push_in_code(
+                diagnostics,
+                scan,
+                "security/no-eval",
+                severity,
+                position,
+                keyword_at,
+                "`new Function` compiles a string into code; write the function directly",
+            );
+        }
 
-        assert!(report.has_errors());
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "flow/type-aware/no-explicit-any")
-        );
-    }
-
-    #[test]
-    fn framework_rule_prefers_component_syntax() {
-        let report = lint_source(
-            &source("// @flow\nimport * as React from '@uniflowed/react';\nfunction Button(): React.Node { return null; }\n"),
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "react/component-syntax")
-        );
-    }
-
-    #[test]
-    fn hook_rule_prefers_flow_hook_syntax() {
-        let report = lint_source(
-            &source("// @flow\nfunction useThing(): number { return 1; }\n"),
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "react/hook-syntax")
-        );
-    }
-
-    #[test]
-    fn server_rule_rejects_secret_reads_in_client_modules() {
-        let report = lint_source(
-            &source("// @flow\n'use client';\nconst token = process.env.PRIVATE_TOKEN;\n"),
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(report.has_errors());
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "server/no-client-secret")
-        );
-    }
-
-    #[test]
-    fn server_actions_require_use_server_directive() {
-        let report = lint_source(
-            &SourceFile {
-                path: "server/actions.js".to_string(),
-                source: "// @flow\nimport { serverAction } from '@uniflowed/server';\nexport const save = serverAction(() => {});\n"
-                    .to_string(),
-            },
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "server/use-server-actions")
-        );
-    }
-
-    #[test]
-    fn server_actions_accept_use_server_directive() {
-        let report = lint_source(
-            &SourceFile {
-                path: "server/actions.js".to_string(),
-                source: "\"use server\";\n// @flow\nimport { serverAction } from '@uniflowed/server';\nexport const save = serverAction(() => {});\n"
-                    .to_string(),
-            },
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            !report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "server/use-server-actions")
-        );
-    }
-
-    #[test]
-    fn router_reserved_files_are_constrained() {
-        let report = lint_source(
-            &SourceFile {
-                path: "app/_uf.route.js".to_string(),
-                source: "// @flow\n".to_string(),
-            },
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "router/reserved-files")
-        );
-    }
-
-    #[test]
-    fn package_json_scripts_are_rejected() {
-        let report = lint_source(
-            &SourceFile {
-                path: "package.json".to_string(),
-                source: "{\n  \"scripts\": { \"dev\": \"vite\" }\n}\n".to_string(),
-            },
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "package/no-npm-scripts")
-        );
-    }
-
-    #[test]
-    fn global_fetch_override_is_rejected() {
-        let report = lint_source(
-            &source("// @flow\nglobalThis.fetch = () => Promise.resolve();\n"),
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "fetch/no-global-override")
-        );
-    }
-
-    #[test]
-    fn render_side_effects_are_errors_by_default() {
-        let report = lint_source(
-            &source("// @flow\ncomponent Clock() { return <p>{Date.now()}</p>; }\n"),
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(report.has_errors());
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "react/no-render-side-effects")
-        );
-    }
-
-    #[test]
-    fn react_native_rule_prefers_platform_files() {
-        let report = lint_source(
-            &SourceFile {
-                path: "src/app/Button.jsx".to_string(),
-                source: "// @flow\nimport { Platform } from '@uniflowed/react-native';\nconst name = Platform.OS;\n"
-                    .to_string(),
-            },
-            &UniflowedConfig::default(),
-        )
-        .expect("lint");
-
-        assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.rule == "react-native/platform-split")
-        );
+        for timer in TIMER_FUNCTIONS {
+            for at in find_words(code, timer) {
+                let Some((paren_at, b'(')) = next_non_space(code, at + timer.len()) else {
+                    continue;
+                };
+                if !next_non_space(code, paren_at + 1)
+                    .is_some_and(|(_, byte)| matches!(byte, b'\'' | b'"' | b'`'))
+                {
+                    continue;
+                }
+                push_in_code(
+                    diagnostics,
+                    scan,
+                    "security/no-eval",
+                    severity,
+                    position,
+                    at,
+                    "a string timer body is evaluated as code; pass a function instead",
+                );
+            }
+        }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_lint/src/rules.rs
+++ b/crates/uf_lint/src/rules.rs
@@ -1,0 +1,647 @@
+//! The rule catalogue: one descriptor per lint `uf lint` knows about.
+//!
+//! `uf lint` is the union of Flow's built-in lint set (see
+//! [`crate::flow_builtin`]) and uf's own framework rules, so the catalogue is the
+//! place `uf inspect` and the docs read to answer "what can this linter check?".
+
+use std::sync::LazyLock;
+
+use serde::Serialize;
+use uf_config::RuleLevel;
+
+use crate::flow_builtin::FlowBuiltinLint;
+
+/// Which part of the toolchain a rule belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleCategory {
+    /// Flow's own built-in lints plus Flow parse diagnostics.
+    Flow,
+    /// Toolchain-wide hygiene rules.
+    Uniflowed,
+    /// React and Flow component/hook syntax rules.
+    React,
+    /// React Native specific rules.
+    ReactNative,
+    /// Server component, server action, and client/server boundary rules.
+    Server,
+    /// File-system router rules.
+    Router,
+    /// `package.json` rules.
+    Package,
+    /// `@uniflowed/fetch` rules.
+    Fetch,
+    /// Rules that exist to keep a known vulnerability class out of the codebase.
+    Security,
+}
+
+/// What a rule needs in order to produce an answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleRequirement {
+    /// Decidable from the source text alone; the rule runs today.
+    SourceText,
+    /// Needs type inference. uf has no type checker yet, so an enabled rule of
+    /// this kind is reported through [`crate::LintReport::unavailable`] rather
+    /// than silently passing.
+    TypeChecker,
+}
+
+impl RuleRequirement {
+    /// Whether `uf lint` can evaluate rules with this requirement today.
+    #[inline]
+    pub fn is_available(self) -> bool {
+        matches!(self, Self::SourceText)
+    }
+}
+
+/// Everything `uf inspect` and the docs need to describe one rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleDescriptor {
+    /// Stable rule id, e.g. `"flow/unclear-type"`.
+    pub id: &'static str,
+    /// Which part of the toolchain owns the rule.
+    pub category: RuleCategory,
+    /// Level applied by [`uf_config::LintConfig::default`].
+    pub default_level: RuleLevel,
+    /// What the rule needs in order to run.
+    pub requirement: RuleRequirement,
+    /// One-line summary, suitable for `uf inspect` output.
+    pub description: &'static str,
+}
+
+/// Rule ids that older configs may still use, mapped to their replacement.
+///
+/// `flow/type-aware/no-explicit-any` was uf's hand-rolled `any` check before the
+/// Flow built-in set landed; Flow's own name for it is `unclear-type`.
+static DEPRECATED_ALIASES: phf::Map<&'static str, &'static str> = phf::phf_map! {
+    "flow/type-aware/no-explicit-any" => "flow/unclear-type",
+};
+
+/// Per-lint metadata for the Flow built-ins, indexed by discriminant.
+///
+/// Ids and names live in [`crate::flow_builtin`]; only the uf-specific policy
+/// (default level, requirement, blurb) lives here.
+struct FlowLintMeta {
+    default_level: RuleLevel,
+    requirement: RuleRequirement,
+    description: &'static str,
+}
+
+const fn meta(
+    default_level: RuleLevel,
+    requirement: RuleRequirement,
+    description: &'static str,
+) -> FlowLintMeta {
+    FlowLintMeta {
+        default_level,
+        requirement,
+        description,
+    }
+}
+
+use RuleRequirement::{SourceText, TypeChecker};
+
+/// uf's deliberate policy for each Flow built-in lint.
+///
+/// Flow itself defaults every lint to `off`. uf is opinionated instead: a rule is
+/// `error` when the pattern it catches is a bug or an unsound escape hatch in a
+/// large Flow codebase, `warn` when the pattern is merely suspicious or when uf's
+/// current check only covers a syntactic subset, and `off` only when leaving it on
+/// would double-report. Rationale per lint is on each row.
+///
+/// The order must match [`FlowBuiltinLint`]'s discriminant order.
+static FLOW_META: [FlowLintMeta; FlowBuiltinLint::COUNT] = [
+    // ambiguous-object-type: a large codebase cannot afford object types whose
+    // exactness depends on a config flag; readers must see `{| |}` or `{ ... }`.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "object type annotations must state exactness explicitly",
+    ),
+    // default-import-access: reading named exports off a default import is almost
+    // always a CommonJS interop mistake.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "do not read named exports off a default import",
+    ),
+    // deprecated-type: `bool` is a legacy alias; one-line fix, no downside.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "the `bool` type alias is deprecated; write `boolean`",
+    ),
+    // export-renamed-default: legal but confusing; warn rather than block.
+    meta(
+        RuleLevel::Warn,
+        SourceText,
+        "avoid `export { value as default }`; use an explicit default export",
+    ),
+    // internal-type: Flow's internal types are unstable and change between
+    // releases, so depending on them makes upgrades break silently.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "do not reference Flow's internal types directly",
+    ),
+    // invalid-import-star-use: namespace objects are not values; misuse is a bug.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "namespace imports may only be used for member access",
+    ),
+    // invalid-this-arg: rebinding a method to a foreign receiver is unsound.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "do not rebind a method to an incompatible receiver",
+    ),
+    // libdef-override: silently shadowing a builtin libdef breaks every consumer.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "library definitions must not override built-in declarations",
+    ),
+    // mixed-import-and-require: uf ships ESM only; mixing the two module systems
+    // in one file defeats static analysis and tree shaking.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "do not mix `import` and `require` in one module",
+    ),
+    // nested-component: a component declared inside another is a fresh type every
+    // render, so React remounts its whole subtree.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "do not declare a component inside another component or hook",
+    ),
+    // nested-hook: same remount/identity problem as nested components.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "do not declare a hook inside another component or hook",
+    ),
+    // non-const-var-export: a mutable export is a live binding consumers cannot
+    // reason about, and it blocks tree shaking.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "exported bindings must be `const`",
+    ),
+    // nonstrict-import: only actionable once `@flow strict` adoption is underway,
+    // so warn instead of blocking a migration.
+    meta(
+        RuleLevel::Warn,
+        TypeChecker,
+        "`@flow strict` modules may only import other strict modules",
+    ),
+    // react-intrinsic-overlap: shadowing `div`/`span` silently changes what JSX
+    // means at the use site.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "local bindings must not shadow a JSX intrinsic element name",
+    ),
+    // require-explicit-enum-checks: warn, because the explicit form is verbose and
+    // the implicit form is not itself a bug.
+    meta(
+        RuleLevel::Warn,
+        TypeChecker,
+        "compare Flow enum values explicitly instead of testing truthiness",
+    ),
+    // require-explicit-enum-switch-cases: same reasoning as above.
+    meta(
+        RuleLevel::Warn,
+        TypeChecker,
+        "list Flow enum switch cases explicitly instead of relying on `default`",
+    ),
+    // sketchy-null (umbrella): `if (count)` skipping `0` and `""` is the single
+    // most common Flow-catchable production bug, so it is on by default. The five
+    // typed variants below stay `off` so one violation is not reported twice.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "existence check on a value that may be both nullish and falsey",
+    ),
+    // sketchy-null-bigint: covered by the `sketchy-null` umbrella above.
+    meta(
+        RuleLevel::Off,
+        TypeChecker,
+        "existence check on a `?bigint` (covered by `flow/sketchy-null`)",
+    ),
+    // sketchy-null-bool: covered by the `sketchy-null` umbrella above.
+    meta(
+        RuleLevel::Off,
+        TypeChecker,
+        "existence check on a `?boolean` (covered by `flow/sketchy-null`)",
+    ),
+    // sketchy-null-mixed: covered by the `sketchy-null` umbrella above.
+    meta(
+        RuleLevel::Off,
+        TypeChecker,
+        "existence check on a `mixed` value (covered by `flow/sketchy-null`)",
+    ),
+    // sketchy-null-number: covered by the `sketchy-null` umbrella above.
+    meta(
+        RuleLevel::Off,
+        TypeChecker,
+        "existence check on a `?number` (covered by `flow/sketchy-null`)",
+    ),
+    // sketchy-null-string: covered by the `sketchy-null` umbrella above.
+    meta(
+        RuleLevel::Off,
+        TypeChecker,
+        "existence check on a `?string` (covered by `flow/sketchy-null`)",
+    ),
+    // sketchy-number: `{count && <List />}` renders a literal `0` in React. This
+    // ships user-visible bugs, so it is an error.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "a number in a boolean position renders or branches on `0`",
+    ),
+    // this-in-exported-function: legal in methods, so warn rather than block.
+    meta(
+        RuleLevel::Warn,
+        TypeChecker,
+        "avoid `this` inside an exported standalone function",
+    ),
+    // unclear-type: `any`, `Object` and `Function` switch the checker off. This is
+    // the rule formerly known as `flow/type-aware/no-explicit-any`.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "avoid `any`, `Object`, and `Function` type annotations",
+    ),
+    // uninitialized-instance-property: reading a field before the constructor
+    // finishes yields `undefined` at runtime with no type error.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "do not read an instance property before the constructor initializes it",
+    ),
+    // unnecessary-invariant: dead code, not a bug; warn.
+    meta(
+        RuleLevel::Warn,
+        TypeChecker,
+        "`invariant` on a condition already known to be truthy",
+    ),
+    // unnecessary-optional-chain: uf can only see the syntactic subset today (a
+    // base that is never nullable), so warn rather than block.
+    meta(
+        RuleLevel::Warn,
+        SourceText,
+        "`?.` applied to a base that can never be nullish",
+    ),
+    // unsafe-getters-setters: accessors hide side effects behind property syntax,
+    // but they are legitimate in some UI code, so warn.
+    meta(
+        RuleLevel::Warn,
+        SourceText,
+        "avoid getters and setters; they hide side effects behind property access",
+    ),
+    // unsafe-object-assign: `Object.assign` mutates its target and is unsound in
+    // Flow; object spread is both safer and faster.
+    meta(
+        RuleLevel::Error,
+        SourceText,
+        "prefer object spread over `Object.assign`",
+    ),
+    // untyped-import: an untyped dependency turns every value it exports into
+    // `any`, which quietly disables checking far from the import site.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "importing from an untyped module produces `any`",
+    ),
+    // untyped-type-import: same silent-`any` problem, in type position.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "importing a type from an untyped module produces an `any` alias",
+    ),
+    // unused-promise: a floating promise swallows rejections and loses ordering.
+    meta(
+        RuleLevel::Error,
+        TypeChecker,
+        "do not ignore a `Promise`; await it or handle its rejection",
+    ),
+];
+
+/// uf's own rules, on top of the Flow built-in set.
+static OWN_RULES: &[RuleDescriptor] = &[
+    RuleDescriptor {
+        id: "flow/syntax",
+        category: RuleCategory::Flow,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "the file must parse with the official Flow parser",
+    },
+    RuleDescriptor {
+        id: "uniflowed/no-tabs",
+        category: RuleCategory::Uniflowed,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "indent with spaces, never tabs",
+    },
+    RuleDescriptor {
+        id: "uniflowed/no-trailing-whitespace",
+        category: RuleCategory::Uniflowed,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "lines must not end in whitespace",
+    },
+    RuleDescriptor {
+        id: "uniflowed/no-npm-script-invocation",
+        category: RuleCategory::Uniflowed,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "shell out to uf tasks, not `npm run`/`yarn`/`pnpm`/`bunx`",
+    },
+    RuleDescriptor {
+        id: "uniflowed/unknown-lint-suppression",
+        category: RuleCategory::Uniflowed,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "`uf-lint-disable` comments must name a rule this linter knows",
+    },
+    RuleDescriptor {
+        id: "react/component-syntax",
+        category: RuleCategory::React,
+        default_level: RuleLevel::Warn,
+        requirement: SourceText,
+        description: "declare React components with Flow `component` syntax",
+    },
+    RuleDescriptor {
+        id: "react/hook-syntax",
+        category: RuleCategory::React,
+        default_level: RuleLevel::Warn,
+        requirement: SourceText,
+        description: "declare React hooks with Flow `hook` syntax",
+    },
+    RuleDescriptor {
+        id: "react/hooks-rules",
+        category: RuleCategory::React,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "call hooks only at the top level of a component, hook, or `useX` function",
+    },
+    // `warn`, not `error`, for the same reason as `react/component-syntax`: this
+    // is a convention the ecosystem (and uf's own `uf create app` scaffold) is
+    // still migrating to, and a linter must not fail a freshly created project.
+    // It becomes an error once the scaffold ships named exports.
+    RuleDescriptor {
+        id: "react/no-default-export-component",
+        category: RuleCategory::React,
+        default_level: RuleLevel::Warn,
+        requirement: SourceText,
+        description: "modules that declare components must use named exports",
+    },
+    RuleDescriptor {
+        id: "react/no-render-side-effects",
+        category: RuleCategory::React,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "keep render idempotent; no clocks, randomness, or storage reads",
+    },
+    RuleDescriptor {
+        id: "react-native/platform-split",
+        category: RuleCategory::ReactNative,
+        default_level: RuleLevel::Warn,
+        requirement: SourceText,
+        description: "prefer platform-specific files over `Platform.OS` branches",
+    },
+    RuleDescriptor {
+        id: "server/no-client-secret",
+        category: RuleCategory::Server,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "client modules must not read server secrets",
+    },
+    RuleDescriptor {
+        id: "server/no-server-only-import-in-client",
+        category: RuleCategory::Server,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "client modules must not import server-only modules",
+    },
+    RuleDescriptor {
+        id: "server/use-client-directive-position",
+        category: RuleCategory::Server,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "`use client`/`use server` must be the module's first statement",
+    },
+    RuleDescriptor {
+        id: "server/use-server-actions",
+        category: RuleCategory::Server,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "server action modules must open with `\"use server\";`",
+    },
+    RuleDescriptor {
+        id: "router/reserved-files",
+        category: RuleCategory::Router,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "`_uf.*` file names are reserved for layout, page, and middleware",
+    },
+    RuleDescriptor {
+        id: "package/no-npm-scripts",
+        category: RuleCategory::Package,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "declare tasks in `uf.config.js`, not `package.json` scripts",
+    },
+    RuleDescriptor {
+        id: "fetch/no-global-override",
+        category: RuleCategory::Fetch,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "do not monkey-patch global `fetch`",
+    },
+    RuleDescriptor {
+        id: "security/no-dangerously-set-inner-html",
+        category: RuleCategory::Security,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "render HTML only through a sanitizing `@uniflowed/markdown` helper",
+    },
+    RuleDescriptor {
+        id: "security/no-eval",
+        category: RuleCategory::Security,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "never turn strings into code via `eval`, `new Function`, or timer strings",
+    },
+];
+
+/// Every rule, sorted by id so [`rule`] can binary search.
+static ALL_RULES: LazyLock<Box<[RuleDescriptor]>> = LazyLock::new(|| {
+    let mut all = Vec::with_capacity(FlowBuiltinLint::COUNT + OWN_RULES.len());
+    for lint in FlowBuiltinLint::all() {
+        let meta = &FLOW_META[lint as usize];
+        all.push(RuleDescriptor {
+            id: lint.as_rule_id(),
+            category: RuleCategory::Flow,
+            default_level: meta.default_level,
+            requirement: meta.requirement,
+            description: meta.description,
+        });
+    }
+    all.extend_from_slice(OWN_RULES);
+    all.sort_unstable_by_key(|descriptor| descriptor.id);
+    all.into_boxed_slice()
+});
+
+/// Every rule `uf lint` knows about, sorted by rule id.
+///
+/// This is what `uf inspect` and the documentation enumerate.
+pub fn rules() -> &'static [RuleDescriptor] {
+    &ALL_RULES
+}
+
+/// Look up one rule by its canonical id.
+///
+/// Deprecated aliases are **not** resolved here; call [`canonical_rule_id`] first
+/// if the id may come from a user-written config or suppression comment.
+pub fn rule(id: &str) -> Option<&'static RuleDescriptor> {
+    rules()
+        .binary_search_by_key(&id, |descriptor| descriptor.id)
+        .ok()
+        .map(|index| &rules()[index])
+}
+
+/// Resolve a user-written rule id to its canonical spelling.
+///
+/// Returns `None` when the id names no rule at all, which is what
+/// `uniflowed/unknown-lint-suppression` reports on.
+pub fn canonical_rule_id(id: &str) -> Option<&'static str> {
+    if let Some(canonical) = DEPRECATED_ALIASES.get(id) {
+        return Some(canonical);
+    }
+    rule(id).map(|descriptor| descriptor.id)
+}
+
+/// Iterate the deprecated aliases pointing at `canonical`.
+pub(crate) fn deprecated_aliases_for(canonical: &str) -> impl Iterator<Item = &'static str> {
+    DEPRECATED_ALIASES
+        .entries()
+        .filter(move |(_, target)| **target == canonical)
+        .map(|(alias, _)| *alias)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalogue_covers_flow_builtins_and_uf_rules() {
+        assert_eq!(rules().len(), FlowBuiltinLint::COUNT + OWN_RULES.len());
+    }
+
+    #[test]
+    fn catalogue_is_sorted_and_free_of_duplicate_ids() {
+        let ids = rules()
+            .iter()
+            .map(|descriptor| descriptor.id)
+            .collect::<Vec<_>>();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(ids, sorted);
+    }
+
+    #[test]
+    fn every_flow_builtin_lint_has_a_descriptor() {
+        for lint in FlowBuiltinLint::all() {
+            let descriptor = rule(lint.as_rule_id())
+                .unwrap_or_else(|| panic!("{} has no descriptor", lint.as_rule_id()));
+            assert_eq!(descriptor.category, RuleCategory::Flow);
+        }
+    }
+
+    #[test]
+    fn every_flow_namespaced_descriptor_is_a_builtin_or_flow_syntax() {
+        for descriptor in rules() {
+            let Some(name) = descriptor.id.strip_prefix("flow/") else {
+                continue;
+            };
+            if name == "syntax" {
+                continue;
+            }
+            assert!(
+                FlowBuiltinLint::from_rule_id(descriptor.id).is_some(),
+                "{} is not a Flow built-in lint",
+                descriptor.id
+            );
+        }
+    }
+
+    #[test]
+    fn descriptions_are_one_line_and_non_empty() {
+        for descriptor in rules() {
+            assert!(!descriptor.description.is_empty(), "{}", descriptor.id);
+            assert!(!descriptor.description.contains('\n'), "{}", descriptor.id);
+        }
+    }
+
+    #[test]
+    fn deprecated_alias_points_at_flow_unclear_type() {
+        assert_eq!(
+            canonical_rule_id("flow/type-aware/no-explicit-any"),
+            Some(FlowBuiltinLint::UnclearType.as_rule_id())
+        );
+        assert_eq!(
+            deprecated_aliases_for(FlowBuiltinLint::UnclearType.as_rule_id()).collect::<Vec<_>>(),
+            vec!["flow/type-aware/no-explicit-any"]
+        );
+    }
+
+    #[test]
+    fn every_deprecated_alias_resolves_to_a_real_rule() {
+        for (alias, target) in DEPRECATED_ALIASES.entries() {
+            assert!(rule(target).is_some(), "{alias} points at unknown {target}");
+            assert!(rule(alias).is_none(), "{alias} must not be a rule itself");
+        }
+    }
+
+    #[test]
+    fn canonical_rule_id_rejects_unknown_ids() {
+        assert_eq!(canonical_rule_id("flow/does-not-exist"), None);
+        assert_eq!(canonical_rule_id(""), None);
+    }
+
+    #[test]
+    fn type_checker_rules_are_reported_as_unavailable() {
+        assert!(!RuleRequirement::TypeChecker.is_available());
+        assert!(RuleRequirement::SourceText.is_available());
+    }
+
+    #[test]
+    fn sketchy_null_variants_default_off_so_violations_report_once() {
+        for member in FlowBuiltinLint::SketchyNull.members() {
+            let descriptor = rule(member.as_rule_id()).expect("descriptor");
+            assert_eq!(descriptor.default_level, RuleLevel::Off);
+        }
+        let umbrella = rule(FlowBuiltinLint::SketchyNull.as_rule_id()).expect("descriptor");
+        assert_eq!(umbrella.default_level, RuleLevel::Error);
+    }
+
+    #[test]
+    fn security_rules_are_errors_by_default() {
+        for descriptor in rules() {
+            if descriptor.category == RuleCategory::Security {
+                assert_eq!(
+                    descriptor.default_level,
+                    RuleLevel::Error,
+                    "{}",
+                    descriptor.id
+                );
+            }
+        }
+    }
+}

--- a/crates/uf_lint/src/scan.rs
+++ b/crates/uf_lint/src/scan.rs
@@ -1,0 +1,532 @@
+//! One pass over a file, shared by every rule.
+//!
+//! Rules used to re-walk `source.lines()` once each, which meant N passes and N
+//! chances to disagree about where a line starts. [`FileScan`] does the walk once:
+//! it builds the [`LineIndex`] a single time, records each line's byte offset, the
+//! sub-slice of the line that is *not* inside a comment, and the brace depth the
+//! line opens at. Rules then borrow those slices instead of re-scanning.
+
+use uf_infra::LineIndex;
+
+use crate::SourceFile;
+
+/// A single physical line, plus the derived facts rules need about it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Line<'a> {
+    /// Byte offset of the line's first byte within the file.
+    pub offset: usize,
+    /// Line contents with the terminator (and a CRLF `\r`) removed.
+    pub text: &'a str,
+    /// Byte range of `text` that lies outside comments.
+    code_start: usize,
+    code_end: usize,
+    /// Brace nesting depth at the first byte of this line.
+    pub depth_at_start: u32,
+}
+
+impl<'a> Line<'a> {
+    /// The part of the line that is code, i.e. outside `//` and `/* */` comments.
+    ///
+    /// String literals are *not* stripped: rules such as
+    /// `uniflowed/no-npm-script-invocation` exist precisely to look inside them.
+    #[inline]
+    pub fn code(&self) -> &'a str {
+        &self.text[self.code_start..self.code_end]
+    }
+
+    /// Byte offset of [`Line::code`] within [`Line::text`].
+    #[inline]
+    pub fn code_offset(&self) -> usize {
+        self.code_start
+    }
+
+    /// The trailing comment on this line, including its `//` or `/*` opener.
+    #[inline]
+    pub fn trailing_comment(&self) -> &'a str {
+        &self.text[self.code_end..]
+    }
+
+    /// Byte offset of [`Line::trailing_comment`] within [`Line::text`].
+    #[inline]
+    pub fn comment_offset(&self) -> usize {
+        self.code_end
+    }
+}
+
+/// Cheap whole-file predicates, computed once so rules can bail out early.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct FileFacts {
+    /// The file uses Flow `component` declaration syntax.
+    pub declares_component: bool,
+    /// The file carries a `use client` directive somewhere.
+    pub has_use_client: bool,
+    /// The file mentions React at all.
+    pub mentions_react: bool,
+    /// The file mentions React Native at all.
+    pub mentions_react_native: bool,
+    /// Index into [`FileScan::lines`] of the first line with any code on it.
+    pub first_code_line: Option<usize>,
+    /// The file has at least one ESM `import` statement.
+    pub has_esm_import: bool,
+}
+
+/// Everything the rules need about one file, computed once.
+pub(crate) struct FileScan<'a> {
+    /// The file under test.
+    pub file: &'a SourceFile,
+    /// Offset → line/column index, built exactly once per file.
+    pub index: LineIndex,
+    /// Physical lines with their comment-stripped code slices.
+    pub lines: Vec<Line<'a>>,
+    /// Whole-file predicates.
+    pub facts: FileFacts,
+}
+
+/// State carried from one line into the next by the comment scanner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Carry {
+    /// Ordinary code.
+    Code,
+    /// Inside a `/* ... */` comment.
+    BlockComment,
+    /// Inside a backtick template literal.
+    Template,
+}
+
+impl<'a> FileScan<'a> {
+    /// Walk `file` once and record everything the rules need.
+    pub fn new(file: &'a SourceFile) -> Self {
+        let source = file.source.as_str();
+        let index = LineIndex::new(source);
+
+        let mut lines = Vec::with_capacity(index.line_count());
+        let mut facts = FileFacts::default();
+        let mut carry = Carry::Code;
+        let mut depth: u32 = 0;
+        let mut offset = 0usize;
+
+        for raw in split_lines(source) {
+            let text = raw.strip_suffix('\r').unwrap_or(raw);
+            let scanned = scan_line(text, carry);
+            carry = scanned.carry;
+
+            let line = Line {
+                offset,
+                text,
+                code_start: scanned.code_start,
+                code_end: scanned.code_end,
+                depth_at_start: depth,
+            };
+            depth = depth.saturating_add_signed(scanned.brace_delta);
+
+            if facts.first_code_line.is_none() && !line.code().trim().is_empty() {
+                facts.first_code_line = Some(lines.len());
+            }
+
+            lines.push(line);
+            offset += raw.len() + 1;
+        }
+
+        facts.declares_component = source.contains("component ");
+        facts.has_use_client = source.contains("\"use client\"") || source.contains("'use client'");
+        facts.mentions_react = source.contains("React");
+        facts.mentions_react_native = source.contains("react-native");
+        facts.has_esm_import = lines.iter().any(|line| {
+            let code = line.code().trim_start();
+            code.starts_with("import ") || code.starts_with("import{")
+        });
+
+        Self {
+            file,
+            index,
+            lines,
+            facts,
+        }
+    }
+}
+
+/// Split on `\n` with `str::lines` semantics but without dropping the final
+/// empty line's offset bookkeeping.
+fn split_lines(source: &str) -> impl Iterator<Item = &str> {
+    source.split('\n')
+}
+
+/// Result of classifying one physical line.
+struct ScannedLine {
+    code_start: usize,
+    code_end: usize,
+    carry: Carry,
+    /// Net `{` minus `}` outside comments and string literals.
+    brace_delta: i32,
+}
+
+/// Classify one line into `[code_start, code_end)` plus the state the next line
+/// starts in, counting braces that are really braces on the way.
+///
+/// Known, deliberate simplification: when a `/* ... */` comment opens *and*
+/// closes on the same line, the code after the closing `*/` is dropped rather
+/// than stitched back together. That costs a few diagnostics on lines like
+/// `const a = /* why */ any;` and never invents one, which is the right way for a
+/// linter to be wrong.
+fn scan_line(text: &str, carry: Carry) -> ScannedLine {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut i = 0usize;
+    let mut code_start = 0usize;
+
+    match carry {
+        Carry::BlockComment => match find_pair(bytes, 0, b'*', b'/') {
+            Some(pos) => {
+                i = pos + 2;
+                code_start = i;
+            }
+            None => {
+                return ScannedLine {
+                    code_start: 0,
+                    code_end: 0,
+                    carry: Carry::BlockComment,
+                    brace_delta: 0,
+                };
+            }
+        },
+        Carry::Template => match find_unescaped(bytes, 0, b'`') {
+            Some(pos) => i = pos + 1,
+            None => {
+                return ScannedLine {
+                    code_start: 0,
+                    code_end: len,
+                    carry: Carry::Template,
+                    brace_delta: 0,
+                };
+            }
+        },
+        Carry::Code => {}
+    }
+
+    let mut carry = Carry::Code;
+    let mut code_end = len;
+    let mut brace_delta = 0i32;
+    while i < len {
+        match bytes[i] {
+            b'/' if i + 1 < len && bytes[i + 1] == b'/' => {
+                code_end = i;
+                break;
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                code_end = i;
+                if find_pair(bytes, i + 2, b'*', b'/').is_none() {
+                    carry = Carry::BlockComment;
+                }
+                break;
+            }
+            quote @ (b'\'' | b'"') => {
+                i = match find_unescaped(bytes, i + 1, quote) {
+                    Some(pos) => pos + 1,
+                    None => len,
+                };
+            }
+            b'`' => match find_unescaped(bytes, i + 1, b'`') {
+                Some(pos) => i = pos + 1,
+                None => {
+                    carry = Carry::Template;
+                    i = len;
+                }
+            },
+            b'{' => {
+                brace_delta += 1;
+                i += 1;
+            }
+            b'}' => {
+                brace_delta -= 1;
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+
+    ScannedLine {
+        code_start,
+        code_end: code_end.max(code_start),
+        carry,
+        brace_delta,
+    }
+}
+
+/// First `needle` at or after `from` that is not backslash escaped.
+fn find_unescaped(bytes: &[u8], from: usize, needle: u8) -> Option<usize> {
+    let mut i = from;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            byte if byte == needle => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// First occurrence of the two-byte sequence `first`,`second` at or after `from`.
+fn find_pair(bytes: &[u8], from: usize, first: u8, second: u8) -> Option<usize> {
+    if from >= bytes.len() {
+        return None;
+    }
+    uf_infra::memchr_iter(first, &bytes[from..])
+        .map(|offset| from + offset)
+        .find(|&pos| bytes.get(pos + 1) == Some(&second))
+}
+
+/// Whether `byte` can appear inside a JavaScript identifier.
+#[inline]
+pub(crate) fn is_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+/// Whether the byte at `at` starts a word (nothing word-ish precedes it).
+#[inline]
+pub(crate) fn starts_word(haystack: &str, at: usize) -> bool {
+    at == 0 || !is_word_byte(haystack.as_bytes()[at - 1])
+}
+
+/// Whether `at + len` ends a word (nothing word-ish follows it).
+#[inline]
+pub(crate) fn ends_word(haystack: &str, end: usize) -> bool {
+    haystack
+        .as_bytes()
+        .get(end)
+        .is_none_or(|&byte| !is_word_byte(byte))
+}
+
+/// Byte offsets of every occurrence of `needle` in `haystack`.
+///
+/// Uses `memchr` on the needle's first byte rather than a naive character walk.
+pub(crate) fn find_all<'a>(haystack: &'a str, needle: &'a str) -> impl Iterator<Item = usize> + 'a {
+    let first = needle.as_bytes().first().copied();
+    let bytes = haystack.as_bytes();
+    first
+        .into_iter()
+        .flat_map(move |first| uf_infra::memchr_iter(first, bytes))
+        .filter(move |&at| haystack.as_bytes()[at..].starts_with(needle.as_bytes()))
+}
+
+/// Byte offsets of every standalone-word occurrence of `needle` in `haystack`.
+pub(crate) fn find_words<'a>(
+    haystack: &'a str,
+    needle: &'a str,
+) -> impl Iterator<Item = usize> + 'a {
+    find_all(haystack, needle)
+        .filter(move |&at| starts_word(haystack, at) && ends_word(haystack, at + needle.len()))
+}
+
+/// The next non-whitespace byte at or after `from`.
+#[inline]
+pub(crate) fn next_non_space(haystack: &str, from: usize) -> Option<(usize, u8)> {
+    haystack.as_bytes()[from.min(haystack.len())..]
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .map(|offset| (from + offset, haystack.as_bytes()[from + offset]))
+}
+
+/// The last non-whitespace byte strictly before `before`.
+#[inline]
+pub(crate) fn prev_non_space(haystack: &str, before: usize) -> Option<(usize, u8)> {
+    haystack.as_bytes()[..before.min(haystack.len())]
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map(|at| (at, haystack.as_bytes()[at]))
+}
+
+/// The identifier immediately before `before`, skipping whitespace.
+///
+/// Returns its start offset and text, or `None` when the preceding token is not
+/// an identifier.
+#[inline]
+pub(crate) fn previous_word(haystack: &str, before: usize) -> Option<(usize, &str)> {
+    let (end, byte) = prev_non_space(haystack, before)?;
+    if !is_word_byte(byte) {
+        return None;
+    }
+    let bytes = haystack.as_bytes();
+    let mut start = end;
+    while start > 0 && is_word_byte(bytes[start - 1]) {
+        start -= 1;
+    }
+    Some((start, &haystack[start..=end]))
+}
+
+/// Length of the identifier starting at `from`, or zero if none starts there.
+#[inline]
+pub(crate) fn identifier_len(haystack: &str, from: usize) -> usize {
+    let bytes = haystack.as_bytes();
+    if from >= bytes.len() || bytes[from].is_ascii_digit() || !is_word_byte(bytes[from]) {
+        return 0;
+    }
+    let mut end = from;
+    while end < bytes.len() && is_word_byte(bytes[end]) {
+        end += 1;
+    }
+    end - from
+}
+
+/// Whether `name` follows React's `useSomething` hook naming convention.
+#[inline]
+pub(crate) fn is_hook_name(name: &str) -> bool {
+    name.len() > 3 && name.starts_with("use") && name.as_bytes()[3].is_ascii_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(source: &str) -> SourceFile {
+        SourceFile {
+            path: "app/index.js".to_string(),
+            source: source.to_string(),
+        }
+    }
+
+    fn codes(source: &str) -> Vec<String> {
+        let file = file(source);
+        FileScan::new(&file)
+            .lines
+            .iter()
+            .map(|line| line.code().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn line_comments_are_stripped_from_code() {
+        assert_eq!(codes("let a = 1; // note\n"), vec!["let a = 1; ", ""]);
+    }
+
+    #[test]
+    fn urls_inside_strings_are_not_mistaken_for_comments() {
+        assert_eq!(
+            codes("const u = \"https://x.dev\"; // real\n"),
+            vec!["const u = \"https://x.dev\"; ", ""]
+        );
+    }
+
+    #[test]
+    fn block_comments_span_lines() {
+        assert_eq!(
+            codes("a;\n/* one\n two */ b;\nc;\n"),
+            vec!["a;", "", " b;", "c;", ""]
+        );
+    }
+
+    #[test]
+    fn unterminated_template_literals_carry_across_lines() {
+        assert_eq!(
+            codes("const t = `a\n// not a comment\n`;\n"),
+            vec!["const t = `a", "// not a comment", "`;", ""]
+        );
+    }
+
+    #[test]
+    fn escaped_quotes_do_not_end_a_string() {
+        assert_eq!(
+            codes("const s = 'a\\'// b'; c;\n"),
+            vec!["const s = 'a\\'// b'; c;", ""]
+        );
+    }
+
+    #[test]
+    fn crlf_terminators_are_trimmed_from_line_text() {
+        let file = file("a;\r\nb;\r\n");
+        let scan = FileScan::new(&file);
+        assert_eq!(scan.lines[0].text, "a;");
+        assert_eq!(scan.lines[1].text, "b;");
+    }
+
+    #[test]
+    fn line_offsets_match_the_line_index() {
+        let file = file("one\ntwo\nthree\n");
+        let scan = FileScan::new(&file);
+        for (position, line) in scan.lines.iter().enumerate() {
+            assert_eq!(scan.index.line_col(line.offset).line, position + 1);
+        }
+    }
+
+    #[test]
+    fn brace_depth_tracks_across_lines() {
+        let file = file("component A() {\n  const x = { y: 1 };\n}\n");
+        let scan = FileScan::new(&file);
+        assert_eq!(scan.lines[0].depth_at_start, 0);
+        assert_eq!(scan.lines[1].depth_at_start, 1);
+        assert_eq!(scan.lines[2].depth_at_start, 1);
+        assert_eq!(scan.lines[3].depth_at_start, 0);
+    }
+
+    #[test]
+    fn first_code_line_skips_comments_and_blanks() {
+        let file = file("\n// @flow\n\n'use client';\n");
+        let scan = FileScan::new(&file);
+        assert_eq!(scan.facts.first_code_line, Some(3));
+    }
+
+    #[test]
+    fn empty_input_has_one_empty_line() {
+        let file = file("");
+        let scan = FileScan::new(&file);
+        assert_eq!(scan.lines.len(), 1);
+        assert_eq!(scan.facts.first_code_line, None);
+    }
+
+    #[test]
+    fn byte_order_mark_does_not_break_offsets() {
+        let file = file("\u{feff}// @flow\nlet a = 1;\n");
+        let scan = FileScan::new(&file);
+        assert_eq!(scan.lines[1].text, "let a = 1;");
+        assert_eq!(scan.index.line_col(scan.lines[1].offset).line, 2);
+    }
+
+    #[test]
+    fn non_ascii_lines_keep_byte_offsets_consistent() {
+        let file = file("const s = 'ünïcødé'; // ok\nlet a = 1;\n");
+        let scan = FileScan::new(&file);
+        assert_eq!(scan.lines[1].text, "let a = 1;");
+        assert_eq!(scan.index.line_col(scan.lines[1].offset).column, 1);
+    }
+
+    #[test]
+    fn find_words_respects_identifier_boundaries() {
+        assert_eq!(
+            find_words("any anything many any", "any").collect::<Vec<_>>(),
+            vec![0, 18]
+        );
+        assert_eq!(
+            find_words("$any", "any").collect::<Vec<_>>(),
+            Vec::<usize>::new()
+        );
+    }
+
+    #[test]
+    fn find_all_reports_every_occurrence() {
+        assert_eq!(find_all("aXbXc", "X").collect::<Vec<_>>(), vec![1, 3]);
+        assert_eq!(find_all("abc", "").collect::<Vec<_>>(), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn identifier_len_rejects_digit_starts() {
+        assert_eq!(identifier_len("useThing(", 0), 8);
+        assert_eq!(identifier_len("9lives", 0), 0);
+        assert_eq!(identifier_len("(", 0), 0);
+    }
+
+    #[test]
+    fn hook_names_need_an_uppercase_fourth_character() {
+        assert!(is_hook_name("useState"));
+        assert!(!is_hook_name("used"));
+        assert!(!is_hook_name("use"));
+        assert!(!is_hook_name("useful"));
+    }
+
+    #[test]
+    fn very_large_input_scans_without_quadratic_blowup() {
+        let source = "let a = 1; // c\n".repeat(20_000);
+        let file = file(&source);
+        let scan = FileScan::new(&file);
+        assert_eq!(scan.lines.len(), 20_001);
+        assert_eq!(scan.lines[0].code(), "let a = 1; ");
+    }
+}

--- a/crates/uf_lint/src/suppression.rs
+++ b/crates/uf_lint/src/suppression.rs
@@ -1,0 +1,325 @@
+//! `uf-lint-disable` comment handling.
+//!
+//! Two forms are supported, both in `//` comments:
+//!
+//! ```js
+//! // uf-lint-disable-next-line flow/unclear-type
+//! // uf-lint-disable flow/unclear-type, react/hooks-rules
+//! // uf-lint-enable flow/unclear-type
+//! ```
+//!
+//! A suppression that names a rule this linter does not know is **not** a silent
+//! no-op: it raises `uniflowed/unknown-lint-suppression`. A typo'd suppression
+//! that quietly suppressed nothing would be indistinguishable from a working one,
+//! which is exactly how a rule stops being enforced without anyone noticing.
+
+use uf_infra::SmallVec;
+
+use crate::rules::canonical_rule_id;
+use crate::scan::{FileScan, next_non_space};
+
+/// Rule id reported when a suppression comment names an unknown rule.
+pub(crate) const UNKNOWN_SUPPRESSION_RULE: &str = "uniflowed/unknown-lint-suppression";
+
+const DISABLE_NEXT_LINE: &str = "uf-lint-disable-next-line";
+const DISABLE: &str = "uf-lint-disable";
+const ENABLE: &str = "uf-lint-enable";
+
+/// A suppression comment that could not be honoured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BadSuppression {
+    /// 1-based line of the offending comment.
+    pub line: usize,
+    /// 1-based byte column of the offending token.
+    pub column: usize,
+    /// Human-readable explanation.
+    pub message: String,
+}
+
+/// Resolved suppressions for one file.
+#[derive(Debug, Default)]
+pub(crate) struct Suppressions {
+    /// `(rule id, 1-based line)` pairs from `uf-lint-disable-next-line`.
+    single: Vec<(&'static str, usize)>,
+    /// `(rule id, first line, last line)` inclusive ranges from block form.
+    ranges: Vec<(&'static str, usize, usize)>,
+}
+
+impl Suppressions {
+    /// Whether the file carries no suppression comments at all.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.single.is_empty() && self.ranges.is_empty()
+    }
+
+    /// Whether `rule` is suppressed on the given 1-based `line`.
+    pub fn is_suppressed(&self, rule: &str, line: usize) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        self.single
+            .iter()
+            .any(|&(suppressed, at)| at == line && suppressed == rule)
+            || self
+                .ranges
+                .iter()
+                .any(|&(suppressed, start, end)| line >= start && line <= end && suppressed == rule)
+    }
+}
+
+/// Parse every suppression comment in `scan`.
+///
+/// Returns the resolved suppressions plus every comment that named a rule the
+/// linter does not know about.
+pub(crate) fn collect(scan: &FileScan<'_>) -> (Suppressions, Vec<BadSuppression>) {
+    let mut suppressions = Suppressions::default();
+    let mut bad = Vec::new();
+    // Block-form directives that have not seen a matching `uf-lint-enable`.
+    let mut open: SmallVec<[(&'static str, usize); 4]> = SmallVec::new();
+
+    for (position, line) in scan.lines.iter().enumerate() {
+        let comment = line.trailing_comment();
+        let Some(body) = comment.strip_prefix("//") else {
+            continue;
+        };
+        let base = line.comment_offset() + 2;
+        let Some((directive_at, _)) = next_non_space(body, 0) else {
+            continue;
+        };
+        let rest = &body[directive_at..];
+        let number = position + 1;
+
+        let (kind, args_at) = if let Some(args) = rest.strip_prefix(DISABLE_NEXT_LINE) {
+            (Directive::DisableNextLine, rest.len() - args.len())
+        } else if let Some(args) = rest.strip_prefix(DISABLE) {
+            (Directive::Disable, rest.len() - args.len())
+        } else if let Some(args) = rest.strip_prefix(ENABLE) {
+            (Directive::Enable, rest.len() - args.len())
+        } else {
+            continue;
+        };
+
+        // `uf-lint-disabled` must not be read as `uf-lint-disable` plus junk.
+        if rest
+            .as_bytes()
+            .get(args_at)
+            .is_some_and(|&byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+        {
+            continue;
+        }
+
+        let mut named_any = false;
+        for (offset, name) in split_rule_ids(&rest[args_at..]) {
+            named_any = true;
+            let column = base + directive_at + args_at + offset + 1;
+            let Some(rule) = canonical_rule_id(name) else {
+                bad.push(BadSuppression {
+                    line: number,
+                    column,
+                    message: format!("unknown lint rule `{name}` in suppression comment"),
+                });
+                continue;
+            };
+            match kind {
+                Directive::DisableNextLine => suppressions.single.push((rule, number + 1)),
+                Directive::Disable => open.push((rule, number)),
+                Directive::Enable => {
+                    if let Some(index) = open.iter().rposition(|&(open, _)| open == rule) {
+                        let (rule, start) = open.remove(index);
+                        suppressions.ranges.push((rule, start, number));
+                    }
+                }
+            }
+        }
+
+        if !named_any {
+            bad.push(BadSuppression {
+                line: number,
+                column: base + directive_at + 1,
+                message: "suppression comment must name at least one lint rule".to_string(),
+            });
+        }
+    }
+
+    for (rule, start) in open {
+        suppressions.ranges.push((rule, start, usize::MAX));
+    }
+
+    (suppressions, bad)
+}
+
+/// Which suppression directive a comment carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Directive {
+    DisableNextLine,
+    Disable,
+    Enable,
+}
+
+/// Split a directive's argument list into `(offset, rule id)` pairs.
+///
+/// Rule ids are separated by whitespace and/or commas, so both
+/// `a/b, c/d` and `a/b c/d` work.
+fn split_rule_ids(args: &str) -> impl Iterator<Item = (usize, &str)> {
+    args.split(|ch: char| ch.is_whitespace() || ch == ',')
+        .filter(|token| !token.is_empty())
+        .map(move |token| {
+            let offset = token.as_ptr() as usize - args.as_ptr() as usize;
+            (offset, token)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SourceFile;
+
+    fn parse(source: &str) -> (Suppressions, Vec<BadSuppression>) {
+        let file = SourceFile {
+            path: "app/index.js".to_string(),
+            source: source.to_string(),
+        };
+        let scan = FileScan::new(&file);
+        let (suppressions, bad) = collect(&scan);
+        (suppressions, bad)
+    }
+
+    #[test]
+    fn disable_next_line_targets_only_the_following_line() {
+        let (suppressions, bad) =
+            parse("// uf-lint-disable-next-line flow/unclear-type\nlet a: any;\nlet b: any;\n");
+
+        assert!(bad.is_empty());
+        assert!(suppressions.is_suppressed("flow/unclear-type", 2));
+        assert!(!suppressions.is_suppressed("flow/unclear-type", 3));
+        assert!(!suppressions.is_suppressed("flow/unclear-type", 1));
+    }
+
+    #[test]
+    fn disable_next_line_only_suppresses_the_named_rule() {
+        let (suppressions, _) = parse("// uf-lint-disable-next-line flow/unclear-type\nx\n");
+
+        assert!(!suppressions.is_suppressed("security/no-eval", 2));
+    }
+
+    #[test]
+    fn block_form_covers_the_directive_line_through_the_enable() {
+        let (suppressions, bad) = parse(
+            "// uf-lint-disable security/no-eval\neval('a');\neval('b');\n// uf-lint-enable security/no-eval\neval('c');\n",
+        );
+
+        assert!(bad.is_empty());
+        assert!(suppressions.is_suppressed("security/no-eval", 2));
+        assert!(suppressions.is_suppressed("security/no-eval", 3));
+        assert!(!suppressions.is_suppressed("security/no-eval", 5));
+    }
+
+    #[test]
+    fn block_form_without_an_enable_runs_to_end_of_file() {
+        let (suppressions, bad) = parse("// uf-lint-disable security/no-eval\neval('a');\n");
+
+        assert!(bad.is_empty());
+        assert!(suppressions.is_suppressed("security/no-eval", 99_999));
+    }
+
+    #[test]
+    fn several_rule_ids_may_share_one_comment() {
+        let (suppressions, bad) =
+            parse("// uf-lint-disable-next-line flow/unclear-type, security/no-eval\nx\n");
+
+        assert!(bad.is_empty());
+        assert!(suppressions.is_suppressed("flow/unclear-type", 2));
+        assert!(suppressions.is_suppressed("security/no-eval", 2));
+    }
+
+    #[test]
+    fn trailing_suppression_comments_are_honoured() {
+        let (suppressions, bad) =
+            parse("let a = 1; // uf-lint-disable-next-line security/no-eval\n");
+
+        assert!(bad.is_empty());
+        assert!(suppressions.is_suppressed("security/no-eval", 2));
+    }
+
+    #[test]
+    fn deprecated_rule_ids_resolve_to_their_replacement() {
+        let (suppressions, bad) =
+            parse("// uf-lint-disable-next-line flow/type-aware/no-explicit-any\nx\n");
+
+        assert!(bad.is_empty());
+        assert!(suppressions.is_suppressed("flow/unclear-type", 2));
+    }
+
+    #[test]
+    fn unknown_rule_ids_are_reported_not_ignored() {
+        let (suppressions, bad) = parse("// uf-lint-disable-next-line flow/typo-here\nx\n");
+
+        assert!(suppressions.is_empty());
+        assert_eq!(bad.len(), 1);
+        assert_eq!(bad[0].line, 1);
+        assert_eq!(bad[0].column, 30);
+        assert!(bad[0].message.contains("flow/typo-here"));
+    }
+
+    #[test]
+    fn a_suppression_with_no_rule_id_is_reported() {
+        let (_, bad) = parse("// uf-lint-disable-next-line\nx\n");
+
+        assert_eq!(bad.len(), 1);
+        assert!(bad[0].message.contains("at least one lint rule"));
+    }
+
+    #[test]
+    fn known_and_unknown_ids_in_one_comment_are_handled_independently() {
+        let (suppressions, bad) =
+            parse("// uf-lint-disable-next-line security/no-eval nope/nope\nx\n");
+
+        assert_eq!(bad.len(), 1);
+        assert!(suppressions.is_suppressed("security/no-eval", 2));
+    }
+
+    #[test]
+    fn similar_looking_words_are_not_directives() {
+        let (suppressions, bad) = parse("// uf-lint-disabled security/no-eval\nx\n");
+
+        assert!(suppressions.is_empty());
+        assert!(bad.is_empty());
+    }
+
+    #[test]
+    fn files_without_suppressions_take_the_empty_fast_path() {
+        let (suppressions, bad) = parse("let a = 1;\n// an ordinary comment\n");
+
+        assert!(suppressions.is_empty());
+        assert!(bad.is_empty());
+        assert!(!suppressions.is_suppressed("security/no-eval", 1));
+    }
+
+    #[test]
+    fn nested_block_directives_close_in_reverse_order() {
+        let (suppressions, _) = parse(
+            "// uf-lint-disable security/no-eval\n// uf-lint-disable flow/unclear-type\nx\n// uf-lint-enable flow/unclear-type\ny\n// uf-lint-enable security/no-eval\nz\n",
+        );
+
+        assert!(suppressions.is_suppressed("flow/unclear-type", 3));
+        assert!(!suppressions.is_suppressed("flow/unclear-type", 5));
+        assert!(suppressions.is_suppressed("security/no-eval", 5));
+        assert!(!suppressions.is_suppressed("security/no-eval", 7));
+    }
+
+    #[test]
+    fn an_enable_without_a_disable_is_harmless() {
+        let (suppressions, bad) = parse("// uf-lint-enable security/no-eval\nx\n");
+
+        assert!(suppressions.is_empty());
+        assert!(bad.is_empty());
+    }
+
+    #[test]
+    fn suppression_text_inside_a_string_is_not_a_directive() {
+        let (suppressions, bad) = parse("const s = \"// uf-lint-disable security/no-eval\";\n");
+
+        assert!(suppressions.is_empty());
+        assert!(bad.is_empty());
+    }
+}

--- a/crates/uf_lint/src/tests.rs
+++ b/crates/uf_lint/src/tests.rs
@@ -1,0 +1,1303 @@
+use uf_config::{RuleLevel, UniflowedConfig};
+use uf_infra::CompactString;
+
+use super::*;
+
+fn source(source: &str) -> SourceFile {
+    SourceFile {
+        path: "src/app/page.jsx".to_string(),
+        source: source.to_string(),
+    }
+}
+
+fn at(path: &str, source: &str) -> SourceFile {
+    SourceFile {
+        path: path.to_string(),
+        source: source.to_string(),
+    }
+}
+
+/// A config with exactly one rule enabled, so a rule's tests cannot be muddied by
+/// another rule firing on the same fixture.
+fn only(rule: &str) -> UniflowedConfig {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    config
+        .lint
+        .rules
+        .insert(CompactString::from(rule), RuleLevel::Error);
+    config
+}
+
+/// Diagnostics produced by `rule` alone for `path`/`text`.
+fn lint_one(rule: &str, path: &str, text: &str) -> Vec<Diagnostic> {
+    lint_source(&at(path, text), &only(rule))
+        .expect("lint")
+        .diagnostics
+}
+
+/// Diagnostics produced by `rule` alone for a default `.js` module.
+fn lint_js(rule: &str, text: &str) -> Vec<Diagnostic> {
+    lint_one(rule, "app/index.js", text)
+}
+
+fn fired(diagnostics: &[Diagnostic], rule: &str) -> bool {
+    diagnostics.iter().any(|diagnostic| diagnostic.rule == rule)
+}
+
+// ---------------------------------------------------------------------------
+// Catalogue / config agreement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_default_rule_has_a_descriptor() {
+    let config = UniflowedConfig::default();
+    for id in config.lint.rules.keys() {
+        assert!(
+            rule(id.as_str()).is_some(),
+            "{id} is configured by default but has no RuleDescriptor"
+        );
+    }
+}
+
+#[test]
+fn every_descriptor_has_a_default_rule_level() {
+    let config = UniflowedConfig::default();
+    for descriptor in rules() {
+        assert!(
+            config.lint.rules.contains_key(descriptor.id),
+            "{} has a RuleDescriptor but no default level",
+            descriptor.id
+        );
+    }
+}
+
+#[test]
+fn default_levels_match_the_descriptor_catalogue() {
+    let config = UniflowedConfig::default();
+    for descriptor in rules() {
+        assert_eq!(
+            config.lint.rules.get(descriptor.id).copied(),
+            Some(descriptor.default_level),
+            "{} disagrees between uf_config and uf_lint",
+            descriptor.id
+        );
+    }
+}
+
+#[test]
+fn catalogue_and_config_have_the_same_size() {
+    assert_eq!(UniflowedConfig::default().lint.rules.len(), rules().len());
+}
+
+#[test]
+fn every_flow_builtin_lint_is_enabled_or_deliberately_off() {
+    let config = UniflowedConfig::default();
+    for lint in FlowBuiltinLint::all() {
+        assert!(
+            config.lint.rules.contains_key(lint.as_rule_id()),
+            "{} has no default level",
+            lint.as_rule_id()
+        );
+    }
+}
+
+#[test]
+fn rules_are_enumerable_for_inspect() {
+    let descriptor = rule("flow/unclear-type").expect("descriptor");
+    assert_eq!(descriptor.category, RuleCategory::Flow);
+    assert_eq!(descriptor.requirement, RuleRequirement::SourceText);
+    assert!(!descriptor.description.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Type-checker-dependent rules are surfaced, never silently skipped
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_checker_rules_are_reported_as_unavailable() {
+    let report = lint_source(&source("// @flow\n"), &UniflowedConfig::default()).expect("lint");
+
+    assert!(
+        report
+            .unavailable
+            .iter()
+            .any(|entry| entry.rule == "flow/sketchy-null")
+    );
+    assert!(
+        report
+            .unavailable
+            .iter()
+            .all(|entry| entry.requirement == RuleRequirement::TypeChecker)
+    );
+    assert!(
+        report
+            .unavailable
+            .iter()
+            .all(|entry| entry.level.is_enabled())
+    );
+}
+
+#[test]
+fn unavailable_rules_do_not_count_as_errors() {
+    let report = lint_source(&source("// @flow\n"), &UniflowedConfig::default()).expect("lint");
+
+    assert!(!report.unavailable.is_empty());
+    assert!(!report.has_errors());
+}
+
+#[test]
+fn disabled_type_checker_rules_are_not_reported_as_unavailable() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    let report = lint_source(&source("// @flow\n"), &config).expect("lint");
+
+    assert!(report.unavailable.is_empty());
+}
+
+#[test]
+fn unavailable_rules_explain_themselves() {
+    let report = lint_source(&source("// @flow\n"), &UniflowedConfig::default()).expect("lint");
+    let entry = report
+        .unavailable
+        .iter()
+        .find(|entry| entry.rule == "flow/unused-promise")
+        .expect("unused-promise is enabled by default");
+
+    assert!(entry.reason().contains("type inference"));
+}
+
+#[test]
+fn unavailable_rules_are_listed_once_regardless_of_file_count() {
+    let files = (0..8)
+        .map(|index| at(&format!("app/{index}.js"), "// @flow\n"))
+        .collect::<Vec<_>>();
+    let report = lint_sources(&files, &UniflowedConfig::default()).expect("lint");
+
+    let sketchy = report
+        .unavailable
+        .iter()
+        .filter(|entry| entry.rule == "flow/sketchy-null")
+        .count();
+    assert_eq!(sketchy, 1);
+    assert_eq!(report.files_checked, 8);
+}
+
+// ---------------------------------------------------------------------------
+// The deprecated `flow/type-aware/no-explicit-any` alias
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deprecated_any_rule_id_still_configures_unclear_type() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    config.lint.rules.insert(
+        CompactString::const_new("flow/type-aware/no-explicit-any"),
+        RuleLevel::Error,
+    );
+
+    let report = lint_source(&source("// @flow\ntype P = { v: any };\n"), &config).expect("lint");
+
+    assert!(fired(&report.diagnostics, "flow/unclear-type"));
+    assert!(!fired(
+        &report.diagnostics,
+        "flow/type-aware/no-explicit-any"
+    ));
+}
+
+#[test]
+fn deprecated_any_rule_id_can_still_switch_the_rule_off() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    config.lint.rules.insert(
+        CompactString::const_new("flow/type-aware/no-explicit-any"),
+        RuleLevel::Off,
+    );
+
+    let report = lint_source(&source("// @flow\ntype P = { v: any };\n"), &config).expect("lint");
+
+    assert!(report.diagnostics.is_empty());
+}
+
+#[test]
+fn the_canonical_id_wins_over_the_deprecated_alias() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    config.lint.rules.insert(
+        CompactString::const_new("flow/type-aware/no-explicit-any"),
+        RuleLevel::Error,
+    );
+    config.lint.rules.insert(
+        CompactString::const_new("flow/unclear-type"),
+        RuleLevel::Off,
+    );
+
+    let report = lint_source(&source("// @flow\ntype P = { v: any };\n"), &config).expect("lint");
+
+    assert!(report.diagnostics.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// flow/* built-ins implemented from source text
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unclear_type_rejects_any_object_and_function() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\ntype A = any;\ntype B = Object;\ntype C = Function;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 3);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 10));
+    assert_eq!((diagnostics[1].line, diagnostics[1].column), (3, 10));
+    assert_eq!((diagnostics[2].line, diagnostics[2].column), (4, 10));
+}
+
+#[test]
+fn unclear_type_accepts_precise_annotations() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\ntype A = mixed;\ntype B = { +id: string, ... };\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn unclear_type_ignores_value_positions() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\nconst keys = Object.keys(props);\nconst ok = list.any;\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn unclear_type_ignores_identifiers_that_merely_contain_any() {
+    let diagnostics = lint_js("flow/unclear-type", "// @flow\nconst company = 1;\n");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn unclear_type_ignores_comments() {
+    let diagnostics = lint_js("flow/unclear-type", "// @flow\n// TODO: replace any here\n");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn deprecated_type_rejects_the_bool_alias() {
+    let diagnostics = lint_js("flow/deprecated-type", "// @flow\ntype A = bool;\n");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 10));
+}
+
+#[test]
+fn deprecated_type_accepts_boolean() {
+    let diagnostics = lint_js(
+        "flow/deprecated-type",
+        "// @flow\ntype A = boolean;\nconst o = { bool: true };\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn internal_type_rejects_flow_internals() {
+    let diagnostics = lint_js(
+        "flow/internal-type",
+        "// @flow\ntype N = React$Node;\ntype T = $TEMPORARY$object;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].line, 2);
+    assert_eq!(diagnostics[1].line, 3);
+}
+
+#[test]
+fn internal_type_accepts_the_public_equivalents() {
+    let diagnostics = lint_js(
+        "flow/internal-type",
+        "// @flow\nimport type { Node } from '@uniflowed/react';\ntype N = Node;\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn ambiguous_object_type_rejects_unmarked_object_types() {
+    let diagnostics = lint_js(
+        "flow/ambiguous-object-type",
+        "// @flow\ntype Props = { id: string };\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 14));
+}
+
+#[test]
+fn ambiguous_object_type_accepts_exact_and_explicitly_inexact_types() {
+    let diagnostics = lint_js(
+        "flow/ambiguous-object-type",
+        "// @flow\ntype A = {| id: string |};\ntype B = { id: string, ... };\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn ambiguous_object_type_reaches_nested_object_types() {
+    let diagnostics = lint_js(
+        "flow/ambiguous-object-type",
+        "// @flow\ntype Props = {\n  id: string,\n  meta: { title: string },\n  ...\n};\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 4);
+}
+
+#[test]
+fn ambiguous_object_type_ignores_object_literals() {
+    let diagnostics = lint_js(
+        "flow/ambiguous-object-type",
+        "// @flow\nconst defaults = { id: 'x' };\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn unsafe_getters_setters_rejects_accessors() {
+    let diagnostics = lint_js(
+        "flow/unsafe-getters-setters",
+        "// @flow\nclass Box {\n  get value(): number { return 1; }\n  set value(next: number) {}\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (3, 3));
+}
+
+#[test]
+fn unsafe_getters_setters_accepts_plain_methods() {
+    let diagnostics = lint_js(
+        "flow/unsafe-getters-setters",
+        "// @flow\nclass Box {\n  getValue(): number { return 1; }\n}\nconst v = map.get(key);\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn unsafe_object_assign_rejects_object_assign() {
+    let diagnostics = lint_js(
+        "flow/unsafe-object-assign",
+        "// @flow\nconst merged = Object.assign({}, base, patch);\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 16));
+}
+
+#[test]
+fn unsafe_object_assign_accepts_object_spread() {
+    let diagnostics = lint_js(
+        "flow/unsafe-object-assign",
+        "// @flow\nconst merged = { ...base, ...patch };\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn unnecessary_optional_chain_rejects_optional_this() {
+    let diagnostics = lint_js(
+        "flow/unnecessary-optional-chain",
+        "// @flow\nclass A { run() { return this?.value; } }\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 2);
+}
+
+#[test]
+fn unnecessary_optional_chain_accepts_chains_on_nullable_bases() {
+    let diagnostics = lint_js(
+        "flow/unnecessary-optional-chain",
+        "// @flow\nconst v = props?.meta?.title;\nconst w = this.value;\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn mixed_import_and_require_rejects_a_require_in_an_esm_module() {
+    let diagnostics = lint_js(
+        "flow/mixed-import-and-require",
+        "// @flow\nimport { a } from './a.js';\nconst b = require('./b.js');\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (3, 11));
+}
+
+#[test]
+fn mixed_import_and_require_accepts_a_pure_esm_module() {
+    let diagnostics = lint_js(
+        "flow/mixed-import-and-require",
+        "// @flow\nimport { a } from './a.js';\nimport { b } from './b.js';\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn non_const_var_export_rejects_mutable_exports() {
+    let diagnostics = lint_js(
+        "flow/non-const-var-export",
+        "// @flow\nexport let count = 0;\nexport var total = 0;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 8));
+}
+
+#[test]
+fn non_const_var_export_accepts_const_exports() {
+    let diagnostics = lint_js(
+        "flow/non-const-var-export",
+        "// @flow\nexport const count = 0;\nlet local = 1;\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn export_renamed_default_rejects_as_default() {
+    let diagnostics = lint_js(
+        "flow/export-renamed-default",
+        "// @flow\nconst page = 1;\nexport { page as default };\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 3);
+}
+
+#[test]
+fn export_renamed_default_accepts_importing_the_default() {
+    let diagnostics = lint_js(
+        "flow/export-renamed-default",
+        "// @flow\nimport { default as page } from './page.js';\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn react_intrinsic_overlap_rejects_shadowed_tag_names() {
+    let diagnostics = lint_js(
+        "flow/react-intrinsic-overlap",
+        "// @flow\nconst div = 1;\nexport function span() {}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 7));
+}
+
+#[test]
+fn react_intrinsic_overlap_accepts_ordinary_names() {
+    let diagnostics = lint_js(
+        "flow/react-intrinsic-overlap",
+        "// @flow\nconst divider = 1;\ncomponent Section() { return null; }\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn nested_component_declarations_are_rejected() {
+    let diagnostics = lint_js(
+        "flow/nested-component",
+        "// @flow\ncomponent Outer() {\n  component Inner() { return null; }\n  return <Inner />;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (3, 3));
+}
+
+#[test]
+fn sibling_component_declarations_are_accepted() {
+    let diagnostics = lint_js(
+        "flow/nested-component",
+        "// @flow\ncomponent Inner() { return null; }\ncomponent Outer() { return <Inner />; }\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn nested_hook_declarations_are_rejected() {
+    let diagnostics = lint_js(
+        "flow/nested-hook",
+        "// @flow\ncomponent Outer() {\n  hook useInner(): number { return 1; }\n  return null;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 3);
+}
+
+#[test]
+fn top_level_hook_declarations_are_accepted() {
+    let diagnostics = lint_js(
+        "flow/nested-hook",
+        "// @flow\nhook useInner(): number { return 1; }\ncomponent Outer() { return null; }\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// react/*
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hooks_rules_reject_conditional_hook_calls() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\ncomponent Page(flag: boolean) {\n  if (flag) {\n    const [a] = useState(0);\n  }\n  return null;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 4);
+    assert!(diagnostics[0].message.contains("top level"));
+}
+
+#[test]
+fn hooks_rules_reject_hook_calls_in_callbacks() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\ncomponent List(items: Array<string>) {\n  items.forEach(() => {\n    useEffect(() => {});\n  });\n  return null;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 4);
+}
+
+#[test]
+fn hooks_rules_reject_hook_calls_outside_any_component() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\nconst value = useState(0);\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert!(diagnostics[0].message.contains("component"));
+}
+
+#[test]
+fn hooks_rules_reject_hook_calls_in_plain_functions() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\nfunction helper() {\n  return useState(0);\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn hooks_rules_accept_top_level_calls_in_a_component() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\ncomponent Page() {\n  const [a, setA] = useState(0);\n  useEffect(() => {});\n  return null;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn hooks_rules_accept_top_level_calls_in_a_hook_declaration() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\nhook useThing(): number {\n  const [a] = useState(0);\n  return a;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn hooks_rules_accept_top_level_calls_in_a_use_prefixed_function() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\nexport const useThing = (): number => {\n  const [a] = useState(0);\n  return a;\n};\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn hooks_rules_do_not_treat_a_declaration_as_a_call() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\nfunction useThing(): number {\n  return 1;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn hooks_rules_ignore_property_reads_that_look_like_hooks() {
+    let diagnostics = lint_js("// @flow", "// @flow\n");
+    assert!(diagnostics.is_empty());
+
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\ncomponent Page(api: Api) {\n  api.useThing();\n  return null;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn hooks_rules_tolerate_jsx_expression_containers() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\ncomponent Page() {\n  return <main>{useThing()}</main>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn hooks_rules_are_not_confused_by_braces_inside_strings() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\ncomponent Page() {\n  const s = \"}\";\n  const [a] = useState(0);\n  return s;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn no_default_export_component_rejects_a_default_export() {
+    let diagnostics = lint_js(
+        "react/no-default-export-component",
+        "// @flow\ncomponent Page() { return null; }\nexport default Page;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (3, 1));
+}
+
+#[test]
+fn no_default_export_component_accepts_named_exports() {
+    let diagnostics = lint_js(
+        "react/no-default-export-component",
+        "// @flow\nexport component Page() { return null; }\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn no_default_export_component_covers_reserved_router_modules() {
+    let diagnostics = lint_one(
+        "react/no-default-export-component",
+        "app/_uf.page.js",
+        "// @flow\nexport default function Page() { return null; }\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn no_default_export_component_leaves_plain_modules_alone() {
+    let diagnostics = lint_js(
+        "react/no-default-export-component",
+        "// @flow\nexport default { id: 1 };\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// server/*
+// ---------------------------------------------------------------------------
+
+#[test]
+fn client_modules_may_not_import_server_only_modules() {
+    let diagnostics = lint_js(
+        "server/no-server-only-import-in-client",
+        "// @flow\n'use client';\nimport { db } from '@uniflowed/server';\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 3);
+}
+
+#[test]
+fn client_modules_may_not_import_dot_server_modules() {
+    let diagnostics = lint_js(
+        "server/no-server-only-import-in-client",
+        "// @flow\n'use client';\nimport { load } from './data.server.js';\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn server_modules_may_import_server_only_modules() {
+    let diagnostics = lint_js(
+        "server/no-server-only-import-in-client",
+        "// @flow\nimport { db } from '@uniflowed/server';\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn client_modules_may_import_shared_modules() {
+    let diagnostics = lint_js(
+        "server/no-server-only-import-in-client",
+        "// @flow\n'use client';\nimport { format } from './format.js';\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn a_boundary_directive_must_lead_the_module() {
+    let diagnostics = lint_js(
+        "server/use-client-directive-position",
+        "// @flow\nimport { a } from './a.js';\n'use client';\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (3, 1));
+}
+
+#[test]
+fn a_leading_boundary_directive_is_accepted() {
+    let diagnostics = lint_js(
+        "server/use-client-directive-position",
+        "// @flow\n'use client';\nimport { a } from './a.js';\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn an_inline_use_server_directive_is_not_a_module_directive() {
+    let diagnostics = lint_js(
+        "server/use-client-directive-position",
+        "// @flow\nexport async function save() {\n  'use server';\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// uniflowed/*
+// ---------------------------------------------------------------------------
+
+#[test]
+fn npm_script_invocations_are_rejected() {
+    let diagnostics = lint_js(
+        "uniflowed/no-npm-script-invocation",
+        "// @flow\nspawn('npm run build');\nspawn('pnpm install');\n",
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 8));
+}
+
+#[test]
+fn uf_task_invocations_are_accepted() {
+    let diagnostics = lint_js(
+        "uniflowed/no-npm-script-invocation",
+        "// @flow\nexport const tasks = { build: 'uf build' };\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn npm_mentions_in_comments_are_not_invocations() {
+    let diagnostics = lint_js(
+        "uniflowed/no-npm-script-invocation",
+        "// @flow\n// migrated away from npm run build\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// security/*
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dangerously_set_inner_html_is_rejected_without_a_sanitizer() {
+    let diagnostics = lint_js(
+        "security/no-dangerously-set-inner-html",
+        "// @flow\ncomponent Body(html: string) {\n  return <div dangerouslySetInnerHTML={{ __html: html }} />;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 3);
+    assert!(diagnostics[0].message.contains("XSS"));
+}
+
+#[test]
+fn dangerously_set_inner_html_is_accepted_via_a_markdown_helper() {
+    let diagnostics = lint_js(
+        "security/no-dangerously-set-inner-html",
+        "// @flow\nimport { renderMarkdown } from '@uniflowed/markdown';\ncomponent Body(md: string) {\n  return <div dangerouslySetInnerHTML={{ __html: renderMarkdown(md) }} />;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn dangerously_set_inner_html_allows_the_value_on_the_next_line() {
+    let diagnostics = lint_js(
+        "security/no-dangerously-set-inner-html",
+        "// @flow\nimport { renderMarkdown } from '@uniflowed/markdown';\ncomponent Body(md: string) {\n  return (\n    <div\n      dangerouslySetInnerHTML={{\n        __html: renderMarkdown(md),\n      }}\n    />\n  );\n}\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn a_markdown_import_does_not_whitelist_an_unrelated_value() {
+    let diagnostics = lint_js(
+        "security/no-dangerously-set-inner-html",
+        "// @flow\nimport { renderMarkdown } from '@uniflowed/markdown';\ncomponent Body(html: string) {\n  return <div dangerouslySetInnerHTML={{ __html: html }} />;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn eval_and_friends_are_rejected() {
+    let diagnostics = lint_js(
+        "security/no-eval",
+        "// @flow\neval(input);\nconst f = new Function('return 1');\nsetTimeout('tick()', 10);\nsetInterval(`tick()`, 10);\n",
+    );
+
+    assert_eq!(diagnostics.len(), 4);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 1));
+    assert_eq!((diagnostics[1].line, diagnostics[1].column), (3, 11));
+    assert_eq!(diagnostics[2].line, 4);
+    assert_eq!(diagnostics[3].line, 5);
+}
+
+#[test]
+fn safe_timers_and_ordinary_identifiers_are_accepted() {
+    let diagnostics = lint_js(
+        "security/no-eval",
+        "// @flow\nsetTimeout(() => tick(), 10);\nconst evaluate = 1;\nconst f = function () {};\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Suppression comments, end to end
+// ---------------------------------------------------------------------------
+
+#[test]
+fn disable_next_line_suppresses_the_diagnostic() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\n// uf-lint-disable-next-line flow/unclear-type\ntype A = any;\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn disable_next_line_does_not_leak_to_later_lines() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\n// uf-lint-disable-next-line flow/unclear-type\ntype A = any;\ntype B = any;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 4);
+}
+
+#[test]
+fn block_suppression_covers_a_range() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\n// uf-lint-disable flow/unclear-type\ntype A = any;\n// uf-lint-enable flow/unclear-type\ntype B = any;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 5);
+}
+
+#[test]
+fn suppressing_one_rule_leaves_others_reporting() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    config.lint.rules.insert(
+        CompactString::const_new("flow/unclear-type"),
+        RuleLevel::Error,
+    );
+    config.lint.rules.insert(
+        CompactString::const_new("flow/deprecated-type"),
+        RuleLevel::Error,
+    );
+
+    let report = lint_source(
+        &at(
+            "app/index.js",
+            "// @flow\n// uf-lint-disable-next-line flow/unclear-type\ntype A = { a: any, b: bool };\n",
+        ),
+        &config,
+    )
+    .expect("lint");
+
+    assert_eq!(report.diagnostics.len(), 1);
+    assert_eq!(report.diagnostics[0].rule, "flow/deprecated-type");
+}
+
+#[test]
+fn an_unknown_suppression_rule_id_is_its_own_diagnostic() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    config.lint.rules.insert(
+        CompactString::const_new("uniflowed/unknown-lint-suppression"),
+        RuleLevel::Error,
+    );
+    config.lint.rules.insert(
+        CompactString::const_new("flow/unclear-type"),
+        RuleLevel::Error,
+    );
+
+    let report = lint_source(
+        &at(
+            "app/index.js",
+            "// @flow\n// uf-lint-disable-next-line flow/unclear-typo\ntype A = any;\n",
+        ),
+        &config,
+    )
+    .expect("lint");
+
+    assert_eq!(report.diagnostics.len(), 2);
+    assert_eq!(
+        report.diagnostics[0].rule,
+        "uniflowed/unknown-lint-suppression"
+    );
+    assert_eq!(report.diagnostics[0].line, 2);
+    assert_eq!(report.diagnostics[1].rule, "flow/unclear-type");
+}
+
+#[test]
+fn an_unknown_suppression_rule_id_never_suppresses_anything() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\n// uf-lint-disable-next-line flow/unclear-typo\ntype A = any;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule, "flow/unclear-type");
+}
+
+#[test]
+fn the_deprecated_alias_works_in_suppression_comments() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\n// uf-lint-disable-next-line flow/type-aware/no-explicit-any\ntype A = any;\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Positions and edge-case inputs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_input_produces_no_diagnostics() {
+    let report = lint_source(&at("app/index.js", ""), &UniflowedConfig::default()).expect("lint");
+
+    assert!(report.diagnostics.is_empty());
+    assert_eq!(report.files_checked, 1);
+}
+
+#[test]
+fn crlf_line_endings_do_not_shift_positions() {
+    let diagnostics = lint_js("flow/unclear-type", "// @flow\r\ntype A = any;\r\n");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (2, 10));
+}
+
+#[test]
+fn crlf_line_endings_are_not_trailing_whitespace() {
+    let diagnostics = lint_js("uniflowed/no-trailing-whitespace", "let a = 1;\r\n");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn a_byte_order_mark_does_not_shift_later_lines() {
+    let diagnostics = lint_js("flow/unclear-type", "\u{feff}// @flow\ntype A = any;\n");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 2);
+}
+
+#[test]
+fn non_ascii_content_keeps_line_numbers_correct() {
+    let diagnostics = lint_js(
+        "flow/unclear-type",
+        "// @flow\nconst s = 'ようこそ — добро пожаловать';\ntype A = any;\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 3);
+}
+
+#[test]
+fn a_file_without_a_trailing_newline_is_linted() {
+    let diagnostics = lint_js("flow/unclear-type", "// @flow\ntype A = any;");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 2);
+}
+
+#[test]
+fn very_large_input_is_linted_without_blowing_up() {
+    let mut text = String::from("// @flow\n");
+    for index in 0..5_000 {
+        text.push_str("type A");
+        text.push_str(&index.to_string());
+        text.push_str(" = any;\n");
+    }
+    let diagnostics = lint_js("flow/unclear-type", &text);
+
+    assert_eq!(diagnostics.len(), 5_000);
+    assert_eq!(diagnostics[4_999].line, 5_001);
+}
+
+#[test]
+fn diagnostics_are_sorted_by_position() {
+    let report = lint_source(
+        &at("app/index.js", "// @flow\ntype A = any;\ntype B = bool;\n"),
+        &UniflowedConfig::default(),
+    )
+    .expect("lint");
+
+    let positions = report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.line, diagnostic.column))
+        .collect::<Vec<_>>();
+    let mut sorted = positions.clone();
+    sorted.sort_unstable();
+    assert_eq!(positions, sorted);
+}
+
+#[test]
+fn linting_is_idempotent() {
+    let file = at("app/index.js", "// @flow\ntype A = { v: any };\n");
+    let config = UniflowedConfig::default();
+
+    let first = lint_source(&file, &config).expect("lint");
+    let second = lint_source(&file, &config).expect("lint");
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn parallel_and_sequential_linting_agree() {
+    let files = vec![
+        at("app/a.js", "// @flow\ntype A = any;\n"),
+        at("app/b.js", "// @flow\ntype B = bool;\n"),
+    ];
+    let config = UniflowedConfig::default();
+
+    let parallel = lint_sources(&files, &config).expect("lint");
+    let mut sequential = files
+        .iter()
+        .flat_map(|file| lint_source(file, &config).expect("lint").diagnostics)
+        .collect::<Vec<_>>();
+    sort_diagnostics(&mut sequential);
+
+    assert_eq!(parallel.diagnostics, sequential);
+    assert_eq!(parallel.files_checked, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Rules that existed before the Flow built-in set landed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reports_tabs_and_trailing_whitespace() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.clear();
+    config.lint.rules.insert(
+        CompactString::const_new("uniflowed/no-tabs"),
+        RuleLevel::Error,
+    );
+    config.lint.rules.insert(
+        CompactString::const_new("uniflowed/no-trailing-whitespace"),
+        RuleLevel::Error,
+    );
+
+    let report =
+        lint_source(&source("// @flow\n\tconst x: number = 1;  \n"), &config).expect("lint");
+
+    assert!(report.has_errors());
+    assert_eq!(report.diagnostics.len(), 2);
+    assert_eq!(report.diagnostics[0].rule, "uniflowed/no-tabs");
+    assert_eq!(
+        report.diagnostics[1].rule,
+        "uniflowed/no-trailing-whitespace"
+    );
+}
+
+#[test]
+fn rule_levels_can_disable_builtin_rules() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.insert(
+        CompactString::const_new("uniflowed/no-tabs"),
+        RuleLevel::Off,
+    );
+
+    let report = lint_source(&source("// @flow\n\tconst x: number = 1;\n"), &config).expect("lint");
+
+    assert!(!report.has_errors());
+    assert!(report.diagnostics.is_empty());
+}
+
+#[test]
+fn reports_flow_parse_errors() {
+    let diagnostics = lint_one("flow/syntax", "src/app/page.jsx", "// @flow\ntype = ;\n");
+
+    assert!(!diagnostics.is_empty());
+    assert_eq!(diagnostics[0].rule, "flow/syntax");
+}
+
+#[test]
+fn type_aware_rule_blocks_explicit_any() {
+    let report = lint_source(
+        &source("// @flow\ntype Props = { value: any };\n"),
+        &UniflowedConfig::default(),
+    )
+    .expect("lint");
+
+    assert!(report.has_errors());
+    assert!(fired(&report.diagnostics, "flow/unclear-type"));
+}
+
+#[test]
+fn framework_rule_prefers_component_syntax() {
+    let diagnostics = lint_one(
+        "react/component-syntax",
+        "src/app/page.jsx",
+        "// @flow\nimport * as React from '@uniflowed/react';\nfunction Button(): React.Node { return null; }\n",
+    );
+
+    assert!(fired(&diagnostics, "react/component-syntax"));
+}
+
+#[test]
+fn hook_rule_prefers_flow_hook_syntax() {
+    let diagnostics = lint_one(
+        "react/hook-syntax",
+        "src/app/page.jsx",
+        "// @flow\nfunction useThing(): number { return 1; }\n",
+    );
+
+    assert!(fired(&diagnostics, "react/hook-syntax"));
+}
+
+#[test]
+fn server_rule_rejects_secret_reads_in_client_modules() {
+    let diagnostics = lint_one(
+        "server/no-client-secret",
+        "src/app/page.jsx",
+        "// @flow\n'use client';\nconst token = process.env.PRIVATE_TOKEN;\n",
+    );
+
+    assert!(fired(&diagnostics, "server/no-client-secret"));
+}
+
+#[test]
+fn server_actions_require_use_server_directive() {
+    let diagnostics = lint_one(
+        "server/use-server-actions",
+        "server/actions.js",
+        "// @flow\nimport { serverAction } from '@uniflowed/server';\nexport const save = serverAction(() => {});\n",
+    );
+
+    assert!(fired(&diagnostics, "server/use-server-actions"));
+}
+
+#[test]
+fn server_actions_accept_use_server_directive() {
+    let diagnostics = lint_one(
+        "server/use-server-actions",
+        "server/actions.js",
+        "\"use server\";\n// @flow\nimport { serverAction } from '@uniflowed/server';\nexport const save = serverAction(() => {});\n",
+    );
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn router_reserved_files_are_constrained() {
+    let diagnostics = lint_one("router/reserved-files", "app/_uf.route.js", "// @flow\n");
+
+    assert!(fired(&diagnostics, "router/reserved-files"));
+}
+
+#[test]
+fn package_json_scripts_are_rejected() {
+    let diagnostics = lint_one(
+        "package/no-npm-scripts",
+        "package.json",
+        "{\n  \"scripts\": { \"dev\": \"vite\" }\n}\n",
+    );
+
+    assert!(fired(&diagnostics, "package/no-npm-scripts"));
+}
+
+#[test]
+fn global_fetch_override_is_rejected() {
+    let diagnostics = lint_one(
+        "fetch/no-global-override",
+        "src/app/page.jsx",
+        "// @flow\nglobalThis.fetch = () => Promise.resolve();\n",
+    );
+
+    assert!(fired(&diagnostics, "fetch/no-global-override"));
+}
+
+#[test]
+fn render_side_effects_are_errors_by_default() {
+    let diagnostics = lint_one(
+        "react/no-render-side-effects",
+        "src/app/page.jsx",
+        "// @flow\ncomponent Clock() { return <p>{Date.now()}</p>; }\n",
+    );
+
+    assert!(fired(&diagnostics, "react/no-render-side-effects"));
+}
+
+#[test]
+fn react_native_rule_prefers_platform_files() {
+    let diagnostics = lint_one(
+        "react-native/platform-split",
+        "src/app/Button.jsx",
+        "// @flow\nimport { Platform } from '@uniflowed/react-native';\nconst name = Platform.OS;\n",
+    );
+
+    assert!(fired(&diagnostics, "react-native/platform-split"));
+}


### PR DESCRIPTION
`uf lint` is now the union of Flow's built-in lint set and uf's framework
rules, with one catalogue describing both.

Flow built-ins
- New `uf_lint::flow_builtin` models all 33 configurable Flow lint names under
  a `flow/` namespace, table-driven (a const array indexed by discriminant plus
  a `phf` name map) so there is one source of truth and no `format!` at lookup
  time. The list is taken from Flow's own `flow_lint_settings` crate and
  cross-checked against flow.org; `implicit-inexact-object`,
  `unused-promise-in-async-scope`, `require-explicit-import-type`, and
  `deprecated-class-static-blocks` are deliberately absent because current Flow
  does not accept them.
- 13 of them are decided from source text today: `unclear-type`,
  `deprecated-type`, `internal-type`, `ambiguous-object-type`,
  `unsafe-getters-setters`, `unsafe-object-assign`, `unnecessary-optional-chain`
  (syntactic subset), `mixed-import-and-require`, `non-const-var-export`,
  `export-renamed-default`, `react-intrinsic-overlap`, `nested-component`,
  `nested-hook`.
- The 20 that need type inference carry `RuleRequirement::TypeChecker` and are
  reported through `LintReport::unavailable` rather than silently passing.
- `flow/type-aware/no-explicit-any` is folded into `flow/unclear-type` and kept
  working as a deprecated alias, in config and in suppression comments.

uf's own rules
- Adds `react/no-default-export-component`, `react/hooks-rules`,
  `server/no-server-only-import-in-client`, `server/use-client-directive-position`,
  `uniflowed/no-npm-script-invocation`, `security/no-dangerously-set-inner-html`
  (XSS sink), and `security/no-eval` (string-to-code execution).
- `// uf-lint-disable-next-line <rule>` and `// uf-lint-disable`/`-enable` block
  form; an unknown rule id raises `uniflowed/unknown-lint-suppression` instead of
  quietly suppressing nothing.

Plumbing
- `FileScan` walks each file once: one `LineIndex`, per-line code slices with
  comments stripped, brace depth, and whole-file predicates, replacing the
  per-rule `source.lines()` passes. All positions resolve through that index.
- `uf_lint::rules()` exposes the catalogue for `uf inspect`, which now prints and
  emits it; `uf_config::LintConfig::default()` gives every rule an explicit,
  documented level, and a test asserts config and catalogue agree in both
  directions.
- Benchmarks cover the new rule set: 113 MiB/s clean, 63 MiB/s with diagnostics,
  105 MiB/s with suppressions active.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790916850&installation_model_id=422833&pr_number=11&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F11&signature=81ba8cae29804eacc90ab7fb8890364c146f372d0dbb2b901548e2d6f6eded0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->