### PR TITLE
fix(flow): create each worker's parser before rayon nests the stack

### DIFF
--- a/crates/uf_flow/src/lib.rs
+++ b/crates/uf_flow/src/lib.rs
@@ -119,6 +119,28 @@ pub const fn active_backend() -> ParserBackend {
     }
 }
 
+/// Initialize this thread's parser state before any nested work begins.
+///
+/// Backends that host a JavaScript engine budget their stack from wherever the
+/// engine was created, so creating one lazily inside a work-stealing job leaves
+/// the parser with less headroom than it expects and makes ordinary files look
+/// like syntax errors. Callers that parse from a thread pool should call this
+/// once per worker, from a shallow frame, before fanning out. It is idempotent,
+/// cheap after the first call, and a no-op for backends that need no setup.
+pub fn prepare_thread() -> Result<(), FlowError> {
+    #[cfg(all(feature = "official-parser", not(feature = "upstream-parser")))]
+    {
+        quickjs::prepare_thread()
+    }
+    #[cfg(any(
+        feature = "upstream-parser",
+        not(any(feature = "upstream-parser", feature = "official-parser"))
+    ))]
+    {
+        Ok(())
+    }
+}
+
 /// Validate `source` with the active Flow parser backend.
 pub fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
     #[cfg(feature = "upstream-parser")]
@@ -302,6 +324,14 @@ mod tests {
         let outcome = validate_source(source).expect("parse result");
 
         assert!(outcome.is_ok(), "{:?}", outcome.diagnostics);
+    }
+
+    #[test]
+    fn preparing_a_thread_is_idempotent() {
+        prepare_thread().expect("first");
+        prepare_thread().expect("second");
+
+        assert!(validate_source("// @flow\nconst a = 1;\n").is_ok());
     }
 
     #[test]

--- a/crates/uf_flow/src/quickjs.rs
+++ b/crates/uf_flow/src/quickjs.rs
@@ -2,6 +2,24 @@
 //!
 //! This backend predates Flow component syntax, so sources are normalized
 //! through [`crate::normalize_modern_flow_for_parser`] before parsing.
+//!
+//! # Stack budget
+//!
+//! QuickJS records the stack pointer when the runtime is created and enforces a
+//! fixed 256 KB budget measured from that point (`JS_DEFAULT_STACK_SIZE`), which
+//! it reports as a `SyntaxError: stack overflow`. That budget is relative, not
+//! absolute, so *where* the runtime is created decides how much of it the
+//! embedder has already spent.
+//!
+//! Creating it lazily inside a work-stealing job is therefore a trap: a later
+//! job on the same worker can run several frames deeper than the one that
+//! created the runtime, so the parser starts with much of its 256 KB already
+//! consumed and Flow's recursive-descent parser trips the limit on ordinary
+//! files. It looks like a syntax error in the user's code, and it scales with
+//! parallelism rather than with input size.
+//!
+//! [`prepare_thread`] exists so callers can create the runtime from a shallow
+//! frame, before any nested work begins.
 
 use std::cell::RefCell;
 
@@ -9,19 +27,28 @@ use crate::{
     FlowError, ParseDiagnostic, ParseOutcome, ParserKind, normalize_modern_flow_for_parser,
 };
 
-pub(crate) fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
-    thread_local! {
-        static PARSER: RefCell<Option<flowjs_parser::FlowParser>> = const { RefCell::new(None) };
-    }
+thread_local! {
+    static PARSER: RefCell<Option<flowjs_parser::FlowParser>> = const { RefCell::new(None) };
+}
 
-    let parser_source = normalize_modern_flow_for_parser(source);
-    let diagnostics = PARSER.with(|slot| {
+/// Create this thread's QuickJS runtime now, at the current stack depth.
+///
+/// Idempotent, and cheap after the first call.
+pub(crate) fn prepare_thread() -> Result<(), FlowError> {
+    PARSER.with(|slot| {
         if slot.borrow().is_none() {
             let parser = flowjs_parser::FlowParser::new()
                 .map_err(|error| FlowError::Initialize(error.to_string()))?;
             *slot.borrow_mut() = Some(parser);
         }
+        Ok(())
+    })
+}
 
+pub(crate) fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
+    let parser_source = normalize_modern_flow_for_parser(source);
+    prepare_thread()?;
+    let diagnostics = PARSER.with(|slot| {
         let parser = slot.borrow();
         let parser = parser.as_ref().expect("parser initialized");
         parser

--- a/crates/uf_lint/src/lib.rs
+++ b/crates/uf_lint/src/lib.rs
@@ -131,6 +131,15 @@ pub fn lint_sources(
     files: &[SourceFile],
     config: &UniflowedConfig,
 ) -> Result<LintReport, LintError> {
+    // Give every worker its parser now, from this shallow frame. Rayon runs
+    // later jobs several frames deeper on the same worker, and a parser created
+    // down there starts with much of its stack budget already spent — see
+    // `uf_flow::prepare_thread`.
+    let prepared = rayon::broadcast(|_| uf_flow::prepare_thread());
+    for outcome in prepared {
+        outcome?;
+    }
+
     let per_file = files
         .par_iter()
         .map(|file| lint_file(file, config))

--- a/crates/uf_lint/src/tests.rs
+++ b/crates/uf_lint/src/tests.rs
@@ -1301,3 +1301,37 @@ fn react_native_rule_prefers_platform_files() {
 
     assert!(fired(&diagnostics, "react-native/platform-split"));
 }
+
+/// Regression test for the QuickJS stack-budget trap.
+///
+/// Before `uf_flow::prepare_thread` was broadcast to the pool, linting a few
+/// hundred perfectly valid files in parallel failed with
+/// `Flow parser runtime error: SyntaxError: stack overflow`, because rayon ran
+/// later jobs several frames deeper than the one that created each worker's
+/// parser. The failure scaled with parallelism rather than with input size, so
+/// a small project never saw it and a real one always did.
+#[test]
+fn lints_hundreds_of_files_in_parallel_without_exhausting_the_parser_stack() {
+    let config = UniflowedConfig::default();
+    let files = (0..800)
+        .map(|index| SourceFile {
+            path: format!("app/route{index}/_uf.page.js"),
+            source: format!(
+                "// @flow\ncomponent Page{index}() renders React.Node {{\n  return <main>hello</main>;\n}}\n"
+            ),
+        })
+        .collect::<Vec<_>>();
+
+    let report = lint_sources(&files, &config).expect("lint must not fail on valid sources");
+
+    assert_eq!(report.files_checked, 800);
+    let syntax = report
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.rule == "flow/syntax")
+        .collect::<Vec<_>>();
+    assert!(
+        syntax.is_empty(),
+        "unexpected syntax diagnostics: {syntax:?}"
+    );
+}


### PR DESCRIPTION
## Summary

`uf lint` on a real project died with

```
error: Flow parser runtime error: SyntaxError: stack overflow
```

on ordinary, **valid** Flow files. Reproduced from about a hundred files upward
in an optimized build, and disappeared entirely under `RAYON_NUM_THREADS=1` — so
it scaled with *parallelism*, not with input size. A small project never saw it;
a real one always did. This was a hard blocker for adopting `uf` at scale.

## Root cause

QuickJS records the stack pointer at `JS_NewRuntime` and enforces a **256 KB
budget measured from that point** (`JS_DEFAULT_STACK_SIZE`). The budget is
relative, so *where* the runtime is created decides how much of it the embedder
has already spent.

`uf_flow` created the runtime lazily, inside a rayon job. Rayon's work-stealing
runs later jobs several frames deeper on the same worker, so the parser began
with much of its budget already consumed, and Flow's recursive-descent parser
tripped the limit on files it parses fine in isolation. QuickJS reports that as
a `SyntaxError`, which made a toolchain bug look like broken user code.

## Fix

`uf_flow::prepare_thread()` creates the runtime at the caller's stack depth, and
`lint_sources` broadcasts it across the pool before fanning out — so every
worker gets its parser from a shallow frame. It is idempotent, and a no-op for
the upstream Rust backend, which has no JavaScript engine to budget.

## Verification

- [x] End to end: **2 008 route files lint in 1.22 s wall (7.38 s CPU)** with no
      parser errors. Before this change the same tree failed immediately.
- [x] The regression test lints 800 files in parallel and **fails with the
      original stack overflow when the broadcast is removed** — verified by
      deleting it and watching the test panic with
      `Flow(Runtime("... SyntaxError: stack overflow"))`.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 557 passed, 0 failed
- [x] `cargo +nightly test --workspace --all-features` (upstream Rust backend) — clean
- [x] `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`

## Worth saying plainly

This is a stopgap for a backend we intend to delete. The QuickJS-hosted parser
is **0.03 MB/s** against the upstream Rust port's **12.97 MB/s**, and it carries
a C dependency and this class of engine-internal limit. The Rust port needs
nightly until `never_type` stabilizes; flipping `upstream-parser` to the default
is a one-line change once the toolchain pin can move, and the case for moving it
is now stronger than a benchmark alone.

Separately, `uf lint` on a freshly scaffolded app reports
`router/reserved-files` errors for `_uf.page.native.js` and `_uf.page.test.js`,
which `uf create` itself generates. That is a pre-existing three-way
inconsistency between the scaffold, `uf_router`'s validator, and the lint rule —
not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790918226&installation_model_id=422833&pr_number=13&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F13&signature=4225c4a62ab08e898a4595e3321fa8f94eb97b7bad273497383ac4ba7928dc21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->