### PR TITLE
docs(architecture): record that shipped packages are .js-only

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,8 +89,11 @@ starts with platform split diagnostics for generic files that branch on
 Flow module surface. The initial package is declaration-first, then the runtime
 loader can map `@uniflowed/*` modules to native implementations.
 
-User-authored Flow source uses `.js` files with `// @flow`. Package declaration
-files may still use Flow's `.js.flow` convention when publishing typed modules.
+User-authored Flow source uses `.js` files with `// @flow`, and so do the
+published `@uniflowed/*` packages: there are no `.js.flow` declaration files.
+A shipped module owns its own declarations, raises only when a native binding is
+actually called, and runs nothing at import time, so `"sideEffects": false` and
+per-subpath exports let a bundler drop everything an application never touches.
 
 Implemented native slices already cover:
 


### PR DESCRIPTION
Follow-up to #14.

`crates/uf_lib/lib` no longer contains a `.js.flow` file, `uf_package` generates
`index.js`, `uf_lint` stopped treating `.flow` as a Flow source extension, and
`uf_lib`'s `package_surface` tests fail the build if any of that regresses. The
line in `docs/architecture.md` saying package declaration files "may still use
Flow's `.js.flow` convention when publishing typed modules" now documents the
opposite of what the code enforces.

Replaced with the actual convention, including the two properties the tests
guard: a shipped module owns its own declarations and runs nothing at import
time, so `"sideEffects": false` plus per-subpath exports let a bundler drop
everything an application never touches.

Docs only — no code change. `cargo fmt --all -- --check`,
`cargo clippy --workspace --all-targets -- -D warnings` and
`cargo test --workspace` (665 passing) are clean on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790918931&installation_model_id=422833&pr_number=17&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F17&signature=6d2d861dc240f125a25887a37775ca727e147ce01c324b5388ee95bd1753c1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->