### PR TITLE
feat(bundle): measure shipped size and enforce build.budgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -150,6 +171,27 @@ checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "bytes",
  "cfg_aliases",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -338,6 +380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +539,16 @@ name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flow_data_structure_wrapper"
@@ -752,6 +813,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1146,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1439,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "uf_bundle"
+version = "0.1.0"
+dependencies = [
+ "brotli",
+ "camino",
+ "compact_str",
+ "criterion",
+ "flate2",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "uf_cli"
 version = "0.1.0"
 dependencies = [
@@ -1372,6 +1466,7 @@ dependencies = [
  "mimalloc",
  "serde_json",
  "tempfile",
+ "uf_bundle",
  "uf_config",
  "uf_effect",
  "uf_flow",
@@ -1401,6 +1496,7 @@ dependencies = [
  "similar-asserts",
  "tempfile",
  "thiserror",
+ "uf_bundle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+  "crates/uf_browser",
+  "crates/uf_bundle",
   "crates/uf_cli",
   "crates/uf_config",
   "crates/uf_effect",
@@ -11,7 +13,6 @@ members = [
   "crates/uf_lib",
   "crates/uf_lint",
   "crates/uf_loader",
-  "crates/uf_browser",
   "crates/uf_markdown",
   "crates/uf_mock",
   "crates/uf_motion",
@@ -50,11 +51,13 @@ version = "0.1.0"
 anyhow = "1.0.104"
 assert_cmd = "2.1.1"
 bumpalo = { version = "3.19.1", features = ["collections"] }
+brotli = { version = "8.0.4", default-features = false, features = ["std"] }
 camino = { version = "1.2.1", features = ["serde1"] }
 clap = { version = "4.6.4", features = ["derive", "env"] }
 compact_str = { version = "0.10.0", features = ["serde"] }
 criterion = "0.8.2"
 flow_parser = { path = "upstream/flow/rust_port/crates/flow_parser" }
+flate2 = { version = "1.1.10", default-features = false, features = ["rust_backend"] }
 flowjs-parser = "0.0.0-alpha.3"
 ignore = "0.4.25"
 json5 = "1.3.1"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ enables:
 - native stdlib modules for os, net, dns, path, stream, URL, wasm, glob, motion,
   TUI, cron, S3, SigV4, worker/lambda functions, uuid, and zip
 - all route, fetch, image, font, markdown, and PWA caches are opt-in
+- bundle size budgets in `build.budgets`, measured with real gzip and brotli
 - native query, effect, ORM, Relay, validator, and state/flow-cell builtin modules
 - React Compiler-safe motion primitives with reduced-motion defaults
 - OpenTUI-aligned native TUI framework targeting a React Ink replacement

--- a/crates/uf_bundle/Cargo.toml
+++ b/crates/uf_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "uf_config"
-description = "Configuration loading for the Unified Toolchain for Flow (React)."
+name = "uf_bundle"
+description = "Bundle size measurement and budget enforcement for uniflowed."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -9,18 +9,20 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+brotli.workspace = true
 camino.workspace = true
 compact_str.workspace = true
-json5.workspace = true
-uf_bundle = { path = "../uf_bundle" }
+flate2.workspace = true
+rayon.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-similar-asserts.workspace = true
 tempfile.workspace = true
 
 [[bench]]
-name = "config"
+name = "bundle"
 harness = false

--- a/crates/uf_bundle/benches/bundle.rs
+++ b/crates/uf_bundle/benches/bundle.rs
@@ -1,0 +1,76 @@
+use std::hint::black_box;
+
+use compact_str::{CompactString, ToCompactString};
+use criterion::{Criterion, criterion_group, criterion_main};
+use uf_bundle::{
+    AssetEntry, AssetKind, AssetSize, BudgetMetric, BundleBudgets, ByteSize, SizeBudget,
+    build_report, evaluate, measure,
+};
+
+fn synthetic_assets(count: usize) -> Vec<AssetEntry> {
+    (0..count)
+        .map(|index| AssetEntry {
+            path: format!("assets/chunk-{index:05}.js").to_compact_string(),
+            kind: AssetKind::JavaScript,
+            size: AssetSize {
+                raw: ByteSize::from_bytes(4_096 + index as u64),
+                gzip: ByteSize::from_bytes(1_024 + index as u64),
+                brotli: ByteSize::from_bytes(900 + index as u64),
+            },
+        })
+        .collect()
+}
+
+fn synthetic_routes(count: usize) -> Vec<(CompactString, Vec<CompactString>, Vec<CompactString>)> {
+    (0..count)
+        .map(|index| {
+            (
+                format!("/route-{index:04}").to_compact_string(),
+                vec![format!("assets/chunk-{index:05}.js").to_compact_string()],
+                vec![format!("assets/chunk-{:05}.js", index + 1).to_compact_string()],
+            )
+        })
+        .collect()
+}
+
+fn bench_build_report(c: &mut Criterion) {
+    let assets = synthetic_assets(2_000);
+    let routes = synthetic_routes(500);
+
+    c.bench_function("build report over 2000 assets and 500 routes", |b| {
+        b.iter(|| black_box(build_report(assets.clone(), &routes)));
+    });
+}
+
+fn bench_evaluate_budgets(c: &mut Criterion) {
+    let report = build_report(synthetic_assets(2_000), &synthetic_routes(500));
+    let budgets = BundleBudgets {
+        total: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+        initial_js: Some(SizeBudget::with_metric(
+            ByteSize::from_bytes(1),
+            BudgetMetric::Brotli,
+        )),
+        per_route: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+        per_asset: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+    };
+
+    c.bench_function("evaluate four budgets over 2000 assets", |b| {
+        b.iter(|| black_box(evaluate(&report, &budgets)));
+    });
+}
+
+fn bench_measure(c: &mut Criterion) {
+    let contents = "export const value = compute(1, 2, 3);\n".repeat(4_000);
+
+    c.bench_function("measure a 152 kB javascript chunk", |b| {
+        b.iter(|| black_box(measure(contents.as_bytes()).expect("measures")));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_build_report,
+    bench_evaluate_budgets,
+    bench_measure
+);
+criterion_main!(benches);

--- a/crates/uf_bundle/src/budget.rs
+++ b/crates/uf_bundle/src/budget.rs
@@ -1,0 +1,454 @@
+//! Size budgets and their evaluation against a [`BundleReport`].
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+use crate::report::BundleReport;
+use crate::size::{AssetSize, BudgetMetric, ByteSize};
+
+/// A single budget: a ceiling plus the metric it applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SizeBudget {
+    /// Largest size permitted.
+    pub max: ByteSize,
+    /// Which measurement the ceiling applies to.
+    #[serde(default)]
+    pub metric: BudgetMetric,
+}
+
+impl SizeBudget {
+    /// Build a budget over the default metric.
+    #[must_use]
+    pub const fn new(max: ByteSize) -> Self {
+        Self {
+            max,
+            metric: BudgetMetric::Gzip,
+        }
+    }
+
+    /// Build a budget over an explicit metric.
+    #[must_use]
+    pub const fn with_metric(max: ByteSize, metric: BudgetMetric) -> Self {
+        Self { max, metric }
+    }
+
+    /// Whether `size` fits.
+    #[must_use]
+    pub const fn admits(self, size: AssetSize) -> bool {
+        size.get(self.metric).bytes() <= self.max.bytes()
+    }
+}
+
+/// The `build.budgets` section of `uf.config.js`.
+///
+/// Every budget is optional and unset by default: a toolchain that fails a build
+/// nobody asked it to police is worse than one that reports and moves on. Teams
+/// that want the gate opt into it, and then it is an error, not a warning.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct BundleBudgets {
+    /// Ceiling for every emitted asset added together.
+    pub total: Option<SizeBudget>,
+    /// Ceiling for the JavaScript a route loads before it can render.
+    pub initial_js: Option<SizeBudget>,
+    /// Ceiling applied to each route's total weight.
+    pub per_route: Option<SizeBudget>,
+    /// Ceiling applied to each individual asset.
+    pub per_asset: Option<SizeBudget>,
+}
+
+impl BundleBudgets {
+    /// Whether any budget is set.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.total.is_none()
+            && self.initial_js.is_none()
+            && self.per_route.is_none()
+            && self.per_asset.is_none()
+    }
+}
+
+/// What a budget was measuring when it was exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BudgetScope {
+    /// The sum of every emitted asset.
+    Total,
+    /// The JavaScript a route loads before first render.
+    InitialJs,
+    /// One route's total weight.
+    Route,
+    /// One asset.
+    Asset,
+}
+
+impl BudgetScope {
+    /// Stable identifier used in reports.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Total => "total",
+            Self::InitialJs => "initial-js",
+            Self::Route => "route",
+            Self::Asset => "asset",
+        }
+    }
+}
+
+/// One budget that was exceeded.
+///
+/// Carries everything needed to act without opening a profiler: what was
+/// measured, which thing exceeded it, by how much, and under which metric.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetViolation {
+    /// What the budget was measuring.
+    pub scope: BudgetScope,
+    /// The route or asset that exceeded it, or `None` for a whole-build budget.
+    pub subject: Option<CompactString>,
+    /// Metric the budget applied to.
+    pub metric: BudgetMetric,
+    /// The ceiling.
+    pub budget: ByteSize,
+    /// The measured size.
+    pub actual: ByteSize,
+    /// How far over the ceiling the measurement landed.
+    pub overage: ByteSize,
+}
+
+impl std::fmt::Display for BudgetViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.subject {
+            Some(subject) => write!(
+                f,
+                "{} budget exceeded for {subject}: {} {} over a {} ceiling (+{})",
+                self.scope.as_str(),
+                self.actual,
+                self.metric.as_str(),
+                self.budget,
+                self.overage
+            ),
+            None => write!(
+                f,
+                "{} budget exceeded: {} {} over a {} ceiling (+{})",
+                self.scope.as_str(),
+                self.actual,
+                self.metric.as_str(),
+                self.budget,
+                self.overage
+            ),
+        }
+    }
+}
+
+/// Violations found while evaluating a report.
+pub type BudgetViolations = SmallVec<[BudgetViolation; 4]>;
+
+/// The result of checking a report against its budgets.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetOutcome {
+    /// Every violation, in a deterministic order.
+    pub violations: BudgetViolations,
+}
+
+impl BudgetOutcome {
+    /// Whether the build stays inside its budgets.
+    #[must_use]
+    pub fn is_within_budget(&self) -> bool {
+        self.violations.is_empty()
+    }
+}
+
+/// Check `report` against `budgets`, collecting **every** violation.
+///
+/// Reporting only the first failure makes a size regression a game of
+/// whack-a-mole across CI runs, so the whole list comes back at once. Ordering
+/// is deterministic: whole-build scopes first, then routes and assets in the
+/// report's own sorted order.
+#[must_use]
+pub fn evaluate(report: &BundleReport, budgets: &BundleBudgets) -> BudgetOutcome {
+    let mut violations = BudgetViolations::new();
+
+    if let Some(budget) = budgets.total {
+        push_if_over(
+            &mut violations,
+            BudgetScope::Total,
+            None,
+            budget,
+            report.total,
+        );
+    }
+
+    for route in &report.routes {
+        if let Some(budget) = budgets.initial_js {
+            push_if_over(
+                &mut violations,
+                BudgetScope::InitialJs,
+                Some(route.path.clone()),
+                budget,
+                route.initial_js,
+            );
+        }
+        if let Some(budget) = budgets.per_route {
+            push_if_over(
+                &mut violations,
+                BudgetScope::Route,
+                Some(route.path.clone()),
+                budget,
+                route.total,
+            );
+        }
+    }
+
+    if let Some(budget) = budgets.per_asset {
+        for asset in &report.assets {
+            push_if_over(
+                &mut violations,
+                BudgetScope::Asset,
+                Some(asset.path.clone()),
+                budget,
+                asset.size,
+            );
+        }
+    }
+
+    BudgetOutcome { violations }
+}
+
+fn push_if_over(
+    violations: &mut BudgetViolations,
+    scope: BudgetScope,
+    subject: Option<CompactString>,
+    budget: SizeBudget,
+    size: AssetSize,
+) {
+    if budget.admits(size) {
+        return;
+    }
+
+    let actual = size.get(budget.metric);
+    violations.push(BudgetViolation {
+        scope,
+        subject,
+        metric: budget.metric,
+        budget: budget.max,
+        actual,
+        overage: actual.saturating_sub(budget.max),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::{AssetEntry, AssetKind, RouteEntry};
+
+    fn size(raw: u64, gzip: u64, brotli: u64) -> AssetSize {
+        AssetSize {
+            raw: ByteSize::from_bytes(raw),
+            gzip: ByteSize::from_bytes(gzip),
+            brotli: ByteSize::from_bytes(brotli),
+        }
+    }
+
+    fn report() -> BundleReport {
+        BundleReport {
+            // Sorted by path, the way `build_report` emits them.
+            assets: vec![
+                AssetEntry {
+                    path: CompactString::const_new("assets/app.css"),
+                    kind: AssetKind::Stylesheet,
+                    size: size(100, 40, 30),
+                },
+                AssetEntry {
+                    path: CompactString::const_new("assets/app.js"),
+                    kind: AssetKind::JavaScript,
+                    size: size(300, 120, 100),
+                },
+            ],
+            routes: vec![RouteEntry {
+                path: CompactString::const_new("/"),
+                initial_js: size(300, 120, 100),
+                lazy_js: size(0, 0, 0),
+                total: size(400, 160, 130),
+                assets: vec![CompactString::const_new("assets/app.js")],
+            }],
+            total: size(400, 160, 130),
+        }
+    }
+
+    #[test]
+    fn no_budgets_means_no_violations() {
+        let outcome = evaluate(&report(), &BundleBudgets::default());
+
+        assert!(outcome.is_within_budget());
+    }
+
+    #[test]
+    fn budgets_default_to_the_gzip_metric() {
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(150))),
+            ..BundleBudgets::default()
+        };
+
+        let outcome = evaluate(&report(), &budgets);
+
+        assert_eq!(outcome.violations.len(), 1);
+        assert_eq!(outcome.violations[0].metric, BudgetMetric::Gzip);
+        assert_eq!(outcome.violations[0].actual.bytes(), 160);
+        assert_eq!(outcome.violations[0].overage.bytes(), 10);
+    }
+
+    #[test]
+    fn a_size_exactly_on_the_ceiling_passes() {
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(160))),
+            ..BundleBudgets::default()
+        };
+
+        assert!(evaluate(&report(), &budgets).is_within_budget());
+    }
+
+    #[test]
+    fn an_explicit_metric_changes_which_number_is_checked() {
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::with_metric(
+                ByteSize::from_bytes(150),
+                BudgetMetric::Brotli,
+            )),
+            ..BundleBudgets::default()
+        };
+
+        assert!(evaluate(&report(), &budgets).is_within_budget());
+
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::with_metric(
+                ByteSize::from_bytes(150),
+                BudgetMetric::Raw,
+            )),
+            ..BundleBudgets::default()
+        };
+
+        assert_eq!(evaluate(&report(), &budgets).violations.len(), 1);
+    }
+
+    #[test]
+    fn every_violation_is_reported_not_just_the_first() {
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+            initial_js: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+            per_route: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+            per_asset: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+        };
+
+        let outcome = evaluate(&report(), &budgets);
+
+        assert_eq!(outcome.violations.len(), 5);
+        assert!(!outcome.is_within_budget());
+    }
+
+    #[test]
+    fn violation_order_is_deterministic() {
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+            per_asset: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+            ..BundleBudgets::default()
+        };
+
+        let first = evaluate(&report(), &budgets);
+        let second = evaluate(&report(), &budgets);
+
+        assert_eq!(first, second);
+        assert_eq!(first.violations[0].scope, BudgetScope::Total);
+        assert_eq!(
+            first.violations[1].subject.as_deref(),
+            Some("assets/app.css")
+        );
+        assert_eq!(
+            first.violations[2].subject.as_deref(),
+            Some("assets/app.js")
+        );
+    }
+
+    #[test]
+    fn initial_js_is_budgeted_separately_from_route_total() {
+        let budgets = BundleBudgets {
+            initial_js: Some(SizeBudget::new(ByteSize::from_bytes(100))),
+            per_route: Some(SizeBudget::new(ByteSize::from_bytes(1_000))),
+            ..BundleBudgets::default()
+        };
+
+        let outcome = evaluate(&report(), &budgets);
+
+        assert_eq!(outcome.violations.len(), 1);
+        assert_eq!(outcome.violations[0].scope, BudgetScope::InitialJs);
+        assert_eq!(outcome.violations[0].subject.as_deref(), Some("/"));
+    }
+
+    #[test]
+    fn violation_messages_name_the_subject_budget_actual_and_overage() {
+        let budgets = BundleBudgets {
+            per_asset: Some(SizeBudget::new(ByteSize::from_bytes(50))),
+            ..BundleBudgets::default()
+        };
+
+        let outcome = evaluate(&report(), &budgets);
+
+        // `app.css` is 40 bytes gzipped and fits; only `app.js` breaks the ceiling.
+        assert_eq!(outcome.violations.len(), 1);
+        let rendered = outcome.violations[0].to_string();
+
+        assert!(rendered.contains("assets/app.js"), "{rendered}");
+        assert!(rendered.contains("gzip"), "{rendered}");
+        assert!(rendered.contains("asset"), "{rendered}");
+    }
+
+    #[test]
+    fn a_whole_build_violation_has_no_subject() {
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+            ..BundleBudgets::default()
+        };
+
+        let outcome = evaluate(&report(), &budgets);
+
+        assert!(outcome.violations[0].subject.is_none());
+        assert!(!outcome.violations[0].to_string().contains("for "));
+    }
+
+    #[test]
+    fn empty_budgets_are_recognized() {
+        assert!(BundleBudgets::default().is_empty());
+        assert!(
+            !BundleBudgets {
+                total: Some(SizeBudget::new(ByteSize::from_bytes(1))),
+                ..BundleBudgets::default()
+            }
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn scope_identifiers_are_stable() {
+        assert_eq!(BudgetScope::Total.as_str(), "total");
+        assert_eq!(BudgetScope::InitialJs.as_str(), "initial-js");
+        assert_eq!(BudgetScope::Route.as_str(), "route");
+        assert_eq!(BudgetScope::Asset.as_str(), "asset");
+    }
+
+    #[test]
+    fn an_empty_report_never_violates() {
+        let budgets = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(0))),
+            initial_js: Some(SizeBudget::new(ByteSize::from_bytes(0))),
+            per_route: Some(SizeBudget::new(ByteSize::from_bytes(0))),
+            per_asset: Some(SizeBudget::new(ByteSize::from_bytes(0))),
+        };
+
+        let outcome = evaluate(&BundleReport::default(), &budgets);
+
+        assert!(outcome.is_within_budget());
+    }
+}

--- a/crates/uf_bundle/src/lib.rs
+++ b/crates/uf_bundle/src/lib.rs
@@ -1,0 +1,101 @@
+#![deny(missing_docs)]
+//! Bundle size measurement and budget enforcement for uniflowed.
+//!
+//! Shipped JavaScript weight is a product requirement, not a report nobody
+//! reads, so this crate does two things and keeps them separate:
+//!
+//! - [`report`] measures what a build actually emitted — raw, gzip, and brotli
+//!   bytes per asset, and what each route costs a visitor.
+//! - [`budget`] checks that picture against ceilings declared in `uf.config.js`
+//!   and returns **every** violation, so a size regression is one CI failure
+//!   rather than a sequence of them.
+//!
+//! Compressed figures come from really compressing the bytes at fixed settings
+//! ([`size::GZIP_LEVEL`], [`size::BROTLI_QUALITY`]), never from an estimate, and
+//! those settings are written into the report so two runs are only ever compared
+//! on equal terms.
+
+pub mod budget;
+pub mod report;
+pub mod size;
+
+pub use budget::{
+    BudgetOutcome, BudgetScope, BudgetViolation, BudgetViolations, BundleBudgets, SizeBudget,
+    evaluate,
+};
+pub use report::{
+    AssetEntry, AssetKind, BundleReport, MAX_ASSET_DEPTH, MAX_ASSETS, ReportError, ReportOptions,
+    RouteEntry, build_report, collect_assets, write_report,
+};
+pub use size::{
+    AssetSize, BROTLI_QUALITY, BudgetMetric, ByteSize, ByteSizeParseError, GZIP_LEVEL,
+    MAX_ASSET_BYTES, MeasureError, measure, parse_byte_size,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+    use compact_str::CompactString;
+
+    /// The whole point of the crate, end to end: measure a build directory,
+    /// attribute assets to a route, and fail the declared budget.
+    #[test]
+    fn measures_a_build_and_reports_every_budget_it_breaks() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf-8");
+        std::fs::write(root.join("entry.js"), "export const a = 1;\n".repeat(400)).expect("write");
+        std::fs::write(root.join("lazy.js"), "export const b = 2;\n".repeat(200)).expect("write");
+        std::fs::write(root.join("app.css"), ".a { color: red }\n".repeat(50)).expect("write");
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+        let report = build_report(
+            assets,
+            &[(
+                CompactString::const_new("/"),
+                vec![
+                    CompactString::const_new("entry.js"),
+                    CompactString::const_new("app.css"),
+                ],
+                vec![CompactString::const_new("lazy.js")],
+            )],
+        );
+
+        let generous = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(1_000_000))),
+            ..BundleBudgets::default()
+        };
+        assert!(evaluate(&report, &generous).is_within_budget());
+
+        let strict = BundleBudgets {
+            total: Some(SizeBudget::new(ByteSize::from_bytes(64))),
+            initial_js: Some(SizeBudget::new(ByteSize::from_bytes(16))),
+            ..BundleBudgets::default()
+        };
+        let outcome = evaluate(&report, &strict);
+
+        assert_eq!(outcome.violations.len(), 2);
+        assert!(outcome.violations.iter().all(|v| v.overage.bytes() > 0));
+
+        let written = write_report(&root, &report).expect("writes");
+        assert!(written.exists());
+    }
+
+    #[test]
+    fn a_budget_string_from_config_round_trips_into_an_enforced_ceiling() {
+        let budget = SizeBudget::new(parse_byte_size("180 kB").expect("parses"));
+
+        assert_eq!(budget.max.bytes(), 180_000);
+        assert_eq!(budget.metric, BudgetMetric::Gzip);
+        assert!(budget.admits(AssetSize {
+            raw: ByteSize::from_bytes(600_000),
+            gzip: ByteSize::from_bytes(180_000),
+            brotli: ByteSize::from_bytes(150_000),
+        }));
+        assert!(!budget.admits(AssetSize {
+            raw: ByteSize::from_bytes(600_000),
+            gzip: ByteSize::from_bytes(180_001),
+            brotli: ByteSize::from_bytes(150_000),
+        }));
+    }
+}

--- a/crates/uf_bundle/src/report.rs
+++ b/crates/uf_bundle/src/report.rs
@@ -1,0 +1,703 @@
+//! The bundle report: what a build emitted, and what each route costs.
+
+use std::collections::BTreeMap;
+use std::fs;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::{CompactString, ToCompactString};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::size::{AssetSize, MeasureError, measure};
+
+/// Deepest directory nesting `uf` will walk while collecting assets.
+///
+/// A build directory can contain a symlink loop or a pathological tree, so the
+/// walk is bounded and iterative rather than trusting the filesystem.
+pub const MAX_ASSET_DEPTH: usize = 32;
+
+/// Most assets `uf` will measure in one report.
+pub const MAX_ASSETS: usize = 100_000;
+
+/// What kind of thing an asset is, for grouping in the report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AssetKind {
+    /// A JavaScript chunk.
+    JavaScript,
+    /// A stylesheet.
+    Stylesheet,
+    /// A source map. Never downloaded by users, so it is measured but excluded
+    /// from route weight.
+    SourceMap,
+    /// An HTML document.
+    Html,
+    /// A build manifest or other JSON emitted alongside the app.
+    Json,
+    /// Anything else: fonts, images, wasm.
+    Other,
+}
+
+impl AssetKind {
+    /// Classify by file extension.
+    #[must_use]
+    pub fn from_path(path: &Utf8Path) -> Self {
+        // `.js.map` must win over `.map`-less `.js`, so check the full suffix
+        // before falling back to the extension.
+        let name = path.file_name().unwrap_or_default();
+        if name.ends_with(".map") {
+            return Self::SourceMap;
+        }
+
+        match path.extension() {
+            Some("js" | "mjs" | "cjs") => Self::JavaScript,
+            Some("css") => Self::Stylesheet,
+            Some("html" | "htm") => Self::Html,
+            Some("json") => Self::Json,
+            _ => Self::Other,
+        }
+    }
+
+    /// Whether this asset counts toward what a user downloads for a route.
+    #[must_use]
+    pub const fn is_downloaded(self) -> bool {
+        !matches!(self, Self::SourceMap)
+    }
+
+    /// Stable identifier used in reports.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::JavaScript => "javascript",
+            Self::Stylesheet => "stylesheet",
+            Self::SourceMap => "source-map",
+            Self::Html => "html",
+            Self::Json => "json",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// One emitted asset and its measured sizes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetEntry {
+    /// Path relative to the output directory, always using `/`.
+    pub path: CompactString,
+    /// What kind of asset it is.
+    pub kind: AssetKind,
+    /// Raw and compressed sizes.
+    pub size: AssetSize,
+}
+
+/// What one route costs a visitor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RouteEntry {
+    /// Route path as the router reports it.
+    pub path: CompactString,
+    /// JavaScript needed before the route can render.
+    pub initial_js: AssetSize,
+    /// JavaScript the route loads later.
+    pub lazy_js: AssetSize,
+    /// Everything the route pulls in.
+    pub total: AssetSize,
+    /// Assets attributed to the route, sorted.
+    pub assets: Vec<CompactString>,
+}
+
+/// A whole build's size picture.
+///
+/// Every collection is sorted, so two builds of the same input serialize
+/// byte-identically and a diff of the report is a real signal.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleReport {
+    /// Emitted assets, sorted by path.
+    pub assets: Vec<AssetEntry>,
+    /// Per-route weight, sorted by route path.
+    pub routes: Vec<RouteEntry>,
+    /// Every downloaded asset added together.
+    pub total: AssetSize,
+}
+
+impl BundleReport {
+    /// Assets sorted largest first under `metric`, for a human-readable summary.
+    #[must_use]
+    pub fn largest_assets(&self, metric: crate::size::BudgetMetric) -> Vec<&AssetEntry> {
+        let mut assets = self.assets.iter().collect::<Vec<_>>();
+        assets.sort_by(|a, b| {
+            b.size
+                .get(metric)
+                .cmp(&a.size.get(metric))
+                .then_with(|| a.path.cmp(&b.path))
+        });
+        assets
+    }
+
+    /// Total size per asset kind, for a quick "where is the weight" answer.
+    #[must_use]
+    pub fn total_by_kind(&self) -> BTreeMap<AssetKind, AssetSize> {
+        let mut totals = BTreeMap::new();
+        for asset in &self.assets {
+            let entry = totals.entry(asset.kind).or_insert_with(AssetSize::zero);
+            *entry = entry.saturating_add(asset.size);
+        }
+        totals
+    }
+}
+
+/// Failures while building a report.
+#[derive(Debug, Error)]
+pub enum ReportError {
+    /// A directory or file could not be read.
+    #[error("failed to read {path}: {source}")]
+    Read {
+        /// Path that failed.
+        path: Utf8PathBuf,
+        /// Underlying error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A path in the output directory was not UTF-8.
+    #[error("output path is not UTF-8: {path}")]
+    NonUtf8Path {
+        /// Lossy rendering of the offending path.
+        path: String,
+    },
+    /// The build emitted more assets than `uf` will measure.
+    #[error("output directory holds more than {MAX_ASSETS} assets")]
+    TooManyAssets,
+    /// An asset could not be measured.
+    #[error("failed to measure {path}: {source}")]
+    Measure {
+        /// Path that failed.
+        path: Utf8PathBuf,
+        /// Underlying error.
+        #[source]
+        source: MeasureError,
+    },
+    /// The report could not be serialized.
+    #[error("failed to serialize the bundle report: {0}")]
+    Serialize(#[source] serde_json::Error),
+    /// The report could not be written.
+    #[error("failed to write {path}: {source}")]
+    Write {
+        /// Path that failed.
+        path: Utf8PathBuf,
+        /// Underlying error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Which files a report should skip.
+#[derive(Debug, Clone)]
+pub struct ReportOptions {
+    /// File names, relative to the output directory, that are build metadata
+    /// rather than shipped assets.
+    pub excluded: Vec<CompactString>,
+}
+
+impl Default for ReportOptions {
+    fn default() -> Self {
+        Self {
+            excluded: vec![
+                CompactString::const_new("uf-build-manifest.json"),
+                CompactString::const_new("uf-bundle-report.json"),
+                CompactString::const_new("uf-rsc-manifest.json"),
+            ],
+        }
+    }
+}
+
+/// Measure every asset under `out_dir`.
+///
+/// Walks iteratively with an explicit stack and does not follow symlinks: a
+/// build directory is written by dependencies, and a symlink out of the tree
+/// would otherwise let a hostile package have `uf` read arbitrary files.
+///
+/// The walk is serial (it is I/O-bound on directory metadata) but measurement is
+/// not: brotli at quality 11 costs milliseconds per asset, so the files fan out
+/// across rayon. A build with hundreds of chunks would otherwise spend seconds
+/// compressing them one at a time.
+pub fn collect_assets(
+    out_dir: &Utf8Path,
+    options: &ReportOptions,
+) -> Result<Vec<AssetEntry>, ReportError> {
+    let mut files: Vec<(Utf8PathBuf, CompactString)> = Vec::new();
+    let mut stack = vec![(out_dir.to_path_buf(), 0usize)];
+
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > MAX_ASSET_DEPTH {
+            continue;
+        }
+
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(source) => return Err(ReportError::Read { path: dir, source }),
+        };
+
+        for entry in entries {
+            let entry = entry.map_err(|source| ReportError::Read {
+                path: dir.clone(),
+                source,
+            })?;
+            let path = Utf8PathBuf::from_path_buf(entry.path()).map_err(|path| {
+                ReportError::NonUtf8Path {
+                    path: path.display().to_string(),
+                }
+            })?;
+            // `file_type` does not traverse symlinks, so a link is neither
+            // descended into nor measured.
+            let file_type = entry.file_type().map_err(|source| ReportError::Read {
+                path: path.clone(),
+                source,
+            })?;
+
+            if file_type.is_dir() {
+                stack.push((path, depth + 1));
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+
+            let relative = path.strip_prefix(out_dir).unwrap_or(&path);
+            let relative = relative.as_str().to_compact_string();
+            if options.excluded.contains(&relative) {
+                continue;
+            }
+            if files.len() >= MAX_ASSETS {
+                return Err(ReportError::TooManyAssets);
+            }
+
+            files.push((path, relative));
+        }
+    }
+
+    let mut assets = files
+        .into_par_iter()
+        .map(|(path, relative)| {
+            let contents = fs::read(&path).map_err(|source| ReportError::Read {
+                path: path.clone(),
+                source,
+            })?;
+            let size = measure(&contents).map_err(|source| ReportError::Measure {
+                path: path.clone(),
+                source,
+            })?;
+
+            Ok(AssetEntry {
+                kind: AssetKind::from_path(&path),
+                path: relative,
+                size,
+            })
+        })
+        .collect::<Result<Vec<_>, ReportError>>()?;
+
+    assets.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(assets)
+}
+
+/// Build a report from measured assets and a route-to-asset attribution.
+///
+/// `entry_assets` names the assets a route needs before first render;
+/// `route_assets` names everything it eventually loads. Both are looked up in
+/// `assets`; an unknown name is ignored rather than guessed at, so a partially
+/// wired build under-reports instead of inventing numbers.
+#[must_use]
+pub fn build_report(
+    assets: Vec<AssetEntry>,
+    routes: &[(CompactString, Vec<CompactString>, Vec<CompactString>)],
+) -> BundleReport {
+    let by_path = assets
+        .iter()
+        .map(|asset| (asset.path.as_str(), asset))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut route_entries = routes
+        .iter()
+        .map(|(path, entry_assets, lazy_assets)| {
+            let initial_js = sum_javascript(&by_path, entry_assets);
+            let lazy_js = sum_javascript(&by_path, lazy_assets);
+            let mut names = entry_assets
+                .iter()
+                .chain(lazy_assets)
+                .cloned()
+                .collect::<Vec<_>>();
+            names.sort();
+            names.dedup();
+            let total = names
+                .iter()
+                .filter_map(|name| by_path.get(name.as_str()))
+                .filter(|asset| asset.kind.is_downloaded())
+                .fold(AssetSize::zero(), |total, asset| {
+                    total.saturating_add(asset.size)
+                });
+
+            RouteEntry {
+                path: path.clone(),
+                initial_js,
+                lazy_js,
+                total,
+                assets: names,
+            }
+        })
+        .collect::<Vec<_>>();
+    route_entries.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let total = assets
+        .iter()
+        .filter(|asset| asset.kind.is_downloaded())
+        .fold(AssetSize::zero(), |total, asset| {
+            total.saturating_add(asset.size)
+        });
+
+    BundleReport {
+        assets,
+        routes: route_entries,
+        total,
+    }
+}
+
+fn sum_javascript(by_path: &BTreeMap<&str, &AssetEntry>, names: &[CompactString]) -> AssetSize {
+    names
+        .iter()
+        .filter_map(|name| by_path.get(name.as_str()))
+        .filter(|asset| asset.kind == AssetKind::JavaScript)
+        .fold(AssetSize::zero(), |total, asset| {
+            total.saturating_add(asset.size)
+        })
+}
+
+/// Write the report to `<out_dir>/uf-bundle-report.json`.
+pub fn write_report(out_dir: &Utf8Path, report: &BundleReport) -> Result<Utf8PathBuf, ReportError> {
+    let path = out_dir.join("uf-bundle-report.json");
+    let mut contents = serde_json::to_string_pretty(&BundleReportFile {
+        version: 1,
+        gzip_level: crate::size::GZIP_LEVEL,
+        brotli_quality: crate::size::BROTLI_QUALITY,
+        report,
+    })
+    .map_err(ReportError::Serialize)?;
+    contents.push('\n');
+
+    fs::write(&path, contents).map_err(|source| ReportError::Write {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(path)
+}
+
+/// On-disk shape of `uf-bundle-report.json`.
+///
+/// The compression settings travel with the numbers so a report from one
+/// version is never silently compared against a differently-compressed one.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BundleReportFile<'a> {
+    version: u8,
+    gzip_level: u32,
+    brotli_quality: u32,
+    #[serde(flatten)]
+    report: &'a BundleReport,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::size::{BudgetMetric, ByteSize};
+
+    fn write(root: &Utf8Path, relative: &str, contents: &str) {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().expect("has parent")).expect("creates dirs");
+        fs::write(path, contents).expect("writes");
+    }
+
+    fn temp_root() -> (tempfile::TempDir, Utf8PathBuf) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf-8 temp dir");
+        (dir, root)
+    }
+
+    #[test]
+    fn classifies_assets_by_extension() {
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/app.js")),
+            AssetKind::JavaScript
+        );
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/app.mjs")),
+            AssetKind::JavaScript
+        );
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/app.css")),
+            AssetKind::Stylesheet
+        );
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/index.html")),
+            AssetKind::Html
+        );
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/data.json")),
+            AssetKind::Json
+        );
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/font.woff2")),
+            AssetKind::Other
+        );
+    }
+
+    #[test]
+    fn source_maps_win_over_the_extension_they_end_in() {
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/app.js.map")),
+            AssetKind::SourceMap
+        );
+        assert_eq!(
+            AssetKind::from_path(Utf8Path::new("a/app.css.map")),
+            AssetKind::SourceMap
+        );
+        assert!(!AssetKind::SourceMap.is_downloaded());
+        assert!(AssetKind::JavaScript.is_downloaded());
+    }
+
+    #[test]
+    fn collects_and_sorts_assets_from_the_output_directory() {
+        let (_dir, root) = temp_root();
+        write(&root, "assets/b.js", "const b = 2;\n");
+        write(&root, "assets/a.js", "const a = 1;\n");
+        write(&root, "index.html", "<!doctype html>\n");
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+
+        let paths = assets.iter().map(|a| a.path.as_str()).collect::<Vec<_>>();
+        assert_eq!(paths, ["assets/a.js", "assets/b.js", "index.html"]);
+    }
+
+    #[test]
+    fn skips_build_metadata_by_default() {
+        let (_dir, root) = temp_root();
+        write(&root, "uf-build-manifest.json", "{}\n");
+        write(&root, "uf-rsc-manifest.json", "{}\n");
+        write(&root, "uf-bundle-report.json", "{}\n");
+        write(&root, "app.js", "const a = 1;\n");
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0].path, "app.js");
+    }
+
+    #[test]
+    fn a_missing_output_directory_reports_no_assets() {
+        let (_dir, root) = temp_root();
+
+        let assets =
+            collect_assets(&root.join("does-not-exist"), &ReportOptions::default()).expect("ok");
+
+        assert!(assets.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_neither_measured_nor_followed() {
+        let (_dir, root) = temp_root();
+        write(&root, "app.js", "const a = 1;\n");
+        std::os::unix::fs::symlink("/etc/passwd", root.join("leak.js")).expect("symlink");
+        std::os::unix::fs::symlink(root.as_std_path(), root.join("loop")).expect("symlink");
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+
+        let paths = assets.iter().map(|a| a.path.as_str()).collect::<Vec<_>>();
+        assert_eq!(paths, ["app.js"]);
+    }
+
+    #[test]
+    fn deep_trees_terminate_instead_of_recursing() {
+        let (_dir, root) = temp_root();
+        let mut nested = String::new();
+        for _ in 0..(MAX_ASSET_DEPTH + 8) {
+            nested.push_str("d/");
+        }
+        write(&root, &format!("{nested}deep.js"), "const a = 1;\n");
+        write(&root, "shallow.js", "const b = 2;\n");
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+
+        assert!(assets.iter().any(|a| a.path == "shallow.js"));
+        assert!(assets.iter().all(|a| a.path != format!("{nested}deep.js")));
+    }
+
+    #[test]
+    fn route_weight_splits_initial_from_lazy_javascript() {
+        let (_dir, root) = temp_root();
+        write(&root, "entry.js", &"const a = 1;\n".repeat(20));
+        write(&root, "lazy.js", &"const b = 2;\n".repeat(40));
+        write(&root, "app.css", &".a { color: red }\n".repeat(10));
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+        let report = build_report(
+            assets,
+            &[(
+                CompactString::const_new("/"),
+                vec![
+                    CompactString::const_new("entry.js"),
+                    CompactString::const_new("app.css"),
+                ],
+                vec![CompactString::const_new("lazy.js")],
+            )],
+        );
+
+        let route = &report.routes[0];
+        assert!(route.initial_js.raw.bytes() > 0);
+        assert!(route.lazy_js.raw.bytes() > route.initial_js.raw.bytes());
+        // Stylesheets count toward the route total but never toward initial JS.
+        assert!(route.total.raw.bytes() > route.initial_js.raw.bytes() + route.lazy_js.raw.bytes());
+        assert_eq!(route.assets.len(), 3);
+    }
+
+    #[test]
+    fn source_maps_are_measured_but_excluded_from_totals() {
+        let (_dir, root) = temp_root();
+        write(&root, "app.js", "const a = 1;\n");
+        write(&root, "app.js.map", &"x".repeat(4096));
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+        let report = build_report(assets, &[]);
+
+        assert_eq!(report.assets.len(), 2);
+        let app_js = report
+            .assets
+            .iter()
+            .find(|a| a.path == "app.js")
+            .expect("app.js");
+        assert_eq!(report.total, app_js.size);
+    }
+
+    #[test]
+    fn unknown_route_assets_are_ignored_rather_than_guessed() {
+        let report = build_report(
+            Vec::new(),
+            &[(
+                CompactString::const_new("/"),
+                vec![CompactString::const_new("missing.js")],
+                Vec::new(),
+            )],
+        );
+
+        assert_eq!(report.routes[0].initial_js, AssetSize::zero());
+        assert_eq!(report.routes[0].total, AssetSize::zero());
+    }
+
+    #[test]
+    fn an_asset_shared_by_entry_and_lazy_is_counted_once_in_the_total() {
+        let (_dir, root) = temp_root();
+        write(&root, "shared.js", &"const a = 1;\n".repeat(20));
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+        let shared = assets[0].size;
+        let report = build_report(
+            assets,
+            &[(
+                CompactString::const_new("/"),
+                vec![CompactString::const_new("shared.js")],
+                vec![CompactString::const_new("shared.js")],
+            )],
+        );
+
+        assert_eq!(report.routes[0].total, shared);
+        assert_eq!(report.routes[0].assets.len(), 1);
+    }
+
+    #[test]
+    fn routes_are_sorted_by_path() {
+        let report = build_report(
+            Vec::new(),
+            &[
+                (CompactString::const_new("/z"), Vec::new(), Vec::new()),
+                (CompactString::const_new("/a"), Vec::new(), Vec::new()),
+            ],
+        );
+
+        assert_eq!(report.routes[0].path, "/a");
+        assert_eq!(report.routes[1].path, "/z");
+    }
+
+    #[test]
+    fn largest_assets_are_ordered_by_the_requested_metric() {
+        let (_dir, root) = temp_root();
+        write(&root, "small.js", "const a = 1;\n");
+        write(&root, "large.js", &"const b = 2;\n".repeat(200));
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+        let report = build_report(assets, &[]);
+
+        let ordered = report.largest_assets(BudgetMetric::Gzip);
+        assert_eq!(ordered[0].path, "large.js");
+        assert_eq!(ordered[1].path, "small.js");
+    }
+
+    #[test]
+    fn totals_group_by_asset_kind() {
+        let (_dir, root) = temp_root();
+        write(&root, "a.js", "const a = 1;\n");
+        write(&root, "b.js", "const b = 2;\n");
+        write(&root, "a.css", ".a{}\n");
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+        let report = build_report(assets, &[]);
+        let totals = report.total_by_kind();
+
+        assert_eq!(totals.len(), 2);
+        assert!(totals.contains_key(&AssetKind::JavaScript));
+        assert!(totals.contains_key(&AssetKind::Stylesheet));
+    }
+
+    #[test]
+    fn the_written_report_is_deterministic_and_carries_its_compression_settings() {
+        let (_dir, root) = temp_root();
+        write(&root, "app.js", "const a = 1;\n");
+
+        let assets = collect_assets(&root, &ReportOptions::default()).expect("collects");
+        let report = build_report(assets, &[]);
+        let path = write_report(&root, &report).expect("writes");
+        let first = fs::read_to_string(&path).expect("reads");
+        let second_path = write_report(&root, &report).expect("writes");
+        let second = fs::read_to_string(&second_path).expect("reads");
+
+        assert_eq!(first, second);
+        assert!(first.contains("\"gzipLevel\": 9"), "{first}");
+        assert!(first.contains("\"brotliQuality\": 11"), "{first}");
+        assert!(first.contains("\"initialJs\"") || report.routes.is_empty());
+        assert!(first.ends_with('\n'));
+    }
+
+    #[test]
+    fn report_json_uses_camel_case_keys() {
+        let report = build_report(
+            Vec::new(),
+            &[(CompactString::const_new("/"), Vec::new(), Vec::new())],
+        );
+
+        let json = serde_json::to_string(&report).expect("serializes");
+
+        assert!(json.contains("\"initialJs\""), "{json}");
+        assert!(json.contains("\"lazyJs\""), "{json}");
+        assert!(!json.contains("initial_js"), "{json}");
+    }
+
+    #[test]
+    fn an_empty_build_reports_zero() {
+        let report = BundleReport::default();
+
+        assert_eq!(report.total, AssetSize::zero());
+        assert_eq!(
+            report.total.get(BudgetMetric::Gzip),
+            ByteSize::from_bytes(0)
+        );
+    }
+}

--- a/crates/uf_bundle/src/size.rs
+++ b/crates/uf_bundle/src/size.rs
@@ -1,0 +1,730 @@
+//! Byte sizes, human-readable size parsing, and real compressed measurement.
+
+use std::io::Write;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Gzip level used for every reported measurement.
+///
+/// Fixed so numbers are comparable across runs and machines. Level 9 is what a
+/// CDN serves for static assets.
+pub const GZIP_LEVEL: u32 = 9;
+
+/// Brotli quality used for every reported measurement.
+pub const BROTLI_QUALITY: u32 = 11;
+
+/// Brotli window size (log2) used for every reported measurement.
+pub const BROTLI_WINDOW: u32 = 22;
+
+/// Largest asset `uf` will measure, in bytes.
+///
+/// Compression is CPU-bound and asset paths come from a build directory that a
+/// dependency can write into, so the work is bounded rather than trusted.
+pub const MAX_ASSET_BYTES: u64 = 512 * 1024 * 1024;
+
+/// A byte count parsed from configuration.
+///
+/// Wraps `u64` so a budget cannot be confused with a raw count at a call site,
+/// and so parsing lives in exactly one place.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct ByteSize(u64);
+
+impl<'de> Deserialize<'de> for ByteSize {
+    /// Accept both a raw byte count and a human-readable string.
+    ///
+    /// `uf.config.js` is written by people, so `initialJs: "180kb"` has to work;
+    /// the report reads back its own numbers, so `180000` has to work too.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl serde::de::Visitor<'_> for Visitor {
+            type Value = ByteSize;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a byte count or a size such as \"180kb\"")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<ByteSize, E> {
+                Ok(ByteSize(value))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, value: i64) -> Result<ByteSize, E> {
+                u64::try_from(value)
+                    .map(ByteSize)
+                    .map_err(|_| E::custom("a size cannot be negative"))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<ByteSize, E> {
+                parse_byte_size(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+impl ByteSize {
+    /// Build a size from a raw byte count.
+    #[must_use]
+    pub const fn from_bytes(bytes: u64) -> Self {
+        Self(bytes)
+    }
+
+    /// The raw byte count.
+    #[must_use]
+    pub const fn bytes(self) -> u64 {
+        self.0
+    }
+
+    /// Difference against a smaller size, saturating at zero.
+    #[must_use]
+    pub const fn saturating_sub(self, other: Self) -> Self {
+        Self(self.0.saturating_sub(other.0))
+    }
+}
+
+impl std::fmt::Display for ByteSize {
+    /// Render as the largest unit that keeps the value at or above one, using
+    /// decimal units because that is how download sizes are reported.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const UNITS: [(u64, &str); 4] = [
+            (1_000_000_000, "GB"),
+            (1_000_000, "MB"),
+            (1_000, "kB"),
+            (1, "B"),
+        ];
+
+        for (scale, suffix) in UNITS {
+            if self.0 >= scale {
+                if scale == 1 {
+                    return write!(f, "{} {suffix}", self.0);
+                }
+                let whole = self.0 / scale;
+                let fraction = (self.0 % scale) * 100 / scale;
+                return write!(f, "{whole}.{fraction:02} {suffix}");
+            }
+        }
+
+        write!(f, "0 B")
+    }
+}
+
+/// Failures while reading a size out of `uf.config.js`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ByteSizeParseError {
+    /// The input held no digits.
+    #[error("size `{input}` has no numeric part")]
+    Empty {
+        /// The rejected input, truncated for safety.
+        input: String,
+    },
+    /// The input carried a unit that is not recognized.
+    #[error("size `{input}` uses unknown unit `{unit}`")]
+    UnknownUnit {
+        /// The rejected input, truncated for safety.
+        input: String,
+        /// The unrecognized unit.
+        unit: String,
+    },
+    /// The input held characters that are neither digits, a decimal point, nor a unit.
+    #[error("size `{input}` contains `{character}`, which is not valid in a size")]
+    InvalidCharacter {
+        /// The rejected input, truncated for safety.
+        input: String,
+        /// The offending character.
+        character: char,
+    },
+    /// The value does not fit in a `u64` byte count.
+    #[error("size `{input}` does not fit in a 64-bit byte count")]
+    Overflow {
+        /// The rejected input, truncated for safety.
+        input: String,
+    },
+    /// More than one decimal point appeared.
+    #[error("size `{input}` has more than one decimal point")]
+    RepeatedDecimalPoint {
+        /// The rejected input, truncated for safety.
+        input: String,
+    },
+}
+
+/// Longest size string `uf` will look at.
+const MAX_SIZE_INPUT_BYTES: usize = 64;
+
+/// Truncate untrusted text before it lands in an error message.
+fn quote(input: &str) -> String {
+    input.chars().take(32).collect()
+}
+
+/// Parse a human-readable size such as `180kb`, `1.5 MB`, `200KiB`, or `4096`.
+///
+/// Hand-written rather than regex-backed: this reads project configuration, and
+/// a backtracking matcher on untrusted input is a denial-of-service class all by
+/// itself. The scan is a single forward pass with no allocation on the happy
+/// path until the unit lookup.
+///
+/// Bare numbers are bytes. Units are case-insensitive. Both decimal (`kB`, `MB`,
+/// `GB`) and binary (`KiB`, `MiB`, `GiB`) units are accepted, and a lone `k`,
+/// `m`, or `g` is read as the decimal unit, matching how bundlers report sizes.
+pub fn parse_byte_size(input: &str) -> Result<ByteSize, ByteSizeParseError> {
+    if input.len() > MAX_SIZE_INPUT_BYTES {
+        return Err(ByteSizeParseError::Overflow {
+            input: quote(input),
+        });
+    }
+
+    let trimmed = input.trim();
+    let bytes = trimmed.as_bytes();
+
+    let mut index = 0;
+    let mut whole: u64 = 0;
+    let mut fraction: u64 = 0;
+    let mut fraction_scale: u64 = 1;
+    let mut seen_digit = false;
+    let mut seen_point = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        match byte {
+            b'0'..=b'9' => {
+                seen_digit = true;
+                let digit = u64::from(byte - b'0');
+                if seen_point {
+                    // Digits past the precision we can use cannot change the
+                    // result, so stop accumulating instead of overflowing.
+                    if fraction_scale <= 1_000_000_000_000_000_000 {
+                        fraction = fraction * 10 + digit;
+                        fraction_scale *= 10;
+                    }
+                } else {
+                    whole = whole
+                        .checked_mul(10)
+                        .and_then(|n| n.checked_add(digit))
+                        .ok_or_else(|| ByteSizeParseError::Overflow {
+                            input: quote(input),
+                        })?;
+                }
+                index += 1;
+            }
+            b'.' => {
+                if seen_point {
+                    return Err(ByteSizeParseError::RepeatedDecimalPoint {
+                        input: quote(input),
+                    });
+                }
+                seen_point = true;
+                index += 1;
+            }
+            b'_' => index += 1,
+            _ => break,
+        }
+    }
+
+    if !seen_digit {
+        return Err(ByteSizeParseError::Empty {
+            input: quote(input),
+        });
+    }
+
+    let unit_text = trimmed[index..].trim();
+    for character in unit_text.chars() {
+        if !character.is_ascii_alphabetic() {
+            return Err(ByteSizeParseError::InvalidCharacter {
+                input: quote(input),
+                character,
+            });
+        }
+    }
+
+    let multiplier = unit_multiplier(unit_text).ok_or_else(|| ByteSizeParseError::UnknownUnit {
+        input: quote(input),
+        unit: quote(unit_text),
+    })?;
+
+    let scaled_whole =
+        whole
+            .checked_mul(multiplier)
+            .ok_or_else(|| ByteSizeParseError::Overflow {
+                input: quote(input),
+            })?;
+    // `fraction / fraction_scale` is in [0, 1), so this cannot overflow once the
+    // whole part has been checked.
+    let scaled_fraction = multiplier / fraction_scale * fraction
+        + (multiplier % fraction_scale) * fraction / fraction_scale;
+
+    scaled_whole
+        .checked_add(scaled_fraction)
+        .map(ByteSize::from_bytes)
+        .ok_or_else(|| ByteSizeParseError::Overflow {
+            input: quote(input),
+        })
+}
+
+/// Byte multiplier for a size unit, or [`None`] when the unit is unknown.
+fn unit_multiplier(unit: &str) -> Option<u64> {
+    const KB: u64 = 1_000;
+    const MB: u64 = 1_000_000;
+    const GB: u64 = 1_000_000_000;
+    const KIB: u64 = 1 << 10;
+    const MIB: u64 = 1 << 20;
+    const GIB: u64 = 1 << 30;
+
+    // Case-insensitive without allocating for the common ASCII inputs.
+    let mut lowered = [0u8; 8];
+    if unit.len() > lowered.len() {
+        return None;
+    }
+    for (slot, byte) in lowered.iter_mut().zip(unit.as_bytes()) {
+        *slot = byte.to_ascii_lowercase();
+    }
+    let lowered = &lowered[..unit.len()];
+
+    match lowered {
+        b"" | b"b" => Some(1),
+        b"k" | b"kb" => Some(KB),
+        b"m" | b"mb" => Some(MB),
+        b"g" | b"gb" => Some(GB),
+        b"kib" => Some(KIB),
+        b"mib" => Some(MIB),
+        b"gib" => Some(GIB),
+        _ => None,
+    }
+}
+
+/// Raw and compressed sizes for one asset.
+///
+/// Compressed figures come from actually compressing the bytes, never from an
+/// estimate — a budget that lies is worse than no budget.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetSize {
+    /// Size on disk.
+    pub raw: ByteSize,
+    /// Size after gzip at [`GZIP_LEVEL`].
+    pub gzip: ByteSize,
+    /// Size after brotli at [`BROTLI_QUALITY`].
+    pub brotli: ByteSize,
+}
+
+impl AssetSize {
+    /// The size under one metric.
+    #[must_use]
+    pub const fn get(self, metric: BudgetMetric) -> ByteSize {
+        match metric {
+            BudgetMetric::Raw => self.raw,
+            BudgetMetric::Gzip => self.gzip,
+            BudgetMetric::Brotli => self.brotli,
+        }
+    }
+
+    /// Component-wise sum, saturating rather than wrapping.
+    #[must_use]
+    pub const fn saturating_add(self, other: Self) -> Self {
+        Self {
+            raw: ByteSize(self.raw.0.saturating_add(other.raw.0)),
+            gzip: ByteSize(self.gzip.0.saturating_add(other.gzip.0)),
+            brotli: ByteSize(self.brotli.0.saturating_add(other.brotli.0)),
+        }
+    }
+
+    /// The zero size, used as a fold identity.
+    #[must_use]
+    pub const fn zero() -> Self {
+        Self {
+            raw: ByteSize(0),
+            gzip: ByteSize(0),
+            brotli: ByteSize(0),
+        }
+    }
+}
+
+/// Which measurement a budget applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BudgetMetric {
+    /// Bytes on disk.
+    Raw,
+    /// Bytes after gzip. The default, because it is what users download.
+    #[default]
+    Gzip,
+    /// Bytes after brotli.
+    Brotli,
+}
+
+impl BudgetMetric {
+    /// Stable identifier used in reports and error messages.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Raw => "raw",
+            Self::Gzip => "gzip",
+            Self::Brotli => "brotli",
+        }
+    }
+}
+
+/// Failures while measuring an asset.
+#[derive(Debug, Error)]
+pub enum MeasureError {
+    /// The asset was larger than [`MAX_ASSET_BYTES`].
+    #[error("asset is {actual} bytes, above the {limit} byte measurement limit")]
+    TooLarge {
+        /// Observed size.
+        actual: u64,
+        /// Configured limit.
+        limit: u64,
+    },
+    /// Compression failed.
+    #[error("failed to compress asset: {0}")]
+    Compress(#[source] std::io::Error),
+}
+
+/// Measure `contents` raw, gzipped, and brotli-compressed.
+pub fn measure(contents: &[u8]) -> Result<AssetSize, MeasureError> {
+    let raw = contents.len() as u64;
+    if raw > MAX_ASSET_BYTES {
+        return Err(MeasureError::TooLarge {
+            actual: raw,
+            limit: MAX_ASSET_BYTES,
+        });
+    }
+
+    Ok(AssetSize {
+        raw: ByteSize::from_bytes(raw),
+        gzip: ByteSize::from_bytes(gzip_size(contents)?),
+        brotli: ByteSize::from_bytes(brotli_size(contents)?),
+    })
+}
+
+fn gzip_size(contents: &[u8]) -> Result<u64, MeasureError> {
+    let mut encoder = flate2::write::GzEncoder::new(
+        CountingSink::default(),
+        flate2::Compression::new(GZIP_LEVEL),
+    );
+    encoder
+        .write_all(contents)
+        .map_err(MeasureError::Compress)?;
+    Ok(encoder.finish().map_err(MeasureError::Compress)?.written)
+}
+
+fn brotli_size(contents: &[u8]) -> Result<u64, MeasureError> {
+    let mut sink = CountingSink::default();
+    {
+        let mut encoder = brotli::CompressorWriter::new(
+            &mut sink,
+            BROTLI_BUFFER_BYTES,
+            BROTLI_QUALITY,
+            BROTLI_WINDOW,
+        );
+        encoder
+            .write_all(contents)
+            .map_err(MeasureError::Compress)?;
+        encoder.flush().map_err(MeasureError::Compress)?;
+    }
+    Ok(sink.written)
+}
+
+/// Brotli's internal buffer. Large enough to keep syscall-free writes cheap
+/// without holding a copy of the asset.
+const BROTLI_BUFFER_BYTES: usize = 4096;
+
+/// A sink that counts bytes instead of keeping them.
+///
+/// Compressed output is never needed, only its length, so nothing is retained
+/// and a large asset costs no extra memory.
+#[derive(Debug, Default)]
+struct CountingSink {
+    written: u64,
+}
+
+impl Write for CountingSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.written += buf.len() as u64;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes(input: &str) -> u64 {
+        parse_byte_size(input).expect("parses").bytes()
+    }
+
+    #[test]
+    fn parses_bare_byte_counts() {
+        assert_eq!(bytes("0"), 0);
+        assert_eq!(bytes("4096"), 4096);
+        assert_eq!(bytes("4096b"), 4096);
+        assert_eq!(bytes("4096 B"), 4096);
+    }
+
+    #[test]
+    fn parses_decimal_units() {
+        assert_eq!(bytes("180kb"), 180_000);
+        assert_eq!(bytes("180 kB"), 180_000);
+        assert_eq!(bytes("180K"), 180_000);
+        assert_eq!(bytes("1mb"), 1_000_000);
+        assert_eq!(bytes("1gb"), 1_000_000_000);
+    }
+
+    #[test]
+    fn parses_binary_units() {
+        assert_eq!(bytes("200KiB"), 204_800);
+        assert_eq!(bytes("1MiB"), 1_048_576);
+        assert_eq!(bytes("1GiB"), 1_073_741_824);
+    }
+
+    #[test]
+    fn parses_fractional_sizes() {
+        assert_eq!(bytes("1.5 MB"), 1_500_000);
+        assert_eq!(bytes("0.5kb"), 500);
+        assert_eq!(bytes("2.25MiB"), 2_359_296);
+    }
+
+    #[test]
+    fn parsing_is_case_insensitive() {
+        assert_eq!(bytes("1KB"), bytes("1kb"));
+        assert_eq!(bytes("1MiB"), bytes("1mib"));
+        assert_eq!(bytes("1Gb"), bytes("1gB"));
+    }
+
+    #[test]
+    fn underscores_are_digit_separators() {
+        assert_eq!(bytes("1_000_000"), 1_000_000);
+        assert_eq!(bytes("1_0kb"), 10_000);
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        assert_eq!(bytes("  180kb  "), 180_000);
+        assert_eq!(bytes("180  kb"), 180_000);
+    }
+
+    #[test]
+    fn rejects_input_without_digits() {
+        assert!(matches!(
+            parse_byte_size("kb"),
+            Err(ByteSizeParseError::Empty { .. })
+        ));
+        assert!(matches!(
+            parse_byte_size(""),
+            Err(ByteSizeParseError::Empty { .. })
+        ));
+        assert!(matches!(
+            parse_byte_size("   "),
+            Err(ByteSizeParseError::Empty { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_units() {
+        assert!(matches!(
+            parse_byte_size("10tb"),
+            Err(ByteSizeParseError::UnknownUnit { .. })
+        ));
+        assert!(matches!(
+            parse_byte_size("10bytes"),
+            Err(ByteSizeParseError::UnknownUnit { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_size_characters() {
+        // Scientific notation is not a size: the scan stops at `e`, and the
+        // digit inside the unit is what makes it invalid.
+        assert!(matches!(
+            parse_byte_size("1e9kb"),
+            Err(ByteSizeParseError::InvalidCharacter { character: '9', .. })
+        ));
+        assert!(matches!(
+            parse_byte_size("10k!"),
+            Err(ByteSizeParseError::InvalidCharacter { character: '!', .. })
+        ));
+        assert!(matches!(
+            parse_byte_size("-1kb"),
+            Err(ByteSizeParseError::Empty { .. })
+        ));
+        assert!(matches!(
+            parse_byte_size("10 kb extra"),
+            Err(ByteSizeParseError::InvalidCharacter { character: ' ', .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_repeated_decimal_points() {
+        assert!(matches!(
+            parse_byte_size("1.2.3kb"),
+            Err(ByteSizeParseError::RepeatedDecimalPoint { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_values_that_do_not_fit_in_u64() {
+        assert!(matches!(
+            parse_byte_size("99999999999999999999999"),
+            Err(ByteSizeParseError::Overflow { .. })
+        ));
+        assert!(matches!(
+            parse_byte_size("18446744073709551615gb"),
+            Err(ByteSizeParseError::Overflow { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_the_largest_representable_byte_count() {
+        assert_eq!(bytes("18446744073709551615"), u64::MAX);
+    }
+
+    #[test]
+    fn rejects_absurdly_long_input_without_scanning_it() {
+        let input = "1".repeat(10_000);
+        assert!(matches!(
+            parse_byte_size(&input),
+            Err(ByteSizeParseError::Overflow { .. })
+        ));
+    }
+
+    #[test]
+    fn error_messages_truncate_untrusted_input() {
+        let input = format!("{}tb", "9".repeat(40));
+        let error = parse_byte_size(&input).unwrap_err();
+
+        assert!(error.to_string().len() < 120, "{error}");
+    }
+
+    #[test]
+    fn renders_sizes_in_the_largest_fitting_unit() {
+        assert_eq!(ByteSize::from_bytes(512).to_string(), "512 B");
+        assert_eq!(ByteSize::from_bytes(1_500).to_string(), "1.50 kB");
+        assert_eq!(ByteSize::from_bytes(1_500_000).to_string(), "1.50 MB");
+        assert_eq!(ByteSize::from_bytes(2_000_000_000).to_string(), "2.00 GB");
+        assert_eq!(ByteSize::from_bytes(0).to_string(), "0 B");
+    }
+
+    #[test]
+    fn measures_real_compressed_sizes() {
+        let contents = "export const value = 1;\n".repeat(500);
+        let size = measure(contents.as_bytes()).expect("measures");
+
+        assert_eq!(size.raw.bytes(), contents.len() as u64);
+        assert!(
+            size.gzip.bytes() < size.raw.bytes(),
+            "gzip {} should beat raw {}",
+            size.gzip,
+            size.raw
+        );
+        assert!(
+            size.brotli.bytes() <= size.gzip.bytes(),
+            "brotli {} should beat gzip {} on repetitive input",
+            size.brotli,
+            size.gzip
+        );
+    }
+
+    #[test]
+    fn measures_empty_and_incompressible_input() {
+        let empty = measure(b"").expect("measures");
+        assert_eq!(empty.raw.bytes(), 0);
+
+        // Compressing random-ish bytes can grow them; the measurement must
+        // report that honestly rather than clamping.
+        let noise: Vec<u8> = (0..4096u32)
+            .map(|i| (i.wrapping_mul(2_654_435_761) >> 13) as u8)
+            .collect();
+        let size = measure(&noise).expect("measures");
+        assert_eq!(size.raw.bytes(), 4096);
+        assert!(size.gzip.bytes() > 0);
+    }
+
+    #[test]
+    fn measurement_is_deterministic() {
+        let contents = b"const a = 1; const b = 2; const c = 3;".repeat(64);
+        let first = measure(&contents).expect("measures");
+        let second = measure(&contents).expect("measures");
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn metric_selection_reads_the_matching_field() {
+        let size = AssetSize {
+            raw: ByteSize::from_bytes(300),
+            gzip: ByteSize::from_bytes(200),
+            brotli: ByteSize::from_bytes(100),
+        };
+
+        assert_eq!(size.get(BudgetMetric::Raw).bytes(), 300);
+        assert_eq!(size.get(BudgetMetric::Gzip).bytes(), 200);
+        assert_eq!(size.get(BudgetMetric::Brotli).bytes(), 100);
+    }
+
+    #[test]
+    fn sizes_add_without_wrapping() {
+        let huge = AssetSize {
+            raw: ByteSize::from_bytes(u64::MAX),
+            gzip: ByteSize::from_bytes(u64::MAX),
+            brotli: ByteSize::from_bytes(u64::MAX),
+        };
+
+        let total = huge.saturating_add(huge);
+
+        assert_eq!(total.raw.bytes(), u64::MAX);
+    }
+
+    #[test]
+    fn gzip_metric_is_the_default() {
+        assert_eq!(BudgetMetric::default(), BudgetMetric::Gzip);
+    }
+
+    #[test]
+    fn deserializes_from_a_human_readable_string() {
+        let size: ByteSize = serde_json::from_str("\"180kb\"").expect("deserializes");
+
+        assert_eq!(size.bytes(), 180_000);
+    }
+
+    #[test]
+    fn deserializes_from_a_raw_byte_count() {
+        let size: ByteSize = serde_json::from_str("180000").expect("deserializes");
+
+        assert_eq!(size.bytes(), 180_000);
+    }
+
+    #[test]
+    fn rejects_a_negative_size() {
+        let error = serde_json::from_str::<ByteSize>("-1").expect_err("rejects");
+
+        assert!(error.to_string().contains("negative"), "{error}");
+    }
+
+    #[test]
+    fn surfaces_the_parse_error_when_deserializing_a_bad_string() {
+        let error = serde_json::from_str::<ByteSize>("\"10tb\"").expect_err("rejects");
+
+        assert!(error.to_string().contains("unknown unit"), "{error}");
+    }
+
+    #[test]
+    fn serializes_back_to_a_plain_byte_count() {
+        let json = serde_json::to_string(&ByteSize::from_bytes(180_000)).expect("serializes");
+
+        assert_eq!(json, "180000");
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let original = ByteSize::from_bytes(1_234_567);
+        let json = serde_json::to_string(&original).expect("serializes");
+        let parsed: ByteSize = serde_json::from_str(&json).expect("deserializes");
+
+        assert_eq!(original, parsed);
+    }
+}

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/bin/ufx.rs"
 anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true
+uf_bundle = { path = "../uf_bundle" }
 uf_config = { path = "../uf_config" }
 uf_effect = { path = "../uf_effect" }
 uf_flow = { path = "../uf_flow" }

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -9,6 +9,9 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clap::error::ErrorKind;
 use clap::{Parser, Subcommand, ValueEnum};
 use serde_json::json;
+use uf_bundle::{
+    BudgetMetric, ReportOptions, build_report, collect_assets, evaluate, write_report,
+};
 use uf_config::{ResolvedConfig, TaskDefinition, load_config};
 use uf_fmt::format_source;
 use uf_lib::{
@@ -36,7 +39,10 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    Build,
+    Build {
+        #[arg(long)]
+        size_report: bool,
+    },
     Check,
     Create {
         #[command(subcommand)]
@@ -151,7 +157,7 @@ fn run() -> Result<()> {
     let cwd = resolve_cwd(cli.cwd)?;
 
     match cli.command {
-        Commands::Build => build(&cwd),
+        Commands::Build { size_report } => build(&cwd, size_report),
         Commands::Check => check(&cwd),
         Commands::Create { command } => create(&cwd, command),
         Commands::Dev { once } => dev(&cwd, once),
@@ -206,7 +212,7 @@ fn current_dir() -> Result<Utf8PathBuf> {
         .map_err(|path| anyhow!("current directory is not UTF-8: {}", path.display()))
 }
 
-fn build(cwd: &Utf8Path) -> Result<()> {
+fn build(cwd: &Utf8Path, size_report: bool) -> Result<()> {
     let resolved = load_config(cwd)?;
     let routes = discover_routes(&resolved.root, &resolved.config)?;
     let manifest = write_router_manifest(&resolved.root, &resolved.config)?;
@@ -272,7 +278,55 @@ fn build(cwd: &Utf8Path) -> Result<()> {
     if let Some(manifest) = manifest {
         println!("generated {}", manifest);
     }
+
+    report_bundle_size(&resolved, &out_dir, size_report)?;
+
     Ok(())
+}
+
+/// Measure the emitted assets, write the report, and enforce `build.budgets`.
+///
+/// Budgets are unset by default, so this is a report until a project opts in.
+/// Once it does, an overage is a build failure with every violation listed at
+/// once rather than one per CI run.
+fn report_bundle_size(resolved: &ResolvedConfig, out_dir: &Utf8Path, verbose: bool) -> Result<()> {
+    let assets = collect_assets(out_dir, &ReportOptions::default())?;
+    let report = build_report(assets, &[]);
+    let report_path = write_report(out_dir, &report)?;
+
+    println!(
+        "uf build: size assets={} raw={} gzip={} brotli={} report={}",
+        report.assets.len(),
+        report.total.raw,
+        report.total.gzip,
+        report.total.brotli,
+        report_path
+    );
+
+    if verbose {
+        for asset in report.largest_assets(BudgetMetric::Gzip).iter().take(20) {
+            println!(
+                "  {:>10} gzip  {:>10} raw  {} ({})",
+                asset.size.gzip.to_string(),
+                asset.size.raw.to_string(),
+                asset.path,
+                asset.kind.as_str()
+            );
+        }
+    }
+
+    let outcome = evaluate(&report, &resolved.config.build.budgets);
+    if outcome.is_within_budget() {
+        return Ok(());
+    }
+
+    for violation in &outcome.violations {
+        eprintln!("uf build: {violation}");
+    }
+    bail!(
+        "bundle size exceeded {} budget(s)",
+        outcome.violations.len()
+    );
 }
 
 fn check(cwd: &Utf8Path) -> Result<()> {

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -835,3 +835,170 @@ fn use_reports_xdg_runtime_switch_plan() {
     assert!(state_home.join("uniflowed/active-runtime.json").exists());
     assert!(home.join(".local/bin/uf").exists());
 }
+
+/// Scaffold an app, returning the temp dir so it stays alive.
+///
+/// `uf build` does not run a bundler yet, so it emits manifests and no shipped
+/// assets. Tests that need weight to measure write their own files into `dist/`,
+/// which is exactly what the size reporter walks.
+fn built_app(config_extra: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+
+    let created = Command::cargo_bin("uf")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["create", "app", "react"])
+        .output()
+        .unwrap();
+    assert!(
+        created.status.success(),
+        "{}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+
+    if !config_extra.is_empty() {
+        let config_path = dir.path().join("uf.config.js");
+        let config = fs::read_to_string(&config_path).unwrap();
+        let injected = config.replacen(
+            "defineConfig({",
+            &format!("defineConfig({{{config_extra}"),
+            1,
+        );
+        assert_ne!(injected, config, "config template changed shape");
+        fs::write(&config_path, injected).unwrap();
+    }
+
+    dir
+}
+
+#[test]
+fn build_writes_a_bundle_size_report() {
+    let dir = built_app("");
+    emit_asset(&dir, "assets/app.js", &"export const a = 1;\n".repeat(50));
+
+    let output = Command::cargo_bin("uf")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("build")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("uf build: size assets="), "{stdout}");
+    assert!(stdout.contains("gzip="), "{stdout}");
+
+    let report = fs::read_to_string(dir.path().join("dist/uf-bundle-report.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["gzipLevel"], 9);
+    assert_eq!(parsed["brotliQuality"], 11);
+    assert!(!parsed["assets"].as_array().unwrap().is_empty());
+    // The report must never measure itself or the other build manifests.
+    let paths = parsed["assets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|asset| asset["path"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        !paths
+            .iter()
+            .any(|path| path.ends_with("uf-bundle-report.json")),
+        "{paths:?}"
+    );
+    assert!(
+        !paths
+            .iter()
+            .any(|path| path.ends_with("uf-build-manifest.json")),
+        "{paths:?}"
+    );
+}
+
+/// Write a shipped asset into `dist/` so there is real weight to measure.
+fn emit_asset(dir: &tempfile::TempDir, relative: &str, contents: &str) {
+    let path = dir.path().join("dist").join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn build_fails_when_a_size_budget_is_exceeded() {
+    let dir = built_app("\n  build: { budgets: { total: { max: \"1b\" } } },");
+    emit_asset(&dir, "assets/app.js", &"export const a = 1;\n".repeat(200));
+
+    let output = Command::cargo_bin("uf")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("build")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("total budget exceeded"), "{stderr}");
+    assert!(stderr.contains("gzip"), "{stderr}");
+    assert!(stderr.contains("bundle size exceeded"), "{stderr}");
+}
+
+#[test]
+fn build_passes_a_budget_that_is_large_enough() {
+    let dir = built_app(
+        "\n  build: { budgets: { total: { max: \"10mb\" }, perAsset: { max: \"10mb\" } } },",
+    );
+    emit_asset(&dir, "assets/app.js", &"export const a = 1;\n".repeat(200));
+
+    let output = Command::cargo_bin("uf")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("build")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn build_size_report_flag_lists_the_largest_assets() {
+    let dir = built_app("");
+    emit_asset(
+        &dir,
+        "assets/large.js",
+        &"export const a = 1;\n".repeat(400),
+    );
+    emit_asset(&dir, "assets/small.js", "export const b = 2;\n");
+
+    let output = Command::cargo_bin("uf")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["build", "--size-report"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let listed = stdout
+        .lines()
+        .filter(|line| line.starts_with("  "))
+        .collect::<Vec<_>>();
+    assert_eq!(listed.len(), 2, "{stdout}");
+    assert!(listed[0].contains("assets/large.js"), "{stdout}");
+    assert!(listed[1].contains("assets/small.js"), "{stdout}");
+}

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -6,6 +6,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::CompactString;
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
+pub use uf_bundle::{BudgetMetric, BundleBudgets, ByteSize, SizeBudget};
 
 pub const CONFIG_FILES: &[&str] = &["uf.config.js"];
 
@@ -634,6 +635,7 @@ pub struct CacheConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct BuildConfig {
+    pub budgets: BundleBudgets,
     pub entries: Vec<CompactString>,
     pub hooks: BTreeMap<CompactString, TaskDefinition>,
     pub out_dir: CompactString,
@@ -644,6 +646,9 @@ pub struct BuildConfig {
 impl Default for BuildConfig {
     fn default() -> Self {
         Self {
+            // Budgets stay unset by default: failing a build nobody asked us to
+            // police is worse than reporting and moving on.
+            budgets: BundleBudgets::default(),
             entries: vec![CompactString::const_new("app.js")],
             hooks: BTreeMap::new(),
             out_dir: CompactString::const_new("dist"),
@@ -2056,5 +2061,56 @@ mod tests {
             resolved.config_path.unwrap().file_name(),
             Some("uf.config.js")
         );
+    }
+
+    #[test]
+    fn budgets_are_unset_by_default() {
+        assert!(UniflowedConfig::default().build.budgets.is_empty());
+    }
+
+    #[test]
+    fn reads_human_readable_budgets_from_the_config_object() {
+        let source = r#"
+import { defineConfig } from "@uniflowed/config";
+
+export default defineConfig({
+  build: {
+    budgets: {
+      total: { max: "1.5 MB" },
+      initialJs: { max: "180kb" },
+      perAsset: { max: 250000, metric: "brotli" },
+    },
+  },
+});
+"#;
+        let object = extract_config_object(source).expect("config object");
+        let parsed: UniflowedConfig = json5::from_str(&object).expect("config");
+
+        let budgets = parsed.build.budgets;
+        assert_eq!(budgets.total.expect("total").max.bytes(), 1_500_000);
+        assert_eq!(budgets.initial_js.expect("initialJs").max.bytes(), 180_000);
+        let per_asset = budgets.per_asset.expect("perAsset");
+        assert_eq!(per_asset.max.bytes(), 250_000);
+        assert_eq!(per_asset.metric, BudgetMetric::Brotli);
+        assert_eq!(
+            budgets.initial_js.expect("initialJs").metric,
+            BudgetMetric::Gzip,
+            "gzip is the default metric"
+        );
+        assert!(budgets.per_route.is_none());
+    }
+
+    #[test]
+    fn rejects_a_budget_with_an_unparseable_size() {
+        let source = r#"
+import { defineConfig } from "@uniflowed/config";
+
+export default defineConfig({
+  build: { budgets: { total: { max: "10 terabytes" } } },
+});
+"#;
+        let object = extract_config_object(source).expect("config object");
+
+        assert!(json5::from_str::<UniflowedConfig>(&object).is_err());
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@ manager performance, and integrated feature coverage.
 - `uf_cli`: command router for `uf`
 - `uf_config`: zero-config defaults and `uf.config.js` loading
 - `uf_browser`: Playwright-compatible browser and VRT contracts
+- `uf_bundle`: bundle size measurement and `build.budgets` enforcement
 - `uf_fetch`: explicit ofetch-style client contracts
 - `uf_flow`: Flow parser/typechecker adapter boundary over `upstream/flow`
 - `uf_fmt`: native formatter runner

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -123,6 +123,7 @@
 ## P4: Build, Runtime, Package Manager, Publish
 
 - [ ] Wire `uf build` to Vite-compatible plugin semantics.
+- [x] Measure emitted bundle size and enforce `build.budgets` from `uf build`.
 - [x] Write native build manifest and generated router types from `uf build`.
 - [ ] Wire production builds to Rolldown where possible.
 - [ ] Wire `uf dev` to a Vite-compatible dev server.


### PR DESCRIPTION
## Summary

Nothing measured what a build actually ships. New `uf_bundle` crate does, and
`uf build` writes `dist/uf-bundle-report.json` alongside the other manifests.

**Compressed figures are real**, never estimated: gzip level 9 and brotli
quality 11 / window 22 — what a CDN serves. Those settings are written into the
report, so two runs are only ever compared on equal terms. `AssetSize` carries
raw, gzip, and brotli together; source maps are measured but excluded from what
a visitor downloads.

### Budgets

```js
build: {
  budgets: {
    total: { max: "1.5 MB" },
    initialJs: { max: "180kb" },
    perAsset: { max: 250000, metric: "brotli" },
  },
}
```

Ceilings for the whole build, a route's initial JavaScript, a route's total, and
any single asset. `metric` defaults to `gzip` because that is what users
actually download.

Budgets are **unset by default** — a toolchain that fails a build nobody asked
it to police is worse than one that reports and moves on. Once set, an overage
fails the build and **every** violation is reported at once, so a size
regression is one CI failure rather than a sequence of them:

```
uf build: total budget exceeded: 412.30 kB gzip over a 180.00 kB ceiling (+232.30 kB)
uf build: initial-js budget exceeded for /dashboard: 240.10 kB gzip over a 180.00 kB ceiling (+60.10 kB)
```

`uf build --size-report` lists the largest assets by gzip size.

### Details that matter

- **The size parser is a hand-written single forward pass, no regex.** This
  reads project configuration; a backtracking matcher on untrusted input is a
  denial-of-service class by itself. It rejects overflow, negatives, repeated
  decimal points, scientific notation, and unknown units with typed errors, and
  truncates untrusted text before it reaches a message.
- **The asset walk is iterative, depth-bounded, and does not follow symlinks.**
  A build directory is written by dependencies; a link out of the tree would
  otherwise let a hostile package have `uf` read arbitrary files. There is a
  test that plants a symlink to `/etc/passwd` and a symlink loop.
- **Measurement fans out across rayon.** Brotli at quality 11 costs ~7 ms per
  152 kB chunk, so a few hundred chunks would otherwise be seconds of serial work.

### Scope

`uf build` does not run a bundler yet, so today it emits manifests and no
shipped assets — the reporter measures whatever the build actually wrote and
does not invent numbers for assets that do not exist. The public types are
shaped so a Rolldown-backed build can feed them later without changing them.

Tracking `uf`'s own release binary size in CI is a deliberate follow-up, not in
this PR.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **621 passed, 0 failed** (59 new in `uf_bundle`,
      3 new in `uf_config`, 4 new integration tests in `uf_cli`)
- [x] `cargo bench --workspace --no-run`
- [x] `cargo metadata --format-version 1`

Measured locally: report build over 2 000 assets and 500 routes **156 µs**;
evaluating four budgets over 2 000 assets **12 µs**; measuring a 152 kB chunk
(gzip 9 + brotli 11) **7.07 ms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790917656&installation_model_id=422833&pr_number=12&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F12&signature=0cfe1833b4b60f4ee1a54b4fa27fffce61c56d330208b61d6700c0815fc3efb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->