### PR TITLE
fix(upstream): check out the Flow library definitions the port includes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,28 @@ nightly for now. Both real backends report
 `active_backend()` reports which implementation a build selected, and
 `upstream-parser` always wins when both are enabled.
 
+### What the port can and cannot give us yet
+
+Measured against `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`:
+
+- **The parser works, and its nightly requirement is expiring.** `flow_parser`'s
+  only unstable feature is `never_type`, and that compiler already reports it as
+  *stable since 1.100.0-nightly*. When the toolchain pin reaches 1.100 stable,
+  `upstream-parser` becomes the default with no nightly involved — a one-line
+  change to `uf_flow`'s default features.
+- **The type checker does not build at all, and this is upstream's problem to
+  solve.** 23 crates in the port, including `flow_common` and everything under
+  `flow_typing*`, declare `#![feature(box_patterns)]`. That feature has been
+  *removed* from the compiler, not merely left unstable, so those crates fail on
+  today's nightly and on every nightly from here. `uf check` cannot run Flow's
+  own inference until upstream migrates off it. There is no workaround on our
+  side worth having: pinning a nightly old enough to still accept `box_patterns`
+  would freeze the whole toolchain on a compiler that is going stale.
+
+`flow_flowlib` embeds Flow's library definitions with `include_str!` paths that
+reach outside `rust_port` into `lib/`, `prelude/`, and `tslib/`, so
+`tools/upstream/sync.sh` checks those out too and asserts they arrived.
+
 ## Flow And React
 
 The default app preset is Flow-first React. New app templates use Flow component

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -24,6 +24,8 @@
       submodule and Meta's official Flow Rust port.
 - [ ] Make `upstream-parser` the default once `never_type` reaches stable Rust.
 - [ ] Integrate Flow typecheck diagnostics without requiring `.flowconfig`.
+      Blocked upstream: the port's typing crates need `box_patterns`, which the
+      compiler has removed. See docs/architecture.md.
 - [ ] Replace whitespace formatter with a Flow AST printer.
 - [x] Default formatter settings to double quotes and semicolons.
 - [ ] Add large-project file discovery tests with ignored directories and non-UTF8 guardrails.

--- a/tools/upstream/sync.sh
+++ b/tools/upstream/sync.sh
@@ -15,13 +15,32 @@ repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
 submodule_path="upstream/flow"
-sparse_subtree="rust_port"
+
+# `rust_port` holds the crates, but several of them reach outside it with
+# `include_str!`: `flow_flowlib` embeds Flow's own library definitions from
+# `lib/`, `prelude/`, and `tslib/`. Leaving those out builds fine until the day
+# someone enables the type checker, then fails with an unhelpful missing-file
+# error from a macro. Check them out up front.
+sparse_subtrees="rust_port lib prelude tslib"
 
 git submodule update --init --depth 1 --filter=blob:none "$submodule_path"
-git -C "$submodule_path" sparse-checkout set "$sparse_subtree"
+# shellcheck disable=SC2086 # deliberate word splitting: one argument per subtree
+git -C "$submodule_path" sparse-checkout set $sparse_subtrees
 
-if [ ! -f "$submodule_path/$sparse_subtree/Cargo.toml" ]; then
-  echo "upstream sync failed: $submodule_path/$sparse_subtree/Cargo.toml is missing" >&2
+for required in \
+  "rust_port/Cargo.toml" \
+  "lib/core.js" \
+  "lib/react.js" \
+  "prelude/prelude.js"
+do
+  if [ ! -f "$submodule_path/$required" ]; then
+    echo "upstream sync failed: $submodule_path/$required is missing" >&2
+    exit 1
+  fi
+done
+
+if [ ! -d "$submodule_path/tslib" ]; then
+  echo "upstream sync failed: $submodule_path/tslib is missing" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

`tools/upstream/sync.sh` checked out only `rust_port`, but several crates in it
reach outside with `include_str!`:

```
flow_flowlib/src/flowlib_contents.rs  -> ../../../../lib/core.js
                                         ../../../../lib/react.js
flow_flowlib/src/prelude_contents.rs  -> ../../../../prelude/prelude.js
flow_flowlib/src/tslib_contents.rs    -> ../../../../tslib/
```

Nothing noticed, because no crate we build today pulls `flow_flowlib` in. It
would have failed the first time someone wired up the type checker — with a
missing-file error from inside a macro, which is a bad place to learn this.

The script now checks those subtrees out and **asserts each one arrived**, so it
fails where the cause is visible. Cost went from 24 MB to 27 MB. CI runs the
script in every job, so the assertions are exercised on every PR.

## Two findings, worth writing down

Both measured against `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`.

### The parser's nightly requirement is expiring

`flow_parser`'s only unstable feature is `never_type`, and the compiler now says
so itself:

```
warning: the feature `never_type` has been stable since 1.100.0-nightly
         and no longer requires an attribute to enable
```

Once the toolchain pin reaches **1.100 stable**, `upstream-parser` becomes the
default with no nightly involved — a one-line change to `uf_flow`'s default
features. Given it is ~376× faster than the QuickJS backend and does not carry
that backend's engine-internal stack limit (#13), that is the plan.

### The type checker does not build, and will not until upstream moves

23 crates in the port — including `flow_common` and everything under
`flow_typing*` — declare `#![feature(box_patterns)]`:

```
error: `box_patterns` has been removed
    --> upstream/flow/rust_port/crates/flow_common/src/reason.rs:1672:20
```

**Removed**, not merely still-unstable. So those crates fail on today's nightly
and on every nightly from here, and `uf check` cannot run Flow's own inference
until upstream migrates. There is no workaround on our side worth having:
pinning a nightly old enough to still accept `box_patterns` would freeze the
whole toolchain on a compiler that is going stale.

Recorded in `docs/architecture.md` and marked as blocked in the roadmap, so the
next person does not rediscover it.

## Verification

- [x] `tools/upstream/sync.sh` runs clean and its four assertions pass
- [x] Each `include_str!` path resolves to a real file: `lib/core.js` (171 226 B),
      `lib/react.js` (53 324 B), `prelude/prelude.js` (2 641 B), `tslib/` (96 files)
- [x] `cargo +nightly test -p uf_flow --no-default-features --features upstream-parser` — 10 passed
- [x] `cargo test --workspace` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790919393&installation_model_id=422833&pr_number=20&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F20&signature=f91fec72816a34015a64a0a389c6c948ca0c6b60489192e5c469319a128a86dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->