### PR TITLE
feat(effect): give the effect system a real failure and retry model

### DIFF
--- a/crates/uf_effect/src/cause.rs
+++ b/crates/uf_effect/src/cause.rs
@@ -1,0 +1,254 @@
+//! Why an effect did not produce a value.
+//!
+//! An effect system that collapses every failure into one error value throws
+//! away the thing that makes it worth having: a program can fail in the way its
+//! type said it might (`Fail`), fail in a way nobody declared (`Die`), be
+//! cancelled (`Interrupt`), or — once effects run concurrently — fail in several
+//! of those ways at once. [`Cause`] keeps that structure so a report can say
+//! what actually happened instead of picking a winner.
+//!
+//! Modelled on Effect-TS's `Cause`, expressed in Rust so the native runtime and
+//! the Flow surface agree on one definition.
+
+use std::fmt;
+
+/// A defect: a failure nobody declared in the effect's error channel.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Defect {
+    /// What went wrong, for a human.
+    pub message: String,
+}
+
+impl Defect {
+    /// Build a defect from anything renderable.
+    pub fn new(message: impl fmt::Display) -> Self {
+        Self {
+            message: message.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for Defect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+/// Why an effect did not produce a value.
+///
+/// `E` is the declared error channel. The distinction between the two composite
+/// variants is deliberate: [`Cause::Sequential`] records "this failed, and then
+/// cleanup also failed", [`Cause::Parallel`] records "these failed at the same
+/// time". Collapsing them into one list would lose which is which.
+///
+/// Both composites are n-ary rather than pairs. `Effect.all` over ten thousand
+/// items that all fail produces one `Parallel` with ten thousand children, not a
+/// tree ten thousand levels deep — so cloning, comparing, and dropping a cause
+/// stay proportional to real nesting rather than to how many things failed. A
+/// binary shape makes the *reporting* of a large failure overflow the stack,
+/// which is a poor way to end a program.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Cause<E> {
+    /// The effect finished without failing. The identity for [`Cause::then`] and
+    /// [`Cause::both`].
+    Empty,
+    /// A declared failure: the error the effect's type said it could produce.
+    Fail(E),
+    /// An undeclared failure. A bug, not a modelled outcome.
+    Die(Defect),
+    /// The effect was cancelled.
+    Interrupt,
+    /// Failures in the order they happened.
+    Sequential(Vec<Cause<E>>),
+    /// Failures that happened concurrently, in no meaningful order.
+    Parallel(Vec<Cause<E>>),
+}
+
+impl<E> Cause<E> {
+    /// A declared failure.
+    pub const fn fail(error: E) -> Self {
+        Self::Fail(error)
+    }
+
+    /// An undeclared failure.
+    pub fn die(message: impl fmt::Display) -> Self {
+        Self::Die(Defect::new(message))
+    }
+
+    /// Whether nothing failed.
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    /// Whether this cause is interruption and nothing else.
+    ///
+    /// Cancelling a program is not the same as it failing, and a supervisor that
+    /// cannot tell the difference retries work the user asked it to stop.
+    pub fn is_interrupted_only(&self) -> bool {
+        match self {
+            Self::Interrupt => true,
+            Self::Empty => false,
+            Self::Fail(_) | Self::Die(_) => false,
+            Self::Sequential(parts) | Self::Parallel(parts) => {
+                parts
+                    .iter()
+                    .all(|part| part.is_empty() || part.is_interrupted_only())
+                    && parts.iter().any(|part| !part.is_empty())
+            }
+        }
+    }
+
+    /// Whether any part of this cause is a defect.
+    pub fn has_defect(&self) -> bool {
+        self.fold(false, |found, cause| found || matches!(cause, Self::Die(_)))
+    }
+
+    /// This cause, then `next`.
+    ///
+    /// [`Cause::Empty`] is the identity on both sides, so a cleanup step that
+    /// succeeded never widens the cause. Composition flattens from both sides,
+    /// which makes it genuinely associative rather than merely equivalent:
+    /// `a.then(b).then(c)` and `a.then(b.then(c))` are the same value.
+    pub fn then(self, next: Self) -> Self {
+        match (self, next) {
+            (Self::Empty, other) | (other, Self::Empty) => other,
+            (Self::Sequential(mut left), Self::Sequential(right)) => {
+                left.extend(right);
+                Self::Sequential(left)
+            }
+            (Self::Sequential(mut left), right) => {
+                left.push(right);
+                Self::Sequential(left)
+            }
+            (left, Self::Sequential(right)) => {
+                let mut parts = Vec::with_capacity(right.len() + 1);
+                parts.push(left);
+                parts.extend(right);
+                Self::Sequential(parts)
+            }
+            (left, right) => Self::Sequential(vec![left, right]),
+        }
+    }
+
+    /// This cause alongside `other`, with no ordering between them.
+    ///
+    /// Associative for the same reason [`Cause::then`] is.
+    pub fn both(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Empty, other) | (other, Self::Empty) => other,
+            (Self::Parallel(mut left), Self::Parallel(right)) => {
+                left.extend(right);
+                Self::Parallel(left)
+            }
+            (Self::Parallel(mut left), right) => {
+                left.push(right);
+                Self::Parallel(left)
+            }
+            (left, Self::Parallel(right)) => {
+                let mut parts = Vec::with_capacity(right.len() + 1);
+                parts.push(left);
+                parts.extend(right);
+                Self::Parallel(parts)
+            }
+            (left, right) => Self::Parallel(vec![left, right]),
+        }
+    }
+
+    /// Every declared failure in the tree, in left-to-right order.
+    pub fn failures(&self) -> Vec<&E> {
+        let mut found = Vec::new();
+        self.visit(&mut |cause| {
+            if let Self::Fail(error) = cause {
+                found.push(error);
+            }
+        });
+        found
+    }
+
+    /// Every defect in the tree, in left-to-right order.
+    pub fn defects(&self) -> Vec<&Defect> {
+        let mut found = Vec::new();
+        self.visit(&mut |cause| {
+            if let Self::Die(defect) = cause {
+                found.push(defect);
+            }
+        });
+        found
+    }
+
+    /// Rewrite the declared error type, leaving the structure alone.
+    pub fn map<F>(self, transform: &mut impl FnMut(E) -> F) -> Cause<F> {
+        match self {
+            Self::Empty => Cause::Empty,
+            Self::Fail(error) => Cause::Fail(transform(error)),
+            Self::Die(defect) => Cause::Die(defect),
+            Self::Interrupt => Cause::Interrupt,
+            Self::Sequential(parts) => {
+                Cause::Sequential(parts.into_iter().map(|part| part.map(transform)).collect())
+            }
+            Self::Parallel(parts) => {
+                Cause::Parallel(parts.into_iter().map(|part| part.map(transform)).collect())
+            }
+        }
+    }
+
+    /// Walk every node, parents before children, left before right.
+    ///
+    /// Iterative rather than recursive: a long chain of `acquireRelease` cleanup
+    /// failures builds a deep tree, and blowing the stack while *reporting* a
+    /// failure is a poor way to end a program.
+    pub fn visit<'a>(&'a self, apply: &mut impl FnMut(&'a Self)) {
+        let mut stack = vec![self];
+        while let Some(cause) = stack.pop() {
+            apply(cause);
+            if let Self::Sequential(parts) | Self::Parallel(parts) = cause {
+                stack.extend(parts.iter().rev());
+            }
+        }
+    }
+
+    /// Fold every node into an accumulator.
+    pub fn fold<'a, A>(&'a self, initial: A, mut combine: impl FnMut(A, &'a Self) -> A) -> A {
+        let mut accumulator = Some(initial);
+        self.visit(&mut |cause| {
+            let current = accumulator.take().expect("accumulator is always present");
+            accumulator = Some(combine(current, cause));
+        });
+        accumulator.expect("accumulator is always present")
+    }
+
+    /// How many nodes the tree holds, counting the empty ones.
+    pub fn len(&self) -> usize {
+        self.fold(0, |count, _| count + 1)
+    }
+}
+
+impl<E: fmt::Display> fmt::Display for Cause<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("no failure"),
+            Self::Fail(error) => write!(f, "{error}"),
+            Self::Die(defect) => write!(f, "defect: {defect}"),
+            Self::Interrupt => f.write_str("interrupted"),
+            Self::Sequential(parts) => write_joined(f, parts, ", then "),
+            Self::Parallel(parts) => write_joined(f, parts, ", and concurrently "),
+        }
+    }
+}
+
+fn write_joined<E: fmt::Display>(
+    f: &mut fmt::Formatter<'_>,
+    parts: &[Cause<E>],
+    separator: &str,
+) -> fmt::Result {
+    for (index, part) in parts.iter().enumerate() {
+        if index > 0 {
+            f.write_str(separator)?;
+        }
+        write!(f, "{part}")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_effect/src/cause/tests.rs
+++ b/crates/uf_effect/src/cause/tests.rs
@@ -1,0 +1,246 @@
+use super::*;
+
+fn fail(error: &str) -> Cause<String> {
+    Cause::fail(error.to_string())
+}
+
+#[test]
+fn empty_is_the_identity_for_sequential_composition() {
+    let cause = fail("boom");
+
+    assert_eq!(cause.clone().then(Cause::Empty), cause);
+    assert_eq!(Cause::Empty.then(cause.clone()), cause);
+    assert_eq!(
+        Cause::<String>::Empty.then(Cause::Empty),
+        Cause::<String>::Empty
+    );
+}
+
+#[test]
+fn empty_is_the_identity_for_parallel_composition() {
+    let cause = fail("boom");
+
+    assert_eq!(cause.clone().both(Cause::Empty), cause);
+    assert_eq!(Cause::Empty.both(cause.clone()), cause);
+}
+
+#[test]
+fn sequential_composition_is_associative() {
+    let a = fail("a");
+    let b = fail("b");
+    let c = fail("c");
+
+    let left = a.clone().then(b.clone()).then(c.clone());
+    let right = a.then(b.then(c));
+
+    // Flattening from both sides makes this exact rather than merely
+    // equivalent: the two are the same value, not two shapes that happen to
+    // record the same failures.
+    assert_eq!(left, right);
+    assert_eq!(
+        left,
+        Cause::Sequential(vec![fail("a"), fail("b"), fail("c")])
+    );
+}
+
+#[test]
+fn parallel_composition_is_associative() {
+    let a = fail("a");
+    let b = fail("b");
+    let c = fail("c");
+
+    assert_eq!(a.clone().both(b.clone()).both(c.clone()), a.both(b.both(c)));
+}
+
+#[test]
+fn parallel_composition_records_both_sides() {
+    let cause = fail("left").both(fail("right"));
+
+    let failures = cause.failures();
+    assert_eq!(failures.len(), 2);
+    assert_eq!(failures[0], "left");
+    assert_eq!(failures[1], "right");
+}
+
+#[test]
+fn sequential_and_parallel_stay_distinguishable() {
+    let sequential = fail("a").then(fail("b"));
+    let parallel = fail("a").both(fail("b"));
+
+    assert_ne!(sequential, parallel);
+    assert!(matches!(sequential, Cause::Sequential(_)));
+    assert!(matches!(parallel, Cause::Parallel(_)));
+}
+
+#[test]
+fn a_defect_is_not_a_declared_failure() {
+    let cause = Cause::<String>::die("index out of bounds");
+
+    assert!(cause.has_defect());
+    assert!(cause.failures().is_empty());
+    assert_eq!(cause.defects().len(), 1);
+    assert_eq!(cause.defects()[0].message, "index out of bounds");
+}
+
+#[test]
+fn a_declared_failure_is_not_a_defect() {
+    let cause = fail("not found");
+
+    assert!(!cause.has_defect());
+    assert_eq!(cause.failures().len(), 1);
+    assert!(cause.defects().is_empty());
+}
+
+#[test]
+fn a_defect_anywhere_in_the_tree_is_found() {
+    let cause = fail("a").then(fail("b").both(Cause::die("bug")));
+
+    assert!(cause.has_defect());
+}
+
+#[test]
+fn interruption_alone_is_recognized() {
+    assert!(Cause::<String>::Interrupt.is_interrupted_only());
+    assert!(
+        Cause::<String>::Interrupt
+            .then(Cause::Interrupt)
+            .is_interrupted_only()
+    );
+    assert!(
+        Cause::<String>::Interrupt
+            .both(Cause::Interrupt)
+            .is_interrupted_only()
+    );
+}
+
+#[test]
+fn interruption_mixed_with_failure_is_not_interruption_only() {
+    // A supervisor that cannot tell these apart retries work the user cancelled.
+    assert!(!Cause::Interrupt.then(fail("boom")).is_interrupted_only());
+    assert!(!fail("boom").both(Cause::Interrupt).is_interrupted_only());
+    assert!(
+        !Cause::<String>::Interrupt
+            .then(Cause::die("bug"))
+            .is_interrupted_only()
+    );
+}
+
+#[test]
+fn an_empty_cause_is_not_interruption() {
+    assert!(!Cause::<String>::Empty.is_interrupted_only());
+}
+
+#[test]
+fn mapping_rewrites_errors_and_keeps_the_shape() {
+    let cause = fail("a").then(fail("b").both(Cause::die("bug")));
+
+    let mapped = cause.map(&mut |error| error.len());
+
+    assert_eq!(
+        mapped.failures().into_iter().copied().collect::<Vec<_>>(),
+        vec![1, 1]
+    );
+    assert_eq!(mapped.defects().len(), 1);
+    assert!(matches!(mapped, Cause::Sequential(_)));
+}
+
+#[test]
+fn mapping_preserves_interruption_and_defects() {
+    let cause = Cause::<String>::Interrupt.both(Cause::die("bug"));
+
+    let mapped = cause.map(&mut |_| 0u8);
+
+    assert!(mapped.is_interrupted_only() || mapped.has_defect());
+    assert_eq!(mapped.defects()[0].message, "bug");
+}
+
+#[test]
+fn visiting_reaches_every_node_left_to_right() {
+    let cause = fail("a").then(fail("b")).both(fail("c"));
+
+    let mut seen = Vec::new();
+    cause.visit(&mut |node| {
+        if let Cause::Fail(error) = node {
+            seen.push(error.clone());
+        }
+    });
+
+    assert_eq!(seen, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn folding_counts_every_node() {
+    let cause = fail("a").then(fail("b"));
+
+    // One `Sequential` plus two `Fail`.
+    assert_eq!(cause.len(), 3);
+}
+
+/// A hundred thousand failures is a wide cause, not a deep one.
+///
+/// `Effect.all` over a large collection that fails produces exactly this, and
+/// with a binary tree the *reporting* of that failure would overflow the stack —
+/// on clone, on comparison, and on drop, none of which an iterative walker
+/// helps with. Flattening is what makes it safe.
+#[test]
+fn a_hundred_thousand_failures_stay_shallow() {
+    let mut cause = fail("root");
+    for index in 0..100_000 {
+        cause = cause.then(fail(&format!("cleanup {index}")));
+    }
+
+    assert_eq!(cause.failures().len(), 100_001);
+    assert!(!cause.has_defect());
+    assert!(!cause.is_interrupted_only());
+
+    // The operations a binary shape would have blown the stack on.
+    let cloned = cause.clone();
+    assert_eq!(cloned, cause);
+    let mapped = cause.map(&mut |error| error.len());
+    assert_eq!(mapped.failures().len(), 100_001);
+}
+
+#[test]
+fn a_wide_parallel_cause_stays_shallow_too() {
+    let mut cause = fail("root");
+    for _ in 0..50_000 {
+        cause = cause.both(fail("concurrent"));
+    }
+
+    assert_eq!(cause.failures().len(), 50_001);
+    assert_eq!(cause.len(), 50_002, "one Parallel node plus its children");
+}
+
+#[test]
+fn nesting_sequential_inside_parallel_keeps_both_shapes() {
+    let cause = fail("a").then(fail("b")).both(fail("c").then(fail("d")));
+
+    assert!(matches!(cause, Cause::Parallel(_)));
+    assert_eq!(
+        cause.failures().into_iter().cloned().collect::<Vec<_>>(),
+        vec!["a", "b", "c", "d"]
+    );
+}
+
+#[test]
+fn rendering_says_what_happened() {
+    assert_eq!(Cause::<String>::Empty.to_string(), "no failure");
+    assert_eq!(fail("boom").to_string(), "boom");
+    assert_eq!(Cause::<String>::die("bug").to_string(), "defect: bug");
+    assert_eq!(Cause::<String>::Interrupt.to_string(), "interrupted");
+    assert_eq!(fail("a").then(fail("b")).to_string(), "a, then b");
+    assert_eq!(
+        fail("a").then(fail("b")).then(fail("c")).to_string(),
+        "a, then b, then c"
+    );
+    assert_eq!(
+        fail("a").both(fail("b")).to_string(),
+        "a, and concurrently b"
+    );
+}
+
+#[test]
+fn an_empty_cause_reports_itself_as_empty() {
+    assert!(Cause::<String>::Empty.is_empty());
+    assert!(!fail("boom").is_empty());
+}

--- a/crates/uf_effect/src/exit.rs
+++ b/crates/uf_effect/src/exit.rs
@@ -1,0 +1,125 @@
+//! How a fiber ended, and what state it is in while it runs.
+
+use crate::cause::Cause;
+
+/// The result of running an effect to completion.
+///
+/// A failure carries a whole [`Cause`], not a single error, because by the time
+/// an effect finishes it may have failed in several ways at once — see the
+/// module docs on [`crate::cause`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Exit<A, E> {
+    /// The effect produced a value.
+    Success(A),
+    /// The effect did not.
+    Failure(Cause<E>),
+}
+
+impl<A, E> Exit<A, E> {
+    /// An exit that failed with one declared error.
+    pub const fn fail(error: E) -> Self {
+        Self::Failure(Cause::Fail(error))
+    }
+
+    /// An exit that was cancelled.
+    pub const fn interrupt() -> Self {
+        Self::Failure(Cause::Interrupt)
+    }
+
+    /// Whether the effect produced a value.
+    pub const fn is_success(&self) -> bool {
+        matches!(self, Self::Success(_))
+    }
+
+    /// Whether the effect ended only because it was cancelled.
+    ///
+    /// Distinct from failing: a supervisor that cannot tell them apart retries
+    /// work the caller asked it to stop.
+    pub fn is_interrupted(&self) -> bool {
+        match self {
+            Self::Success(_) => false,
+            Self::Failure(cause) => cause.is_interrupted_only(),
+        }
+    }
+
+    /// The value, if there is one.
+    pub fn value(&self) -> Option<&A> {
+        match self {
+            Self::Success(value) => Some(value),
+            Self::Failure(_) => None,
+        }
+    }
+
+    /// The cause, if the effect failed.
+    pub const fn cause(&self) -> Option<&Cause<E>> {
+        match self {
+            Self::Success(_) => None,
+            Self::Failure(cause) => Some(cause),
+        }
+    }
+
+    /// Rewrite the success value.
+    pub fn map<B>(self, transform: impl FnOnce(A) -> B) -> Exit<B, E> {
+        match self {
+            Self::Success(value) => Exit::Success(transform(value)),
+            Self::Failure(cause) => Exit::Failure(cause),
+        }
+    }
+
+    /// Rewrite the declared error type.
+    pub fn map_error<F>(self, mut transform: impl FnMut(E) -> F) -> Exit<A, F> {
+        match self {
+            Self::Success(value) => Exit::Success(value),
+            Self::Failure(cause) => Exit::Failure(cause.map(&mut transform)),
+        }
+    }
+}
+
+impl<A, E> From<Result<A, E>> for Exit<A, E> {
+    fn from(result: Result<A, E>) -> Self {
+        match result {
+            Ok(value) => Self::Success(value),
+            Err(error) => Self::fail(error),
+        }
+    }
+}
+
+/// Where a fiber is in its life.
+///
+/// `Interrupting` is a state of its own rather than a flag on `Running`: a fiber
+/// that has been asked to stop is still executing its cleanup, and treating that
+/// window as either "running" or "done" is how cancellation leaks resources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FiberState<A, E> {
+    /// Executing.
+    Running,
+    /// Waiting on something external.
+    Suspended,
+    /// Asked to stop, still unwinding.
+    Interrupting,
+    /// Finished.
+    Done(Exit<A, E>),
+}
+
+impl<A, E> FiberState<A, E> {
+    /// Whether the fiber has finished.
+    pub const fn is_done(&self) -> bool {
+        matches!(self, Self::Done(_))
+    }
+
+    /// Whether the fiber can still make progress on its own.
+    pub const fn is_active(&self) -> bool {
+        matches!(self, Self::Running | Self::Interrupting)
+    }
+
+    /// The exit, once there is one.
+    pub const fn exit(&self) -> Option<&Exit<A, E>> {
+        match self {
+            Self::Done(exit) => Some(exit),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_effect/src/exit/tests.rs
+++ b/crates/uf_effect/src/exit/tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+use crate::cause::Cause;
+
+type Run = Exit<u32, String>;
+
+#[test]
+fn a_success_carries_its_value() {
+    let exit: Run = Exit::Success(7);
+
+    assert!(exit.is_success());
+    assert_eq!(exit.value(), Some(&7));
+    assert!(exit.cause().is_none());
+}
+
+#[test]
+fn a_failure_carries_a_whole_cause_not_one_error() {
+    let exit: Run =
+        Exit::Failure(Cause::fail("first".to_string()).both(Cause::fail("second".to_string())));
+
+    assert!(!exit.is_success());
+    assert_eq!(exit.value(), None);
+    assert_eq!(exit.cause().expect("cause").failures().len(), 2);
+}
+
+#[test]
+fn interruption_is_distinguishable_from_failure() {
+    let interrupted: Run = Exit::interrupt();
+    let failed: Run = Exit::fail("boom".to_string());
+    let succeeded: Run = Exit::Success(1);
+
+    assert!(interrupted.is_interrupted());
+    assert!(!failed.is_interrupted());
+    assert!(!succeeded.is_interrupted());
+}
+
+#[test]
+fn an_interrupted_run_that_also_failed_is_not_merely_interrupted() {
+    let exit: Run = Exit::Failure(Cause::Interrupt.then(Cause::fail("cleanup failed".to_string())));
+
+    assert!(!exit.is_interrupted());
+}
+
+#[test]
+fn mapping_rewrites_the_value_and_leaves_failures_alone() {
+    let success: Run = Exit::Success(2);
+    let failure: Run = Exit::fail("boom".to_string());
+
+    assert_eq!(success.map(|value| value * 10), Exit::Success(20));
+    assert_eq!(
+        failure.clone().map(|value| value * 10),
+        Exit::Failure(Cause::fail("boom".to_string()))
+    );
+}
+
+#[test]
+fn mapping_the_error_rewrites_every_failure_in_the_cause() {
+    let exit: Run = Exit::Failure(Cause::fail("a".to_string()).then(Cause::fail("bb".to_string())));
+
+    let mapped = exit.map_error(|error| error.len());
+
+    assert_eq!(
+        mapped
+            .cause()
+            .expect("cause")
+            .failures()
+            .into_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+}
+
+#[test]
+fn a_result_converts_into_an_exit() {
+    let ok: Run = Ok(3).into();
+    let err: Run = Err("boom".to_string()).into();
+
+    assert_eq!(ok, Exit::Success(3));
+    assert_eq!(err, Exit::fail("boom".to_string()));
+}
+
+#[test]
+fn a_running_fiber_is_active_and_not_done() {
+    let state: FiberState<u32, String> = FiberState::Running;
+
+    assert!(state.is_active());
+    assert!(!state.is_done());
+    assert!(state.exit().is_none());
+}
+
+#[test]
+fn an_interrupting_fiber_is_still_active() {
+    // It is unwinding, and treating that window as "done" is how cancellation
+    // leaks resources.
+    let state: FiberState<u32, String> = FiberState::Interrupting;
+
+    assert!(state.is_active());
+    assert!(!state.is_done());
+}
+
+#[test]
+fn a_suspended_fiber_is_neither_active_nor_done() {
+    let state: FiberState<u32, String> = FiberState::Suspended;
+
+    assert!(!state.is_active());
+    assert!(!state.is_done());
+}
+
+#[test]
+fn a_done_fiber_exposes_its_exit() {
+    let state: FiberState<u32, String> = FiberState::Done(Exit::Success(9));
+
+    assert!(state.is_done());
+    assert!(!state.is_active());
+    assert_eq!(state.exit().and_then(Exit::value), Some(&9));
+}

--- a/crates/uf_effect/src/lib.rs
+++ b/crates/uf_effect/src/lib.rs
@@ -1,3 +1,19 @@
+//! Typed native EffectSystem core for uniflowed.
+//!
+//! Three pieces, kept separate because they answer different questions:
+//! [`EffectGraph`] records what a program is made of, [`cause`] records why a
+//! run did not produce a value, and [`schedule`] decides whether to try again.
+//! The Rust side owns these definitions so the native runtime and the Flow
+//! surface in `@uniflowed/effect` cannot drift apart.
+
+pub mod cause;
+pub mod exit;
+pub mod schedule;
+
+pub use crate::cause::{Cause, Defect};
+pub use crate::exit::{Exit, FiberState};
+pub use crate::schedule::{Attempt, Decision, MAX_DELAY, Schedule};
+
 use std::marker::PhantomData;
 
 use compact_str::{CompactString, ToCompactString};

--- a/crates/uf_effect/src/schedule.rs
+++ b/crates/uf_effect/src/schedule.rs
@@ -1,0 +1,344 @@
+//! Retry and repeat schedules.
+//!
+//! A schedule answers one question, repeatedly: given that an effect has now run
+//! `n` times and `elapsed` has passed, should it run again, and after how long?
+//! Keeping that as data rather than a loop is what lets `retry` and `repeat`
+//! share one vocabulary, and lets a schedule be combined
+//! ([`Schedule::intersect`], [`Schedule::union`]) instead of re-implemented.
+//!
+//! All arithmetic saturates. A schedule is a policy for handling failure, so
+//! overflowing one is a spectacular way to turn a recoverable error into a
+//! panic — `exponential` with a large factor reaches `Duration::MAX` and stays
+//! there rather than wrapping to zero and spinning.
+
+use std::time::Duration;
+
+/// Largest delay a schedule will ever ask for.
+///
+/// `Duration::MAX` is over five hundred billion years; a bound that a human can
+/// reason about makes "the backoff saturated" visible instead of looking like a
+/// hang.
+pub const MAX_DELAY: Duration = Duration::from_secs(60 * 60 * 24 * 365);
+
+/// What a schedule decides after one step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Run again after this delay.
+    Continue(Duration),
+    /// Stop.
+    Done,
+}
+
+impl Decision {
+    /// The delay, or [`None`] when the schedule is finished.
+    pub const fn delay(self) -> Option<Duration> {
+        match self {
+            Self::Continue(delay) => Some(delay),
+            Self::Done => None,
+        }
+    }
+
+    /// Whether the schedule wants another attempt.
+    pub const fn is_continue(self) -> bool {
+        matches!(self, Self::Continue(_))
+    }
+}
+
+/// How many times an effect has run, and for how long.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Attempt {
+    /// Completed runs so far. The first decision is made with `count == 0`.
+    pub count: u32,
+    /// Time since the first attempt started.
+    pub elapsed: Duration,
+}
+
+impl Attempt {
+    /// The state before the first run.
+    pub const fn first() -> Self {
+        Self {
+            count: 0,
+            elapsed: Duration::ZERO,
+        }
+    }
+
+    /// The state after one more run that took `taken`.
+    pub const fn advance(self, taken: Duration) -> Self {
+        Self {
+            count: self.count.saturating_add(1),
+            elapsed: self.elapsed.saturating_add(taken),
+        }
+    }
+}
+
+/// A retry or repeat policy.
+///
+/// Deliberately a closed enum rather than a boxed closure: a schedule that can
+/// be inspected can be logged, serialized into a build manifest, and tested for
+/// equality, and none of the combinators need more expressiveness than this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Schedule {
+    /// Run at most `n` more times, immediately.
+    Recurs(u32),
+    /// Wait a fixed delay, forever.
+    Spaced(Duration),
+    /// `base * factor^count`, saturating at [`MAX_DELAY`].
+    ///
+    /// `factor` is scaled by 100, so 200 doubles and 150 grows by half. Integer
+    /// arithmetic keeps the schedule exactly reproducible across machines, which
+    /// a float would not.
+    Exponential {
+        /// Delay before the first retry.
+        base: Duration,
+        /// Growth per attempt, in hundredths.
+        factor_percent: u32,
+    },
+    /// `base * fib(count)`, saturating at [`MAX_DELAY`].
+    Fibonacci(Duration),
+    /// Stop once `elapsed` reaches this.
+    UpTo(Duration),
+    /// Continue only while both agree; take the longer delay.
+    Intersect(Box<Schedule>, Box<Schedule>),
+    /// Continue while either agrees; take the shorter delay.
+    Union(Box<Schedule>, Box<Schedule>),
+    /// Follow the inner schedule, but never wait longer than this.
+    ///
+    /// A ceiling is not the same as [`Schedule::Intersect`] with
+    /// [`Schedule::Spaced`]: that takes the *longer* of the two delays, which
+    /// turns a cap into a floor. Capping needs its own shape.
+    Capped(Box<Schedule>, Duration),
+    /// Never continue.
+    Stop,
+    /// Always continue, immediately.
+    Forever,
+}
+
+impl Schedule {
+    /// Run at most `n` more times with no delay.
+    pub const fn recurs(n: u32) -> Self {
+        Self::Recurs(n)
+    }
+
+    /// Wait `delay` between attempts, forever.
+    pub const fn spaced(delay: Duration) -> Self {
+        Self::Spaced(delay)
+    }
+
+    /// Exponential backoff, doubling.
+    pub const fn exponential(base: Duration) -> Self {
+        Self::Exponential {
+            base,
+            factor_percent: 200,
+        }
+    }
+
+    /// Exponential backoff with an explicit growth factor in hundredths.
+    pub const fn exponential_with(base: Duration, factor_percent: u32) -> Self {
+        Self::Exponential {
+            base,
+            factor_percent,
+        }
+    }
+
+    /// Fibonacci backoff.
+    pub const fn fibonacci(base: Duration) -> Self {
+        Self::Fibonacci(base)
+    }
+
+    /// Give up once this much time has passed.
+    pub const fn up_to(budget: Duration) -> Self {
+        Self::UpTo(budget)
+    }
+
+    /// Continue only while both schedules agree, waiting the longer delay.
+    pub fn intersect(self, other: Self) -> Self {
+        Self::Intersect(Box::new(self), Box::new(other))
+    }
+
+    /// Continue while either schedule agrees, waiting the shorter delay.
+    pub fn union(self, other: Self) -> Self {
+        Self::Union(Box::new(self), Box::new(other))
+    }
+
+    /// Cap every delay this schedule produces.
+    pub fn max_delay(self, cap: Duration) -> Self {
+        Self::Capped(Box::new(self), cap)
+    }
+
+    /// Decide what to do after `attempt`.
+    ///
+    /// Iterative over an explicit stack: `intersect` and `union` nest, and a
+    /// schedule assembled in a loop should not be able to overflow the stack of
+    /// the code recovering from an error.
+    pub fn decide(&self, attempt: Attempt) -> Decision {
+        #[derive(Debug)]
+        enum Step<'a> {
+            Eval(&'a Schedule),
+            CombineIntersect,
+            CombineUnion,
+            Cap(Duration),
+        }
+
+        let mut work = vec![Step::Eval(self)];
+        let mut results: Vec<Decision> = Vec::new();
+
+        while let Some(step) = work.pop() {
+            match step {
+                Step::Eval(schedule) => match schedule {
+                    Self::Intersect(left, right) => {
+                        work.push(Step::CombineIntersect);
+                        work.push(Step::Eval(left));
+                        work.push(Step::Eval(right));
+                    }
+                    Self::Union(left, right) => {
+                        work.push(Step::CombineUnion);
+                        work.push(Step::Eval(left));
+                        work.push(Step::Eval(right));
+                    }
+                    Self::Capped(inner, cap) => {
+                        work.push(Step::Cap(*cap));
+                        work.push(Step::Eval(inner));
+                    }
+                    leaf => results.push(leaf.decide_leaf(attempt)),
+                },
+                Step::CombineIntersect => {
+                    let left = results.pop().expect("left decision");
+                    let right = results.pop().expect("right decision");
+                    results.push(match (left, right) {
+                        (Decision::Continue(a), Decision::Continue(b)) => {
+                            Decision::Continue(a.max(b))
+                        }
+                        _ => Decision::Done,
+                    });
+                }
+                Step::CombineUnion => {
+                    let left = results.pop().expect("left decision");
+                    let right = results.pop().expect("right decision");
+                    results.push(match (left, right) {
+                        (Decision::Continue(a), Decision::Continue(b)) => {
+                            Decision::Continue(a.min(b))
+                        }
+                        (Decision::Continue(delay), Decision::Done)
+                        | (Decision::Done, Decision::Continue(delay)) => Decision::Continue(delay),
+                        (Decision::Done, Decision::Done) => Decision::Done,
+                    });
+                }
+                Step::Cap(cap) => {
+                    let inner = results.pop().expect("inner decision");
+                    results.push(match inner {
+                        Decision::Continue(delay) => Decision::Continue(delay.min(cap)),
+                        Decision::Done => Decision::Done,
+                    });
+                }
+            }
+        }
+
+        results.pop().expect("a decision")
+    }
+
+    fn decide_leaf(&self, attempt: Attempt) -> Decision {
+        match self {
+            Self::Stop => Decision::Done,
+            Self::Forever => Decision::Continue(Duration::ZERO),
+            Self::Recurs(limit) => {
+                if attempt.count < *limit {
+                    Decision::Continue(Duration::ZERO)
+                } else {
+                    Decision::Done
+                }
+            }
+            Self::Spaced(delay) => Decision::Continue(clamp_delay(*delay)),
+            Self::Exponential {
+                base,
+                factor_percent,
+            } => Decision::Continue(exponential_delay(*base, *factor_percent, attempt.count)),
+            Self::Fibonacci(base) => Decision::Continue(fibonacci_delay(*base, attempt.count)),
+            Self::UpTo(budget) => {
+                if attempt.elapsed < *budget {
+                    Decision::Continue(Duration::ZERO)
+                } else {
+                    Decision::Done
+                }
+            }
+            Self::Intersect(_, _) | Self::Union(_, _) | Self::Capped(_, _) => {
+                unreachable!("composites are handled by `decide`")
+            }
+        }
+    }
+
+    /// Every delay this schedule would ask for, up to `limit` attempts.
+    ///
+    /// Bounded on purpose: a `Forever` schedule has no last element, and a
+    /// helper that hangs on one is worse than no helper.
+    pub fn delays(&self, limit: usize) -> Vec<Duration> {
+        let mut delays = Vec::new();
+        let mut attempt = Attempt::first();
+        for _ in 0..limit {
+            match self.decide(attempt) {
+                Decision::Continue(delay) => {
+                    delays.push(delay);
+                    attempt = attempt.advance(delay);
+                }
+                Decision::Done => break,
+            }
+        }
+        delays
+    }
+}
+
+/// Clamp a delay to [`MAX_DELAY`].
+fn clamp_delay(delay: Duration) -> Duration {
+    if delay > MAX_DELAY { MAX_DELAY } else { delay }
+}
+
+/// `base * (factor_percent / 100)^count`, saturating.
+fn exponential_delay(base: Duration, factor_percent: u32, count: u32) -> Duration {
+    let mut nanos = base.as_nanos();
+    let max_nanos = MAX_DELAY.as_nanos();
+    let factor = u128::from(factor_percent);
+
+    for _ in 0..count {
+        if nanos >= max_nanos {
+            return MAX_DELAY;
+        }
+        nanos = nanos.saturating_mul(factor) / 100;
+    }
+
+    if nanos >= max_nanos {
+        MAX_DELAY
+    } else {
+        duration_from_nanos(nanos)
+    }
+}
+
+/// `base * fib(count)`, saturating, with `fib(0) = 1`.
+fn fibonacci_delay(base: Duration, count: u32) -> Duration {
+    let mut previous: u128 = 1;
+    let mut current: u128 = 1;
+    for _ in 0..count {
+        let next = previous.saturating_add(current);
+        previous = current;
+        current = next;
+        if current > u128::from(u64::MAX) {
+            return MAX_DELAY;
+        }
+    }
+
+    let nanos = base.as_nanos().saturating_mul(current);
+    if nanos >= MAX_DELAY.as_nanos() {
+        MAX_DELAY
+    } else {
+        duration_from_nanos(nanos)
+    }
+}
+
+/// Build a `Duration` from nanoseconds already known to be under [`MAX_DELAY`].
+fn duration_from_nanos(nanos: u128) -> Duration {
+    const NANOS_PER_SEC: u128 = 1_000_000_000;
+    let secs = u64::try_from(nanos / NANOS_PER_SEC).unwrap_or(u64::MAX);
+    let subsec = u32::try_from(nanos % NANOS_PER_SEC).unwrap_or(0);
+    Duration::new(secs, subsec)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_effect/src/schedule/tests.rs
+++ b/crates/uf_effect/src/schedule/tests.rs
@@ -1,0 +1,283 @@
+use super::*;
+
+fn ms(millis: u64) -> Duration {
+    Duration::from_millis(millis)
+}
+
+fn at(count: u32) -> Attempt {
+    Attempt {
+        count,
+        elapsed: Duration::ZERO,
+    }
+}
+
+#[test]
+fn recurs_runs_a_bounded_number_of_times() {
+    let schedule = Schedule::recurs(3);
+
+    assert_eq!(schedule.delays(10).len(), 3);
+    assert!(schedule.decide(at(2)).is_continue());
+    assert_eq!(schedule.decide(at(3)), Decision::Done);
+}
+
+#[test]
+fn recurs_zero_never_retries() {
+    assert_eq!(Schedule::recurs(0).decide(at(0)), Decision::Done);
+    assert!(Schedule::recurs(0).delays(10).is_empty());
+}
+
+#[test]
+fn spaced_waits_the_same_delay_every_time() {
+    let delays = Schedule::spaced(ms(250)).delays(4);
+
+    assert_eq!(delays, vec![ms(250), ms(250), ms(250), ms(250)]);
+}
+
+#[test]
+fn exponential_doubles_by_default() {
+    let delays = Schedule::exponential(ms(100)).delays(5);
+
+    assert_eq!(delays, vec![ms(100), ms(200), ms(400), ms(800), ms(1_600)]);
+}
+
+#[test]
+fn exponential_accepts_a_fractional_growth_factor() {
+    let delays = Schedule::exponential_with(ms(100), 150).delays(4);
+
+    // 337.5ms is not a whole millisecond, and rounding it away would make the
+    // schedule drift from its own definition.
+    assert_eq!(
+        delays,
+        vec![ms(100), ms(150), ms(225), Duration::from_micros(337_500)]
+    );
+}
+
+#[test]
+fn exponential_with_a_factor_below_one_shrinks() {
+    let delays = Schedule::exponential_with(ms(1_000), 50).delays(3);
+
+    assert_eq!(delays, vec![ms(1_000), ms(500), ms(250)]);
+}
+
+#[test]
+fn fibonacci_grows_by_the_sequence() {
+    let delays = Schedule::fibonacci(ms(100)).delays(6);
+
+    assert_eq!(
+        delays,
+        vec![ms(100), ms(200), ms(300), ms(500), ms(800), ms(1_300)]
+    );
+}
+
+#[test]
+fn up_to_stops_once_the_budget_is_spent() {
+    let schedule = Schedule::up_to(ms(500));
+
+    assert!(
+        schedule
+            .decide(Attempt {
+                count: 0,
+                elapsed: ms(499)
+            })
+            .is_continue()
+    );
+    assert_eq!(
+        schedule.decide(Attempt {
+            count: 0,
+            elapsed: ms(500)
+        }),
+        Decision::Done
+    );
+}
+
+#[test]
+fn intersect_stops_as_soon_as_either_side_stops() {
+    let schedule = Schedule::spaced(ms(10)).intersect(Schedule::recurs(2));
+
+    assert_eq!(schedule.delays(10).len(), 2);
+}
+
+#[test]
+fn intersect_waits_the_longer_of_the_two_delays() {
+    let schedule = Schedule::spaced(ms(10)).intersect(Schedule::spaced(ms(50)));
+
+    assert_eq!(schedule.decide(at(0)), Decision::Continue(ms(50)));
+}
+
+#[test]
+fn union_continues_while_either_side_wants_to() {
+    let schedule = Schedule::recurs(1).union(Schedule::recurs(4));
+
+    assert_eq!(schedule.delays(10).len(), 4);
+}
+
+#[test]
+fn union_waits_the_shorter_of_the_two_delays() {
+    let schedule = Schedule::spaced(ms(10)).union(Schedule::spaced(ms(50)));
+
+    assert_eq!(schedule.decide(at(0)), Decision::Continue(ms(10)));
+}
+
+#[test]
+fn union_uses_the_live_side_when_one_has_stopped() {
+    let schedule = Schedule::recurs(1).union(Schedule::spaced(ms(30)));
+
+    assert_eq!(schedule.decide(at(5)), Decision::Continue(ms(30)));
+}
+
+/// A ceiling, not a floor. `intersect` with `spaced` takes the *longer* of the
+/// two delays, so using it to cap turns the cap into a minimum.
+#[test]
+fn max_delay_caps_exponential_growth() {
+    let schedule = Schedule::exponential(ms(100)).max_delay(ms(500));
+
+    assert_eq!(
+        schedule.delays(6),
+        vec![ms(100), ms(200), ms(400), ms(500), ms(500), ms(500)]
+    );
+}
+
+#[test]
+fn capping_a_schedule_that_stops_still_stops() {
+    let schedule = Schedule::recurs(2).max_delay(ms(10));
+
+    assert_eq!(schedule.delays(10).len(), 2);
+    assert_eq!(schedule.decide(at(2)), Decision::Done);
+}
+
+#[test]
+fn a_realistic_policy_composes_from_the_pieces() {
+    // Exponential backoff, capped at a second, giving up after five tries.
+    let schedule = Schedule::exponential(ms(50))
+        .max_delay(ms(1_000))
+        .intersect(Schedule::recurs(5));
+
+    let delays = schedule.delays(20);
+
+    assert_eq!(delays.len(), 5);
+    assert_eq!(delays[0], ms(50));
+    assert!(delays.iter().all(|delay| *delay <= ms(1_000)));
+    assert!(delays.windows(2).all(|pair| pair[0] <= pair[1]));
+}
+
+#[test]
+fn stop_never_continues_and_forever_always_does() {
+    assert_eq!(Schedule::Stop.decide(at(0)), Decision::Done);
+    assert_eq!(
+        Schedule::Forever.decide(at(u32::MAX)),
+        Decision::Continue(Duration::ZERO)
+    );
+}
+
+#[test]
+fn exponential_saturates_instead_of_wrapping() {
+    // A schedule is a policy for handling failure; overflowing one turns a
+    // recoverable error into a panic, or worse, into a zero delay and a spin.
+    let schedule = Schedule::exponential_with(Duration::from_secs(1), u32::MAX);
+
+    for count in [1u32, 2, 10, 1_000, u32::MAX] {
+        let decision = schedule.decide(at(count));
+        assert_eq!(decision, Decision::Continue(MAX_DELAY), "count {count}");
+    }
+}
+
+#[test]
+fn exponential_from_a_huge_base_saturates() {
+    let schedule = Schedule::exponential(Duration::MAX);
+
+    assert_eq!(schedule.decide(at(0)), Decision::Continue(MAX_DELAY));
+    assert_eq!(schedule.decide(at(64)), Decision::Continue(MAX_DELAY));
+}
+
+#[test]
+fn fibonacci_saturates_instead_of_wrapping() {
+    let schedule = Schedule::fibonacci(Duration::from_secs(1));
+
+    for count in [100u32, 1_000, 100_000] {
+        assert_eq!(schedule.decide(at(count)), Decision::Continue(MAX_DELAY));
+    }
+}
+
+#[test]
+fn spaced_beyond_the_maximum_is_clamped() {
+    assert_eq!(
+        Schedule::spaced(Duration::MAX).decide(at(0)),
+        Decision::Continue(MAX_DELAY)
+    );
+}
+
+#[test]
+fn ten_thousand_attempts_terminate() {
+    let schedule = Schedule::exponential(ms(1)).intersect(Schedule::recurs(10_000));
+
+    assert_eq!(schedule.delays(20_000).len(), 10_000);
+}
+
+/// `decide` runs on every retry, so it walks an explicit stack rather than
+/// recursing. Construction depth is a different matter: a schedule is written by
+/// hand from a handful of combinators, never grown from untrusted input, so a
+/// thousand levels is far past anything real.
+#[test]
+fn deeply_nested_combinators_do_not_overflow_the_stack() {
+    let mut schedule = Schedule::spaced(ms(1));
+    for _ in 0..1_000 {
+        schedule = schedule.intersect(Schedule::Forever);
+    }
+
+    assert_eq!(schedule.decide(at(0)), Decision::Continue(ms(1)));
+}
+
+#[test]
+fn an_attempt_advances_without_overflowing() {
+    let attempt = Attempt {
+        count: u32::MAX,
+        elapsed: Duration::MAX,
+    };
+
+    let next = attempt.advance(Duration::from_secs(1));
+
+    assert_eq!(next.count, u32::MAX);
+    assert_eq!(next.elapsed, Duration::MAX);
+}
+
+#[test]
+fn the_first_attempt_starts_at_zero() {
+    let first = Attempt::first();
+
+    assert_eq!(first.count, 0);
+    assert_eq!(first.elapsed, Duration::ZERO);
+}
+
+#[test]
+fn delays_are_bounded_by_the_requested_limit() {
+    assert_eq!(Schedule::Forever.delays(7).len(), 7);
+    assert!(Schedule::Forever.delays(0).is_empty());
+}
+
+#[test]
+fn a_decision_reports_its_delay() {
+    assert_eq!(Decision::Continue(ms(5)).delay(), Some(ms(5)));
+    assert_eq!(Decision::Done.delay(), None);
+    assert!(Decision::Continue(ms(5)).is_continue());
+    assert!(!Decision::Done.is_continue());
+}
+
+#[test]
+fn intersect_is_commutative_in_its_decisions() {
+    let left = Schedule::spaced(ms(10)).intersect(Schedule::recurs(3));
+    let right = Schedule::recurs(3).intersect(Schedule::spaced(ms(10)));
+
+    for count in 0..6 {
+        assert_eq!(left.decide(at(count)), right.decide(at(count)), "{count}");
+    }
+}
+
+#[test]
+fn union_is_commutative_in_its_decisions() {
+    let left = Schedule::spaced(ms(10)).union(Schedule::recurs(3));
+    let right = Schedule::recurs(3).union(Schedule::spaced(ms(10)));
+
+    for count in 0..6 {
+        assert_eq!(left.decide(at(count)), right.decide(at(count)), "{count}");
+    }
+}


### PR DESCRIPTION
## Summary

`uf_effect` described what a program is *made of* and nothing about what happens
when it does not work. Effect-TS's answer to that is `Cause`, `Exit`, and
`Schedule` — and those are semantics, not syntax, so they belong in Rust where
the native runtime and the Flow surface share one definition.

### `Cause` — keep the structure of a failure

A declared `Fail`, an undeclared `Die`, an `Interrupt`, and the two ways several
of those combine: `Sequential` for "this failed, then cleanup also failed",
`Parallel` for "these failed at once". Collapsing those into one list is what
makes an effect system's error reporting no better than a `catch`.

**Both composites are n-ary rather than pairs, and that is the load-bearing
decision here.** `Effect.all` over ten thousand items that all fail is a *wide*
failure, not a deep one. With a binary tree, reporting it overflows the stack on
`clone`, on `PartialEq`, and on `Drop` — and an iterative walker helps with none
of those, because the derived impls are the ones recursing. There is a test at a
hundred thousand failures that clones, compares, and maps.

Flattening from both sides also makes composition **genuinely associative**:
`a.then(b).then(c)` and `a.then(b.then(c))` are the same value, not two shapes
that happen to record the same failures.

### `Exit` — cancelled is not failed

`FiberState::Interrupting` is a state rather than a flag on `Running`, because a
fiber that has been asked to stop is still running its cleanup, and treating
that window as either "running" or "done" is how cancellation leaks resources.
`Exit::is_interrupted` is false for a run that was cancelled *and* whose cleanup
then failed — a supervisor that cannot tell those apart retries work the caller
asked it to stop.

### `Schedule` — a policy you can inspect

A closed enum rather than a boxed closure, so a retry policy can be logged,
serialized into a build manifest, and compared for equality. `recurs`, `spaced`,
`exponential` (integer hundredths, so it is reproducible across machines — a
float would not be), `fibonacci`, `upTo`, `intersect`, `union`, `maxDelay`.

Two details worth the review:

- **All arithmetic saturates** at a one-year ceiling. A schedule is a policy for
  handling failure, so overflowing one turns a recoverable error into a panic —
  or worse, into a zero delay and a spin. Tested at `u32::MAX` growth factors and
  `Duration::MAX` bases.
- **`max_delay` is its own variant**, not `intersect(spaced(cap))`. `intersect`
  takes the *longer* of two delays, which turns a cap into a floor. I wrote it
  the wrong way first and the test caught it.

`decide` walks an explicit stack, since it runs on every retry.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **726 passed, 0 failed** (65 new in `uf_effect`)
- [x] Every file under the 400-line guideline: largest is `schedule.rs` at 344

## Scope

This is the semantics half. The Flow surface in `@uniflowed/core/effect` is
still the older saga-shaped API (`call`/`fork`/`take`/`put`) rather than
Effect-TS's `Effect<A, E, R>` with its error and requirements channels — that
rewrite touches the published package surface and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790919905&installation_model_id=422833&pr_number=21&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F21&signature=c8a2ca1a2add6404dfb0fbb35fa2e98346baa780e6d110d6ab977d50814dba14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->