### PR TITLE
feat(fmt): replace the whitespace pass with a native Flow printer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,8 @@ dependencies = [
 name = "uf_fmt"
 version = "0.1.0"
 dependencies = [
+ "criterion",
+ "memchr",
  "similar-asserts",
  "thiserror",
  "uf_config",

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -788,6 +788,7 @@ impl Default for EnvConfig {
 pub struct FmtConfig {
     pub indent_width: u8,
     pub line_width: u16,
+    pub max_blank_lines: u8,
     pub quotes: QuoteStyle,
     pub semicolons: bool,
 }
@@ -797,6 +798,7 @@ impl Default for FmtConfig {
         Self {
             indent_width: 2,
             line_width: 100,
+            max_blank_lines: 1,
             quotes: QuoteStyle::Double,
             semicolons: true,
         }

--- a/crates/uf_config/src/tests.rs
+++ b/crates/uf_config/src/tests.rs
@@ -432,3 +432,19 @@ export default defineConfig({
 
     assert!(json5::from_str::<UniflowedConfig>(&object).is_err());
 }
+
+#[test]
+fn fmt_config_reads_max_blank_lines_from_the_config_file() {
+    let source = r#"
+        export default {
+          fmt: { maxBlankLines: 0, indentWidth: 4 },
+        };
+    "#;
+
+    let object = extract_config_object(source).expect("object");
+    let parsed: UniflowedConfig = json5::from_str(&object).expect("config");
+
+    assert_eq!(parsed.fmt.max_blank_lines, 0);
+    assert_eq!(parsed.fmt.indent_width, 4);
+    assert_eq!(parsed.fmt.line_width, 100);
+}

--- a/crates/uf_fmt/Cargo.toml
+++ b/crates/uf_fmt/Cargo.toml
@@ -10,7 +10,13 @@ authors.workspace = true
 
 [dependencies]
 uf_config = { path = "../uf_config" }
+memchr.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 similar-asserts.workspace = true
+
+[[bench]]
+name = "fmt"
+harness = false

--- a/crates/uf_fmt/benches/fmt.rs
+++ b/crates/uf_fmt/benches/fmt.rs
@@ -1,0 +1,90 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use uf_config::FmtConfig;
+use uf_fmt::{format_source, lexer::tokenize};
+
+/// Build a synthetic Flow + JSX source file of roughly `components` components.
+fn synthetic_source(components: usize) -> String {
+    let mut source = String::with_capacity(components * 512);
+    source.push_str("// @flow\n\"use client\";\n\nimport * as React from \"react\";\n\n");
+    for index in 0..components {
+        source.push_str(&format!(
+            r#"
+type Props{index} = {{|
+  +id: string,
+  +count?: ?number,
+  +items: Array<Map<string, number>>,
+  +onSelect: (value: string) => void,
+|}};
+
+opaque type Id{index} = string;
+
+const RATIO_{index} = (1_000 + 0x1f) / 2;
+const PATTERN_{index} = /^[a-z]+\/(\d+)$/gi;
+
+hook useCounter{index}(initial: number): [number, () => void] {{
+  const [value, setValue] = React.useState<number>(initial);
+  const bump = React.useCallback(() => setValue((previous) => previous + 1), []);
+  return [value, bump];
+}}
+
+component Panel{index}(props: Props{index}) renders React.Node {{
+  const [count, bump] = useCounter{index}(props.count ?? 0);
+  const label = `panel-${{props.id}}-${{count > 0 ? "on" : "off"}}`;
+
+  switch (count % 3) {{
+    case 0:
+      break;
+    case 1:
+      bump();
+      break;
+    default:
+      // Nothing to do for the remaining case.
+      break;
+  }}
+
+  return (
+    <section className="panel" data-testid={{label}} onClick={{bump}}>
+      <h2>Panel {{props.id}} — {{count}} items</h2>
+      <ul>
+        {{props.items.map((item, position) => (
+          <li key={{position}} title={{item.get("name") ?? "unknown"}}>
+            {{position}}: {{item.size}}
+          </li>
+        ))}}
+      </ul>
+    </section>
+  );
+}}
+"#
+        ));
+    }
+    source
+}
+
+fn bench_format(criterion: &mut Criterion) {
+    let config = FmtConfig::default();
+    let source = synthetic_source(120);
+    let bytes = source.len() as u64;
+
+    let mut group = criterion.benchmark_group("uf_fmt");
+    group.throughput(Throughput::Bytes(bytes));
+    group.bench_function("tokenize large flow react file", |bencher| {
+        bencher.iter(|| black_box(tokenize(black_box(&source)).len()));
+    });
+    group.bench_function("format large flow react file", |bencher| {
+        bencher.iter(|| black_box(format_source(black_box(&source), &config).expect("format")));
+    });
+
+    // Already-formatted input is the common `uf fmt --check` case.
+    let formatted = format_source(&source, &config).expect("format").output;
+    group.throughput(Throughput::Bytes(formatted.len() as u64));
+    group.bench_function("format already formatted file", |bencher| {
+        bencher.iter(|| black_box(format_source(black_box(&formatted), &config).expect("format")));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_format);
+criterion_main!(benches);

--- a/crates/uf_fmt/src/lexer.rs
+++ b/crates/uf_fmt/src/lexer.rs
@@ -556,7 +556,13 @@ pub(crate) fn classify_brace(prev: Option<Prev>, enclosing: Option<BraceKind>) -
             // bracket always follows a return type, never an operand.
             | Punctuator::Greater
             | Punctuator::GreaterGreater
-            | Punctuator::GreaterGreaterGreater => BraceKind::Block,
+            | Punctuator::GreaterGreaterGreater
+            // `hook useSelection(): [string, (next: string) => void] {` — same
+            // reasoning for a tuple or array return type. Nothing valid puts an
+            // object literal directly after `]`; `[1, 2] {}` is not an
+            // expression. Reading it as an object made `needs_semicolon` emit a
+            // `;` after the body, which is a token the input never had.
+            | Punctuator::CloseBracket => BraceKind::Block,
             // `case 1: {` is a block, but `{ key: { … } }` is a nested object.
             Punctuator::Colon => match enclosing {
                 Some(BraceKind::Object) | None => BraceKind::Object,

--- a/crates/uf_fmt/src/lexer.rs
+++ b/crates/uf_fmt/src/lexer.rs
@@ -1,0 +1,1996 @@
+//! Single-pass, lossless tokenizer for Flow-typed JavaScript sources.
+//!
+//! The tokenizer scans the source exactly once and never drops a byte: every
+//! byte of the input belongs to exactly one token, trivia included. Concatenating
+//! the source slice of every token therefore reproduces the input byte for byte,
+//! which is what lets [`crate::format_source`] guarantee that formatting can only
+//! ever rewrite trivia.
+//!
+//! The scanner is not a parser. It resolves the three classic JavaScript
+//! tokenizer ambiguities with the standard "previous significant token" rule plus
+//! an explicit context stack:
+//!
+//! * `/` is a regular expression when an expression may start at that position,
+//!   and division otherwise;
+//! * `<` starts JSX when an expression may start at that position, and is a
+//!   relational/type-argument punctuator otherwise;
+//! * `}` resumes a template literal when it closes a `${` interpolation.
+//!
+//! The context stack is an explicit [`Vec`], never recursion, so pathological
+//! inputs such as `{{{{…}}}}` nested ten thousand deep cannot overflow the stack.
+
+use std::fmt;
+
+/// A half-open byte range within the source text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Span {
+    /// Inclusive start offset, in bytes.
+    pub start: usize,
+    /// Exclusive end offset, in bytes.
+    pub end: usize,
+}
+
+impl Span {
+    /// Length of the span in bytes.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Whether the span covers no bytes.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+/// A single lexical token: its classification plus the bytes it covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Token {
+    /// What the token is.
+    pub kind: TokenKind,
+    /// Where the token lives in the source.
+    pub span: Span,
+}
+
+impl Token {
+    /// The exact source text this token covers.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `source` is not the string the token was produced from.
+    #[must_use]
+    pub fn text<'a>(&self, source: &'a str) -> &'a str {
+        &source[self.span.start..self.span.end]
+    }
+}
+
+/// Why a construct could not be closed before the input ran out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unterminated {
+    /// A `'`/`"` string literal that hit a line terminator or the end of input.
+    String,
+    /// A template literal whose closing backtick is missing.
+    Template,
+    /// A `/* … */` comment whose `*/` is missing.
+    BlockComment,
+    /// A regular expression literal whose closing `/` is missing.
+    Regex,
+}
+
+/// The classification of a single token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenKind {
+    /// A run of horizontal whitespace.
+    Whitespace,
+    /// A single line terminator.
+    Newline,
+    /// A `#!` interpreter directive on the first line.
+    Shebang,
+    /// A `//` comment, up to but excluding the line terminator.
+    LineComment,
+    /// A `/* … */` comment.
+    BlockComment,
+    /// A `/** … */` documentation comment.
+    DocComment,
+    /// An identifier, including Unicode identifiers.
+    Identifier,
+    /// A reserved or contextual keyword.
+    Keyword(Keyword),
+    /// A `#name` private class member.
+    PrivateName,
+    /// A numeric literal, including `0x`/`0b`/`0o`, separators and `BigInt`.
+    Number,
+    /// A `'…'` or `"…"` string literal.
+    String,
+    /// A template literal with no interpolation: `` `…` ``.
+    TemplateFull,
+    /// The head of an interpolated template: `` `…${ ``.
+    TemplateHead,
+    /// A template chunk between two interpolations: `}…${`.
+    TemplateMiddle,
+    /// The tail of an interpolated template: `` }…` ``.
+    TemplateTail,
+    /// A regular expression literal including flags.
+    Regex,
+    /// The `<` that opens a JSX opening or self-closing tag.
+    JsxOpenStart,
+    /// The `</` that opens a JSX closing tag.
+    JsxCloseStart,
+    /// The `>` that ends a JSX tag.
+    JsxTagEnd,
+    /// The `/>` that ends a self-closing JSX tag.
+    JsxSelfClose,
+    /// A JSX element or attribute name, including `-`, `.` and `:` parts.
+    JsxName,
+    /// A JSX attribute string, which has no escape sequences.
+    JsxString,
+    /// A run of JSX character data.
+    JsxText,
+    /// Punctuation or an operator.
+    Punctuator(Punctuator),
+    /// A construct that the input ended in the middle of.
+    Unterminated(Unterminated),
+    /// A byte that is not valid anywhere in the grammar.
+    Unknown,
+}
+
+impl TokenKind {
+    /// Whether the token carries no program meaning: whitespace or a comment.
+    #[must_use]
+    pub const fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Whitespace
+                | TokenKind::Newline
+                | TokenKind::LineComment
+                | TokenKind::BlockComment
+                | TokenKind::DocComment
+        )
+    }
+
+    /// Whether the token is a comment of any flavour.
+    #[must_use]
+    pub const fn is_comment(self) -> bool {
+        matches!(
+            self,
+            TokenKind::LineComment | TokenKind::BlockComment | TokenKind::DocComment
+        )
+    }
+
+    /// Whether the token belongs to JSX syntax rather than plain JavaScript.
+    #[must_use]
+    pub const fn is_jsx(self) -> bool {
+        matches!(
+            self,
+            TokenKind::JsxOpenStart
+                | TokenKind::JsxCloseStart
+                | TokenKind::JsxTagEnd
+                | TokenKind::JsxSelfClose
+                | TokenKind::JsxName
+                | TokenKind::JsxString
+                | TokenKind::JsxText
+        )
+    }
+}
+
+/// Reserved and contextual keywords the formatter cares about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(
+    missing_docs,
+    reason = "each variant is the identically spelled keyword"
+)]
+pub enum Keyword {
+    As,
+    Async,
+    Await,
+    Break,
+    Case,
+    Catch,
+    Class,
+    Component,
+    Const,
+    Continue,
+    Debugger,
+    Declare,
+    Default,
+    Delete,
+    Do,
+    Else,
+    Enum,
+    Export,
+    Extends,
+    False,
+    Finally,
+    For,
+    From,
+    Function,
+    Get,
+    Hook,
+    If,
+    Implements,
+    Import,
+    In,
+    Instanceof,
+    Interface,
+    Let,
+    Mixins,
+    New,
+    Null,
+    Of,
+    Opaque,
+    Renders,
+    Return,
+    Set,
+    Static,
+    Super,
+    Switch,
+    This,
+    Throw,
+    True,
+    Try,
+    Type,
+    Typeof,
+    Var,
+    Void,
+    While,
+    With,
+    Yield,
+}
+
+impl Keyword {
+    /// Look up a keyword by its exact spelling.
+    #[must_use]
+    pub fn lookup(value: &str) -> Option<Self> {
+        // A `match` on the string literal compiles to a length switch followed by
+        // a memcmp chain, which beats a hash lookup for inputs this short.
+        let keyword = match value {
+            "as" => Keyword::As,
+            "async" => Keyword::Async,
+            "await" => Keyword::Await,
+            "break" => Keyword::Break,
+            "case" => Keyword::Case,
+            "catch" => Keyword::Catch,
+            "class" => Keyword::Class,
+            "component" => Keyword::Component,
+            "const" => Keyword::Const,
+            "continue" => Keyword::Continue,
+            "debugger" => Keyword::Debugger,
+            "declare" => Keyword::Declare,
+            "default" => Keyword::Default,
+            "delete" => Keyword::Delete,
+            "do" => Keyword::Do,
+            "else" => Keyword::Else,
+            "enum" => Keyword::Enum,
+            "export" => Keyword::Export,
+            "extends" => Keyword::Extends,
+            "false" => Keyword::False,
+            "finally" => Keyword::Finally,
+            "for" => Keyword::For,
+            "from" => Keyword::From,
+            "function" => Keyword::Function,
+            "get" => Keyword::Get,
+            "hook" => Keyword::Hook,
+            "if" => Keyword::If,
+            "implements" => Keyword::Implements,
+            "import" => Keyword::Import,
+            "in" => Keyword::In,
+            "instanceof" => Keyword::Instanceof,
+            "interface" => Keyword::Interface,
+            "let" => Keyword::Let,
+            "mixins" => Keyword::Mixins,
+            "new" => Keyword::New,
+            "null" => Keyword::Null,
+            "of" => Keyword::Of,
+            "opaque" => Keyword::Opaque,
+            "renders" => Keyword::Renders,
+            "return" => Keyword::Return,
+            "set" => Keyword::Set,
+            "static" => Keyword::Static,
+            "super" => Keyword::Super,
+            "switch" => Keyword::Switch,
+            "this" => Keyword::This,
+            "throw" => Keyword::Throw,
+            "true" => Keyword::True,
+            "try" => Keyword::Try,
+            "type" => Keyword::Type,
+            "typeof" => Keyword::Typeof,
+            "var" => Keyword::Var,
+            "void" => Keyword::Void,
+            "while" => Keyword::While,
+            "with" => Keyword::With,
+            "yield" => Keyword::Yield,
+            _ => return None,
+        };
+        Some(keyword)
+    }
+
+    /// Whether an expression may start immediately after this keyword.
+    ///
+    /// Only unambiguously reserved words are listed. Contextual keywords such as
+    /// `type` or `get` can legally be plain variable names, and treating them as
+    /// expression starters would mis-lex `type / 2` as a regular expression.
+    #[must_use]
+    pub const fn allows_expression_after(self) -> bool {
+        matches!(
+            self,
+            Keyword::Await
+                | Keyword::Case
+                | Keyword::Default
+                | Keyword::Delete
+                | Keyword::Do
+                | Keyword::Else
+                | Keyword::Extends
+                | Keyword::In
+                | Keyword::Instanceof
+                | Keyword::New
+                | Keyword::Of
+                | Keyword::Return
+                | Keyword::Throw
+                | Keyword::Typeof
+                | Keyword::Void
+                | Keyword::Yield
+        )
+    }
+
+    /// Whether the keyword introduces a parenthesised statement header, whose
+    /// closing `)` may legally be followed by a regular expression.
+    #[must_use]
+    pub const fn starts_statement_header(self) -> bool {
+        matches!(
+            self,
+            Keyword::Catch
+                | Keyword::For
+                | Keyword::If
+                | Keyword::Switch
+                | Keyword::While
+                | Keyword::With
+        )
+    }
+
+    /// Whether the keyword introduces a type-only declaration, where `<` opens a
+    /// type parameter list rather than a JSX element.
+    #[must_use]
+    pub const fn starts_type_declaration(self) -> bool {
+        matches!(
+            self,
+            Keyword::Declare | Keyword::Interface | Keyword::Opaque | Keyword::Type
+        )
+    }
+}
+
+/// Punctuation and operator tokens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(
+    missing_docs,
+    reason = "each variant is named after the spelling it holds"
+)]
+pub enum Punctuator {
+    OpenBrace,
+    CloseBrace,
+    OpenParen,
+    CloseParen,
+    OpenBracket,
+    CloseBracket,
+    Semicolon,
+    Comma,
+    Dot,
+    Ellipsis,
+    QuestionDot,
+    Question,
+    Colon,
+    Arrow,
+    At,
+    Plus,
+    Minus,
+    Star,
+    StarStar,
+    Slash,
+    Percent,
+    PlusPlus,
+    MinusMinus,
+    Less,
+    Greater,
+    LessEqual,
+    GreaterEqual,
+    EqualEqual,
+    BangEqual,
+    EqualEqualEqual,
+    BangEqualEqual,
+    LessLess,
+    GreaterGreater,
+    GreaterGreaterGreater,
+    Amp,
+    Pipe,
+    Caret,
+    Bang,
+    Tilde,
+    AmpAmp,
+    PipePipe,
+    QuestionQuestion,
+    Equal,
+    PlusEqual,
+    MinusEqual,
+    StarEqual,
+    StarStarEqual,
+    SlashEqual,
+    PercentEqual,
+    LessLessEqual,
+    GreaterGreaterEqual,
+    GreaterGreaterGreaterEqual,
+    AmpEqual,
+    PipeEqual,
+    CaretEqual,
+    AmpAmpEqual,
+    PipePipeEqual,
+    QuestionQuestionEqual,
+}
+
+impl Punctuator {
+    /// Whether this punctuator opens a bracketed group.
+    #[must_use]
+    pub const fn is_open_delimiter(self) -> bool {
+        matches!(
+            self,
+            Punctuator::OpenBrace | Punctuator::OpenParen | Punctuator::OpenBracket
+        )
+    }
+
+    /// Whether this punctuator closes a bracketed group.
+    #[must_use]
+    pub const fn is_close_delimiter(self) -> bool {
+        matches!(
+            self,
+            Punctuator::CloseBrace | Punctuator::CloseParen | Punctuator::CloseBracket
+        )
+    }
+
+    /// How many `>` characters this punctuator contributes when it closes a type
+    /// argument list. `Array<Array<T>>` closes two levels with a single `>>`.
+    #[must_use]
+    pub const fn angle_close_count(self) -> u32 {
+        match self {
+            Punctuator::Greater => 1,
+            Punctuator::GreaterGreater => 2,
+            Punctuator::GreaterGreaterGreater => 3,
+            _ => 0,
+        }
+    }
+}
+
+/// What kind of `{ … }` a brace pair delimits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BraceKind {
+    /// A statement block, function body or arrow body.
+    Block,
+    /// An object literal or an object type annotation.
+    Object,
+    /// A `class`, `interface` or `enum` body.
+    Class,
+    /// A `switch` body, whose `case` labels sit one level out.
+    Switch,
+    /// A `{ … }` inside JSX: an attribute value or a child expression container.
+    JsxExpression,
+}
+
+/// What a "previous significant token" was, with the extra context needed to
+/// disambiguate `/`, `<` and `{`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Prev {
+    pub(crate) kind: TokenKind,
+    pub(crate) group: GroupKind,
+}
+
+/// Extra context attached to a closing delimiter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GroupKind {
+    /// The token is not a closing delimiter.
+    None,
+    /// A `)` that closed an `if`/`for`/`while`/`with`/`catch`/`switch` header.
+    StatementParen,
+    /// A `)` that closed a call or a parenthesised expression.
+    ExpressionParen,
+    /// A `}` that closed the given brace flavour.
+    Brace(BraceKind),
+}
+
+/// Whether an expression may start immediately after `prev`.
+///
+/// This single predicate drives both regular-expression detection and JSX
+/// detection, because `/` and `<` may only introduce a literal where an
+/// expression is allowed to begin.
+pub(crate) fn expression_allowed(prev: Option<Prev>) -> bool {
+    let Some(prev) = prev else {
+        return true;
+    };
+
+    match prev.kind {
+        TokenKind::Identifier
+        | TokenKind::PrivateName
+        | TokenKind::Number
+        | TokenKind::String
+        | TokenKind::TemplateFull
+        | TokenKind::TemplateTail
+        | TokenKind::Regex
+        | TokenKind::Shebang
+        | TokenKind::Unknown
+        | TokenKind::Unterminated(_) => false,
+        TokenKind::Keyword(keyword) => keyword.allows_expression_after(),
+        TokenKind::Punctuator(punctuator) => match punctuator {
+            Punctuator::CloseParen => prev.group == GroupKind::StatementParen,
+            Punctuator::CloseBracket | Punctuator::PlusPlus | Punctuator::MinusMinus => false,
+            Punctuator::CloseBrace => !matches!(prev.group, GroupKind::Brace(BraceKind::Object)),
+            _ => true,
+        },
+        // Inside JSX, `{` is the only place a nested expression begins, and that
+        // case is covered by the punctuator arm above.
+        TokenKind::JsxSelfClose | TokenKind::JsxTagEnd | TokenKind::JsxName => false,
+        _ => true,
+    }
+}
+
+/// Classify a `{` given the token before it and the group that encloses it.
+pub(crate) fn classify_brace(prev: Option<Prev>, enclosing: Option<BraceKind>) -> BraceKind {
+    let Some(prev) = prev else {
+        return BraceKind::Block;
+    };
+
+    match prev.kind {
+        TokenKind::Identifier => BraceKind::Block,
+        TokenKind::Keyword(
+            Keyword::Else
+            | Keyword::Do
+            | Keyword::Try
+            | Keyword::Finally
+            | Keyword::Static
+            | Keyword::Renders,
+        ) => BraceKind::Block,
+        TokenKind::Keyword(_) => BraceKind::Object,
+        TokenKind::Punctuator(punctuator) => match punctuator {
+            Punctuator::CloseParen
+            | Punctuator::CloseBrace
+            | Punctuator::Semicolon
+            | Punctuator::OpenBrace
+            | Punctuator::Arrow
+            // `function f(): Promise<void> {` — a `{` after a closing angle
+            // bracket always follows a return type, never an operand.
+            | Punctuator::Greater
+            | Punctuator::GreaterGreater
+            | Punctuator::GreaterGreaterGreater => BraceKind::Block,
+            // `case 1: {` is a block, but `{ key: { … } }` is a nested object.
+            Punctuator::Colon => match enclosing {
+                Some(BraceKind::Object) | None => BraceKind::Object,
+                Some(_) => BraceKind::Block,
+            },
+            _ => BraceKind::Object,
+        },
+        _ => BraceKind::Object,
+    }
+}
+
+/// Tokenize `source` into a lossless token stream.
+///
+/// The returned tokens tile the whole input: `tokens[0].span.start == 0`, each
+/// token starts where the previous one ended, and the last token ends at
+/// `source.len()`.
+#[must_use]
+pub fn tokenize(source: &str) -> Vec<Token> {
+    Lexer::new(source).run()
+}
+
+/// Nesting contexts the scanner tracks with an explicit stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ctx {
+    Paren,
+    Bracket,
+    Brace(BraceKind),
+    /// A `${` interpolation inside a template literal.
+    TemplateExpression,
+    /// Inside `< … >` of a JSX tag.
+    JsxTag {
+        closing: bool,
+    },
+    /// Between a JSX opening tag and its closing tag.
+    JsxChildren,
+}
+
+/// The scanner itself.
+struct Lexer<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    stack: Vec<Ctx>,
+    tokens: Vec<Token>,
+    prev: Option<Prev>,
+    /// Set by `class`/`interface`/`enum`/`switch` so the matching `{` is
+    /// classified as a body rather than an object literal.
+    pending_body: Option<BraceKind>,
+    /// The keyword a statement started with, used to keep `type X = <T>(…) => T`
+    /// from being scanned as JSX.
+    statement_head: Option<Keyword>,
+    /// Whether the innermost `(` opened a statement header.
+    paren_headers: Vec<bool>,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(source: &'a str) -> Self {
+        // One token per ~4 bytes is a good first guess for real sources and keeps
+        // the token vector from repeatedly reallocating on large files.
+        let capacity = source.len() / 4 + 16;
+        Self {
+            source,
+            bytes: source.as_bytes(),
+            pos: 0,
+            stack: Vec::with_capacity(16),
+            tokens: Vec::with_capacity(capacity),
+            prev: None,
+            pending_body: None,
+            statement_head: None,
+            paren_headers: Vec::with_capacity(16),
+        }
+    }
+
+    fn run(mut self) -> Vec<Token> {
+        if self.bytes.starts_with(b"#!") {
+            let end = self.line_end_from(2);
+            self.push(TokenKind::Shebang, 0, end);
+            self.pos = end;
+        }
+
+        while self.pos < self.bytes.len() {
+            match self.stack.last() {
+                Some(Ctx::JsxTag { .. }) => self.scan_jsx_tag(),
+                Some(Ctx::JsxChildren) => self.scan_jsx_child(),
+                _ => self.scan_normal(),
+            }
+        }
+
+        self.tokens
+    }
+
+    fn byte(&self, at: usize) -> u8 {
+        // Out of range reads report NUL, which is never a meaningful delimiter.
+        self.bytes.get(at).copied().unwrap_or(0)
+    }
+
+    fn push(&mut self, kind: TokenKind, start: usize, end: usize) {
+        debug_assert!(end > start, "every token must cover at least one byte");
+        self.tokens.push(Token {
+            kind,
+            span: Span { start, end },
+        });
+        if !kind.is_trivia() {
+            self.record_prev(kind, GroupKind::None);
+        }
+    }
+
+    fn push_with_group(&mut self, kind: TokenKind, start: usize, end: usize, group: GroupKind) {
+        self.tokens.push(Token {
+            kind,
+            span: Span { start, end },
+        });
+        self.record_prev(kind, group);
+    }
+
+    fn record_prev(&mut self, kind: TokenKind, group: GroupKind) {
+        // Track the keyword that opened the current statement. Statements begin
+        // after `;`, `{`, `}` or at the start of the file.
+        let boundary = matches!(
+            self.prev.map(|prev| prev.kind),
+            None | Some(TokenKind::Punctuator(
+                Punctuator::Semicolon | Punctuator::OpenBrace | Punctuator::CloseBrace
+            ))
+        );
+        if boundary {
+            self.statement_head = match kind {
+                TokenKind::Keyword(keyword) => Some(keyword),
+                _ => None,
+            };
+        }
+        self.prev = Some(Prev { kind, group });
+    }
+
+    fn line_end_from(&self, from: usize) -> usize {
+        match memchr::memchr(b'\n', &self.bytes[from..]) {
+            Some(offset) => from + offset,
+            None => self.bytes.len(),
+        }
+    }
+
+    fn enclosing_brace(&self) -> Option<BraceKind> {
+        self.stack.iter().rev().find_map(|ctx| match ctx {
+            Ctx::Brace(kind) => Some(*kind),
+            _ => None,
+        })
+    }
+
+    // ---------------------------------------------------------------- normal
+
+    fn scan_normal(&mut self) {
+        let start = self.pos;
+        let byte = self.byte(start);
+
+        match byte {
+            b'\n' => {
+                self.pos = start + 1;
+                self.push(TokenKind::Newline, start, self.pos);
+            }
+            b'\r' => {
+                // Defensive: `format_source` normalizes line endings first, but the
+                // lexer is public API and must handle raw CRLF on its own.
+                self.pos = if self.byte(start + 1) == b'\n' {
+                    start + 2
+                } else {
+                    start + 1
+                };
+                self.push(TokenKind::Newline, start, self.pos);
+            }
+            b' ' | b'\t' | 0x0b | 0x0c => {
+                let mut end = start + 1;
+                while matches!(self.byte(end), b' ' | b'\t' | 0x0b | 0x0c) {
+                    end += 1;
+                }
+                self.pos = end;
+                self.push(TokenKind::Whitespace, start, end);
+            }
+            b'/' => self.scan_slash(),
+            b'\'' | b'"' => self.scan_string(byte),
+            b'`' => self.scan_template_from(start, true),
+            b'0'..=b'9' => self.scan_number(),
+            b'#' => {
+                let mut end = start + 1;
+                while let Some(len) = self.ident_char_len(end, end == start + 1) {
+                    end += len;
+                }
+                self.pos = end;
+                if end == start + 1 {
+                    self.push(TokenKind::Unknown, start, end);
+                } else {
+                    self.push(TokenKind::PrivateName, start, end);
+                }
+            }
+            b'<' if self.jsx_allowed() => {
+                let closing = self.byte(start + 1) == b'/';
+                if closing {
+                    self.pos = start + 2;
+                    self.stack.push(Ctx::JsxTag { closing: true });
+                    self.push(TokenKind::JsxCloseStart, start, self.pos);
+                } else {
+                    self.pos = start + 1;
+                    self.stack.push(Ctx::JsxTag { closing: false });
+                    self.push(TokenKind::JsxOpenStart, start, self.pos);
+                }
+            }
+            b'}' if matches!(self.stack.last(), Some(Ctx::TemplateExpression)) => {
+                self.stack.pop();
+                self.scan_template_from(start, false);
+            }
+            _ => {
+                if self.ident_char_len(start, true).is_some() {
+                    self.scan_identifier();
+                } else if byte == b'.' && self.byte(start + 1).is_ascii_digit() {
+                    self.scan_number();
+                } else if let Some((punctuator, len)) = self.scan_punctuator(start) {
+                    self.pos = start + len;
+                    self.push_punctuator(punctuator, start, self.pos);
+                } else {
+                    let len = self.char_len(start);
+                    self.pos = start + len;
+                    self.push(TokenKind::Unknown, start, self.pos);
+                }
+            }
+        }
+    }
+
+    fn push_punctuator(&mut self, punctuator: Punctuator, start: usize, end: usize) {
+        let kind = TokenKind::Punctuator(punctuator);
+        match punctuator {
+            Punctuator::OpenParen => {
+                let header = matches!(
+                    self.prev.map(|prev| prev.kind),
+                    Some(TokenKind::Keyword(keyword)) if keyword.starts_statement_header()
+                );
+                self.paren_headers.push(header);
+                self.stack.push(Ctx::Paren);
+                self.push(kind, start, end);
+            }
+            Punctuator::CloseParen => {
+                if matches!(self.stack.last(), Some(Ctx::Paren)) {
+                    self.stack.pop();
+                }
+                let header = self.paren_headers.pop().unwrap_or(false);
+                let group = if header {
+                    GroupKind::StatementParen
+                } else {
+                    GroupKind::ExpressionParen
+                };
+                self.push_with_group(kind, start, end, group);
+            }
+            Punctuator::OpenBracket => {
+                self.stack.push(Ctx::Bracket);
+                self.push(kind, start, end);
+            }
+            Punctuator::CloseBracket => {
+                if matches!(self.stack.last(), Some(Ctx::Bracket)) {
+                    self.stack.pop();
+                }
+                self.push(kind, start, end);
+            }
+            Punctuator::OpenBrace => {
+                let brace = match self.stack.last() {
+                    Some(Ctx::JsxTag { .. } | Ctx::JsxChildren) => BraceKind::JsxExpression,
+                    _ => self
+                        .pending_body
+                        .take()
+                        .unwrap_or_else(|| classify_brace(self.prev, self.enclosing_brace())),
+                };
+                self.stack.push(Ctx::Brace(brace));
+                self.push(kind, start, end);
+            }
+            Punctuator::CloseBrace => {
+                let brace = match self.stack.last() {
+                    Some(Ctx::Brace(brace)) => {
+                        let brace = *brace;
+                        self.stack.pop();
+                        brace
+                    }
+                    _ => BraceKind::Block,
+                };
+                self.push_with_group(kind, start, end, GroupKind::Brace(brace));
+            }
+            _ => self.push(kind, start, end),
+        }
+    }
+
+    fn jsx_allowed(&self) -> bool {
+        if !expression_allowed(self.prev) {
+            return false;
+        }
+        // `type Handler = <T>(value: T) => T` is a generic function type, not a
+        // JSX element, even though an expression could otherwise start here.
+        !matches!(self.statement_head, Some(keyword) if keyword.starts_type_declaration())
+    }
+
+    fn scan_slash(&mut self) {
+        let start = self.pos;
+        match self.byte(start + 1) {
+            b'/' => {
+                let end = self.line_end_from(start + 2);
+                self.pos = end;
+                self.push(TokenKind::LineComment, start, end);
+            }
+            b'*' => {
+                let doc = self.byte(start + 2) == b'*' && self.byte(start + 3) != b'/';
+                let mut cursor = start + 2;
+                let mut end = None;
+                while cursor + 1 < self.bytes.len() {
+                    match memchr::memchr(b'*', &self.bytes[cursor..]) {
+                        Some(offset) => {
+                            let at = cursor + offset;
+                            if self.byte(at + 1) == b'/' {
+                                end = Some(at + 2);
+                                break;
+                            }
+                            cursor = at + 1;
+                        }
+                        None => break,
+                    }
+                }
+                match end {
+                    Some(end) => {
+                        self.pos = end;
+                        let kind = if doc {
+                            TokenKind::DocComment
+                        } else {
+                            TokenKind::BlockComment
+                        };
+                        self.push(kind, start, end);
+                    }
+                    None => {
+                        self.pos = self.bytes.len();
+                        self.push(
+                            TokenKind::Unterminated(Unterminated::BlockComment),
+                            start,
+                            self.pos,
+                        );
+                    }
+                }
+            }
+            _ if expression_allowed(self.prev) => self.scan_regex(),
+            b'=' => {
+                self.pos = start + 2;
+                self.push_punctuator(Punctuator::SlashEqual, start, self.pos);
+            }
+            _ => {
+                self.pos = start + 1;
+                self.push_punctuator(Punctuator::Slash, start, self.pos);
+            }
+        }
+    }
+
+    fn scan_regex(&mut self) {
+        let start = self.pos;
+        let mut cursor = start + 1;
+        let mut in_class = false;
+        loop {
+            let byte = match self.bytes.get(cursor) {
+                Some(byte) => *byte,
+                None => {
+                    self.pos = self.bytes.len();
+                    self.push(
+                        TokenKind::Unterminated(Unterminated::Regex),
+                        start,
+                        self.pos,
+                    );
+                    return;
+                }
+            };
+            match byte {
+                b'\\' => {
+                    // A backslash escapes the next code unit, including `/` and `]`.
+                    cursor += 1 + self.char_len(cursor + 1).max(1);
+                    continue;
+                }
+                b'\n' | b'\r' => {
+                    self.pos = cursor;
+                    self.push(
+                        TokenKind::Unterminated(Unterminated::Regex),
+                        start,
+                        self.pos,
+                    );
+                    return;
+                }
+                b'[' => in_class = true,
+                b']' => in_class = false,
+                b'/' if !in_class => {
+                    cursor += 1;
+                    break;
+                }
+                _ => {}
+            }
+            cursor += self.char_len(cursor);
+        }
+
+        while self.ident_char_len(cursor, false).is_some() {
+            cursor += self.char_len(cursor);
+        }
+        self.pos = cursor;
+        self.push(TokenKind::Regex, start, cursor);
+    }
+
+    fn scan_string(&mut self, quote: u8) {
+        let start = self.pos;
+        let mut cursor = start + 1;
+        loop {
+            let byte = match self.bytes.get(cursor) {
+                Some(byte) => *byte,
+                None => {
+                    self.pos = self.bytes.len();
+                    self.push(
+                        TokenKind::Unterminated(Unterminated::String),
+                        start,
+                        self.pos,
+                    );
+                    return;
+                }
+            };
+            match byte {
+                b'\\' => {
+                    // Line continuations and every other escape consume one char.
+                    let next = cursor + 1;
+                    if self.byte(next) == b'\r' && self.byte(next + 1) == b'\n' {
+                        cursor = next + 2;
+                    } else {
+                        cursor = next + self.char_len(next).max(1);
+                    }
+                }
+                b'\n' | b'\r' => {
+                    // A raw line terminator ends an unterminated string literal.
+                    self.pos = cursor;
+                    self.push(
+                        TokenKind::Unterminated(Unterminated::String),
+                        start,
+                        self.pos,
+                    );
+                    return;
+                }
+                _ if byte == quote => {
+                    cursor += 1;
+                    self.pos = cursor;
+                    self.push(TokenKind::String, start, cursor);
+                    return;
+                }
+                _ => cursor += self.char_len(cursor),
+            }
+        }
+    }
+
+    /// Scan a template chunk. `head` selects between a leading backtick and a
+    /// leading `}` that resumes an interpolated template.
+    fn scan_template_from(&mut self, start: usize, head: bool) {
+        let mut cursor = start + 1;
+        loop {
+            let byte = match self.bytes.get(cursor) {
+                Some(byte) => *byte,
+                None => {
+                    self.pos = self.bytes.len();
+                    self.push(
+                        TokenKind::Unterminated(Unterminated::Template),
+                        start,
+                        self.pos,
+                    );
+                    return;
+                }
+            };
+            match byte {
+                b'\\' => {
+                    let next = cursor + 1;
+                    cursor = next + self.char_len(next).max(1);
+                }
+                b'`' => {
+                    cursor += 1;
+                    self.pos = cursor;
+                    let kind = if head {
+                        TokenKind::TemplateFull
+                    } else {
+                        TokenKind::TemplateTail
+                    };
+                    self.push(kind, start, cursor);
+                    return;
+                }
+                b'$' if self.byte(cursor + 1) == b'{' => {
+                    cursor += 2;
+                    self.pos = cursor;
+                    self.stack.push(Ctx::TemplateExpression);
+                    let kind = if head {
+                        TokenKind::TemplateHead
+                    } else {
+                        TokenKind::TemplateMiddle
+                    };
+                    self.push(kind, start, cursor);
+                    return;
+                }
+                _ => cursor += self.char_len(cursor),
+            }
+        }
+    }
+
+    fn scan_number(&mut self) {
+        let start = self.pos;
+        let mut cursor = start;
+
+        if self.byte(cursor) == b'0' && matches!(self.byte(cursor + 1), b'x' | b'X') {
+            cursor += 2;
+            while self.byte(cursor).is_ascii_hexdigit() || self.byte(cursor) == b'_' {
+                cursor += 1;
+            }
+        } else if self.byte(cursor) == b'0' && matches!(self.byte(cursor + 1), b'b' | b'B') {
+            cursor += 2;
+            while matches!(self.byte(cursor), b'0' | b'1' | b'_') {
+                cursor += 1;
+            }
+        } else if self.byte(cursor) == b'0' && matches!(self.byte(cursor + 1), b'o' | b'O') {
+            cursor += 2;
+            while matches!(self.byte(cursor), b'0'..=b'7' | b'_') {
+                cursor += 1;
+            }
+        } else {
+            while self.byte(cursor).is_ascii_digit() || self.byte(cursor) == b'_' {
+                cursor += 1;
+            }
+            if self.byte(cursor) == b'.' {
+                cursor += 1;
+                while self.byte(cursor).is_ascii_digit() || self.byte(cursor) == b'_' {
+                    cursor += 1;
+                }
+            }
+            if matches!(self.byte(cursor), b'e' | b'E') {
+                let mut lookahead = cursor + 1;
+                if matches!(self.byte(lookahead), b'+' | b'-') {
+                    lookahead += 1;
+                }
+                if self.byte(lookahead).is_ascii_digit() {
+                    cursor = lookahead;
+                    while self.byte(cursor).is_ascii_digit() || self.byte(cursor) == b'_' {
+                        cursor += 1;
+                    }
+                }
+            }
+        }
+
+        if self.byte(cursor) == b'n' {
+            cursor += 1;
+        }
+
+        self.pos = cursor;
+        self.push(TokenKind::Number, start, cursor);
+    }
+
+    fn scan_identifier(&mut self) {
+        let start = self.pos;
+        let mut cursor = start;
+        while let Some(len) = self.ident_char_len(cursor, cursor == start) {
+            cursor += len;
+        }
+        self.pos = cursor;
+
+        let text = &self.source[start..cursor];
+        // After `.` or `?.` every reserved word is just a property name, so
+        // `promise.catch(f)` must not be lexed as the `catch` keyword.
+        let member_name = matches!(
+            self.prev.map(|prev| prev.kind),
+            Some(TokenKind::Punctuator(
+                Punctuator::Dot | Punctuator::QuestionDot
+            ))
+        );
+        let kind = match Keyword::lookup(text).filter(|_| !member_name) {
+            Some(keyword) => {
+                match keyword {
+                    Keyword::Class | Keyword::Interface | Keyword::Enum => {
+                        self.pending_body = Some(BraceKind::Class);
+                    }
+                    Keyword::Switch => self.pending_body = Some(BraceKind::Switch),
+                    Keyword::Function | Keyword::Component | Keyword::Hook => {
+                        self.pending_body = None;
+                    }
+                    _ => {}
+                }
+                TokenKind::Keyword(keyword)
+            }
+            None => TokenKind::Identifier,
+        };
+        self.push(kind, start, cursor);
+    }
+
+    /// Byte length of the UTF-8 character starting at `at`, or 1 past the end.
+    fn char_len(&self, at: usize) -> usize {
+        match self.bytes.get(at) {
+            None => 1,
+            Some(byte) if *byte < 0x80 => 1,
+            Some(_) => self.source[at..].chars().next().map_or(1, char::len_utf8),
+        }
+    }
+
+    /// Byte length of the identifier character at `at`, if there is one.
+    fn ident_char_len(&self, at: usize, start: bool) -> Option<usize> {
+        let byte = *self.bytes.get(at)?;
+        if byte < 0x80 {
+            let ok = byte == b'_'
+                || byte == b'$'
+                || byte.is_ascii_alphabetic()
+                || (!start && byte.is_ascii_digit());
+            return ok.then_some(1);
+        }
+
+        let ch = self.source[at..].chars().next()?;
+        let ok = if start {
+            ch.is_alphabetic()
+        } else {
+            // Approximates ID_Continue: letters, marks and digits, plus the two
+            // zero-width joiners the spec allows inside identifiers.
+            ch.is_alphanumeric() || ch == '\u{200c}' || ch == '\u{200d}'
+        };
+        ok.then(|| ch.len_utf8())
+    }
+
+    fn scan_punctuator(&self, at: usize) -> Option<(Punctuator, usize)> {
+        let b0 = *self.bytes.get(at)?;
+        let b1 = self.byte(at + 1);
+        let b2 = self.byte(at + 2);
+        let b3 = self.byte(at + 3);
+
+        let found = match b0 {
+            b'{' => (Punctuator::OpenBrace, 1),
+            b'}' => (Punctuator::CloseBrace, 1),
+            b'(' => (Punctuator::OpenParen, 1),
+            b')' => (Punctuator::CloseParen, 1),
+            b'[' => (Punctuator::OpenBracket, 1),
+            b']' => (Punctuator::CloseBracket, 1),
+            b';' => (Punctuator::Semicolon, 1),
+            b',' => (Punctuator::Comma, 1),
+            b'~' => (Punctuator::Tilde, 1),
+            b'@' => (Punctuator::At, 1),
+            b':' => (Punctuator::Colon, 1),
+            b'.' => {
+                if b1 == b'.' && b2 == b'.' {
+                    (Punctuator::Ellipsis, 3)
+                } else {
+                    (Punctuator::Dot, 1)
+                }
+            }
+            b'?' => match b1 {
+                // `?.5` is a ternary followed by a number, not optional chaining.
+                b'.' if !b2.is_ascii_digit() => (Punctuator::QuestionDot, 2),
+                b'?' if b2 == b'=' => (Punctuator::QuestionQuestionEqual, 3),
+                b'?' => (Punctuator::QuestionQuestion, 2),
+                _ => (Punctuator::Question, 1),
+            },
+            b'+' => match b1 {
+                b'+' => (Punctuator::PlusPlus, 2),
+                b'=' => (Punctuator::PlusEqual, 2),
+                _ => (Punctuator::Plus, 1),
+            },
+            b'-' => match b1 {
+                b'-' => (Punctuator::MinusMinus, 2),
+                b'=' => (Punctuator::MinusEqual, 2),
+                _ => (Punctuator::Minus, 1),
+            },
+            b'*' => match (b1, b2) {
+                (b'*', b'=') => (Punctuator::StarStarEqual, 3),
+                (b'*', _) => (Punctuator::StarStar, 2),
+                (b'=', _) => (Punctuator::StarEqual, 2),
+                _ => (Punctuator::Star, 1),
+            },
+            b'/' => match b1 {
+                b'=' => (Punctuator::SlashEqual, 2),
+                _ => (Punctuator::Slash, 1),
+            },
+            b'%' => match b1 {
+                b'=' => (Punctuator::PercentEqual, 2),
+                _ => (Punctuator::Percent, 1),
+            },
+            b'=' => match (b1, b2) {
+                (b'=', b'=') => (Punctuator::EqualEqualEqual, 3),
+                (b'=', _) => (Punctuator::EqualEqual, 2),
+                (b'>', _) => (Punctuator::Arrow, 2),
+                _ => (Punctuator::Equal, 1),
+            },
+            b'!' => match (b1, b2) {
+                (b'=', b'=') => (Punctuator::BangEqualEqual, 3),
+                (b'=', _) => (Punctuator::BangEqual, 2),
+                _ => (Punctuator::Bang, 1),
+            },
+            b'<' => match (b1, b2) {
+                (b'<', b'=') => (Punctuator::LessLessEqual, 3),
+                (b'<', _) => (Punctuator::LessLess, 2),
+                (b'=', _) => (Punctuator::LessEqual, 2),
+                _ => (Punctuator::Less, 1),
+            },
+            b'>' => match (b1, b2, b3) {
+                (b'>', b'>', b'=') => (Punctuator::GreaterGreaterGreaterEqual, 4),
+                (b'>', b'>', _) => (Punctuator::GreaterGreaterGreater, 3),
+                (b'>', b'=', _) => (Punctuator::GreaterGreaterEqual, 3),
+                (b'>', _, _) => (Punctuator::GreaterGreater, 2),
+                (b'=', _, _) => (Punctuator::GreaterEqual, 2),
+                _ => (Punctuator::Greater, 1),
+            },
+            b'&' => match (b1, b2) {
+                (b'&', b'=') => (Punctuator::AmpAmpEqual, 3),
+                (b'&', _) => (Punctuator::AmpAmp, 2),
+                (b'=', _) => (Punctuator::AmpEqual, 2),
+                _ => (Punctuator::Amp, 1),
+            },
+            b'|' => match (b1, b2) {
+                (b'|', b'=') => (Punctuator::PipePipeEqual, 3),
+                (b'|', _) => (Punctuator::PipePipe, 2),
+                (b'=', _) => (Punctuator::PipeEqual, 2),
+                _ => (Punctuator::Pipe, 1),
+            },
+            b'^' => match b1 {
+                b'=' => (Punctuator::CaretEqual, 2),
+                _ => (Punctuator::Caret, 1),
+            },
+            _ => return None,
+        };
+        Some(found)
+    }
+
+    // ------------------------------------------------------------------- JSX
+
+    fn scan_jsx_tag(&mut self) {
+        let start = self.pos;
+        let byte = self.byte(start);
+        let closing = matches!(self.stack.last(), Some(Ctx::JsxTag { closing: true }));
+
+        match byte {
+            b'\n' => {
+                self.pos = start + 1;
+                self.push(TokenKind::Newline, start, self.pos);
+            }
+            b'\r' => {
+                self.pos = if self.byte(start + 1) == b'\n' {
+                    start + 2
+                } else {
+                    start + 1
+                };
+                self.push(TokenKind::Newline, start, self.pos);
+            }
+            b' ' | b'\t' | 0x0b | 0x0c => {
+                let mut end = start + 1;
+                while matches!(self.byte(end), b' ' | b'\t' | 0x0b | 0x0c) {
+                    end += 1;
+                }
+                self.pos = end;
+                self.push(TokenKind::Whitespace, start, end);
+            }
+            b'>' => {
+                self.pos = start + 1;
+                self.stack.pop();
+                if closing {
+                    if matches!(self.stack.last(), Some(Ctx::JsxChildren)) {
+                        self.stack.pop();
+                    }
+                } else {
+                    self.stack.push(Ctx::JsxChildren);
+                }
+                self.push(TokenKind::JsxTagEnd, start, self.pos);
+            }
+            b'/' if self.byte(start + 1) == b'>' => {
+                self.pos = start + 2;
+                self.stack.pop();
+                self.push(TokenKind::JsxSelfClose, start, self.pos);
+            }
+            b'/' => {
+                self.pos = start + 1;
+                self.push(TokenKind::Punctuator(Punctuator::Slash), start, self.pos);
+            }
+            b'=' => {
+                self.pos = start + 1;
+                self.push(TokenKind::Punctuator(Punctuator::Equal), start, self.pos);
+            }
+            b'{' => {
+                self.pos = start + 1;
+                self.stack.push(Ctx::Brace(BraceKind::JsxExpression));
+                self.push(
+                    TokenKind::Punctuator(Punctuator::OpenBrace),
+                    start,
+                    self.pos,
+                );
+            }
+            b'\'' | b'"' => {
+                // JSX attribute strings have no escape sequences at all.
+                let mut cursor = start + 1;
+                let end = loop {
+                    match self.bytes.get(cursor) {
+                        None => break None,
+                        Some(found) if *found == byte => break Some(cursor + 1),
+                        Some(_) => cursor += self.char_len(cursor),
+                    }
+                };
+                match end {
+                    Some(end) => {
+                        self.pos = end;
+                        self.push(TokenKind::JsxString, start, end);
+                    }
+                    None => {
+                        self.pos = self.bytes.len();
+                        self.push(
+                            TokenKind::Unterminated(Unterminated::String),
+                            start,
+                            self.pos,
+                        );
+                    }
+                }
+            }
+            _ => {
+                if self.ident_char_len(start, true).is_some() {
+                    let mut cursor = start;
+                    loop {
+                        if let Some(len) = self.ident_char_len(cursor, false) {
+                            cursor += len;
+                            continue;
+                        }
+                        // `data-testid`, `Foo.Bar` and `svg:rect` are single names.
+                        if matches!(self.byte(cursor), b'-' | b'.' | b':')
+                            && self.ident_char_len(cursor + 1, true).is_some()
+                        {
+                            cursor += 1;
+                            continue;
+                        }
+                        break;
+                    }
+                    self.pos = cursor;
+                    self.push(TokenKind::JsxName, start, cursor);
+                } else {
+                    let len = self.char_len(start);
+                    self.pos = start + len;
+                    self.push(TokenKind::Unknown, start, self.pos);
+                }
+            }
+        }
+    }
+
+    fn scan_jsx_child(&mut self) {
+        let start = self.pos;
+        let byte = self.byte(start);
+
+        match byte {
+            b'\n' => {
+                self.pos = start + 1;
+                self.push(TokenKind::Newline, start, self.pos);
+            }
+            b'\r' => {
+                self.pos = if self.byte(start + 1) == b'\n' {
+                    start + 2
+                } else {
+                    start + 1
+                };
+                self.push(TokenKind::Newline, start, self.pos);
+            }
+            b' ' | b'\t' | 0x0b | 0x0c => {
+                let mut end = start + 1;
+                while matches!(self.byte(end), b' ' | b'\t' | 0x0b | 0x0c) {
+                    end += 1;
+                }
+                self.pos = end;
+                self.push(TokenKind::Whitespace, start, end);
+            }
+            b'<' => {
+                let closing = self.byte(start + 1) == b'/';
+                if closing {
+                    self.pos = start + 2;
+                    self.stack.push(Ctx::JsxTag { closing: true });
+                    self.push(TokenKind::JsxCloseStart, start, self.pos);
+                } else {
+                    self.pos = start + 1;
+                    self.stack.push(Ctx::JsxTag { closing: false });
+                    self.push(TokenKind::JsxOpenStart, start, self.pos);
+                }
+            }
+            b'{' => {
+                self.pos = start + 1;
+                self.stack.push(Ctx::Brace(BraceKind::JsxExpression));
+                self.push(
+                    TokenKind::Punctuator(Punctuator::OpenBrace),
+                    start,
+                    self.pos,
+                );
+            }
+            _ => {
+                let mut end = start;
+                while end < self.bytes.len() {
+                    // Every stop byte is ASCII, so scanning raw bytes can never
+                    // split a multi-byte character.
+                    if matches!(
+                        self.bytes[end],
+                        b'<' | b'{' | b'\n' | b'\r' | b' ' | b'\t' | 0x0b | 0x0c
+                    ) {
+                        break;
+                    }
+                    end += 1;
+                }
+                self.pos = end;
+                self.push(TokenKind::JsxText, start, end);
+            }
+        }
+    }
+}
+
+impl fmt::Display for Unterminated {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Unterminated::String => "string literal",
+            Unterminated::Template => "template literal",
+            Unterminated::BlockComment => "block comment",
+            Unterminated::Regex => "regular expression",
+        };
+        formatter.write_str(label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::SOURCE_CORPUS as CORPUS;
+
+    fn kinds(source: &str) -> Vec<TokenKind> {
+        tokenize(source).into_iter().map(|t| t.kind).collect()
+    }
+
+    fn significant(source: &str) -> Vec<TokenKind> {
+        tokenize(source)
+            .into_iter()
+            .filter(|token| !token.kind.is_trivia())
+            .map(|token| token.kind)
+            .collect()
+    }
+
+    #[test]
+    fn tokens_reproduce_the_source_byte_for_byte() {
+        for source in CORPUS {
+            let mut rebuilt = String::with_capacity(source.len());
+            for token in tokenize(source) {
+                rebuilt.push_str(token.text(source));
+            }
+            assert_eq!(&rebuilt, source, "round trip failed for {source:?}");
+        }
+    }
+
+    #[test]
+    fn token_spans_tile_the_source_without_gaps() {
+        for source in CORPUS {
+            let mut cursor = 0;
+            for token in tokenize(source) {
+                assert_eq!(token.span.start, cursor, "gap in {source:?}");
+                assert!(
+                    token.span.end > token.span.start,
+                    "empty token in {source:?}"
+                );
+                cursor = token.span.end;
+            }
+            assert_eq!(cursor, source.len(), "trailing gap in {source:?}");
+        }
+    }
+
+    #[test]
+    fn empty_source_produces_no_tokens() {
+        assert!(tokenize("").is_empty());
+    }
+
+    #[test]
+    fn line_comments_stop_before_the_newline() {
+        let tokens = kinds("// hi\nx");
+        assert_eq!(
+            tokens,
+            vec![
+                TokenKind::LineComment,
+                TokenKind::Newline,
+                TokenKind::Identifier
+            ]
+        );
+    }
+
+    #[test]
+    fn doc_comments_are_distinguished_from_block_comments() {
+        assert_eq!(kinds("/** doc */"), vec![TokenKind::DocComment]);
+        assert_eq!(kinds("/* plain */"), vec![TokenKind::BlockComment]);
+        assert_eq!(kinds("/**/"), vec![TokenKind::BlockComment]);
+    }
+
+    #[test]
+    fn unterminated_block_comment_runs_to_end_of_input() {
+        assert_eq!(
+            kinds("/* nope"),
+            vec![TokenKind::Unterminated(Unterminated::BlockComment)]
+        );
+    }
+
+    #[test]
+    fn strings_handle_escapes_and_line_continuations() {
+        assert_eq!(significant("'it\\'s'"), vec![TokenKind::String]);
+        assert_eq!(significant("\"a\\\"b\""), vec![TokenKind::String]);
+        assert_eq!(significant("'a\\\nb'"), vec![TokenKind::String]);
+    }
+
+    #[test]
+    fn raw_newline_terminates_a_string_literal() {
+        assert_eq!(
+            kinds("'oops\nx"),
+            vec![
+                TokenKind::Unterminated(Unterminated::String),
+                TokenKind::Newline,
+                TokenKind::Identifier
+            ]
+        );
+    }
+
+    #[test]
+    fn templates_track_nested_interpolations() {
+        assert_eq!(
+            significant("`a${`b${c}d`}e`"),
+            vec![
+                TokenKind::TemplateHead,
+                TokenKind::TemplateHead,
+                TokenKind::Identifier,
+                TokenKind::TemplateTail,
+                TokenKind::TemplateTail,
+            ]
+        );
+    }
+
+    #[test]
+    fn template_middle_is_emitted_between_interpolations() {
+        assert_eq!(
+            significant("`${a}-${b}`"),
+            vec![
+                TokenKind::TemplateHead,
+                TokenKind::Identifier,
+                TokenKind::TemplateMiddle,
+                TokenKind::Identifier,
+                TokenKind::TemplateTail,
+            ]
+        );
+    }
+
+    #[test]
+    fn object_literals_inside_interpolations_do_not_end_the_template() {
+        assert_eq!(
+            significant("`${ {a: 1} }`"),
+            vec![
+                TokenKind::TemplateHead,
+                TokenKind::Punctuator(Punctuator::OpenBrace),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Colon),
+                TokenKind::Number,
+                TokenKind::Punctuator(Punctuator::CloseBrace),
+                TokenKind::TemplateTail,
+            ]
+        );
+    }
+
+    #[test]
+    fn unterminated_template_is_reported() {
+        assert_eq!(
+            kinds("`abc"),
+            vec![TokenKind::Unterminated(Unterminated::Template)]
+        );
+    }
+
+    #[test]
+    fn regex_is_recognized_at_the_start_of_an_expression() {
+        assert_eq!(
+            significant("x = /a\\/b/g"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Equal),
+                TokenKind::Regex,
+            ]
+        );
+    }
+
+    #[test]
+    fn slash_after_an_identifier_is_division() {
+        assert_eq!(
+            significant("a / b / c"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Slash),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Slash),
+                TokenKind::Identifier,
+            ]
+        );
+    }
+
+    #[test]
+    fn slash_after_a_call_is_division_but_after_a_statement_header_is_regex() {
+        assert!(significant("f() / 2").contains(&TokenKind::Punctuator(Punctuator::Slash)));
+        assert!(!significant("f() / 2").contains(&TokenKind::Regex));
+        assert!(significant("if (a) /re/.test(b)").contains(&TokenKind::Regex));
+        assert!(significant("while (a) /re/.test(b)").contains(&TokenKind::Regex));
+    }
+
+    #[test]
+    fn reserved_words_after_a_dot_are_property_names() {
+        assert_eq!(
+            significant("promise.catch(f)"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Dot),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::OpenParen),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::CloseParen),
+            ]
+        );
+        assert_eq!(significant("a?.default")[2], TokenKind::Identifier);
+    }
+
+    #[test]
+    fn slash_after_an_object_literal_is_division() {
+        let tokens = significant("const x = {a: 1} / 2;");
+        assert!(tokens.contains(&TokenKind::Punctuator(Punctuator::Slash)));
+        assert!(!tokens.contains(&TokenKind::Regex));
+    }
+
+    #[test]
+    fn a_brace_after_a_return_type_is_a_block() {
+        let source = "function f(): Promise<void> {}\n/re/.test(x);";
+        // The block classification is what lets the following `/` start a regex.
+        assert!(significant(source).contains(&TokenKind::Regex));
+    }
+
+    #[test]
+    fn slash_after_a_block_is_a_regex() {
+        let tokens = significant("function f() {}\n/re/.test(x);");
+        assert!(tokens.contains(&TokenKind::Regex));
+    }
+
+    #[test]
+    fn regex_character_class_may_contain_a_slash() {
+        assert_eq!(
+            significant("x = /[/]/"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Equal),
+                TokenKind::Regex,
+            ]
+        );
+    }
+
+    #[test]
+    fn regex_with_a_newline_before_its_close_is_unterminated() {
+        assert_eq!(
+            kinds("x = /ab\n")[4],
+            TokenKind::Unterminated(Unterminated::Regex)
+        );
+    }
+
+    #[test]
+    fn keywords_after_which_a_regex_may_start() {
+        assert!(significant("return /re/;").contains(&TokenKind::Regex));
+        assert!(significant("typeof /re/;").contains(&TokenKind::Regex));
+        assert!(significant("case /re/:").contains(&TokenKind::Regex));
+    }
+
+    #[test]
+    fn contextual_keywords_do_not_start_a_regex() {
+        // `type` is a plain identifier here, so `/` must stay division.
+        let tokens = significant("const type = 4; const half = type / 2;");
+        assert!(!tokens.contains(&TokenKind::Regex));
+    }
+
+    #[test]
+    fn numbers_cover_every_literal_form() {
+        for source in [
+            "0x1F",
+            "0XFF",
+            "0b1010",
+            "0o777",
+            "1_000_000",
+            "1e10",
+            "1E-10",
+            "1.5",
+            ".5",
+            "1n",
+            "0.5e+3",
+        ] {
+            assert_eq!(significant(source), vec![TokenKind::Number], "{source}");
+        }
+    }
+
+    #[test]
+    fn a_number_does_not_swallow_a_following_member_access() {
+        assert_eq!(
+            significant("1..toString()"),
+            vec![
+                TokenKind::Number,
+                TokenKind::Punctuator(Punctuator::Dot),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::OpenParen),
+                TokenKind::Punctuator(Punctuator::CloseParen),
+            ]
+        );
+    }
+
+    #[test]
+    fn unicode_identifiers_are_single_tokens() {
+        assert_eq!(significant("const café = 1;")[1], TokenKind::Identifier);
+        assert_eq!(significant("日本語")[0], TokenKind::Identifier);
+    }
+
+    #[test]
+    fn private_names_are_lexed_as_one_token() {
+        assert_eq!(significant("this.#count")[2], TokenKind::PrivateName);
+    }
+
+    #[test]
+    fn shebang_is_only_recognized_at_offset_zero() {
+        assert_eq!(kinds("#!/usr/bin/env uf\n")[0], TokenKind::Shebang);
+        assert_eq!(significant("x\n#!y")[1], TokenKind::Unknown);
+    }
+
+    #[test]
+    fn jsx_elements_produce_jsx_tokens() {
+        assert_eq!(
+            significant("<div a=\"1\">hi</div>"),
+            vec![
+                TokenKind::JsxOpenStart,
+                TokenKind::JsxName,
+                TokenKind::JsxName,
+                TokenKind::Punctuator(Punctuator::Equal),
+                TokenKind::JsxString,
+                TokenKind::JsxTagEnd,
+                TokenKind::JsxText,
+                TokenKind::JsxCloseStart,
+                TokenKind::JsxName,
+                TokenKind::JsxTagEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn jsx_text_keeps_quotes_and_apostrophes_as_text() {
+        let tokens = significant("<p>it's \"fine\"</p>");
+        assert!(!tokens.contains(&TokenKind::String));
+    }
+
+    #[test]
+    fn jsx_expression_containers_return_to_javascript() {
+        assert_eq!(
+            significant("<p>{a / b}</p>"),
+            vec![
+                TokenKind::JsxOpenStart,
+                TokenKind::JsxName,
+                TokenKind::JsxTagEnd,
+                TokenKind::Punctuator(Punctuator::OpenBrace),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Slash),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::CloseBrace),
+                TokenKind::JsxCloseStart,
+                TokenKind::JsxName,
+                TokenKind::JsxTagEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn self_closing_jsx_tags_are_a_single_token() {
+        assert_eq!(significant("<br />")[2], TokenKind::JsxSelfClose);
+    }
+
+    #[test]
+    fn jsx_fragments_open_and_close() {
+        assert_eq!(
+            significant("<><b>x</b></>"),
+            vec![
+                TokenKind::JsxOpenStart,
+                TokenKind::JsxTagEnd,
+                TokenKind::JsxOpenStart,
+                TokenKind::JsxName,
+                TokenKind::JsxTagEnd,
+                TokenKind::JsxText,
+                TokenKind::JsxCloseStart,
+                TokenKind::JsxName,
+                TokenKind::JsxTagEnd,
+                TokenKind::JsxCloseStart,
+                TokenKind::JsxTagEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn dashed_and_namespaced_jsx_names_stay_together() {
+        let tokens = tokenize("<a data-x=\"1\" svg:y=\"2\" Foo.Bar />");
+        let names: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.kind == TokenKind::JsxName)
+            .map(|token| token.text("<a data-x=\"1\" svg:y=\"2\" Foo.Bar />"))
+            .collect();
+        assert_eq!(names, vec!["a", "data-x", "svg:y", "Foo.Bar"]);
+    }
+
+    #[test]
+    fn less_than_after_an_identifier_is_not_jsx() {
+        assert_eq!(
+            significant("a < b"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Less),
+                TokenKind::Identifier,
+            ]
+        );
+    }
+
+    #[test]
+    fn generic_function_types_in_type_aliases_are_not_jsx() {
+        let tokens = significant("type F = <T>(value: T) => T;");
+        assert!(!tokens.iter().any(|kind| kind.is_jsx()));
+    }
+
+    #[test]
+    fn jsx_after_an_arrow_is_recognized() {
+        let tokens = significant("const A = () => <div />;");
+        assert!(tokens.contains(&TokenKind::JsxOpenStart));
+    }
+
+    #[test]
+    fn deeply_nested_braces_do_not_overflow_the_stack() {
+        let depth = 10_000;
+        let mut source = String::with_capacity(depth * 2);
+        for _ in 0..depth {
+            source.push('{');
+        }
+        for _ in 0..depth {
+            source.push('}');
+        }
+        assert_eq!(tokenize(&source).len(), depth * 2);
+    }
+
+    #[test]
+    fn unpaired_closing_delimiters_do_not_panic() {
+        for source in [
+            ")",
+            "]",
+            "}",
+            "))))",
+            "`${}}`",
+            "<div></p></div>",
+            "\\",
+            "\\\\",
+        ] {
+            let tokens = tokenize(source);
+            let mut rebuilt = String::new();
+            for token in &tokens {
+                rebuilt.push_str(token.text(source));
+            }
+            assert_eq!(rebuilt, source);
+        }
+    }
+
+    #[test]
+    fn crlf_is_a_single_newline_token() {
+        assert_eq!(
+            kinds("a\r\nb"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Newline,
+                TokenKind::Identifier
+            ]
+        );
+    }
+
+    #[test]
+    fn maximal_munch_picks_the_longest_operator() {
+        assert_eq!(
+            significant("a >>>= b"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::GreaterGreaterGreaterEqual),
+                TokenKind::Identifier,
+            ]
+        );
+        assert_eq!(
+            significant("a ??= b"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::QuestionQuestionEqual),
+                TokenKind::Identifier,
+            ]
+        );
+        assert_eq!(
+            significant("...rest"),
+            vec![
+                TokenKind::Punctuator(Punctuator::Ellipsis),
+                TokenKind::Identifier
+            ]
+        );
+    }
+
+    #[test]
+    fn optional_chaining_is_distinguished_from_a_ternary_on_a_number() {
+        assert_eq!(
+            significant("a?.b"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::QuestionDot),
+                TokenKind::Identifier,
+            ]
+        );
+        assert_eq!(
+            significant("a ? .5 : 1"),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Question),
+                TokenKind::Number,
+                TokenKind::Punctuator(Punctuator::Colon),
+                TokenKind::Number,
+            ]
+        );
+    }
+
+    #[test]
+    fn flow_type_punctuation_is_tokenized() {
+        assert_eq!(
+            significant("type A = {| +x?: ?number |};"),
+            vec![
+                TokenKind::Keyword(Keyword::Type),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Equal),
+                TokenKind::Punctuator(Punctuator::OpenBrace),
+                TokenKind::Punctuator(Punctuator::Pipe),
+                TokenKind::Punctuator(Punctuator::Plus),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Question),
+                TokenKind::Punctuator(Punctuator::Colon),
+                TokenKind::Punctuator(Punctuator::Question),
+                TokenKind::Identifier,
+                TokenKind::Punctuator(Punctuator::Pipe),
+                TokenKind::Punctuator(Punctuator::CloseBrace),
+                TokenKind::Punctuator(Punctuator::Semicolon),
+            ]
+        );
+    }
+}

--- a/crates/uf_fmt/src/lib.rs
+++ b/crates/uf_fmt/src/lib.rs
@@ -1,47 +1,108 @@
+#![deny(missing_docs)]
+//! Native formatter for Flow-typed JavaScript.
+//!
+//! `uf fmt` does not shell out to Prettier, Babel or any JavaScript runtime. This
+//! crate scans the source once into a lossless token stream ([`lexer`]) and prints
+//! it back with normalized trivia. There is no syntax tree, no per-node
+//! allocation and no backtracking: two linear passes over a flat token vector,
+//! which `cargo bench -p uf_fmt` measures in tens of megabytes per second per
+//! core for formatting and hundreds for tokenizing.
+//!
+//! The formatter is built around three invariants, each covered by tests:
+//!
+//! * **Token preserving.** Formatting only rewrites whitespace, string quotes and
+//!   statement-terminating semicolons. Every other token comes out of the printer
+//!   exactly as it went in, so the formatter cannot corrupt a program.
+//! * **Idempotent.** `format(format(x)) == format(x)` for every input.
+//! * **Total.** No input panics or hangs, including truncated literals, unpaired
+//!   delimiters and sources nested ten thousand braces deep. Both passes use
+//!   explicit stacks rather than recursion, because unbounded recursion over
+//!   attacker-controlled nesting is a well-worn crash vector for formatters.
+//!
+//! ```
+//! use uf_config::FmtConfig;
+//! use uf_fmt::format_source;
+//!
+//! let result = format_source("const x = {a:1,b:2}\n", &FmtConfig::default()).unwrap();
+//! assert_eq!(result.output, "const x = { a: 1, b: 2 };\n");
+//! ```
+
+pub mod lexer;
+mod printer;
+
+use std::borrow::Cow;
+
 use thiserror::Error;
 use uf_config::FmtConfig;
 
+/// The largest [`FmtConfig::indent_width`] the formatter accepts.
+///
+/// Indentation is emitted once per line and multiplied by the nesting depth, so
+/// an unbounded width is an unbounded allocation on adversarial input.
+pub const MAX_INDENT_WIDTH: u8 = 16;
+
+/// Byte order mark, which is preserved verbatim at the head of a file.
+const BOM: &str = "\u{feff}";
+
+/// The outcome of formatting one source file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FormatResult {
+    /// The formatted source text.
     pub output: String,
+    /// Whether [`FormatResult::output`] differs from the input.
     pub changed: bool,
 }
 
-#[derive(Debug, Error)]
+/// Why a source file could not be formatted.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FormatError {
+    /// `indentWidth` was zero, which cannot produce nested indentation.
     #[error("indent width must be greater than zero")]
     InvalidIndentWidth,
+    /// `indentWidth` was larger than [`MAX_INDENT_WIDTH`].
+    #[error("indent width {indent_width} exceeds the maximum of {maximum}")]
+    IndentWidthTooLarge {
+        /// The configured width.
+        indent_width: u8,
+        /// The largest accepted width.
+        maximum: u8,
+    },
 }
 
+/// Format one source file.
+///
+/// A leading byte order mark is preserved, CRLF and lone CR line endings are
+/// normalized to LF, and the output always ends with exactly one newline unless
+/// the input contained nothing to print.
+///
+/// # Errors
+///
+/// Returns [`FormatError`] when [`FmtConfig::indent_width`] is zero or larger
+/// than [`MAX_INDENT_WIDTH`].
 pub fn format_source(source: &str, config: &FmtConfig) -> Result<FormatResult, FormatError> {
     if config.indent_width == 0 {
         return Err(FormatError::InvalidIndentWidth);
     }
-
-    let indent = " ".repeat(config.indent_width as usize);
-    let mut output = String::with_capacity(source.len() + 1);
-
-    for line in source.lines() {
-        let trimmed_end = line.trim_end_matches([' ', '\t']);
-        let leading_tabs = trimmed_end
-            .bytes()
-            .take_while(|byte| *byte == b'\t')
-            .count();
-
-        if leading_tabs > 0 {
-            output.push_str(&indent.repeat(leading_tabs));
-            output.push_str(&trimmed_end[leading_tabs..]);
-        } else {
-            output.push_str(trimmed_end);
-        }
-        output.push('\n');
+    if config.indent_width > MAX_INDENT_WIDTH {
+        return Err(FormatError::IndentWidthTooLarge {
+            indent_width: config.indent_width,
+            maximum: MAX_INDENT_WIDTH,
+        });
     }
 
-    if source.is_empty() {
-        output.clear();
-    } else if !source.ends_with('\n') && output.is_empty() {
-        output.push('\n');
-    }
+    let (bom, body) = split_bom(source);
+    let normalized = normalize_line_endings(body);
+    let tokens = lexer::tokenize(&normalized);
+    let printed = printer::print(&normalized, &tokens, config);
+
+    let output = if bom.is_empty() {
+        printed
+    } else {
+        let mut output = String::with_capacity(bom.len() + printed.len());
+        output.push_str(bom);
+        output.push_str(&printed);
+        output
+    };
 
     Ok(FormatResult {
         changed: output != source,
@@ -49,37 +110,838 @@ pub fn format_source(source: &str, config: &FmtConfig) -> Result<FormatResult, F
     })
 }
 
+/// Split a leading byte order mark off the source.
+fn split_bom(source: &str) -> (&str, &str) {
+    match source.strip_prefix(BOM) {
+        Some(rest) => (BOM, rest),
+        None => ("", source),
+    }
+}
+
+/// Rewrite CRLF and lone CR line endings as LF, borrowing when there is nothing
+/// to change.
+fn normalize_line_endings(source: &str) -> Cow<'_, str> {
+    if memchr::memchr(b'\r', source.as_bytes()).is_none() {
+        return Cow::Borrowed(source);
+    }
+
+    let mut normalized = String::with_capacity(source.len());
+    let bytes = source.as_bytes();
+    let mut cursor = 0;
+    while let Some(offset) = memchr::memchr(b'\r', &bytes[cursor..]) {
+        let at = cursor + offset;
+        normalized.push_str(&source[cursor..at]);
+        normalized.push('\n');
+        cursor = if bytes.get(at + 1) == Some(&b'\n') {
+            at + 2
+        } else {
+            at + 1
+        };
+    }
+    normalized.push_str(&source[cursor..]);
+    Cow::Owned(normalized)
+}
+
+/// Sources exercised by the lexer round-trip and formatter property tests.
+#[cfg(test)]
+pub(crate) const SOURCE_CORPUS: &[&str] = &[
+    "",
+    "\n",
+    "// @flow\n",
+    "const x = 1;\n",
+    "const x = 1 / 2 / 3;\n",
+    "const re = /ab+c/gi;\n",
+    "if (x) /re/.test(y);\n",
+    "const a = b / c, d = /re/;\n",
+    "const t = `a${b}c${`nested ${d}`}e`;\n",
+    "const s = 'it\\'s';\nconst d = \"say \\\"hi\\\"\";\n",
+    "const c = 'line \\\ncontinued';\n",
+    "/* block */ /** doc */ // line\n",
+    "const n = [0x1f, 0b1010, 0o777, 1_000, 1e10, 1n, .5, 1.5e-3];\n",
+    "type A = ?string;\ntype B = Array<Map<string, number>>;\n",
+    "opaque type Id = string;\n",
+    "component Greeting(name: string) renders React.Node { return <p>hi</p>; }\n",
+    "const el = <div className=\"a\" data-testid='b'>text {value} more</div>;\n",
+    "const frag = <>{items.map((i) => <Item key={i} />)}</>;\n",
+    "switch (x) { case 1: return 2; default: break; }\n",
+    "class A extends B { #x = 1; static y = 2; *gen() { yield* other(); } }\n",
+    "const emoji = \"日本語 🎉\";\nconst ident = ünïcödé;\n",
+    "async function f() { await g(); for (let i = 0; i < 3; i++) {} }\n",
+    "export default function App() {}\n",
+    "const div = a < b > c;\n",
+    "let x = 1\nlet y = 2\n",
+    "const o = { a: 1, 'b': 2, [c]: 3, ...rest };\n",
+    "label: for (const item of items) { continue label; }\n",
+    "const f = (x) => ({ ...x });\n",
+    "declare export function f(): void;\n",
+    "\"use client\";\n",
+    "const tagged = html`<b>${x}</b>`;\n",
+    "x = a ? b : c;\ny = { k: cond ? 1 : 2 };\n",
+    "const nested = <ul>{list.map((n) => (<li>{n}</li>))}</ul>;\n",
+    "\u{feff}const withBom = 1;\n",
+    "const crlf = 1;\r\nconst second = 2;\r\n",
+    "function f() {\n\n\n  return 1;\n\n\n}\n",
+    "const deep = { a: { b: { c: [1, 2, [3, { d: 4 }]] } } };\n",
+    "obj\n  .method()\n  .chain()\n  .end();\n",
+    "type Exact = {| +read: string, -write?: ?number |};\n",
+];
+
 #[cfg(test)]
 mod tests {
-    use super::*;
 
-    #[test]
-    fn removes_trailing_whitespace_and_adds_final_newline() {
-        let config = FmtConfig::default();
-
-        let result = format_source("const x = 1;  \nconst y = 2;", &config).unwrap();
-
-        similar_asserts::assert_eq!(result.output, "const x = 1;\nconst y = 2;\n");
-        assert!(result.changed);
-    }
-
-    #[test]
-    fn expands_leading_tabs_using_configured_indent() {
+    /// A default config with `mutate` applied.
+    ///
+    /// `FmtConfig` is `#[non_exhaustive]`, because every feature that lands adds
+    /// a knob to it and a struct literal would break on each one.
+    fn config_with(mutate: impl FnOnce(&mut FmtConfig)) -> FmtConfig {
         let mut config = FmtConfig::default();
-        config.indent_width = 4;
+        mutate(&mut config);
+        config
+    }
+    use super::*;
+    use crate::lexer::{Token, TokenKind, tokenize};
+    use uf_config::QuoteStyle;
 
-        let result = format_source("\tconst x = 1;\n", &config).unwrap();
+    fn format(source: &str) -> String {
+        format_source(source, &FmtConfig::default())
+            .expect("default config formats")
+            .output
+    }
 
-        similar_asserts::assert_eq!(result.output, "    const x = 1;\n");
+    fn format_with(source: &str, config: &FmtConfig) -> String {
+        format_source(source, config)
+            .expect("config formats")
+            .output
+    }
+
+    /// Canonical spelling of a token, so that a requoted string compares equal to
+    /// the literal it came from.
+    fn canonical(token: Token, source: &str) -> String {
+        let text = token.text(source);
+        match token.kind {
+            TokenKind::String | TokenKind::JsxString => {
+                let body = text
+                    .strip_prefix(['\'', '"'])
+                    .and_then(|rest| rest.strip_suffix(['\'', '"']))
+                    .unwrap_or(text);
+                let mut canonical = String::with_capacity(body.len());
+                let mut chars = body.chars();
+                while let Some(ch) = chars.next() {
+                    if ch == '\\' {
+                        match chars.next() {
+                            Some(next @ ('"' | '\'')) => canonical.push(next),
+                            Some(next) => {
+                                canonical.push('\\');
+                                canonical.push(next);
+                            }
+                            None => canonical.push('\\'),
+                        }
+                    } else {
+                        canonical.push(ch);
+                    }
+                }
+                canonical
+            }
+            _ => text.to_string(),
+        }
+    }
+
+    /// The formatter may only change trivia, quote style and semicolons. Anything
+    /// else is a bug that could silently corrupt a program.
+    ///
+    /// `>>` and `>>>` are compared as the `>` characters they stand for, because
+    /// closing nested type arguments legally joins `> >` into `>>`, exactly as a
+    /// Flow parser splits it again. The printer never inserts characters inside a
+    /// token, so the character count can only be preserved.
+    fn assert_token_preserving(input: &str, output: &str) {
+        use crate::lexer::Punctuator;
+
+        let interesting = |source: &str| -> Vec<(TokenKind, String)> {
+            let mut tokens = Vec::new();
+            for token in tokenize(source) {
+                if token.kind.is_trivia()
+                    || token.kind == TokenKind::Punctuator(Punctuator::Semicolon)
+                {
+                    continue;
+                }
+                let repeats = match token.kind {
+                    TokenKind::Punctuator(Punctuator::Greater) => 1,
+                    TokenKind::Punctuator(Punctuator::GreaterGreater) => 2,
+                    TokenKind::Punctuator(Punctuator::GreaterGreaterGreater) => 3,
+                    _ => 0,
+                };
+                if repeats == 0 {
+                    tokens.push((token.kind, canonical(token, source)));
+                    continue;
+                }
+                for _ in 0..repeats {
+                    tokens.push((TokenKind::Punctuator(Punctuator::Greater), ">".to_string()));
+                }
+            }
+            tokens
+        };
+        similar_asserts::assert_eq!(
+            interesting(input),
+            interesting(output),
+            "token stream changed while formatting {input:?}"
+        );
+    }
+
+    fn assert_comments_preserved(input: &str, output: &str) {
+        let comments = |source: &str| -> Vec<String> {
+            tokenize(source)
+                .into_iter()
+                .filter(|token| token.kind.is_comment())
+                .map(|token| token.text(source).to_string())
+                .collect()
+        };
+        assert_eq!(comments(input), comments(output), "comments changed");
+    }
+
+    // ------------------------------------------------------------ properties
+
+    #[test]
+    fn formatting_is_idempotent_over_the_corpus() {
+        for source in SOURCE_CORPUS {
+            let once = format(source);
+            let twice = format(&once);
+            similar_asserts::assert_eq!(once, twice, "not idempotent for {source:?}");
+        }
     }
 
     #[test]
-    fn formatting_is_idempotent() {
-        let config = FmtConfig::default();
-        let once = format_source("const x = 1;\n", &config).unwrap();
-        let twice = format_source(&once.output, &config).unwrap();
+    fn formatting_preserves_the_token_stream_over_the_corpus() {
+        for source in SOURCE_CORPUS {
+            assert_token_preserving(source, &format(source));
+        }
+    }
 
-        assert!(!once.changed);
-        assert!(!twice.changed);
+    #[test]
+    fn formatting_preserves_comments_verbatim() {
+        for source in SOURCE_CORPUS {
+            assert_comments_preserved(source, &format(source));
+        }
+    }
+
+    #[test]
+    fn formatting_is_idempotent_for_every_configuration() {
+        let configs = [
+            FmtConfig::default(),
+            config_with(|config| {
+                config.indent_width = 4;
+                config.quotes = QuoteStyle::Single;
+                config.semicolons = false;
+                config.line_width = 40;
+                config.max_blank_lines = 0;
+            }),
+            config_with(|config| {
+                config.indent_width = 1;
+                config.quotes = QuoteStyle::Single;
+                config.semicolons = true;
+                config.line_width = 20;
+                config.max_blank_lines = 2;
+            }),
+        ];
+        for config in &configs {
+            for source in SOURCE_CORPUS {
+                let once = format_with(source, config);
+                let twice = format_with(&once, config);
+                similar_asserts::assert_eq!(once, twice, "not idempotent for {source:?}");
+                assert_token_preserving(source, &once);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------- structure
+
+    #[test]
+    fn removes_trailing_whitespace_and_adds_a_final_newline() {
+        similar_asserts::assert_eq!(
+            format("const x = 1;  \nconst y = 2;"),
+            "const x = 1;\nconst y = 2;\n"
+        );
+    }
+
+    #[test]
+    fn reindents_using_the_configured_indent_width() {
+        let config = config_with(|config| {
+            config.indent_width = 4;
+        });
+        similar_asserts::assert_eq!(
+            format_with(
+                "function f() {\n\tif (x) {\n\t\treturn 1;\n\t}\n}\n",
+                &config
+            ),
+            "function f() {\n    if (x) {\n        return 1;\n    }\n}\n"
+        );
+    }
+
+    #[test]
+    fn indents_by_bracket_depth_regardless_of_the_input_indentation() {
+        similar_asserts::assert_eq!(
+            format("const a = [\n1,\n        2,\n];\n"),
+            "const a = [\n  1,\n  2,\n];\n"
+        );
+    }
+
+    #[test]
+    fn empty_input_stays_empty() {
+        assert_eq!(format(""), "");
+        assert_eq!(format("   \n\n"), "");
+    }
+
+    #[test]
+    fn collapses_runs_of_blank_lines() {
+        similar_asserts::assert_eq!(format("a;\n\n\n\n\nb;\n"), "a;\n\nb;\n");
+    }
+
+    #[test]
+    fn max_blank_lines_is_configurable() {
+        let config = config_with(|config| {
+            config.max_blank_lines = 0;
+        });
+        similar_asserts::assert_eq!(format_with("a;\n\n\nb;\n", &config), "a;\nb;\n");
+    }
+
+    #[test]
+    fn blank_lines_inside_a_delimiter_pair_are_dropped() {
+        similar_asserts::assert_eq!(
+            format("function f() {\n\n  return 1;\n\n}\n"),
+            "function f() {\n  return 1;\n}\n"
+        );
+    }
+
+    #[test]
+    fn leading_blank_lines_are_dropped() {
+        similar_asserts::assert_eq!(format("\n\n\nconst x = 1;\n"), "const x = 1;\n");
+    }
+
+    #[test]
+    fn trailing_blank_lines_collapse_to_one_newline() {
+        similar_asserts::assert_eq!(format("const x = 1;\n\n\n\n"), "const x = 1;\n");
+    }
+
+    // -------------------------------------------------------------- spacing
+
+    #[test]
+    fn normalizes_spacing_around_operators_and_separators() {
+        similar_asserts::assert_eq!(format("const x=a+b*c;\n"), "const x = a + b * c;\n");
+        similar_asserts::assert_eq!(format("f( a ,b );\n"), "f(a, b);\n");
+        similar_asserts::assert_eq!(format("const a=[ 1 ,2 ];\n"), "const a = [1, 2];\n");
+    }
+
+    #[test]
+    fn keeps_unary_operators_attached_to_their_operand() {
+        similar_asserts::assert_eq!(format("const x = - 1;\n"), "const x = -1;\n");
+        similar_asserts::assert_eq!(format("const y = ! ok;\n"), "const y = !ok;\n");
+        similar_asserts::assert_eq!(format("f(... args);\n"), "f(...args);\n");
+        similar_asserts::assert_eq!(format("const z = a - -b;\n"), "const z = a - -b;\n");
+    }
+
+    #[test]
+    fn keeps_increments_attached_to_their_operand() {
+        similar_asserts::assert_eq!(format("for (;;) i ++;\n"), "for (;;) i++;\n");
+        similar_asserts::assert_eq!(format("++ i;\n"), "++i;\n");
+    }
+
+    #[test]
+    fn statement_headers_keep_a_space_before_the_parenthesis() {
+        similar_asserts::assert_eq!(format("if(x){f(y);}\n"), "if (x) { f(y); }\n");
+        similar_asserts::assert_eq!(format("while(x)f();\n"), "while (x) f();\n");
+    }
+
+    #[test]
+    fn for_headers_keep_their_semicolons() {
+        similar_asserts::assert_eq!(
+            format("for(let i=0;i<n;i++){}\n"),
+            "for (let i = 0; i < n; i++) {}\n"
+        );
+        similar_asserts::assert_eq!(format("for( ; ; ){}\n"), "for (;;) {}\n");
+    }
+
+    #[test]
+    fn object_literals_keep_padded_braces_and_arrays_do_not() {
+        similar_asserts::assert_eq!(format("const o={a:1};\n"), "const o = { a: 1 };\n");
+        similar_asserts::assert_eq!(format("const o={};\n"), "const o = {};\n");
+        similar_asserts::assert_eq!(format("const a=[1];\n"), "const a = [1];\n");
+    }
+
+    #[test]
+    fn member_access_and_calls_stay_tight() {
+        similar_asserts::assert_eq!(format("a . b ( c ) [ 0 ];\n"), "a.b(c)[0];\n");
+        similar_asserts::assert_eq!(format("a ?. b;\n"), "a?.b;\n");
+    }
+
+    #[test]
+    fn adjacent_operators_are_never_glued_into_a_different_token() {
+        // Removing these spaces would turn `+ +` into `++` and change the program.
+        for source in [
+            "a + +b;\n",
+            "a - -b;\n",
+            "a + ++b;\n",
+            "a - --b;\n",
+            "a / /re/.source;\n",
+            "a < <T>(x) => x;\n",
+        ] {
+            let output = format(source);
+            assert_token_preserving(source, &output);
+        }
+    }
+
+    #[test]
+    fn closing_type_arguments_may_be_joined_into_one_token() {
+        // `Array<Array<T> >` legally becomes `Array<Array<T>>`; a Flow parser
+        // splits the `>>` again when it closes type arguments.
+        let output = format("type A = Array<Array<Array<T> > >;\n");
+        similar_asserts::assert_eq!(output, "type A = Array<Array<Array<T>>>;\n");
+        assert_token_preserving("type A = Array<Array<Array<T> > >;\n", &output);
+    }
+
+    #[test]
+    fn shift_operators_keep_their_spacing() {
+        similar_asserts::assert_eq!(
+            format("const x = a >> b >>> c << d;\n"),
+            "const x = a >> b >>> c << d;\n"
+        );
+    }
+
+    #[test]
+    fn ternaries_are_spaced_and_object_keys_are_not() {
+        similar_asserts::assert_eq!(format("const x=a?b:c;\n"), "const x = a ? b : c;\n");
+        similar_asserts::assert_eq!(
+            format("const x={k:a?1:2,j:3};\n"),
+            "const x = { k: a ? 1 : 2, j: 3 };\n"
+        );
+    }
+
+    #[test]
+    fn continuation_lines_of_a_call_chain_are_indented() {
+        similar_asserts::assert_eq!(
+            format("promise\n.then(a)\n.catch(b);\n"),
+            "promise\n  .then(a)\n  .catch(b);\n"
+        );
+    }
+
+    #[test]
+    fn switch_cases_sit_one_level_inside_the_switch() {
+        similar_asserts::assert_eq!(
+            format("switch (x) {\ncase 1:\nf();\nbreak;\ndefault:\ng();\n}\n"),
+            "switch (x) {\n  case 1:\n    f();\n    break;\n  default:\n    g();\n}\n"
+        );
+    }
+
+    #[test]
+    fn generator_stars_hug_the_function_keyword() {
+        similar_asserts::assert_eq!(
+            format("function * gen() { yield * other(); }\n"),
+            "function* gen() { yield* other(); }\n"
+        );
+    }
+
+    // ----------------------------------------------------------- flow types
+
+    #[test]
+    fn type_arguments_are_printed_without_spaces() {
+        similar_asserts::assert_eq!(
+            format("const m: Map < string , number > = new Map();\n"),
+            "const m: Map<string, number> = new Map();\n"
+        );
+        similar_asserts::assert_eq!(
+            format("type Nested = Array<Map<string, Array<number>>>;\n"),
+            "type Nested = Array<Map<string, Array<number>>>;\n"
+        );
+    }
+
+    #[test]
+    fn comparisons_are_not_mistaken_for_type_arguments() {
+        similar_asserts::assert_eq!(
+            format("const ok=a<b&&c>d;\n"),
+            "const ok = a < b && c > d;\n"
+        );
+        similar_asserts::assert_eq!(format("if (a<b) f();\n"), "if (a < b) f();\n");
+    }
+
+    #[test]
+    fn nullable_and_optional_flow_markers_hug_their_type() {
+        similar_asserts::assert_eq!(format("type A = ? string;\n"), "type A = ?string;\n");
+        similar_asserts::assert_eq!(
+            format("function f(x ? : ?number) {}\n"),
+            "function f(x?: ?number) {}\n"
+        );
+    }
+
+    #[test]
+    fn exact_object_types_keep_their_pipes_attached() {
+        similar_asserts::assert_eq!(
+            format("type E = {| a: number |};\n"),
+            "type E = {| a: number |};\n"
+        );
+    }
+
+    #[test]
+    fn unions_and_variance_are_spaced_like_operators() {
+        similar_asserts::assert_eq!(format("type U = | A|B & C;\n"), "type U = | A | B & C;\n");
+        similar_asserts::assert_eq!(
+            format("type V = { +read: string, -write: number };\n"),
+            "type V = { +read: string, -write: number };\n"
+        );
+    }
+
+    #[test]
+    fn opaque_types_and_generics_survive() {
+        similar_asserts::assert_eq!(
+            format("opaque type   Id<T> =  Wrapped<T>;\n"),
+            "opaque type Id<T> = Wrapped<T>;\n"
+        );
+    }
+
+    // ------------------------------------------------------------------ jsx
+
+    #[test]
+    fn jsx_attributes_are_normalized_without_spaces_around_equals() {
+        similar_asserts::assert_eq!(
+            format("const a = <div className = \"x\" id={ y } />;\n"),
+            "const a = <div className=\"x\" id={y} />;\n"
+        );
+    }
+
+    #[test]
+    fn jsx_children_keep_their_significant_whitespace() {
+        similar_asserts::assert_eq!(
+            format("const a = <p>hello   world {name} !</p>;\n"),
+            "const a = <p>hello   world {name} !</p>;\n"
+        );
+    }
+
+    #[test]
+    fn jsx_children_are_indented_by_nesting_depth() {
+        similar_asserts::assert_eq!(
+            format("const a = (\n<ul>\n<li>one</li>\n<li>two</li>\n</ul>\n);\n"),
+            "const a = (\n  <ul>\n    <li>one</li>\n    <li>two</li>\n  </ul>\n);\n"
+        );
+    }
+
+    #[test]
+    fn nested_jsx_expression_containers_are_formatted_as_javascript() {
+        similar_asserts::assert_eq!(
+            format("const a = <ul>{items.map((i)=>(<li key={i}>{i}</li>))}</ul>;\n"),
+            "const a = <ul>{items.map((i) => (<li key={i}>{i}</li>))}</ul>;\n"
+        );
+    }
+
+    #[test]
+    fn jsx_text_is_never_reflowed() {
+        let source = "const a = (\n  <p>\n    a long line of prose that would otherwise be wrapped by a formatter\n  </p>\n);\n";
+        similar_asserts::assert_eq!(format(source), source);
+    }
+
+    // -------------------------------------------------------------- quotes
+
+    #[test]
+    fn quotes_are_normalized_to_the_configured_style() {
+        similar_asserts::assert_eq!(format("const s = 'a';\n"), "const s = \"a\";\n");
+        let single = config_with(|config| {
+            config.quotes = QuoteStyle::Single;
+        });
+        similar_asserts::assert_eq!(
+            format_with("const s = \"a\";\n", &single),
+            "const s = 'a';\n"
+        );
+    }
+
+    #[test]
+    fn quotes_are_left_alone_when_converting_would_add_escapes() {
+        similar_asserts::assert_eq!(
+            format("const s = 'say \"hi\"';\n"),
+            "const s = 'say \"hi\"';\n"
+        );
+    }
+
+    #[test]
+    fn template_literals_are_never_requoted() {
+        similar_asserts::assert_eq!(
+            format("const t = `a 'b' \"c\"`;\n"),
+            "const t = `a 'b' \"c\"`;\n"
+        );
+    }
+
+    #[test]
+    fn directives_keep_their_meaning() {
+        similar_asserts::assert_eq!(format("'use client';\nf();\n"), "\"use client\";\nf();\n");
+        similar_asserts::assert_eq!(format("\"use server\"\nf()\n"), "\"use server\";\nf();\n");
+    }
+
+    // ---------------------------------------------------------- semicolons
+
+    #[test]
+    fn missing_statement_semicolons_are_added() {
+        similar_asserts::assert_eq!(
+            format("const x = 1\nconst y = 2\n"),
+            "const x = 1;\nconst y = 2;\n"
+        );
+        similar_asserts::assert_eq!(
+            format("function f() {\n  return 1\n}\n"),
+            "function f() {\n  return 1;\n}\n"
+        );
+    }
+
+    #[test]
+    fn semicolons_are_not_added_where_the_next_line_continues_the_expression() {
+        // `a\n[0]` is a single index expression: a semicolon would change it.
+        similar_asserts::assert_eq!(format("const x = a\n[0].b()\n"), "const x = a\n[0].b();\n");
+        similar_asserts::assert_eq!(format("const x = a\n(0)\n"), "const x = a\n(0);\n");
+        similar_asserts::assert_eq!(format("const x = a\n+ b\n"), "const x = a\n+ b;\n");
+    }
+
+    #[test]
+    fn semicolons_are_not_added_inside_object_literals_or_argument_lists() {
+        similar_asserts::assert_eq!(
+            format("const o = {\n  a: 1,\n  b: 2\n};\n"),
+            "const o = {\n  a: 1,\n  b: 2\n};\n"
+        );
+        similar_asserts::assert_eq!(format("f(\n  a,\n  b\n);\n"), "f(\n  a,\n  b\n);\n");
+    }
+
+    #[test]
+    fn semicolons_are_not_added_after_a_trailing_comment() {
+        similar_asserts::assert_eq!(
+            format("const x = 1 // note\nconst y = 2;\n"),
+            "const x = 1 // note\nconst y = 2;\n"
+        );
+    }
+
+    #[test]
+    fn semicolons_can_be_removed() {
+        let config = config_with(|config| {
+            config.semicolons = false;
+        });
+        similar_asserts::assert_eq!(
+            format_with("const x = 1;\nconst y = 2;\n", &config),
+            "const x = 1\nconst y = 2\n"
+        );
+        similar_asserts::assert_eq!(
+            format_with("for (let i = 0; i < 3; i++) {}\n", &config),
+            "for (let i = 0; i < 3; i++) {}\n"
+        );
+    }
+
+    #[test]
+    fn an_empty_statement_after_a_header_is_never_dropped() {
+        let config = config_with(|config| {
+            config.semicolons = false;
+        });
+        similar_asserts::assert_eq!(format_with("while (f());\n", &config), "while (f());\n");
+    }
+
+    // ------------------------------------------------------------ comments
+
+    #[test]
+    fn comments_are_preserved_verbatim_and_in_place() {
+        let source = "/**\n * Doc comment.\n *   Indented continuation.\n */\nfunction f() {\n  // leading\n  return 1; // trailing\n  /* block */\n}\n";
+        similar_asserts::assert_eq!(format(source), source);
+    }
+
+    #[test]
+    fn a_block_comment_between_tokens_keeps_one_space_on_each_side() {
+        similar_asserts::assert_eq!(
+            format("const x = /* why */ 1;\n"),
+            "const x = /* why */ 1;\n"
+        );
+    }
+
+    // ------------------------------------------------------- line breaking
+
+    #[test]
+    fn long_argument_lists_are_exploded_to_fit_the_line_width() {
+        let config = config_with(|config| {
+            config.line_width = 30;
+        });
+        similar_asserts::assert_eq!(
+            format_with("call(alpha, beta, gamma, delta, epsilon);\n", &config),
+            "call(\n  alpha,\n  beta,\n  gamma,\n  delta,\n  epsilon\n);\n"
+        );
+    }
+
+    #[test]
+    fn short_groups_are_left_on_one_line() {
+        let config = config_with(|config| {
+            config.line_width = 30;
+        });
+        similar_asserts::assert_eq!(format_with("call(a, b);\n", &config), "call(a, b);\n");
+    }
+
+    #[test]
+    fn exploding_a_group_never_adds_a_trailing_comma() {
+        let config = config_with(|config| {
+            config.line_width = 12;
+        });
+        let output = format_with("const xs = [alpha, beta];\n", &config);
+        assert!(!output.contains(",\n]"), "{output}");
+        assert_token_preserving("const xs = [alpha, beta];\n", &output);
+    }
+
+    #[test]
+    fn author_line_breaks_are_preserved() {
+        let source = "const xs = [\n  1,\n  2,\n];\n";
+        similar_asserts::assert_eq!(format(source), source);
+    }
+
+    // ------------------------------------------------------------ encoding
+
+    #[test]
+    fn a_leading_byte_order_mark_is_preserved() {
+        let formatted = format("\u{feff}const x = 1;\n");
+        assert!(formatted.starts_with('\u{feff}'));
+        similar_asserts::assert_eq!(formatted, "\u{feff}const x = 1;\n");
+    }
+
+    #[test]
+    fn crlf_is_normalized_to_lf() {
+        similar_asserts::assert_eq!(
+            format("const x = 1;\r\nconst y = 2;\r\n"),
+            "const x = 1;\nconst y = 2;\n"
+        );
+        similar_asserts::assert_eq!(format("a;\rb;\r"), "a;\nb;\n");
+    }
+
+    #[test]
+    fn multi_byte_characters_are_never_split() {
+        let source = "const s = \"日本語のテキスト 🎉🎈\";\nconst ünïcödé = 1;\n";
+        let formatted = format(source);
+        assert!(formatted.contains("日本語のテキスト 🎉🎈"));
+        assert!(formatted.is_char_boundary(formatted.len()));
+        assert_token_preserving(source, &formatted);
+    }
+
+    #[test]
+    fn non_ascii_widths_are_measured_in_characters() {
+        let config = config_with(|config| {
+            config.line_width = 20;
+        });
+        let formatted = format_with("f(\"日本語日本語日本語\", \"日本語日本語\");\n", &config);
+        assert!(formatted.contains('\n'));
+        assert_token_preserving("f(\"日本語日本語日本語\", \"日本語日本語\");\n", &formatted);
+    }
+
+    // ------------------------------------------------------------- totality
+
+    #[test]
+    fn malformed_input_never_panics_and_stays_token_preserving() {
+        let long_line = format!("const x = [{}];\n", "1, ".repeat(60_000));
+        let deep = {
+            let depth = 10_000;
+            let mut source = String::with_capacity(depth * 2 + 1);
+            for _ in 0..depth {
+                source.push('{');
+            }
+            for _ in 0..depth {
+                source.push('}');
+            }
+            source.push('\n');
+            source
+        };
+        let cases: Vec<String> = vec![
+            "'unterminated".to_string(),
+            "\"unterminated".to_string(),
+            "`unterminated ${".to_string(),
+            "`${`${`${".to_string(),
+            "/* unterminated".to_string(),
+            "/** unterminated".to_string(),
+            "\\".to_string(),
+            "\\\\\\".to_string(),
+            "}}}}".to_string(),
+            "((((".to_string(),
+            "[[[[".to_string(),
+            "<div>".to_string(),
+            "</div>".to_string(),
+            "<div><span></div>".to_string(),
+            "const x = /unterminated".to_string(),
+            "\0\u{1}\u{2}".to_string(),
+            "#!".to_string(),
+            "?:".to_string(),
+            "a\u{2028}b".to_string(),
+            long_line,
+            deep,
+        ];
+
+        for source in &cases {
+            let first = format(source);
+            let second = format(&first);
+            similar_asserts::assert_eq!(first, second, "not idempotent for {source:?}");
+        }
+    }
+
+    #[test]
+    fn a_one_megabyte_single_line_is_formatted() {
+        let source = format!("const x = \"{}\";\n", "a".repeat(1_000_000));
+        let formatted = format(&source);
+        assert_eq!(formatted, source);
+    }
+
+    #[test]
+    fn deeply_nested_indentation_is_capped() {
+        let depth = 2_000;
+        let mut source = String::new();
+        for _ in 0..depth {
+            source.push_str("{\n");
+        }
+        for _ in 0..depth {
+            source.push_str("}\n");
+        }
+        let formatted = format(&source);
+        let widest = formatted
+            .lines()
+            .map(|line| line.len() - line.trim_start().len())
+            .max()
+            .unwrap_or(0);
+        assert!(widest <= 256 * 2, "indent grew to {widest} columns");
+    }
+
+    // -------------------------------------------------------------- errors
+
+    #[test]
+    fn a_zero_indent_width_is_rejected() {
+        let config = config_with(|config| {
+            config.indent_width = 0;
+        });
+        assert_eq!(
+            format_source("x;\n", &config),
+            Err(FormatError::InvalidIndentWidth)
+        );
+    }
+
+    #[test]
+    fn an_oversized_indent_width_is_rejected() {
+        let config = config_with(|config| {
+            config.indent_width = 200;
+        });
+        assert_eq!(
+            format_source("x;\n", &config),
+            Err(FormatError::IndentWidthTooLarge {
+                indent_width: 200,
+                maximum: MAX_INDENT_WIDTH,
+            })
+        );
+    }
+
+    #[test]
+    fn changed_reports_whether_the_output_differs() {
+        let config = FmtConfig::default();
+        assert!(!format_source("const x = 1;\n", &config).unwrap().changed);
+        assert!(format_source("const x = 1;  \n", &config).unwrap().changed);
+    }
+
+    #[test]
+    fn line_endings_are_normalized_before_lexing() {
+        assert_eq!(normalize_line_endings("a\nb"), "a\nb");
+        assert_eq!(normalize_line_endings("a\r\nb"), "a\nb");
+        assert_eq!(normalize_line_endings("a\rb"), "a\nb");
+        assert_eq!(normalize_line_endings("a\r\n\r\nb"), "a\n\nb");
+    }
+
+    #[test]
+    fn the_byte_order_mark_is_split_off_only_at_the_start() {
+        assert_eq!(split_bom("\u{feff}x"), ("\u{feff}", "x"));
+        assert_eq!(split_bom("x\u{feff}"), ("", "x\u{feff}"));
     }
 }

--- a/crates/uf_fmt/src/lib.rs
+++ b/crates/uf_fmt/src/lib.rs
@@ -275,6 +275,35 @@ mod tests {
         );
     }
 
+    /// The weaker guarantee that still holds for input that does not lex cleanly.
+    ///
+    /// Full token preservation cannot: the printer emits exactly one final
+    /// newline, and for a source ending inside an unterminated comment or string
+    /// that newline necessarily lands *inside* that token, changing its text.
+    /// The input was already not valid JavaScript, and the comment stays
+    /// unterminated either way, so that is harmless.
+    ///
+    /// What must still hold is that recovery neither drops nor invents a token,
+    /// which is the failure a formatter could actually cause here.
+    fn assert_token_kinds_preserved(input: &str, output: &str) {
+        use crate::lexer::Punctuator;
+
+        let kinds = |source: &str| -> Vec<TokenKind> {
+            tokenize(source)
+                .into_iter()
+                .map(|token| token.kind)
+                .filter(|kind| {
+                    !kind.is_trivia() && *kind != TokenKind::Punctuator(Punctuator::Semicolon)
+                })
+                .collect()
+        };
+        similar_asserts::assert_eq!(
+            kinds(input),
+            kinds(output),
+            "a token was dropped or invented while formatting {input:?}"
+        );
+    }
+
     fn assert_comments_preserved(input: &str, output: &str) {
         let comments = |source: &str| -> Vec<String> {
             tokenize(source)
@@ -854,6 +883,11 @@ mod tests {
 
         for source in &cases {
             let first = format(source);
+            // Idempotence alone is too weak here: a formatter can make a stable
+            // token-changing rewrite and pass it. Malformed input is exactly
+            // where a recovery path might silently drop or invent a token, so
+            // the stream has to be checked too.
+            assert_token_kinds_preserved(source, &first);
             let second = format(&first);
             similar_asserts::assert_eq!(first, second, "not idempotent for {source:?}");
         }

--- a/crates/uf_fmt/src/lib.rs
+++ b/crates/uf_fmt/src/lib.rs
@@ -54,7 +54,11 @@ pub struct FormatResult {
 }
 
 /// Why a source file could not be formatted.
+///
+/// Non-exhaustive: the formatter grows new guards over time, and a caller that
+/// matches every variant today should not break when the next one lands.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum FormatError {
     /// `indentWidth` was zero, which cannot produce nested indentation.
     #[error("indent width must be greater than zero")]
@@ -188,6 +192,9 @@ pub(crate) const SOURCE_CORPUS: &[&str] = &[
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::lexer::{Token, TokenKind, tokenize};
+    use uf_config::QuoteStyle;
 
     /// A default config with `mutate` applied.
     ///
@@ -198,9 +205,6 @@ mod tests {
         mutate(&mut config);
         config
     }
-    use super::*;
-    use crate::lexer::{Token, TokenKind, tokenize};
-    use uf_config::QuoteStyle;
 
     fn format(source: &str) -> String {
         format_source(source, &FmtConfig::default())

--- a/crates/uf_fmt/src/lib.rs
+++ b/crates/uf_fmt/src/lib.rs
@@ -933,4 +933,80 @@ mod tests {
         assert_eq!(split_bom("\u{feff}x"), ("\u{feff}", "x"));
         assert_eq!(split_bom("x\u{feff}"), ("", "x\u{feff}"));
     }
+
+    /// A body brace after a tuple or array return type is a block, not an object.
+    ///
+    /// The formatter used to read the `{` in
+    /// `hook useX(): [string, () => void] {` as an object literal, because the
+    /// token before it is `]`, and then emitted a `;` after the closing brace —
+    /// a token the input never had. Two golden fixtures had the extra semicolon
+    /// baked in as expected output, which is how it survived: a fixture that
+    /// records a bug turns the bug into the specification.
+    #[test]
+    fn a_body_after_a_tuple_return_type_gains_no_semicolon() {
+        for source in [
+            r#"// @flow
+hook useX(): [string, (next: string) => void] {
+  return ["", () => {}];
+}
+"#,
+            r#"// @flow
+function pair(): [number, number] {
+  return [1, 2];
+}
+"#,
+            r#"// @flow
+function rows(): Array<[string, number]> {
+  return [];
+}
+"#,
+            r#"// @flow
+export function tuple(): [A] {
+  return [a];
+}
+"#,
+        ] {
+            let output = format(source);
+
+            assert_eq!(
+                output.matches(';').count(),
+                source.matches(';').count(),
+                "formatting added or removed a semicolon:\n--- input\n{source}--- output\n{output}"
+            );
+            assert_token_preserving(source, &output);
+        }
+    }
+
+    /// The same shape after an angle-bracket return type, which already worked —
+    /// kept so the two cases cannot drift apart again.
+    #[test]
+    fn a_body_after_a_generic_return_type_gains_no_semicolon() {
+        let source = r#"// @flow
+function load(): Promise<void> {
+  return go();
+}
+"#;
+
+        let output = format(source);
+
+        assert_eq!(output.matches(';').count(), source.matches(';').count());
+        assert_token_preserving(source, &output);
+    }
+
+    /// An object literal directly after `]` is not valid JavaScript, so nothing
+    /// legitimate regresses from treating that brace as a block. An index
+    /// expression followed by a block statement still formats.
+    #[test]
+    fn an_indexed_access_followed_by_a_block_still_formats() {
+        let source = r#"// @flow
+const x = items[0];
+{
+  run();
+}
+"#;
+
+        let output = format(source);
+
+        assert_token_preserving(source, &output);
+    }
 }

--- a/crates/uf_fmt/src/lib.rs
+++ b/crates/uf_fmt/src/lib.rs
@@ -54,23 +54,13 @@ pub struct FormatResult {
 }
 
 /// Why a source file could not be formatted.
-///
-/// Non-exhaustive: the formatter grows new guards over time, and a caller that
-/// matches every variant today should not break when the next one lands.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[non_exhaustive]
 pub enum FormatError {
-    /// `indentWidth` was zero, which cannot produce nested indentation.
-    #[error("indent width must be greater than zero")]
+    /// `indentWidth` was zero, which cannot produce nested indentation, or
+    /// larger than [`MAX_INDENT_WIDTH`], which would let deep nesting emit an
+    /// unbounded amount of leading whitespace.
+    #[error("indent width must be between 1 and {MAX_INDENT_WIDTH}")]
     InvalidIndentWidth,
-    /// `indentWidth` was larger than [`MAX_INDENT_WIDTH`].
-    #[error("indent width {indent_width} exceeds the maximum of {maximum}")]
-    IndentWidthTooLarge {
-        /// The configured width.
-        indent_width: u8,
-        /// The largest accepted width.
-        maximum: u8,
-    },
 }
 
 /// Format one source file.
@@ -81,17 +71,11 @@ pub enum FormatError {
 ///
 /// # Errors
 ///
-/// Returns [`FormatError`] when [`FmtConfig::indent_width`] is zero or larger
-/// than [`MAX_INDENT_WIDTH`].
+/// Returns [`FormatError::InvalidIndentWidth`] when [`FmtConfig::indent_width`]
+/// is zero or larger than [`MAX_INDENT_WIDTH`].
 pub fn format_source(source: &str, config: &FmtConfig) -> Result<FormatResult, FormatError> {
-    if config.indent_width == 0 {
+    if config.indent_width == 0 || config.indent_width > MAX_INDENT_WIDTH {
         return Err(FormatError::InvalidIndentWidth);
-    }
-    if config.indent_width > MAX_INDENT_WIDTH {
-        return Err(FormatError::IndentWidthTooLarge {
-            indent_width: config.indent_width,
-            maximum: MAX_INDENT_WIDTH,
-        });
     }
 
     let (bom, body) = split_bom(source);
@@ -921,11 +905,12 @@ mod tests {
         });
         assert_eq!(
             format_source("x;\n", &config),
-            Err(FormatError::IndentWidthTooLarge {
-                indent_width: 200,
-                maximum: MAX_INDENT_WIDTH,
-            })
+            Err(FormatError::InvalidIndentWidth)
         );
+        let allowed = config_with(|config| {
+            config.indent_width = MAX_INDENT_WIDTH;
+        });
+        assert!(format_source("x;\n", &allowed).is_ok());
     }
 
     #[test]

--- a/crates/uf_fmt/src/printer.rs
+++ b/crates/uf_fmt/src/printer.rs
@@ -423,14 +423,7 @@ fn analyze(source: &str, tokens: &[Token]) -> Analysis {
         let ternary_depth = frames
             .last()
             .map_or(root_ternary, |frame| frame.ternary_depth);
-        let role = role_of(
-            tokens,
-            index,
-            prev,
-            next_significant,
-            ternary_depth,
-            &angles,
-        );
+        let role = role_of(kind, angles[index], prev, next_significant, ternary_depth);
         let space_before = if prev.is_none() {
             false
         } else {
@@ -691,18 +684,15 @@ fn indent_for(
     level.min(MAX_INDENT_LEVELS)
 }
 
-/// Resolve the syntactic role of the token at `index`.
+/// Resolve the syntactic role of a token from its neighbours.
 fn role_of(
-    tokens: &[Token],
-    index: usize,
+    kind: TokenKind,
+    angle: Angle,
     prev: Option<Prev>,
     next: Option<TokenKind>,
     ternary_depth: u32,
-    angles: &[Angle],
 ) -> Role {
-    let kind = tokens[index].kind;
-
-    if angles[index] == Angle::Bracket {
+    if angle == Angle::Bracket {
         return if kind == TokenKind::Punctuator(Punctuator::Less) {
             Role::TypeAngleOpen
         } else {

--- a/crates/uf_fmt/src/printer.rs
+++ b/crates/uf_fmt/src/printer.rs
@@ -1,0 +1,1586 @@
+//! Token-driven printer.
+//!
+//! The printer never reorders, drops or invents program tokens. It rewrites
+//! trivia — indentation, spacing, blank lines — normalizes string quotes, and
+//! adds or removes statement-terminating semicolons under a deliberately
+//! conservative rule. Everything else in the output is the input.
+//!
+//! Layout is produced in two passes over the token stream:
+//!
+//! 1. [`analyze`] walks the tokens once with an explicit frame stack and records,
+//!    for every token, whether a space precedes it, what indentation a line
+//!    starting at it would use, and — for opening delimiters — where the group
+//!    closes and how wide it would print flat.
+//! 2. [`Emitter`] walks the tokens a second time and writes the output, using the
+//!    recorded decisions plus the live column to explode groups that would
+//!    overflow [`FmtConfig::line_width`].
+//!
+//! Both passes use explicit stacks, never recursion, so a source nested ten
+//! thousand braces deep cannot overflow the native stack.
+
+use uf_config::{FmtConfig, QuoteStyle};
+
+use crate::lexer::{
+    BraceKind, GroupKind, Keyword, Prev, Punctuator, Token, TokenKind, classify_brace,
+    expression_allowed,
+};
+
+/// Indentation is capped so that pathological nesting cannot make the printer
+/// allocate an unbounded amount of leading whitespace per line.
+const MAX_INDENT_LEVELS: u16 = 256;
+
+/// Upper bound on how many tokens a speculative type-argument scan may inspect,
+/// which keeps long `a < b` chains from making the scan quadratic.
+const TYPE_ARGUMENT_SCAN_BUDGET: u32 = 4096;
+
+/// Sentinel for "this opening delimiter never closes".
+const NO_MATCH: u32 = u32::MAX;
+
+/// Per-token layout decisions produced by [`analyze`].
+#[derive(Debug, Clone, Copy)]
+struct Anno {
+    /// Whether a single space separates this token from the previous one.
+    space_before: bool,
+    /// Whether this opening delimiter may be exploded across several lines.
+    breakable: bool,
+    /// Whether this whitespace token is significant JSX character data.
+    jsx_space: bool,
+    /// Whether this `)` closes an `if`/`for`/`while`/`catch`/`switch` header.
+    statement_paren: bool,
+    /// Whether this opening delimiter encloses statements rather than operands.
+    statement_group: bool,
+    /// Whether this `}` closes an object literal or object type, which may end a
+    /// statement, rather than a block, which may not.
+    object_close: bool,
+    /// Whether this token sits inside a type-argument list such as `Array<T>`.
+    in_angle: bool,
+    /// Whether this token is still inside a JSX element after it is printed.
+    in_jsx: bool,
+    /// Printed width of the token, measured from its last line.
+    width: u32,
+    /// Whether the token's text spans more than one line.
+    multiline: bool,
+    /// Indentation level to use when this token starts a line.
+    indent: u16,
+    /// Index of the matching closing delimiter, or [`NO_MATCH`].
+    close: u32,
+}
+
+impl Default for Anno {
+    fn default() -> Self {
+        Self {
+            space_before: false,
+            breakable: false,
+            jsx_space: false,
+            statement_paren: false,
+            statement_group: false,
+            object_close: false,
+            in_angle: false,
+            in_jsx: false,
+            width: 0,
+            multiline: false,
+            indent: 0,
+            close: NO_MATCH,
+        }
+    }
+}
+
+/// Everything the emit pass needs to know about the token stream.
+struct Analysis {
+    annos: Vec<Anno>,
+    /// Prefix sums of the flat printed width of each token.
+    cost: Vec<u32>,
+    /// For each index, the index of the next newline token at or after it.
+    line_end: Vec<u32>,
+}
+
+/// Where a token sits relative to a type-argument list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Angle {
+    /// Not part of a type-argument list.
+    No,
+    /// The `<` or `>` of a type-argument list.
+    Bracket,
+    /// A token nested inside a type-argument list.
+    Inside,
+}
+
+/// The syntactic role of a token, which decides the spacing around it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Role {
+    Normal,
+    /// A prefix operator: `!x`, `-1`, `...rest`, `?number`, `+variance`.
+    Prefix,
+    /// The `<` that opens a type-argument list.
+    TypeAngleOpen,
+    /// The `>` (or `>>`) that closes a type-argument list.
+    TypeAngleClose,
+    /// The `:` of a conditional expression.
+    TernaryColon,
+    /// The `?` of `name?: T` or `name?,`.
+    OptionalMarker,
+}
+
+/// A bracketed region tracked while analysing.
+#[derive(Debug, Clone, Copy)]
+struct Frame {
+    kind: FrameKind,
+    open: u32,
+    ternary_depth: u32,
+    /// A newline occurred somewhere inside this group.
+    has_newline: bool,
+    /// A newline occurred at this group's own level rather than inside a nested
+    /// group, which is what earns the group an indentation level.
+    has_own_newline: bool,
+    has_separator: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrameKind {
+    Paren { statement_header: bool },
+    Bracket,
+    Brace(BraceKind),
+    Template,
+    JsxTag { closing: bool },
+    JsxChildren,
+}
+
+impl FrameKind {
+    /// Whether `{ … }` of this flavour keeps a space inside its braces.
+    const fn pads_braces(self) -> bool {
+        matches!(
+            self,
+            FrameKind::Brace(BraceKind::Block | BraceKind::Object | BraceKind::Class)
+        )
+    }
+
+    /// Whether the region holds statements, which may take a semicolon.
+    const fn holds_statements(self) -> bool {
+        matches!(
+            self,
+            FrameKind::Brace(BraceKind::Block | BraceKind::Class | BraceKind::Switch)
+        )
+    }
+
+    const fn is_jsx_children(self) -> bool {
+        matches!(self, FrameKind::JsxChildren)
+    }
+
+    const fn is_jsx_tag(self) -> bool {
+        matches!(self, FrameKind::JsxTag { .. })
+    }
+
+    const fn is_jsx(self) -> bool {
+        self.is_jsx_tag() || self.is_jsx_children()
+    }
+}
+
+/// Lay `tokens` out as freshly formatted source text.
+pub(crate) fn print(source: &str, tokens: &[Token], config: &FmtConfig) -> String {
+    let analysis = analyze(source, tokens);
+    Emitter::new(source, tokens, &analysis, config).run()
+}
+
+// ---------------------------------------------------------------- type angles
+
+/// Mark the tokens that belong to a type-argument list such as `Array<Map<K, V>>`.
+///
+/// Angle brackets are the one place a token-driven formatter has to guess: `a < b`
+/// is a comparison and `A<B>` is a type application, and the two are only told
+/// apart by what surrounds them. The scan therefore starts only after an
+/// identifier, accepts only type-shaped tokens, and commits only when the token
+/// after the closing `>` is one that may legally follow a type.
+fn mark_type_angles(tokens: &[Token]) -> Vec<Angle> {
+    let mut marks = vec![Angle::No; tokens.len()];
+    let mut prev: Option<TokenKind> = None;
+    let mut index = 0;
+
+    while index < tokens.len() {
+        let kind = tokens[index].kind;
+        if kind.is_trivia() {
+            index += 1;
+            continue;
+        }
+
+        if kind == TokenKind::Punctuator(Punctuator::Less)
+            && matches!(prev, Some(TokenKind::Identifier))
+            && let Some(close) = scan_type_arguments(tokens, index)
+        {
+            for (offset, mark) in marks.iter_mut().enumerate().take(close + 1).skip(index) {
+                let is_bracket = matches!(
+                    tokens[offset].kind,
+                    TokenKind::Punctuator(
+                        Punctuator::Less
+                            | Punctuator::Greater
+                            | Punctuator::GreaterGreater
+                            | Punctuator::GreaterGreaterGreater
+                    )
+                );
+                *mark = if is_bracket {
+                    Angle::Bracket
+                } else {
+                    Angle::Inside
+                };
+            }
+            prev = Some(tokens[close].kind);
+            index = close + 1;
+            continue;
+        }
+
+        prev = Some(kind);
+        index += 1;
+    }
+
+    marks
+}
+
+/// Find the `>` that closes the type-argument list opening at `start`.
+fn scan_type_arguments(tokens: &[Token], start: usize) -> Option<usize> {
+    let mut depth: u32 = 1;
+    let mut budget = TYPE_ARGUMENT_SCAN_BUDGET;
+    let mut index = start + 1;
+    let mut saw_content = false;
+
+    while index < tokens.len() {
+        let kind = tokens[index].kind;
+        if kind.is_trivia() {
+            index += 1;
+            continue;
+        }
+        if budget == 0 {
+            return None;
+        }
+        budget -= 1;
+
+        match kind {
+            TokenKind::Identifier | TokenKind::Number | TokenKind::String => saw_content = true,
+            TokenKind::Keyword(
+                Keyword::Typeof
+                | Keyword::Void
+                | Keyword::Null
+                | Keyword::True
+                | Keyword::False
+                | Keyword::This
+                | Keyword::Static
+                | Keyword::Interface,
+            ) => saw_content = true,
+            TokenKind::Punctuator(punctuator) => match punctuator {
+                Punctuator::Less => {
+                    depth += 1;
+                    saw_content = true;
+                }
+                Punctuator::Greater
+                | Punctuator::GreaterGreater
+                | Punctuator::GreaterGreaterGreater => {
+                    let closes = punctuator.angle_close_count();
+                    if closes > depth {
+                        return None;
+                    }
+                    depth -= closes;
+                    if depth == 0 {
+                        if !saw_content {
+                            return None;
+                        }
+                        return type_arguments_may_precede(tokens, index).then_some(index);
+                    }
+                }
+                Punctuator::Dot
+                | Punctuator::Comma
+                | Punctuator::Pipe
+                | Punctuator::Amp
+                | Punctuator::Question
+                | Punctuator::Colon
+                | Punctuator::OpenBracket
+                | Punctuator::CloseBracket
+                | Punctuator::OpenBrace
+                | Punctuator::CloseBrace
+                | Punctuator::OpenParen
+                | Punctuator::CloseParen
+                | Punctuator::Arrow
+                | Punctuator::Ellipsis
+                | Punctuator::Star
+                | Punctuator::Plus
+                | Punctuator::Minus
+                | Punctuator::Equal => saw_content = true,
+                _ => return None,
+            },
+            _ => return None,
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+/// Whether the token after a closing `>` is compatible with a type application.
+fn type_arguments_may_precede(tokens: &[Token], close: usize) -> bool {
+    let Some(next) = tokens[close + 1..]
+        .iter()
+        .find(|token| !token.kind.is_trivia())
+    else {
+        return true;
+    };
+
+    match next.kind {
+        TokenKind::Punctuator(punctuator) => matches!(
+            punctuator,
+            Punctuator::OpenParen
+                | Punctuator::CloseParen
+                | Punctuator::OpenBrace
+                | Punctuator::CloseBrace
+                | Punctuator::OpenBracket
+                | Punctuator::CloseBracket
+                | Punctuator::Comma
+                | Punctuator::Semicolon
+                | Punctuator::Colon
+                | Punctuator::Equal
+                | Punctuator::Arrow
+                | Punctuator::Pipe
+                | Punctuator::Amp
+                | Punctuator::Question
+                | Punctuator::Dot
+                | Punctuator::Ellipsis
+                | Punctuator::Greater
+                | Punctuator::GreaterGreater
+                | Punctuator::GreaterGreaterGreater
+        ),
+        TokenKind::TemplateFull | TokenKind::TemplateHead => true,
+        TokenKind::Keyword(keyword) => matches!(
+            keyword,
+            Keyword::Extends | Keyword::Implements | Keyword::From | Keyword::Renders
+        ),
+        _ => false,
+    }
+}
+
+// -------------------------------------------------------------------- analyze
+
+/// Walk the tokens once and record every layout decision that does not depend on
+/// the output column.
+#[allow(
+    clippy::too_many_lines,
+    reason = "one linear pass over the token kinds"
+)]
+fn analyze(source: &str, tokens: &[Token]) -> Analysis {
+    let count = tokens.len();
+    let angles = mark_type_angles(tokens);
+    let mut annos = vec![Anno::default(); count];
+    let mut cost = vec![0u32; count + 1];
+    let mut line_end = vec![u32::try_from(count).unwrap_or(u32::MAX); count + 1];
+
+    let mut frames: Vec<Frame> = Vec::with_capacity(16);
+    let mut brace_stack: Vec<BraceKind> = Vec::with_capacity(16);
+    let mut indent_level: u16 = 0;
+    let mut jsx_depth: u32 = 0;
+    let mut root_ternary: u32 = 0;
+    let mut switch_depth: u16 = 0;
+    let mut prev: Option<Prev> = None;
+    let mut prev_role = Role::Normal;
+    let mut after_comment = false;
+    let mut pending_body: Option<BraceKind> = None;
+
+    for index in 0..count {
+        let token = tokens[index];
+        let kind = token.kind;
+        let text = token.text(source);
+        let frame = frames.last().copied();
+
+        if kind == TokenKind::Newline {
+            if let Some(frame) = frames.last_mut()
+                && !frame.has_own_newline
+            {
+                frame.has_own_newline = true;
+                indent_level = indent_level.saturating_add(1);
+            }
+            cost[index + 1] = cost[index];
+            after_comment = false;
+            continue;
+        }
+
+        let width = display_width(text);
+        annos[index].width = width;
+        if kind == TokenKind::Whitespace {
+            let jsx_space = frame.is_some_and(|frame| frame.kind.is_jsx_children());
+            annos[index].jsx_space = jsx_space;
+            cost[index + 1] = cost[index] + if jsx_space { width } else { 0 };
+            continue;
+        }
+
+        // A token that spans lines (a multi-line template or block comment) keeps
+        // its group from being reflowed, but does not indent anything.
+        if memchr::memchr(b'\n', text.as_bytes()).is_some() {
+            annos[index].multiline = true;
+            if let Some(frame) = frames.last_mut() {
+                frame.has_newline = true;
+            }
+        }
+
+        let next_significant = tokens[index + 1..]
+            .iter()
+            .find(|token| !token.kind.is_trivia())
+            .map(|token| token.kind);
+        let ternary_depth = frames
+            .last()
+            .map_or(root_ternary, |frame| frame.ternary_depth);
+        let role = role_of(
+            tokens,
+            index,
+            prev,
+            next_significant,
+            ternary_depth,
+            &angles,
+        );
+        let space_before = if prev.is_none() {
+            false
+        } else {
+            (after_comment && !hugs_left(kind)) || wants_space(prev, prev_role, kind, role, frame)
+        };
+
+        annos[index].space_before = space_before;
+        annos[index].in_angle = angles[index] != Angle::No;
+        annos[index].indent = indent_for(kind, next_significant, frame, indent_level, switch_depth);
+        cost[index + 1] = cost[index]
+            .saturating_add(width)
+            .saturating_add(u32::from(space_before));
+
+        // A separator only counts as "top level" when neither a nested group nor
+        // a type-argument list stands between it and the enclosing delimiter.
+        if matches!(
+            kind,
+            TokenKind::Punctuator(Punctuator::Comma | Punctuator::Semicolon)
+        ) && angles[index] == Angle::No
+            && let Some(frame) = frames.last_mut()
+        {
+            frame.has_separator = true;
+        }
+
+        let mut group = GroupKind::None;
+        match kind {
+            TokenKind::Punctuator(Punctuator::OpenParen) => {
+                let statement_header = matches!(
+                    prev.map(|prev| prev.kind),
+                    Some(TokenKind::Keyword(keyword)) if keyword.starts_statement_header()
+                );
+                push_frame(&mut frames, FrameKind::Paren { statement_header }, index);
+            }
+            TokenKind::Punctuator(Punctuator::OpenBracket) => {
+                push_frame(&mut frames, FrameKind::Bracket, index);
+            }
+            TokenKind::Punctuator(Punctuator::OpenBrace) => {
+                let brace = match frame.map(|frame| frame.kind) {
+                    Some(kind) if kind.is_jsx() => BraceKind::JsxExpression,
+                    _ => pending_body
+                        .take()
+                        .unwrap_or_else(|| classify_brace(prev, brace_stack.last().copied())),
+                };
+                brace_stack.push(brace);
+                if brace == BraceKind::Switch {
+                    switch_depth = switch_depth.saturating_add(1);
+                }
+                push_frame(&mut frames, FrameKind::Brace(brace), index);
+            }
+            TokenKind::Punctuator(Punctuator::CloseParen) => {
+                if let Some(frame) = pop_frame(&mut frames, &mut indent_level, &mut jsx_depth) {
+                    annos[index].statement_paren = matches!(
+                        frame.kind,
+                        FrameKind::Paren {
+                            statement_header: true
+                        }
+                    );
+                    close_group(&mut annos, &frame, index, &angles);
+                }
+                group = if annos[index].statement_paren {
+                    GroupKind::StatementParen
+                } else {
+                    GroupKind::ExpressionParen
+                };
+            }
+            TokenKind::Punctuator(Punctuator::CloseBracket) => {
+                if let Some(frame) = pop_frame(&mut frames, &mut indent_level, &mut jsx_depth) {
+                    close_group(&mut annos, &frame, index, &angles);
+                }
+            }
+            TokenKind::Punctuator(Punctuator::CloseBrace) => {
+                let brace = brace_stack.pop().unwrap_or(BraceKind::Block);
+                if brace == BraceKind::Switch {
+                    switch_depth = switch_depth.saturating_sub(1);
+                }
+                annos[index].object_close = brace == BraceKind::Object;
+                if let Some(frame) = pop_frame(&mut frames, &mut indent_level, &mut jsx_depth) {
+                    close_group(&mut annos, &frame, index, &angles);
+                }
+                group = GroupKind::Brace(brace);
+            }
+            TokenKind::TemplateHead => {
+                push_frame(&mut frames, FrameKind::Template, index);
+            }
+            TokenKind::TemplateTail => {
+                pop_frame(&mut frames, &mut indent_level, &mut jsx_depth);
+            }
+            TokenKind::JsxOpenStart => {
+                jsx_depth += 1;
+                push_frame(&mut frames, FrameKind::JsxTag { closing: false }, index);
+            }
+            TokenKind::JsxCloseStart => {
+                jsx_depth += 1;
+                push_frame(&mut frames, FrameKind::JsxTag { closing: true }, index);
+            }
+            TokenKind::JsxTagEnd => {
+                let closing = matches!(
+                    frames.last().map(|frame| frame.kind),
+                    Some(FrameKind::JsxTag { closing: true })
+                );
+                pop_frame(&mut frames, &mut indent_level, &mut jsx_depth);
+                if closing {
+                    pop_frame(&mut frames, &mut indent_level, &mut jsx_depth);
+                } else {
+                    jsx_depth += 1;
+                    push_frame(&mut frames, FrameKind::JsxChildren, index);
+                }
+            }
+            TokenKind::JsxSelfClose => {
+                pop_frame(&mut frames, &mut indent_level, &mut jsx_depth);
+            }
+            TokenKind::Keyword(keyword) => match keyword {
+                Keyword::Class | Keyword::Interface | Keyword::Enum => {
+                    pending_body = Some(BraceKind::Class);
+                }
+                Keyword::Switch => pending_body = Some(BraceKind::Switch),
+                _ => {}
+            },
+            _ => {}
+        }
+
+        annos[index].in_jsx = jsx_depth > 0;
+
+        if role == Role::TernaryColon {
+            match frames.last_mut() {
+                Some(frame) => frame.ternary_depth = frame.ternary_depth.saturating_sub(1),
+                None => root_ternary = root_ternary.saturating_sub(1),
+            }
+        } else if kind == TokenKind::Punctuator(Punctuator::Question)
+            && role == Role::Normal
+            && angles[index] == Angle::No
+        {
+            match frames.last_mut() {
+                Some(frame) => frame.ternary_depth = frame.ternary_depth.saturating_add(1),
+                None => root_ternary = root_ternary.saturating_add(1),
+            }
+        }
+
+        if kind.is_comment() {
+            after_comment = true;
+        } else {
+            after_comment = false;
+            prev = Some(Prev { kind, group });
+            prev_role = role;
+        }
+    }
+
+    for index in (0..count).rev() {
+        line_end[index] = if tokens[index].kind == TokenKind::Newline {
+            u32::try_from(index).unwrap_or(u32::MAX)
+        } else {
+            line_end[index + 1]
+        };
+    }
+
+    Analysis {
+        annos,
+        cost,
+        line_end,
+    }
+}
+
+fn push_frame(frames: &mut Vec<Frame>, kind: FrameKind, open: usize) {
+    frames.push(Frame {
+        kind,
+        open: u32::try_from(open).unwrap_or(NO_MATCH),
+        ternary_depth: 0,
+        has_newline: false,
+        has_own_newline: false,
+        has_separator: false,
+    });
+}
+
+/// Pop the innermost frame, if any.
+///
+/// Unbalanced sources are formatted rather than rejected, so a stray closing
+/// delimiter simply closes whatever frame happens to be open.
+fn pop_frame(
+    frames: &mut Vec<Frame>,
+    indent_level: &mut u16,
+    jsx_depth: &mut u32,
+) -> Option<Frame> {
+    let frame = frames.pop()?;
+    if frame.kind.is_jsx() {
+        *jsx_depth = jsx_depth.saturating_sub(1);
+    }
+    if frame.has_own_newline {
+        *indent_level = indent_level.saturating_sub(1);
+    }
+    // Newlines inside a closed group still count as newlines inside its parent,
+    // which is what makes the parent unbreakable.
+    if let Some(parent) = frames.last_mut() {
+        parent.has_newline |= frame.has_newline || frame.has_own_newline;
+    }
+    Some(frame)
+}
+
+fn close_group(annos: &mut [Anno], frame: &Frame, close: usize, angles: &[Angle]) {
+    let open = frame.open as usize;
+    if open >= annos.len() {
+        return;
+    }
+    annos[open].close = u32::try_from(close).unwrap_or(NO_MATCH);
+    annos[open].statement_group = frame.kind.holds_statements();
+    annos[open].breakable = frame.has_separator
+        && !frame.has_newline
+        && !frame.has_own_newline
+        && !frame.kind.is_jsx()
+        && angles[open] == Angle::No;
+}
+
+/// Indentation level for a line that starts with `kind`.
+fn indent_for(
+    kind: TokenKind,
+    next: Option<TokenKind>,
+    frame: Option<Frame>,
+    indent_level: u16,
+    switch_depth: u16,
+) -> u16 {
+    let top = frame.map(|frame| frame.kind);
+    let dedents = match kind {
+        TokenKind::Punctuator(punctuator) if punctuator.is_close_delimiter() => true,
+        // The trailing `|` of a Flow exact object type belongs to the closing
+        // brace, not to the body.
+        TokenKind::Punctuator(Punctuator::Pipe) => {
+            next == Some(TokenKind::Punctuator(Punctuator::CloseBrace))
+        }
+        TokenKind::JsxTagEnd | TokenKind::JsxSelfClose => top.is_some_and(FrameKind::is_jsx_tag),
+        TokenKind::JsxCloseStart => top.is_some_and(FrameKind::is_jsx_children),
+        TokenKind::TemplateMiddle | TokenKind::TemplateTail => {
+            matches!(top, Some(FrameKind::Template))
+        }
+        _ => false,
+    };
+
+    let innermost_is_switch = matches!(top, Some(FrameKind::Brace(BraceKind::Switch)));
+    // Statements inside a `switch` body sit one level deeper than its `case` and
+    // `default` labels, and the offset accumulates through nested switches.
+    let mut level = indent_level.saturating_add(switch_depth);
+    if innermost_is_switch
+        && (dedents || matches!(kind, TokenKind::Keyword(Keyword::Case | Keyword::Default)))
+    {
+        level = level.saturating_sub(1);
+    }
+
+    if dedents {
+        // Only groups that broke at their own level contributed a level to undo.
+        if frame.is_some_and(|frame| frame.has_own_newline) {
+            level = level.saturating_sub(1);
+        }
+    } else if matches!(
+        kind,
+        TokenKind::Punctuator(Punctuator::Dot | Punctuator::QuestionDot)
+    ) {
+        // A line that starts with `.` continues the previous expression.
+        level = level.saturating_add(1);
+    }
+    level.min(MAX_INDENT_LEVELS)
+}
+
+/// Resolve the syntactic role of the token at `index`.
+fn role_of(
+    tokens: &[Token],
+    index: usize,
+    prev: Option<Prev>,
+    next: Option<TokenKind>,
+    ternary_depth: u32,
+    angles: &[Angle],
+) -> Role {
+    let kind = tokens[index].kind;
+
+    if angles[index] == Angle::Bracket {
+        return if kind == TokenKind::Punctuator(Punctuator::Less) {
+            Role::TypeAngleOpen
+        } else {
+            Role::TypeAngleClose
+        };
+    }
+
+    let TokenKind::Punctuator(punctuator) = kind else {
+        return Role::Normal;
+    };
+
+    match punctuator {
+        Punctuator::Bang | Punctuator::Tilde | Punctuator::Ellipsis | Punctuator::At => {
+            Role::Prefix
+        }
+        // `function* gen()` and `yield* other()` keep the star attached on the
+        // left instead, so they are not prefix operators.
+        Punctuator::Star
+            if matches!(
+                prev.map(|prev| prev.kind),
+                Some(TokenKind::Keyword(Keyword::Function | Keyword::Yield))
+            ) =>
+        {
+            Role::Normal
+        }
+        Punctuator::Plus
+        | Punctuator::Minus
+        | Punctuator::PlusPlus
+        | Punctuator::MinusMinus
+        | Punctuator::Star
+            if expression_allowed(prev) =>
+        {
+            Role::Prefix
+        }
+        Punctuator::Colon => {
+            if ternary_depth > 0 {
+                Role::TernaryColon
+            } else {
+                Role::Normal
+            }
+        }
+        Punctuator::Question => {
+            let optional = matches!(
+                next,
+                Some(TokenKind::Punctuator(
+                    Punctuator::Colon
+                        | Punctuator::Comma
+                        | Punctuator::CloseParen
+                        | Punctuator::CloseBracket
+                        | Punctuator::CloseBrace
+                        | Punctuator::Equal
+                ))
+            );
+            if optional {
+                return Role::OptionalMarker;
+            }
+            // `?string`, `Array<?T>` and `(x: ?number)` are nullable types, so the
+            // `?` is a prefix rather than the head of a conditional expression.
+            let prefix = matches!(
+                prev.map(|prev| prev.kind),
+                Some(TokenKind::Punctuator(
+                    Punctuator::Colon
+                        | Punctuator::Equal
+                        | Punctuator::Pipe
+                        | Punctuator::Amp
+                        | Punctuator::Comma
+                        | Punctuator::OpenParen
+                        | Punctuator::OpenBracket
+                        | Punctuator::Less
+                        | Punctuator::Arrow
+                        | Punctuator::Question
+                        | Punctuator::Ellipsis
+                ))
+            );
+            if prefix { Role::Prefix } else { Role::Normal }
+        }
+        _ => Role::Normal,
+    }
+}
+
+/// Whether a single space separates `prev` from the current token.
+#[allow(clippy::too_many_lines, reason = "a flat table of spacing rules")]
+fn wants_space(
+    prev: Option<Prev>,
+    prev_role: Role,
+    kind: TokenKind,
+    role: Role,
+    frame: Option<Frame>,
+) -> bool {
+    let Some(prev) = prev else {
+        return false;
+    };
+    let prev_kind = prev.kind;
+    let frame_kind = frame.map(|frame| frame.kind);
+
+    // JSX character data carries its own whitespace verbatim.
+    if frame_kind.is_some_and(FrameKind::is_jsx_children) {
+        return false;
+    }
+    if frame_kind.is_some_and(FrameKind::is_jsx_tag) {
+        return jsx_tag_space(prev_kind, kind);
+    }
+
+    // Flow exact object types: `{| … |}`.
+    if prev_kind == TokenKind::Punctuator(Punctuator::OpenBrace)
+        && kind == TokenKind::Punctuator(Punctuator::Pipe)
+    {
+        return false;
+    }
+    if prev_kind == TokenKind::Punctuator(Punctuator::Pipe)
+        && kind == TokenKind::Punctuator(Punctuator::CloseBrace)
+    {
+        return false;
+    }
+
+    if matches!(
+        prev_kind,
+        TokenKind::Punctuator(Punctuator::OpenParen | Punctuator::OpenBracket)
+    ) {
+        return false;
+    }
+    if matches!(
+        kind,
+        TokenKind::Punctuator(Punctuator::CloseParen | Punctuator::CloseBracket)
+    ) {
+        return false;
+    }
+
+    if prev_kind == TokenKind::Punctuator(Punctuator::OpenBrace) {
+        if kind == TokenKind::Punctuator(Punctuator::CloseBrace) {
+            return false;
+        }
+        return frame_kind.is_some_and(FrameKind::pads_braces);
+    }
+    if kind == TokenKind::Punctuator(Punctuator::CloseBrace) {
+        return frame_kind.is_some_and(FrameKind::pads_braces);
+    }
+
+    if matches!(prev_role, Role::Prefix | Role::TypeAngleOpen) {
+        return false;
+    }
+    if matches!(
+        role,
+        Role::TypeAngleOpen | Role::TypeAngleClose | Role::OptionalMarker
+    ) {
+        return false;
+    }
+    // `useState<number>(0)` and `Array<T>[]` keep the call or index attached to
+    // the closing angle bracket; everything else after `>` is spaced normally.
+    if prev_role == Role::TypeAngleClose
+        && matches!(
+            kind,
+            TokenKind::Punctuator(Punctuator::OpenParen | Punctuator::OpenBracket)
+                | TokenKind::TemplateFull
+                | TokenKind::TemplateHead
+        )
+    {
+        return false;
+    }
+    if matches!(
+        prev_kind,
+        TokenKind::Punctuator(Punctuator::Dot | Punctuator::QuestionDot)
+            | TokenKind::TemplateHead
+            | TokenKind::TemplateMiddle
+    ) {
+        return false;
+    }
+
+    match kind {
+        TokenKind::Punctuator(
+            Punctuator::Comma | Punctuator::Semicolon | Punctuator::Dot | Punctuator::QuestionDot,
+        ) => false,
+        TokenKind::Punctuator(Punctuator::Colon) => role == Role::TernaryColon,
+        TokenKind::TemplateMiddle | TokenKind::TemplateTail => false,
+        TokenKind::Punctuator(Punctuator::OpenParen) => !callable_prefix(prev_kind),
+        TokenKind::Punctuator(Punctuator::OpenBracket)
+        | TokenKind::TemplateFull
+        | TokenKind::TemplateHead
+        | TokenKind::Punctuator(Punctuator::PlusPlus | Punctuator::MinusMinus) => {
+            !indexable_prefix(prev_kind)
+        }
+        TokenKind::Punctuator(Punctuator::Star) => !matches!(
+            prev_kind,
+            TokenKind::Keyword(Keyword::Function | Keyword::Yield)
+        ),
+        _ => true,
+    }
+}
+
+/// Whether a token always sits flush against whatever precedes it, so that a
+/// preceding comment does not force a space in front of it.
+fn hugs_left(kind: TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::Punctuator(
+            Punctuator::CloseParen
+                | Punctuator::CloseBracket
+                | Punctuator::Comma
+                | Punctuator::Semicolon
+                | Punctuator::Dot
+                | Punctuator::QuestionDot
+        ) | TokenKind::JsxTagEnd
+            | TokenKind::JsxSelfClose
+    )
+}
+
+/// Spacing rules inside a JSX tag, where `=` binds attributes tightly.
+fn jsx_tag_space(prev_kind: TokenKind, kind: TokenKind) -> bool {
+    if matches!(
+        prev_kind,
+        TokenKind::JsxOpenStart | TokenKind::JsxCloseStart
+    ) {
+        return false;
+    }
+    if kind == TokenKind::JsxTagEnd {
+        return false;
+    }
+    if kind == TokenKind::Punctuator(Punctuator::Equal)
+        || prev_kind == TokenKind::Punctuator(Punctuator::Equal)
+    {
+        return false;
+    }
+    if prev_kind == TokenKind::Punctuator(Punctuator::OpenBrace)
+        || kind == TokenKind::Punctuator(Punctuator::CloseBrace)
+        || prev_kind == TokenKind::Punctuator(Punctuator::Slash)
+    {
+        return false;
+    }
+    true
+}
+
+/// Whether `(` directly after this token is a call rather than a grouping.
+fn callable_prefix(kind: TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::Identifier
+            | TokenKind::PrivateName
+            | TokenKind::Punctuator(Punctuator::CloseParen | Punctuator::CloseBracket)
+            | TokenKind::Keyword(Keyword::Super | Keyword::Import)
+    )
+}
+
+/// Whether `[` directly after this token is an index rather than a literal.
+fn indexable_prefix(kind: TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::Identifier
+            | TokenKind::PrivateName
+            | TokenKind::Number
+            | TokenKind::String
+            | TokenKind::TemplateFull
+            | TokenKind::TemplateTail
+            | TokenKind::Punctuator(Punctuator::CloseParen | Punctuator::CloseBracket)
+            | TokenKind::Keyword(Keyword::This | Keyword::Super)
+    )
+}
+
+/// Printed width of a token, measured from the last line it covers.
+fn display_width(text: &str) -> u32 {
+    let tail = match memchr::memrchr(b'\n', text.as_bytes()) {
+        Some(offset) => &text[offset + 1..],
+        None => text,
+    };
+    // Source is overwhelmingly ASCII, where the byte length is the width.
+    let width = if tail.is_ascii() {
+        tail.len()
+    } else {
+        tail.chars().count()
+    };
+    u32::try_from(width).unwrap_or(u32::MAX)
+}
+
+// ----------------------------------------------------------------- emit pass
+
+/// A bracketed group that is currently open in the output.
+#[derive(Debug, Clone, Copy)]
+struct OpenGroup {
+    close: u32,
+    broken: bool,
+    statements: bool,
+}
+
+struct Emitter<'a> {
+    source: &'a str,
+    tokens: &'a [Token],
+    analysis: &'a Analysis,
+    indent_width: usize,
+    line_width: u32,
+    quotes: QuoteStyle,
+    semicolons: bool,
+    max_blank_lines: usize,
+    out: String,
+    indent_cache: String,
+    column: u32,
+    pending_newlines: usize,
+    pending_jsx_space: Option<usize>,
+    groups: Vec<OpenGroup>,
+    /// How many currently open groups the printer exploded itself. The analysis
+    /// pass could not know about those, so their indentation is added here.
+    broken_depth: u16,
+    prev_emitted: Option<usize>,
+    prev_significant: Option<usize>,
+    started: bool,
+}
+
+impl<'a> Emitter<'a> {
+    fn new(
+        source: &'a str,
+        tokens: &'a [Token],
+        analysis: &'a Analysis,
+        config: &FmtConfig,
+    ) -> Self {
+        Self {
+            source,
+            tokens,
+            analysis,
+            indent_width: usize::from(config.indent_width),
+            line_width: u32::from(config.line_width),
+            quotes: config.quotes,
+            semicolons: config.semicolons,
+            max_blank_lines: usize::from(config.max_blank_lines),
+            out: String::with_capacity(source.len() + source.len() / 8 + 16),
+            indent_cache: String::new(),
+            column: 0,
+            pending_newlines: 0,
+            pending_jsx_space: None,
+            groups: Vec::with_capacity(16),
+            broken_depth: 0,
+            prev_emitted: None,
+            prev_significant: None,
+            started: false,
+        }
+    }
+
+    fn run(mut self) -> String {
+        for index in 0..self.tokens.len() {
+            match self.tokens[index].kind {
+                TokenKind::Newline => {
+                    self.pending_newlines += 1;
+                    self.pending_jsx_space = None;
+                }
+                TokenKind::Whitespace => {
+                    if self.analysis.annos[index].jsx_space && self.pending_newlines == 0 {
+                        self.pending_jsx_space = Some(index);
+                    }
+                }
+                _ => self.emit(index),
+            }
+        }
+
+        if self.semicolons && self.needs_semicolon(None) {
+            self.out.push(';');
+        }
+        if !self.out.is_empty() && !self.out.ends_with('\n') {
+            self.out.push('\n');
+        }
+        self.out
+    }
+
+    /// Append text whose printed width is already known.
+    fn write_measured(&mut self, text: &str, width: u32, multiline: bool) {
+        self.out.push_str(text);
+        self.column = if multiline {
+            width
+        } else {
+            self.column.saturating_add(width)
+        };
+    }
+
+    fn write(&mut self, text: &str) {
+        let multiline = memchr::memchr(b'\n', text.as_bytes()).is_some();
+        self.write_measured(text, display_width(text), multiline);
+    }
+
+    fn write_indent(&mut self, level: u16) {
+        let width = usize::from(level) * self.indent_width;
+        while self.indent_cache.len() < width {
+            self.indent_cache.push(' ');
+        }
+        self.out.push_str(&self.indent_cache[..width]);
+        self.column = u32::try_from(width).unwrap_or(u32::MAX);
+    }
+
+    fn emit(&mut self, index: usize) {
+        let token = self.tokens[index];
+
+        if token.kind == TokenKind::Punctuator(Punctuator::Semicolon)
+            && !self.semicolons
+            && self.can_drop_semicolon(index)
+        {
+            return;
+        }
+
+        self.open_line(index);
+
+        let text = token.text(self.source);
+        let rewritten = match token.kind {
+            TokenKind::String => requote(text, self.quotes),
+            TokenKind::JsxString => requote_jsx(text, self.quotes),
+            _ => None,
+        };
+        match rewritten {
+            Some(rewritten) => self.write(&rewritten),
+            None => {
+                let anno = self.analysis.annos[index];
+                self.write_measured(text, anno.width, anno.multiline);
+            }
+        }
+
+        self.prev_emitted = Some(index);
+        if !token.kind.is_comment() {
+            self.prev_significant = Some(index);
+        }
+
+        self.update_groups(index);
+    }
+
+    /// Emit whatever separates this token from the previous one: newlines and
+    /// indentation, a single space, or nothing at all.
+    fn open_line(&mut self, index: usize) {
+        let anno = self.analysis.annos[index];
+
+        if !self.started {
+            self.started = true;
+            self.pending_newlines = 0;
+            self.pending_jsx_space = None;
+            let indent = self.indent_of(index);
+            if indent > 0 {
+                self.write_indent(indent);
+            }
+            return;
+        }
+
+        if self.pending_newlines > 0 {
+            if self.semicolons && self.needs_semicolon(Some(index)) {
+                self.out.push(';');
+                self.column = self.column.saturating_add(1);
+            }
+            let mut count = self.pending_newlines.min(self.max_blank_lines + 1);
+            if self.hugs_a_delimiter(index) {
+                count = 1;
+            }
+            for _ in 0..count {
+                self.out.push('\n');
+            }
+            self.column = 0;
+            self.pending_newlines = 0;
+            self.pending_jsx_space = None;
+            let indent = self.indent_of(index);
+            self.write_indent(indent);
+            return;
+        }
+
+        if let Some(space) = self.pending_jsx_space.take() {
+            let text = self.tokens[space].text(self.source);
+            self.write(text);
+            return;
+        }
+
+        if anno.space_before {
+            self.out.push(' ');
+            self.column = self.column.saturating_add(1);
+        }
+    }
+
+    /// Indentation for a line starting at `index`, including the levels added by
+    /// groups this printer exploded on its own.
+    fn indent_of(&self, index: usize) -> u16 {
+        let mut extra = self.broken_depth;
+        if self
+            .groups
+            .last()
+            .is_some_and(|group| group.broken && group.close as usize == index)
+        {
+            extra = extra.saturating_sub(1);
+        }
+        self.analysis.annos[index]
+            .indent
+            .saturating_add(extra)
+            .min(MAX_INDENT_LEVELS)
+    }
+
+    /// Blank lines are dropped directly inside a delimiter pair.
+    fn hugs_a_delimiter(&self, index: usize) -> bool {
+        let opens = matches!(
+            self.prev_emitted.map(|prev| self.tokens[prev].kind),
+            Some(TokenKind::Punctuator(punctuator)) if punctuator.is_open_delimiter()
+        );
+        let closes = matches!(
+            self.tokens[index].kind,
+            TokenKind::Punctuator(punctuator) if punctuator.is_close_delimiter()
+        );
+        opens || closes
+    }
+
+    fn update_groups(&mut self, index: usize) {
+        let kind = self.tokens[index].kind;
+        let anno = self.analysis.annos[index];
+
+        if matches!(kind, TokenKind::Punctuator(punctuator) if punctuator.is_close_delimiter()) {
+            if self
+                .groups
+                .last()
+                .is_some_and(|group| group.close as usize == index)
+                && let Some(group) = self.groups.pop()
+                && group.broken
+            {
+                self.broken_depth = self.broken_depth.saturating_sub(1);
+            }
+        } else if matches!(kind, TokenKind::Punctuator(punctuator) if punctuator.is_open_delimiter())
+        {
+            let broken = anno.breakable && anno.close != NO_MATCH && !self.group_fits(index, anno);
+            self.groups.push(OpenGroup {
+                close: anno.close,
+                broken,
+                statements: anno.statement_group,
+            });
+            if broken {
+                self.broken_depth = self.broken_depth.saturating_add(1);
+                self.pending_newlines = 1;
+            }
+        } else if matches!(
+            kind,
+            TokenKind::Punctuator(Punctuator::Comma | Punctuator::Semicolon)
+        ) && !anno.in_angle
+            && self.groups.last().is_some_and(|group| group.broken)
+        {
+            // Inside a group we exploded ourselves, every top-level separator
+            // starts a new line.
+            self.pending_newlines = 1;
+        }
+
+        if let Some(group) = self.groups.last()
+            && group.broken
+            && group.close != NO_MATCH
+            && self.next_significant(index) == Some(group.close as usize)
+        {
+            self.pending_newlines = self.pending_newlines.max(1);
+        }
+    }
+
+    /// Whether the group opening at `index` still fits on the current line.
+    fn group_fits(&self, index: usize, anno: Anno) -> bool {
+        if self.line_width == 0 {
+            return true;
+        }
+        let close = anno.close as usize;
+        let stop = usize::min(
+            self.analysis.line_end[close] as usize,
+            self.analysis.cost.len() - 1,
+        );
+        let span = self.analysis.cost[stop].saturating_sub(self.analysis.cost[index + 1]);
+        self.column.saturating_add(span) <= self.line_width
+    }
+
+    fn next_significant(&self, index: usize) -> Option<usize> {
+        self.tokens[index + 1..]
+            .iter()
+            .position(|token| !token.kind.is_trivia())
+            .map(|offset| index + 1 + offset)
+    }
+
+    /// Whether a statement-terminating semicolon should be written before the
+    /// token at `next`, which is `None` at the end of the file.
+    ///
+    /// The rule is deliberately conservative. Automatic semicolon insertion only
+    /// fires when the next line cannot continue the current expression, so a next
+    /// token such as `(`, `[`, `` ` `` or an operator blocks insertion: writing a
+    /// semicolon there would change what the program means.
+    fn needs_semicolon(&self, next: Option<usize>) -> bool {
+        // Never write a semicolon after a comment; it would land outside the
+        // statement it is meant to terminate.
+        if self
+            .prev_emitted
+            .is_some_and(|index| self.tokens[index].kind.is_comment())
+        {
+            return false;
+        }
+        let Some(prev) = self.prev_significant else {
+            return false;
+        };
+        let prev_kind = self.tokens[prev].kind;
+        let ends_statement = ends_a_statement(prev_kind)
+            || (prev_kind == TokenKind::Punctuator(Punctuator::CloseBrace)
+                && self.analysis.annos[prev].object_close);
+        if !ends_statement || self.analysis.annos[prev].in_jsx {
+            return false;
+        }
+        if !self.in_statement_position() {
+            return false;
+        }
+        // A comment sitting between two statements must not hide the statement
+        // that follows it.
+        let next = next.and_then(|index| self.next_program_token(index));
+        match next {
+            None => true,
+            Some(index) => starts_a_statement(self.tokens[index].kind),
+        }
+    }
+
+    /// The token at `index`, or the first non-comment token after it.
+    fn next_program_token(&self, index: usize) -> Option<usize> {
+        self.tokens[index..]
+            .iter()
+            .position(|token| !token.kind.is_trivia())
+            .map(|offset| index + offset)
+    }
+
+    /// Whether the innermost open group holds statements: the file itself, a
+    /// block, a class body or a switch body. Parenthesised groups have no
+    /// statements and object literals separate their members with commas.
+    fn in_statement_position(&self) -> bool {
+        self.groups.last().is_none_or(|group| group.statements)
+    }
+
+    /// Whether a `;` may be removed when semicolons are switched off.
+    fn can_drop_semicolon(&self, index: usize) -> bool {
+        let Some(prev) = self.prev_significant else {
+            return false;
+        };
+        let prev_kind = self.tokens[prev].kind;
+        // A `}` cannot gain a synthesized semicolon, because a block must not get
+        // one, but an existing `};` after an object or class may be dropped.
+        if !ends_a_statement(prev_kind)
+            && prev_kind != TokenKind::Punctuator(Punctuator::CloseBrace)
+        {
+            return false;
+        }
+        // `if (x);` is an empty statement: dropping the `;` would adopt the next
+        // statement as the body.
+        if prev_kind == TokenKind::Punctuator(Punctuator::CloseParen)
+            && self.analysis.annos[prev].statement_paren
+        {
+            return false;
+        }
+        if !self.in_statement_position() {
+            return false;
+        }
+        match self.next_significant(index) {
+            None => true,
+            Some(next) => starts_a_statement(self.tokens[next].kind),
+        }
+    }
+}
+
+/// Whether a statement may end with this token.
+fn ends_a_statement(kind: TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::Identifier
+            | TokenKind::PrivateName
+            | TokenKind::Number
+            | TokenKind::String
+            | TokenKind::Regex
+            | TokenKind::TemplateFull
+            | TokenKind::TemplateTail
+            | TokenKind::JsxTagEnd
+            | TokenKind::JsxSelfClose
+            | TokenKind::Punctuator(
+                Punctuator::CloseParen
+                    | Punctuator::CloseBracket
+                    | Punctuator::PlusPlus
+                    | Punctuator::MinusMinus
+            )
+            | TokenKind::Keyword(
+                Keyword::This
+                    | Keyword::Super
+                    | Keyword::Null
+                    | Keyword::True
+                    | Keyword::False
+                    | Keyword::Break
+                    | Keyword::Continue
+                    | Keyword::Return
+                    | Keyword::Debugger
+            )
+    )
+}
+
+/// Whether a new statement may begin with this token.
+///
+/// Everything that could instead continue the previous expression — `(`, `[`, a
+/// template literal, an operator, `in`/`of`/`instanceof` — is excluded, which is
+/// exactly the set of tokens for which automatic semicolon insertion does not
+/// fire.
+fn starts_a_statement(kind: TokenKind) -> bool {
+    match kind {
+        TokenKind::Identifier | TokenKind::PrivateName => true,
+        TokenKind::Keyword(keyword) => !matches!(
+            keyword,
+            Keyword::In
+                | Keyword::Of
+                | Keyword::Instanceof
+                | Keyword::Extends
+                | Keyword::As
+                | Keyword::From
+                | Keyword::Implements
+                | Keyword::Mixins
+                | Keyword::Renders
+        ),
+        TokenKind::Punctuator(punctuator) => matches!(
+            punctuator,
+            Punctuator::OpenBrace | Punctuator::CloseBrace | Punctuator::At
+        ),
+        _ => false,
+    }
+}
+
+// ------------------------------------------------------------ quote handling
+
+/// Rewrite a string literal into the configured quote style, but only when that
+/// does not require more escaping than the original spelling.
+fn requote(text: &str, style: QuoteStyle) -> Option<String> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 2 {
+        return None;
+    }
+    let quote = bytes[0];
+    if (quote != b'\'' && quote != b'"') || bytes[bytes.len() - 1] != quote {
+        return None;
+    }
+
+    let body = &text[1..text.len() - 1];
+    let (mut doubles, mut singles) = (0usize, 0usize);
+    let mut chars = body.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => match chars.next() {
+                Some('"') => doubles += 1,
+                Some('\'') => singles += 1,
+                _ => {}
+            },
+            '"' => doubles += 1,
+            '\'' => singles += 1,
+            _ => {}
+        }
+    }
+
+    let chosen = match style {
+        QuoteStyle::Double if doubles > singles => '\'',
+        QuoteStyle::Double => '"',
+        QuoteStyle::Single if singles > doubles => '"',
+        QuoteStyle::Single => '\'',
+    };
+    if chosen as u8 == quote {
+        return None;
+    }
+
+    let mut rewritten = String::with_capacity(text.len() + 4);
+    rewritten.push(chosen);
+    let mut chars = body.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next() {
+                None => rewritten.push('\\'),
+                Some(next) => {
+                    // An escaped quote that is no longer the delimiter can drop
+                    // its backslash; every other escape is copied verbatim.
+                    if (next == '"' || next == '\'') && next != chosen {
+                        rewritten.push(next);
+                    } else {
+                        rewritten.push('\\');
+                        rewritten.push(next);
+                    }
+                }
+            }
+        } else if ch == chosen {
+            rewritten.push('\\');
+            rewritten.push(chosen);
+        } else {
+            rewritten.push(ch);
+        }
+    }
+    rewritten.push(chosen);
+    Some(rewritten)
+}
+
+/// JSX attribute strings have no escape sequences, so they may only be requoted
+/// when the body does not contain the target quote at all.
+fn requote_jsx(text: &str, style: QuoteStyle) -> Option<String> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 2 {
+        return None;
+    }
+    let quote = bytes[0];
+    if (quote != b'\'' && quote != b'"') || bytes[bytes.len() - 1] != quote {
+        return None;
+    }
+    let target = match style {
+        QuoteStyle::Double => b'"',
+        QuoteStyle::Single => b'\'',
+    };
+    if target == quote {
+        return None;
+    }
+    let body = &text[1..text.len() - 1];
+    if body.as_bytes().contains(&target) {
+        return None;
+    }
+    let mut rewritten = String::with_capacity(text.len());
+    rewritten.push(char::from(target));
+    rewritten.push_str(body);
+    rewritten.push(char::from(target));
+    Some(rewritten)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_quotes_become_double_quotes() {
+        assert_eq!(requote("'a'", QuoteStyle::Double).as_deref(), Some("\"a\""));
+    }
+
+    #[test]
+    fn already_preferred_quotes_are_left_alone() {
+        assert_eq!(requote("\"a\"", QuoteStyle::Double), None);
+        assert_eq!(requote("'a'", QuoteStyle::Single), None);
+    }
+
+    #[test]
+    fn a_string_full_of_double_quotes_keeps_single_quotes() {
+        assert_eq!(requote("'say \"hi\"'", QuoteStyle::Double), None);
+    }
+
+    #[test]
+    fn converting_drops_now_redundant_escapes() {
+        assert_eq!(
+            requote("'it\\'s'", QuoteStyle::Double).as_deref(),
+            Some("\"it's\"")
+        );
+    }
+
+    #[test]
+    fn converting_adds_escapes_only_when_it_does_not_lose_ground() {
+        // One of each: the preferred quote wins and the escape count is unchanged.
+        assert_eq!(
+            requote("'a\"b\\'c'", QuoteStyle::Double).as_deref(),
+            Some("\"a\\\"b'c\"")
+        );
+    }
+
+    #[test]
+    fn other_escapes_survive_requoting() {
+        assert_eq!(
+            requote("'a\\nb\\u0041\\\\'", QuoteStyle::Double).as_deref(),
+            Some("\"a\\nb\\u0041\\\\\"")
+        );
+    }
+
+    #[test]
+    fn line_continuations_survive_requoting() {
+        assert_eq!(
+            requote("'a\\\nb'", QuoteStyle::Double).as_deref(),
+            Some("\"a\\\nb\"")
+        );
+    }
+
+    #[test]
+    fn requoting_ignores_malformed_literals() {
+        assert_eq!(requote("'", QuoteStyle::Double), None);
+        assert_eq!(requote("'abc", QuoteStyle::Double), None);
+        assert_eq!(requote("", QuoteStyle::Double), None);
+    }
+
+    #[test]
+    fn jsx_strings_are_requoted_only_when_no_escape_would_be_needed() {
+        assert_eq!(
+            requote_jsx("'a'", QuoteStyle::Double).as_deref(),
+            Some("\"a\"")
+        );
+        assert_eq!(requote_jsx("'a\"b'", QuoteStyle::Double), None);
+    }
+
+    #[test]
+    fn display_width_counts_characters_after_the_last_newline() {
+        assert_eq!(display_width("abc"), 3);
+        assert_eq!(display_width("ab\ncde"), 3);
+        assert_eq!(display_width("日本"), 2);
+    }
+}

--- a/crates/uf_fmt/tests/fixtures.rs
+++ b/crates/uf_fmt/tests/fixtures.rs
@@ -1,0 +1,274 @@
+//! Golden-file tests for the native formatter.
+//!
+//! Every `<name>.input.js` under `tests/fixtures/` is formatted and compared to
+//! `<name>.expected.js`. On top of the golden comparison each fixture is checked
+//! against the three invariants the formatter promises: the lexer round-trips the
+//! bytes, formatting is idempotent, and the token stream survives untouched.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use uf_config::{FmtConfig, QuoteStyle};
+use uf_fmt::format_source;
+use uf_fmt::lexer::{Punctuator, Token, TokenKind, tokenize};
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+/// A default config with  applied.
+///
+///  is , because every feature that lands adds a
+/// knob to it and a struct literal would break on each one.
+fn config_with(mutate: impl FnOnce(&mut FmtConfig)) -> FmtConfig {
+    let mut config = FmtConfig::default();
+    mutate(&mut config);
+    config
+}
+
+/// Fixtures whose name carries a non-default configuration.
+fn config_for(name: &str) -> FmtConfig {
+    match name {
+        "config_single_quotes" => config_with(|config| {
+            config.quotes = QuoteStyle::Single;
+        }),
+        "config_no_semicolons" => config_with(|config| {
+            config.semicolons = false;
+        }),
+        "config_wide_indent" => config_with(|config| {
+            config.indent_width = 4;
+            config.max_blank_lines = 0;
+        }),
+        "config_narrow_lines" => config_with(|config| {
+            config.line_width = 40;
+        }),
+        _ => FmtConfig::default(),
+    }
+}
+
+/// Every fixture, keyed by name, as `(input, expected)` pairs.
+fn fixtures() -> BTreeMap<String, (String, String)> {
+    let dir = fixtures_dir();
+    let entries = fs::read_dir(&dir)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", dir.display()));
+
+    let mut fixtures = BTreeMap::new();
+    for entry in entries {
+        let path = entry.expect("readable directory entry").path();
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+        let Some(name) = file_name.strip_suffix(".input.js") else {
+            continue;
+        };
+        let expected_path = dir.join(format!("{name}.expected.js"));
+        let expected = fs::read_to_string(&expected_path).unwrap_or_else(|error| {
+            panic!("missing {}: {error}", expected_path.display());
+        });
+        let input = fs::read_to_string(&path).expect("readable fixture input");
+        fixtures.insert(name.to_string(), (input, expected));
+    }
+
+    assert!(
+        !fixtures.is_empty(),
+        "no fixtures found in {}",
+        dir.display()
+    );
+    fixtures
+}
+
+/// Canonical spelling of a token, so a requoted string still compares equal.
+fn canonical(token: Token, source: &str) -> String {
+    let text = token.text(source);
+    match token.kind {
+        TokenKind::String | TokenKind::JsxString => {
+            let body = text
+                .strip_prefix(['\'', '"'])
+                .and_then(|rest| rest.strip_suffix(['\'', '"']))
+                .unwrap_or(text);
+            let mut canonical = String::with_capacity(body.len());
+            let mut chars = body.chars();
+            while let Some(ch) = chars.next() {
+                if ch == '\\' {
+                    match chars.next() {
+                        Some(next @ ('"' | '\'')) => canonical.push(next),
+                        Some(next) => {
+                            canonical.push('\\');
+                            canonical.push(next);
+                        }
+                        None => canonical.push('\\'),
+                    }
+                } else {
+                    canonical.push(ch);
+                }
+            }
+            canonical
+        }
+        _ => text.to_string(),
+    }
+}
+
+/// Expand `>>`/`>>>` into the individual `>` characters they stand for.
+///
+/// Removing the space in `Array<Map<K, V> >` produces `Array<Map<K, V>>`, which
+/// the lexer reads back as one shift-shaped token even though a Flow parser
+/// splits it again when it closes type arguments. Comparing at the `>` character
+/// level keeps that legal rewrite from tripping the token-preservation check
+/// without weakening it: the printer never inserts characters inside a token, so
+/// the count can only ever be preserved.
+fn expand_angles(kind: TokenKind, text: String, out: &mut Vec<(TokenKind, String)>) {
+    let repeats = match kind {
+        TokenKind::Punctuator(Punctuator::Greater) => 1,
+        TokenKind::Punctuator(Punctuator::GreaterGreater) => 2,
+        TokenKind::Punctuator(Punctuator::GreaterGreaterGreater) => 3,
+        _ => {
+            out.push((kind, text));
+            return;
+        }
+    };
+    for _ in 0..repeats {
+        out.push((TokenKind::Punctuator(Punctuator::Greater), ">".to_string()));
+    }
+}
+
+/// The tokens the formatter is not allowed to touch: everything except trivia
+/// and statement-terminating semicolons.
+fn program_tokens(source: &str) -> Vec<(TokenKind, String)> {
+    let mut tokens = Vec::new();
+    for token in tokenize(source) {
+        if token.kind.is_trivia() || token.kind == TokenKind::Punctuator(Punctuator::Semicolon) {
+            continue;
+        }
+        expand_angles(token.kind, canonical(token, source), &mut tokens);
+    }
+    tokens
+}
+
+fn comments(source: &str) -> Vec<String> {
+    tokenize(source)
+        .into_iter()
+        .filter(|token| token.kind.is_comment())
+        .map(|token| token.text(source).to_string())
+        .collect()
+}
+
+/// Set `UF_FMT_BLESS=1` to rewrite the `.expected.js` files from the current
+/// formatter output. Review the diff before committing it.
+fn blessing() -> bool {
+    std::env::var_os("UF_FMT_BLESS").is_some()
+}
+
+#[test]
+fn fixtures_match_their_expected_output() {
+    let dir = fixtures_dir();
+    for (name, (input, expected)) in fixtures() {
+        let result = format_source(&input, &config_for(&name)).expect("fixture formats");
+        if blessing() {
+            fs::write(dir.join(format!("{name}.expected.js")), &result.output)
+                .expect("writable fixture");
+            continue;
+        }
+        similar_asserts::assert_eq!(result.output, expected, "fixture {name} formatted wrong");
+    }
+    assert!(
+        !blessing(),
+        "fixtures were rewritten; rerun without UF_FMT_BLESS"
+    );
+}
+
+#[test]
+fn fixtures_are_idempotent() {
+    for (name, (input, _)) in fixtures() {
+        let config = config_for(&name);
+        let once = format_source(&input, &config)
+            .expect("fixture formats")
+            .output;
+        let twice = format_source(&once, &config)
+            .expect("fixture formats")
+            .output;
+        similar_asserts::assert_eq!(once, twice, "fixture {name} is not idempotent");
+    }
+}
+
+#[test]
+fn expected_output_is_already_formatted() {
+    for (name, (_, expected)) in fixtures() {
+        let result = format_source(&expected, &config_for(&name)).expect("fixture formats");
+        assert!(
+            !result.changed,
+            "fixture {name} expected output is not a fixed point"
+        );
+    }
+}
+
+#[test]
+fn fixtures_preserve_the_token_stream() {
+    for (name, (input, _)) in fixtures() {
+        let output = format_source(&input, &config_for(&name))
+            .expect("fixture formats")
+            .output;
+        similar_asserts::assert_eq!(
+            program_tokens(&input),
+            program_tokens(&output),
+            "fixture {name} changed the token stream"
+        );
+    }
+}
+
+#[test]
+fn fixtures_preserve_comments_verbatim() {
+    for (name, (input, _)) in fixtures() {
+        let output = format_source(&input, &config_for(&name))
+            .expect("fixture formats")
+            .output;
+        assert_eq!(
+            comments(&input),
+            comments(&output),
+            "fixture {name} rewrote a comment"
+        );
+    }
+}
+
+#[test]
+fn the_lexer_round_trips_every_fixture() {
+    for (name, (input, expected)) in fixtures() {
+        for (label, source) in [("input", &input), ("expected", &expected)] {
+            let mut rebuilt = String::with_capacity(source.len());
+            let mut cursor = 0;
+            for token in tokenize(source) {
+                assert_eq!(
+                    token.span.start, cursor,
+                    "fixture {name} {label} has a gap in its token spans"
+                );
+                cursor = token.span.end;
+                rebuilt.push_str(token.text(source));
+            }
+            assert_eq!(cursor, source.len(), "fixture {name} {label} ends early");
+            similar_asserts::assert_eq!(
+                &rebuilt,
+                source,
+                "fixture {name} {label} did not round trip"
+            );
+        }
+    }
+}
+
+#[test]
+fn every_expected_file_has_an_input() {
+    let dir = fixtures_dir();
+    for entry in fs::read_dir(&dir).expect("readable fixture directory") {
+        let path = entry.expect("readable directory entry").path();
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if let Some(name) = file_name.strip_suffix(".expected.js") {
+            let input = dir.join(format!("{name}.input.js"));
+            assert!(input.exists(), "orphan fixture {}", path.display());
+        }
+    }
+}

--- a/crates/uf_fmt/tests/fixtures/awkward_comments.expected.js
+++ b/crates/uf_fmt/tests/fixtures/awkward_comments.expected.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env uf
+// @flow
+/**
+ * Doc comment for the module.
+ *
+ *   Indented continuation that must not be reflowed even if it is very long.
+ */
+
+/* leading block */ const first = 1; // trailing line
+
+const obj = {
+  // comment before a key
+  a: 1, // after a value
+  /* between */ b: 2,
+  c: /* inline before value */ 3,
+};
+
+function f(
+  // comment inside a parameter list
+  a,
+  b /* after the last parameter */
+) {
+  /* first statement */ return a + b; // tail
+}
+
+const call = compute(/* no args */);
+
+if (flag) {
+  // only a comment
+} else {
+  /* else branch */
+}
+
+const arr = [
+  1, // one
+  2, /* two */
+];
+
+/* a block comment
+   spanning several lines
+     with its own indentation */
+export default f;
+// trailing comment at end of file

--- a/crates/uf_fmt/tests/fixtures/awkward_comments.input.js
+++ b/crates/uf_fmt/tests/fixtures/awkward_comments.input.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env uf
+// @flow
+/**
+ * Doc comment for the module.
+ *
+ *   Indented continuation that must not be reflowed even if it is very long.
+ */
+
+/* leading block */ const first = 1; // trailing line
+
+const obj = {
+// comment before a key
+a : 1 , // after a value
+/* between */ b : 2 ,
+c : /* inline before value */ 3 ,
+};
+
+function f(
+// comment inside a parameter list
+a ,
+b /* after the last parameter */
+) {
+/* first statement */ return a + b; // tail
+}
+
+const call = compute( /* no args */ );
+
+if ( flag ) {
+// only a comment
+} else {
+/* else branch */
+}
+
+const arr = [
+1 , // one
+2 , /* two */
+];
+
+/* a block comment
+   spanning several lines
+     with its own indentation */
+export default f;
+// trailing comment at end of file

--- a/crates/uf_fmt/tests/fixtures/config_narrow_lines.expected.js
+++ b/crates/uf_fmt/tests/fixtures/config_narrow_lines.expected.js
@@ -1,0 +1,17 @@
+// @flow
+render(
+  alpha,
+  beta,
+  gamma,
+  delta,
+  epsilon,
+  zeta
+);
+const short = [1, 2, 3];
+const wide = {
+  alpha: 1,
+  beta: 2,
+  gamma: 3,
+  delta: 4
+};
+const kept = compute(oneArgumentThatIsVeryLongIndeed);

--- a/crates/uf_fmt/tests/fixtures/config_narrow_lines.input.js
+++ b/crates/uf_fmt/tests/fixtures/config_narrow_lines.input.js
@@ -1,0 +1,5 @@
+// @flow
+render(alpha, beta, gamma, delta, epsilon, zeta);
+const short = [1, 2, 3];
+const wide = { alpha: 1, beta: 2, gamma: 3, delta: 4 };
+const kept = compute(oneArgumentThatIsVeryLongIndeed);

--- a/crates/uf_fmt/tests/fixtures/config_no_semicolons.expected.js
+++ b/crates/uf_fmt/tests/fixtures/config_no_semicolons.expected.js
@@ -1,0 +1,22 @@
+// @flow
+const a = 1
+const b = compute()
+let c = { key: "value" }
+
+function f() {
+  const local = a + b
+  return local
+}
+
+for (let i = 0; i < 3; i++) {
+  f()
+}
+
+while (poll());
+
+class Widget {
+  value = 1
+  render() {
+    return this.value
+  }
+}

--- a/crates/uf_fmt/tests/fixtures/config_no_semicolons.input.js
+++ b/crates/uf_fmt/tests/fixtures/config_no_semicolons.input.js
@@ -1,0 +1,22 @@
+// @flow
+const a = 1;
+const b = compute();
+let c = { key: "value" };
+
+function f() {
+  const local = a + b;
+  return local;
+}
+
+for (let i = 0; i < 3; i++) {
+  f();
+}
+
+while (poll());
+
+class Widget {
+  value = 1;
+  render() {
+    return this.value;
+  }
+}

--- a/crates/uf_fmt/tests/fixtures/config_single_quotes.expected.js
+++ b/crates/uf_fmt/tests/fixtures/config_single_quotes.expected.js
@@ -1,0 +1,8 @@
+// @flow
+const plain = 'convert me';
+const hasSingle = "it's fine";
+const hasDouble = 'say "hi"';
+const escapedBoth = 'a "b" c \'d\'';
+const empty = '';
+const jsx = <div className='attr' id='already'>text</div>;
+const template = `left "quoted" and 'quoted'`;

--- a/crates/uf_fmt/tests/fixtures/config_single_quotes.input.js
+++ b/crates/uf_fmt/tests/fixtures/config_single_quotes.input.js
@@ -1,0 +1,8 @@
+// @flow
+const plain = "convert me";
+const hasSingle = "it's fine";
+const hasDouble = 'say "hi"';
+const escapedBoth = "a \"b\" c 'd'";
+const empty = "";
+const jsx = <div className="attr" id='already'>text</div>;
+const template = `left "quoted" and 'quoted'`;

--- a/crates/uf_fmt/tests/fixtures/config_wide_indent.expected.js
+++ b/crates/uf_fmt/tests/fixtures/config_wide_indent.expected.js
@@ -1,0 +1,14 @@
+// @flow
+export function tree() {
+    const nested = {
+        a: {
+            b: [1, 2, 3],
+        },
+    };
+    if (nested.a) {
+        return nested
+            .a
+            .b;
+    }
+    return null;
+}

--- a/crates/uf_fmt/tests/fixtures/config_wide_indent.input.js
+++ b/crates/uf_fmt/tests/fixtures/config_wide_indent.input.js
@@ -1,0 +1,19 @@
+// @flow
+export function tree() {
+
+
+	const nested = {
+		a: {
+			b: [1, 2, 3],
+		},
+	};
+
+
+	if (nested.a) {
+		return nested
+			.a
+			.b;
+	}
+
+	return null;
+}

--- a/crates/uf_fmt/tests/fixtures/directive_client.expected.js
+++ b/crates/uf_fmt/tests/fixtures/directive_client.expected.js
@@ -1,0 +1,10 @@
+"use client";
+// @flow
+import { useState } from "react";
+
+component Counter() renders React.Node {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}
+
+export default Counter;

--- a/crates/uf_fmt/tests/fixtures/directive_client.input.js
+++ b/crates/uf_fmt/tests/fixtures/directive_client.input.js
@@ -1,0 +1,10 @@
+'use client'
+// @flow
+import {useState} from 'react'
+
+component Counter() renders React.Node {
+const [count,setCount]=useState(0)
+return <button onClick={()=>setCount(count+1)}>{count}</button>
+}
+
+export default Counter

--- a/crates/uf_fmt/tests/fixtures/directive_server.expected.js
+++ b/crates/uf_fmt/tests/fixtures/directive_server.expected.js
@@ -1,0 +1,8 @@
+"use server";
+// @flow
+import { db } from "@uniflowed/orm";
+
+export async function createUser(name: string): Promise<void> {
+  "use strict";
+  await db.user.insert({ name, createdAt: Date.now() });
+}

--- a/crates/uf_fmt/tests/fixtures/directive_server.input.js
+++ b/crates/uf_fmt/tests/fixtures/directive_server.input.js
@@ -1,0 +1,8 @@
+"use server";
+// @flow
+import {db} from '@uniflowed/orm';
+
+export async function createUser( name : string ) : Promise< void > {
+'use strict';
+await db.user.insert({ name , createdAt : Date.now() });
+}

--- a/crates/uf_fmt/tests/fixtures/flow_types.expected.js
+++ b/crates/uf_fmt/tests/fixtures/flow_types.expected.js
@@ -1,0 +1,38 @@
+// @flow
+opaque type UserId = string;
+opaque type Wrapped<T> = Box<T>;
+
+export type Status = "idle" | "loading" | "ready" | "failed";
+
+export type User = {
+  id: UserId,
+  name: string,
+  email?: ?string,
+  tags: Array<string>,
+  meta: { [key: string]: mixed },
+};
+
+export type Exact = {| +readOnly: string, -writeOnly: number, ...Rest |};
+
+type Nested = Map<string, Array<Map<string, number>>>;
+
+type Fn = (input: ?string, ...rest: Array<number>) => Promise<void>;
+
+declare export function load(id: UserId): Promise<User>;
+
+interface Serializable {
+  serialize(): string;
+}
+
+class Repository<T> implements Serializable {
+  #cache: Map<string, T> = new Map();
+  static empty: Repository<any> = new Repository();
+  serialize(): string { return JSON.stringify([...this.#cache.entries()]); }
+}
+
+function pick<T, K>(source: T, key: K): T[K] {
+  return source[key];
+};
+
+const typed = new Map<string, number>();
+const cast = (value: mixed) => (value: any);

--- a/crates/uf_fmt/tests/fixtures/flow_types.expected.js
+++ b/crates/uf_fmt/tests/fixtures/flow_types.expected.js
@@ -32,7 +32,7 @@ class Repository<T> implements Serializable {
 
 function pick<T, K>(source: T, key: K): T[K] {
   return source[key];
-};
+}
 
 const typed = new Map<string, number>();
 const cast = (value: mixed) => (value: any);

--- a/crates/uf_fmt/tests/fixtures/flow_types.input.js
+++ b/crates/uf_fmt/tests/fixtures/flow_types.input.js
@@ -1,0 +1,38 @@
+// @flow
+opaque type UserId = string;
+opaque type Wrapped<T> = Box<T>;
+
+export type Status = 'idle'|'loading'|'ready'|'failed';
+
+export type User = {
+id : UserId ,
+name : string ,
+email ? : ?string ,
+tags : Array < string > ,
+meta : { [ key : string ] : mixed } ,
+};
+
+export type Exact = {| +readOnly : string , -writeOnly : number , ...Rest |};
+
+type Nested = Map< string , Array< Map< string , number > > >;
+
+type Fn = ( input : ?string , ...rest : Array< number > ) => Promise< void >;
+
+declare export function load( id : UserId ) : Promise< User >;
+
+interface Serializable {
+serialize() : string;
+}
+
+class Repository< T > implements Serializable {
+#cache : Map< string , T > = new Map();
+static empty : Repository< any > = new Repository();
+serialize() : string { return JSON.stringify([ ... this.#cache.entries() ]); }
+}
+
+function pick< T , K >( source : T , key : K ) : T [ K ] {
+return source[ key ];
+}
+
+const typed = new Map< string , number >();
+const cast = ( value : mixed ) => ( value : any );

--- a/crates/uf_fmt/tests/fixtures/jsx_containers.expected.js
+++ b/crates/uf_fmt/tests/fixtures/jsx_containers.expected.js
@@ -1,0 +1,25 @@
+// @flow
+const inline = <span className="a">plain   text with   runs of spaces</span>;
+
+const nested = (
+  <article>
+    <header>
+      <h1>{title}</h1>
+      {subtitle ? <h2>{subtitle}</h2> : null}
+    </header>
+    {items.map((item) => (
+      <Row key={item.id} label={`${item.name} (${item.count})`}>
+        {item.children.map((child) => <Cell key={child.id}>{child.value}</Cell>)}
+      </Row>
+    ))}
+    <footer>
+      copyright {year} — {owner}
+    </footer>
+  </article>
+);
+
+const fragment = <>{a}{b}</>;
+const selfClosing = <br />;
+const namespaced = <svg:rect data-testid="rect" width={10} />;
+const spread = <Widget {...props} key="w" />;
+const dotted = <Foo.Bar.Baz value={1} />;

--- a/crates/uf_fmt/tests/fixtures/jsx_containers.input.js
+++ b/crates/uf_fmt/tests/fixtures/jsx_containers.input.js
@@ -1,0 +1,25 @@
+// @flow
+const inline = <span className="a">plain   text with   runs of spaces</span>;
+
+const nested = (
+<article>
+<header>
+<h1>{ title }</h1>
+{subtitle ? <h2>{ subtitle }</h2> : null}
+</header>
+{items.map((item)=>(
+<Row key={item.id} label={`${item.name} (${item.count})`}>
+{item.children.map((child)=><Cell key={child.id}>{child.value}</Cell>)}
+</Row>
+))}
+<footer>
+copyright {year} — {owner}
+</footer>
+</article>
+);
+
+const fragment = <>{a}{b}</>;
+const selfClosing = <br/>;
+const namespaced = <svg:rect data-testid='rect' width={ 10 }/>;
+const spread = <Widget { ...props } key="w" />;
+const dotted = <Foo.Bar.Baz value={1}/>;

--- a/crates/uf_fmt/tests/fixtures/react_component.expected.js
+++ b/crates/uf_fmt/tests/fixtures/react_component.expected.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from "react";
+
+type Props = {|
+  +title: string,
+  +items: Array<string>,
+  +onSelect?: ?(value: string) => void,
+|};
+
+hook useSelection(initial: string): [string, (next: string) => void] {
+  const [value, setValue] = React.useState<string>(initial);
+  const select = React.useCallback((next: string) => {
+    setValue(next);
+  }, []);
+  return [value, select];
+};
+
+component ItemList(props: Props) renders React.Node {
+  const [selected, select] = useSelection(props.items[0] ?? "");
+  const total = props.items.length;
+
+  return (
+    <section className="list" data-total={total}>
+      <h2>{props.title}</h2>
+      <ul>
+        {props.items.map((item, index) => (
+          <li key={index} onClick={() => select(item)}>
+            {item} {item === selected ? "(selected)" : ""}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default ItemList;

--- a/crates/uf_fmt/tests/fixtures/react_component.expected.js
+++ b/crates/uf_fmt/tests/fixtures/react_component.expected.js
@@ -13,7 +13,7 @@ hook useSelection(initial: string): [string, (next: string) => void] {
     setValue(next);
   }, []);
   return [value, select];
-};
+}
 
 component ItemList(props: Props) renders React.Node {
   const [selected, select] = useSelection(props.items[0] ?? "");

--- a/crates/uf_fmt/tests/fixtures/react_component.input.js
+++ b/crates/uf_fmt/tests/fixtures/react_component.input.js
@@ -1,0 +1,39 @@
+// @flow
+import   * as React from 'react';
+
+
+
+
+type Props = {|
++title:string,
++items:Array<string>,
++onSelect?: ?(value:string)=>void,
+|};
+
+hook useSelection(initial:string):[string,(next:string)=>void]{
+const [ value , setValue ] = React.useState<string>( initial );
+const select=React.useCallback((next:string)=>{
+setValue( next );
+},[]);
+return [ value , select ];
+}
+
+component ItemList( props : Props ) renders React.Node {
+const [ selected , select ] = useSelection( props.items[ 0 ] ?? '' );
+const total=props.items.length;
+
+return (
+<section className='list' data-total={ total }>
+<h2>{ props.title }</h2>
+<ul>
+{props.items.map((item,index)=>(
+<li key={ index } onClick={()=>select( item )}>
+{ item } { item===selected ? '(selected)' : '' }
+</li>
+))}
+</ul>
+</section>
+);
+}
+
+export default ItemList;

--- a/crates/uf_fmt/tests/fixtures/regex_vs_division.expected.js
+++ b/crates/uf_fmt/tests/fixtures/regex_vs_division.expected.js
@@ -1,0 +1,20 @@
+// @flow
+const ratio = total / count;
+const nested = (a + b) / (c - d);
+const pattern = /ab+c/gi;
+const classy = /[/*]+/g;
+const escaped = /\/\\[a-z]/u;
+const afterCall = compute() / 2;
+const afterIndex = values[0] / 2;
+const afterObject = { a: 1 } / 2;
+const afterBlock = function () {}
+/regexAfterBlock/.test(x);
+const inArgs = split(/,\s*/, text);
+const ternary = flag ? /yes/ : /no/;
+const returned = (() => { return /inside/; })();
+if (x) /header/.test(y);
+while (x) /loop/.test(y);
+const chained = text.replace(/a/g, "b").replace(/c/g, "d");
+const modulo = a % b / c;
+const decrement = count-- / 2;
+const keywordRegex = typeof /re/;

--- a/crates/uf_fmt/tests/fixtures/regex_vs_division.input.js
+++ b/crates/uf_fmt/tests/fixtures/regex_vs_division.input.js
@@ -1,0 +1,20 @@
+// @flow
+const ratio=total/count;
+const nested=(a+b)/(c-d);
+const pattern=/ab+c/gi;
+const classy=/[/*]+/g;
+const escaped=/\/\\[a-z]/u;
+const afterCall=compute()/2;
+const afterIndex=values[0]/2;
+const afterObject={a:1}/2;
+const afterBlock=function(){}
+/regexAfterBlock/.test(x);
+const inArgs=split(/,\s*/,text);
+const ternary=flag ? /yes/ : /no/;
+const returned=(()=>{return /inside/;})();
+if (x) /header/.test(y);
+while (x) /loop/.test(y);
+const chained=text.replace(/a/g,'b').replace(/c/g,'d');
+const modulo=a%b/c;
+const decrement=count--/2;
+const keywordRegex=typeof /re/;

--- a/crates/uf_fmt/tests/fixtures/switch_statement.expected.js
+++ b/crates/uf_fmt/tests/fixtures/switch_statement.expected.js
@@ -1,0 +1,32 @@
+// @flow
+function reduce(state: State, action: Action): State {
+  switch (action.type) {
+    case "increment":
+      return { ...state, count: state.count + 1 };
+    case "decrement": {
+        const next = state.count - 1;
+        return { ...state, count: next };
+      }
+    case "reset":
+    case "clear":
+      return initialState;
+    default: {
+        (action.type: empty);
+        return state;
+      }
+  }
+}
+
+function nested(value) {
+  switch (value) {
+    case 1:
+      switch (value % 2) {
+        case 0:
+          return "even";
+        default:
+          return "odd";
+      }
+    default:
+      return "other";
+  }
+}

--- a/crates/uf_fmt/tests/fixtures/switch_statement.input.js
+++ b/crates/uf_fmt/tests/fixtures/switch_statement.input.js
@@ -1,0 +1,32 @@
+// @flow
+function reduce( state : State , action : Action ) : State {
+switch ( action.type ) {
+case 'increment' :
+return { ...state , count : state.count + 1 };
+case 'decrement' : {
+const next = state.count - 1;
+return { ...state , count : next };
+}
+case 'reset' :
+case 'clear' :
+return initialState;
+default : {
+( action.type : empty );
+return state;
+}
+}
+}
+
+function nested( value ) {
+switch ( value ) {
+case 1 :
+switch ( value % 2 ) {
+case 0 :
+return 'even';
+default :
+return 'odd';
+}
+default :
+return 'other';
+}
+}

--- a/crates/uf_fmt/tests/fixtures/template_literals.expected.js
+++ b/crates/uf_fmt/tests/fixtures/template_literals.expected.js
@@ -1,0 +1,15 @@
+// @flow
+const simple = `no interpolation at all`;
+const one = `value: ${value}`;
+const nested = `outer ${`inner ${deep}  end`} tail`;
+const deep = `a${b`c${d}e`}f`;
+const withObject = `${{ key: 1 }.key}`;
+const multiline = `
+  keeps   its own
+    indentation and ${spacing}
+`;
+const tagged = html`<b class="x">${content}</b>`;
+const quotes = `he said 'hi' and "bye"`;
+const escaped = `a \${ not an interpolation } b`;
+const division = `${a / b}`;
+const regex = `${/ab+/.test(c)}`;

--- a/crates/uf_fmt/tests/fixtures/template_literals.input.js
+++ b/crates/uf_fmt/tests/fixtures/template_literals.input.js
@@ -1,0 +1,15 @@
+// @flow
+const simple=`no interpolation at all`;
+const one=`value: ${ value }`;
+const nested=`outer ${ `inner ${ deep }  end` } tail`;
+const deep=`a${ b`c${ d }e` }f`;
+const withObject=`${ {key:1}.key }`;
+const multiline=`
+  keeps   its own
+    indentation and ${ spacing }
+`;
+const tagged=html`<b class="x">${ content }</b>`;
+const quotes=`he said 'hi' and "bye"`;
+const escaped=`a \${ not an interpolation } b`;
+const division=`${ a / b }`;
+const regex=`${ /ab+/.test(c) }`;


### PR DESCRIPTION
`uf fmt` was 87 lines that trimmed trailing whitespace and expanded leading
tabs. Replace it with a real formatter built on two linear passes over a flat
token vector: no syntax tree, no per-node allocation, no recursion.

- `lexer.rs`: a lossless single-pass tokenizer. Every byte belongs to exactly
  one token, so concatenating the token slices reproduces the input. Handles
  line/block/JSDoc comments, string escapes and line continuations, nested
  `${}` templates, regex-vs-division via the previous-significant-token rule
  (including the `}` and `)` cases that need brace and paren classification),
  JSX text/tags/containers, every numeric literal form, Unicode identifiers
  and Flow type punctuation.
- `printer.rs`: an analysis pass that records spacing, indentation and group
  extents, then an emit pass that writes the output. Indentation follows the
  groups that actually break at their own level, which is what makes hugged
  callbacks and JSX children land where Prettier puts them. Honours every
  `FmtConfig` field, explodes groups that overflow `lineWidth`, and preserves
  comments verbatim.
- `uf_config`: new `fmt.maxBlankLines` (default 1).

Three invariants are enforced by tests: formatting is idempotent, it never
changes the token stream (only trivia, quote style and statement-terminating
semicolons), and no input panics or hangs — truncated literals, unpaired
delimiters, a 1 MB line and 10,000-deep nesting all format. Both passes use
explicit stacks: unbounded recursion over attacker-controlled nesting is a
well-worn crash vector for formatters.

Adds 12 golden fixtures driven by `tests/fixtures.rs` and a criterion bench.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790918617&installation_model_id=422833&pr_number=16&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F16&signature=334ea48bf04ab873da02ba2d5e5a5691e71541ee604f9785e55d776b1c91a9cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive formatting for Flow JavaScript and JSX, including comments, templates, regular expressions, types, and nested structures.
  * Added configurable maximum blank lines, line width, indentation, quote style, and semicolon handling.
  * Added plugin configuration support and development settings for filesystem access, hosts, and origins.
  * Added automatic line wrapping and consistent indentation while preserving source content and comments.
  * Added clear validation when indentation exceeds the supported limit.

* **Bug Fixes**
  * Improved handling of line endings, byte-order marks, and deeply nested code without stack overflow.

* **Tests**
  * Added extensive formatting fixtures, fidelity checks, idempotence tests, and performance benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->