### PR TITLE
feat(plugin): make every build stage a plugin in one container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "uf_fmt",
  "uf_lib",
  "uf_lint",
+ "uf_plugin",
  "uf_pm",
  "uf_prepare",
  "uf_project",
@@ -1644,6 +1645,22 @@ dependencies = [
  "compact_str",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "uf_plugin"
+version = "0.1.0"
+dependencies = [
+ "camino",
+ "compact_str",
+ "criterion",
+ "json5",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "uf_config",
+ "uf_infra",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/uf_motion",
   "crates/uf_orm",
   "crates/uf_package",
+  "crates/uf_plugin",
   "crates/uf_pm",
   "crates/uf_prepare",
   "crates/uf_project",

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -31,6 +31,7 @@ uf_flow = { path = "../uf_flow" }
 uf_fmt = { path = "../uf_fmt" }
 uf_lib = { path = "../uf_lib" }
 uf_lint = { path = "../uf_lint" }
+uf_plugin = { path = "../uf_plugin" }
 uf_pm = { path = "../uf_pm" }
 uf_prepare = { path = "../uf_prepare" }
 uf_project = { path = "../uf_project" }

--- a/crates/uf_cli/src/commands/inspect.rs
+++ b/crates/uf_cli/src/commands/inspect.rs
@@ -9,6 +9,7 @@ use uf_lib::{
     builtin_modules, hook_descriptors, motion_contract, orm_contract, std_module_descriptors,
     tui_contract, ui_components, vrt_plan,
 };
+use uf_plugin::{PipelineMode, resolve_pipeline};
 use uf_pm::{DetectionOptions, PackageManagerPlan, detect_package_manager_with};
 use uf_rm::RuntimeManagerPlan;
 use uf_router::discover_routes;
@@ -188,10 +189,14 @@ fn inspect_payload(resolved: &ResolvedConfig) -> Result<serde_json::Value> {
     let package_manager = PackageManagerPlan::infer_from_config(&resolved.config);
     let package_manager_detection = detect_project_package_manager(resolved);
     let runtime_manager = RuntimeManagerPlan::infer_from_config(&resolved.config);
+    // Every stage of the build is a plugin, so the resolved order here is the
+    // order that actually runs — including whatever `plugins: [...]` adds.
+    let pipeline = resolve_pipeline(&resolved.config, &resolved.root, PipelineMode::Build)?;
 
     Ok(json!({
         "command": "uf",
         "config": resolved,
+        "plugins": pipeline.report(),
         "routes": routes,
         "nativeModules": builtin_modules(),
         "stdModules": std_module_descriptors(),

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 pub use uf_bundle::{BudgetMetric, BundleBudgets, ByteSize, SizeBudget};
 
+pub mod plugins;
+
+pub use plugins::{ApplyCondition, HookOrder, PipelineMode, PluginEntry, PluginSpec};
+
 pub const CONFIG_FILES: &[&str] = &["uf.config.js"];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,6 +26,11 @@ pub struct UniflowedConfig {
     pub fmt: FmtConfig,
     pub lint: LintConfig,
     pub package: PackageConfig,
+    /// Plugins the project adds, in declaration order.
+    ///
+    /// Entries are raw, untrusted declarations; `uf_plugin` resolves them into
+    /// a run order and rejects any that reach outside the project root.
+    pub plugins: Vec<PluginEntry>,
     pub pm: PackageManagerConfig,
     pub publish: PublishConfig,
     pub release: ReleaseConfig,

--- a/crates/uf_config/src/plugins.rs
+++ b/crates/uf_config/src/plugins.rs
@@ -1,0 +1,202 @@
+//! The `plugins: [...]` surface of `uf.config.js`.
+//!
+//! A uf project declares plugins here and nowhere else. There is no second
+//! config file and no second plugin format, so this module owns the whole
+//! vocabulary a user ever types: a name, and the two ordering knobs that decide
+//! when the plugin runs relative to everything else.
+//!
+//! The declarations are deliberately inert data. Turning one into something the
+//! build actually runs belongs to `uf_plugin`, and that is also where the
+//! project-root containment check lives: a plugin name that names a file is a
+//! request to execute code from disk, so it is untrusted input, not a label.
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+/// One entry of `plugins: [...]` in `uf.config.js`.
+///
+/// Both spellings mean the same thing; the short one is the common case.
+///
+/// ```js
+/// plugins: [
+///   "@uniflowed/plugin-mdx",
+///   { name: "./plugins/metrics.js", order: "post", apply: "build" },
+/// ]
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PluginEntry {
+    /// A bare name, taking the default order and apply condition.
+    Name(CompactString),
+    /// A name with an explicit order and/or apply condition.
+    Spec(PluginSpec),
+}
+
+impl PluginEntry {
+    /// The declared name, exactly as the user typed it.
+    ///
+    /// This is untrusted text: it has not been checked for path escapes yet.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Name(name) => name.as_str(),
+            Self::Spec(spec) => spec.name.as_str(),
+        }
+    }
+
+    /// Where the plugin sits in the run order.
+    pub fn order(&self) -> HookOrder {
+        match self {
+            Self::Name(_) => HookOrder::Normal,
+            Self::Spec(spec) => spec.order,
+        }
+    }
+
+    /// Which pipelines the plugin takes part in.
+    pub fn apply(&self) -> ApplyCondition {
+        match self {
+            Self::Name(_) => ApplyCondition::Always,
+            Self::Spec(spec) => spec.apply,
+        }
+    }
+}
+
+impl From<PluginSpec> for PluginEntry {
+    fn from(spec: PluginSpec) -> Self {
+        Self::Spec(spec)
+    }
+}
+
+/// The long form of a [`PluginEntry`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct PluginSpec {
+    /// Package specifier or project-relative path naming the plugin.
+    pub name: CompactString,
+    /// Where the plugin sits in the run order.
+    pub order: HookOrder,
+    /// Which pipelines the plugin takes part in.
+    pub apply: ApplyCondition,
+}
+
+impl PluginSpec {
+    /// A plugin declared by name, taking the default order and apply condition.
+    pub fn new(name: impl Into<CompactString>) -> Self {
+        Self {
+            name: name.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Place the plugin in a band other than [`HookOrder::Normal`].
+    #[must_use]
+    pub fn with_order(mut self, order: HookOrder) -> Self {
+        self.order = order;
+        self
+    }
+
+    /// Restrict the plugin to one pipeline.
+    #[must_use]
+    pub fn with_apply(mut self, apply: ApplyCondition) -> Self {
+        self.apply = apply;
+        self
+    }
+}
+
+/// Where a plugin sits relative to the plugins that expressed no preference.
+///
+/// Within one band, declaration order in `uf.config.js` decides. That makes the
+/// resolved pipeline a pure function of the config file, so two machines that
+/// read the same config build in the same order.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum HookOrder {
+    /// Runs before every plugin that did not ask for a position.
+    Pre,
+    /// The default band.
+    #[default]
+    Normal,
+    /// Runs after every plugin that did not ask for a position.
+    Post,
+}
+
+impl HookOrder {
+    /// Every band, in the order the container runs them.
+    pub const ALL: [Self; 3] = [Self::Pre, Self::Normal, Self::Post];
+
+    /// The stable id used in `uf inspect --json`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pre => "pre",
+            Self::Normal => "normal",
+            Self::Post => "post",
+        }
+    }
+}
+
+/// Which pipelines a plugin takes part in.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ApplyCondition {
+    /// Only when producing a build.
+    Build,
+    /// Only while the dev server is serving.
+    Serve,
+    /// Both.
+    #[default]
+    Always,
+}
+
+impl ApplyCondition {
+    /// Every condition, for exhaustive tests and tables.
+    pub const ALL: [Self; 3] = [Self::Build, Self::Serve, Self::Always];
+
+    /// Whether a plugin with this condition runs in `mode`.
+    pub const fn admits(self, mode: PipelineMode) -> bool {
+        matches!(
+            (self, mode),
+            (Self::Always, _)
+                | (Self::Build, PipelineMode::Build)
+                | (Self::Serve, PipelineMode::Serve)
+        )
+    }
+
+    /// The stable id used in `uf inspect --json`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Build => "build",
+            Self::Serve => "serve",
+            Self::Always => "always",
+        }
+    }
+}
+
+/// Which pipeline the plugin container is currently driving.
+///
+/// This is runtime state rather than a config field, but it is the other half
+/// of [`ApplyCondition`], so the two live together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PipelineMode {
+    /// `uf build`.
+    Build,
+    /// `uf dev`.
+    Serve,
+}
+
+impl PipelineMode {
+    /// Both modes, for exhaustive tests and tables.
+    pub const ALL: [Self; 2] = [Self::Build, Self::Serve];
+
+    /// The stable id used in `uf inspect --json`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Build => "build",
+            Self::Serve => "serve",
+        }
+    }
+}

--- a/crates/uf_plugin/Cargo.toml
+++ b/crates/uf_plugin/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "uf_plugin"
+description = "Plugin container and built-in pipeline stages for uniflowed."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+camino.workspace = true
+compact_str.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+uf_config = { path = "../uf_config" }
+uf_infra = { path = "../uf_infra" }
+
+[dev-dependencies]
+criterion.workspace = true
+json5.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+
+[[bench]]
+name = "container"
+harness = false

--- a/crates/uf_plugin/benches/container.rs
+++ b/crates/uf_plugin/benches/container.rs
@@ -1,0 +1,145 @@
+//! Per-module dispatch cost through a realistically sized pipeline.
+//!
+//! Dispatch runs once per module per hook, so its cost is multiplied by the
+//! size of the app. The two cases below are the ones that matter: the common
+//! one, where a module passes through every plugin untouched and the container
+//! must not allocate at all, and the worst one, where every plugin rewrites the
+//! module and each rewrite is a real string.
+
+use std::hint::black_box;
+
+use compact_str::CompactString;
+use uf_config::{ApplyCondition, HookOrder, PipelineMode};
+use uf_plugin::{
+    FnPlugin, HookOutcome, HookSet, ModuleCode, Plugin, PluginContainer, PluginDescriptor,
+    PluginHook, PluginSource, ResolvedId,
+};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const PLUGINS: usize = 20;
+const MODULES: usize = 100_000;
+
+fn descriptor(name: String, order: HookOrder) -> PluginDescriptor {
+    let specifier = CompactString::new(&name);
+    PluginDescriptor::project(
+        name,
+        PluginSource::Package { specifier },
+        order,
+        ApplyCondition::Always,
+        HookSet::EMPTY,
+    )
+}
+
+fn band(index: usize) -> HookOrder {
+    match index % 3 {
+        0 => HookOrder::Pre,
+        1 => HookOrder::Normal,
+        _ => HookOrder::Post,
+    }
+}
+
+/// Twenty plugins that all decline: the common case for most modules.
+fn declining_pipeline() -> PluginContainer {
+    let plugins = (0..PLUGINS)
+        .map(|index| {
+            Box::new(
+                FnPlugin::new(descriptor(format!("declines-{index}"), band(index)))
+                    .on_transform(|_| Ok(HookOutcome::Passthrough))
+                    .on_resolve_id(|_| Ok(HookOutcome::Passthrough)),
+            ) as Box<dyn Plugin>
+        })
+        .collect();
+    PluginContainer::build(PipelineMode::Build, plugins).expect("container")
+}
+
+/// Twenty plugins that all rewrite the module.
+fn rewriting_pipeline() -> PluginContainer {
+    let plugins = (0..PLUGINS)
+        .map(|index| {
+            Box::new(
+                FnPlugin::new(descriptor(format!("rewrites-{index}"), band(index))).on_transform(
+                    |input| {
+                        let mut code = String::with_capacity(input.code.len() + 8);
+                        code.push_str(input.code);
+                        code.push_str("\n// pass\n");
+                        Ok(HookOutcome::Handled(ModuleCode::new(code)))
+                    },
+                ),
+            ) as Box<dyn Plugin>
+        })
+        .collect();
+    PluginContainer::build(PipelineMode::Build, plugins).expect("container")
+}
+
+/// One plugin near the end of the order answers; the rest decline.
+fn resolving_pipeline() -> PluginContainer {
+    let mut plugins = (0..PLUGINS - 1)
+        .map(|index| {
+            Box::new(
+                FnPlugin::new(descriptor(format!("declines-{index}"), HookOrder::Pre))
+                    .on_resolve_id(|_| Ok(HookOutcome::Passthrough)),
+            ) as Box<dyn Plugin>
+        })
+        .collect::<Vec<_>>();
+    plugins.push(Box::new(
+        FnPlugin::new(descriptor("answers".to_string(), HookOrder::Post))
+            .on_resolve_id(|input| Ok(HookOutcome::Handled(ResolvedId::bundled(input.specifier)))),
+    ));
+    PluginContainer::build(PipelineMode::Build, plugins).expect("container")
+}
+
+fn module_ids() -> Vec<String> {
+    (0..MODULES)
+        .map(|index| format!("app/routes/section{}/module{index}.js", index % 64))
+        .collect()
+}
+
+fn bench_dispatch(criterion: &mut Criterion) {
+    let ids = module_ids();
+    let source = "// @flow\nexport default function Page() { return null; }\n";
+
+    let declining = declining_pipeline();
+    assert_eq!(declining.len(), PLUGINS);
+    criterion.bench_function("transform 100k modules through 20 declining plugins", |b| {
+        b.iter(|| {
+            for id in &ids {
+                let outcome = declining
+                    .transform(black_box(id), black_box(source))
+                    .expect("transforms");
+                black_box(outcome.is_passthrough());
+            }
+        });
+    });
+
+    let rewriting = rewriting_pipeline();
+    criterion.bench_function("transform 100k modules through 20 rewriting plugins", |b| {
+        b.iter(|| {
+            for id in &ids {
+                let outcome = rewriting
+                    .transform(black_box(id), black_box(source))
+                    .expect("transforms");
+                black_box(outcome.handled().map(|code| code.code.len()));
+            }
+        });
+    });
+
+    let resolving = resolving_pipeline();
+    criterion.bench_function("resolve 100k specifiers through 20 plugins", |b| {
+        b.iter(|| {
+            for id in &ids {
+                let outcome = resolving
+                    .resolve_id(black_box(id), black_box(Some("app/page.js")))
+                    .expect("resolves");
+                black_box(outcome.is_handled());
+            }
+        });
+    });
+
+    criterion.bench_function("hook mask test", |b| {
+        b.iter(|| black_box(declining.implements(black_box(PluginHook::Transform))));
+    });
+}
+
+criterion_group!(benches, bench_dispatch);
+criterion_main!(benches);

--- a/crates/uf_plugin/src/builtin.rs
+++ b/crates/uf_plugin/src/builtin.rs
@@ -1,0 +1,230 @@
+//! uf's own pipeline, expressed as plugins.
+//!
+//! Everything the toolchain does to a module goes through the container, so
+//! there is exactly one mechanism and one run order. What each stage *does*
+//! stays in the crate that owns it — `uf_flow` parses, `uf_router` discovers
+//! routes, `uf_rsc` splits the client boundary — and this module only says
+//! where in the pipeline that work belongs. Wiring the work itself is
+//! [`FnPlugin`](crate::FnPlugin)'s job, which is why no transform is
+//! reimplemented here and why this crate does not depend on any of them.
+
+use serde::Serialize;
+use uf_config::{HookOrder, ReactCompilerMode, StyleEngine, UniflowedConfig};
+
+use crate::descriptor::PluginDescriptor;
+use crate::hook::{HookSet, PluginHook};
+
+/// A stage of uf's own pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BuiltinPlugin {
+    /// Strips Flow types and normalizes the module for everything downstream.
+    Flow,
+    /// Turns the `app/` tree into route modules and their Flow types.
+    Router,
+    /// Splits the server graph from the client bundle at `"use client"`.
+    Rsc,
+    /// Extracts StyleX styles into a static stylesheet.
+    Style,
+    /// Runs the React compiler over components and hooks.
+    ReactCompiler,
+    /// Resolves, fingerprints, and emits non-JavaScript imports.
+    Asset,
+}
+
+impl BuiltinPlugin {
+    /// Every built-in, in pipeline order.
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::Flow,
+        Self::Router,
+        Self::Rsc,
+        Self::Style,
+        Self::ReactCompiler,
+        Self::Asset,
+    ];
+
+    /// How many built-ins exist. [`BuiltinSet`] needs at least this many bits.
+    pub const COUNT: usize = 6;
+
+    /// The plugin's name in the pipeline, and in `uf inspect --json`.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Flow => "uf:flow",
+            Self::Router => "uf:router",
+            Self::Rsc => "uf:rsc",
+            Self::Style => "uf:style",
+            Self::ReactCompiler => "uf:react-compiler",
+            Self::Asset => "uf:asset",
+        }
+    }
+
+    /// Position in [`BuiltinPlugin::ALL`], and the bit index in a [`BuiltinSet`].
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Flow => 0,
+            Self::Router => 1,
+            Self::Rsc => 2,
+            Self::Style => 3,
+            Self::ReactCompiler => 4,
+            Self::Asset => 5,
+        }
+    }
+
+    /// This built-in as a one-bit mask.
+    pub const fn bit(self) -> u8 {
+        1u8 << self.index()
+    }
+
+    /// Which band the stage runs in.
+    ///
+    /// Flow stripping and route generation are `Pre` because every other plugin
+    /// expects to see plain JavaScript and to be able to import a generated
+    /// route module. The React compiler is `Post` because it must be the last
+    /// pass over component code — anything that rewrites JavaScript afterwards
+    /// would invalidate the memoization it just proved sound.
+    pub const fn order(self) -> HookOrder {
+        match self {
+            Self::Flow | Self::Router => HookOrder::Pre,
+            Self::Rsc | Self::Style | Self::Asset => HookOrder::Normal,
+            Self::ReactCompiler => HookOrder::Post,
+        }
+    }
+
+    /// Which hooks the stage implements.
+    pub const fn hooks(self) -> HookSet {
+        match self {
+            Self::Flow => HookSet::of(PluginHook::Transform).with(PluginHook::ModuleParsed),
+            Self::Router => HookSet::of(PluginHook::BuildStart)
+                .with(PluginHook::ResolveId)
+                .with(PluginHook::Load)
+                .with(PluginHook::ConfigureServer)
+                .with(PluginHook::HandleHotUpdate),
+            Self::Rsc => HookSet::of(PluginHook::ModuleParsed)
+                .with(PluginHook::Transform)
+                .with(PluginHook::BuildEnd)
+                .with(PluginHook::GenerateBundle)
+                .with(PluginHook::WriteBundle),
+            Self::Style => HookSet::of(PluginHook::Transform)
+                .with(PluginHook::RenderChunk)
+                .with(PluginHook::GenerateBundle),
+            Self::ReactCompiler => HookSet::of(PluginHook::Transform),
+            Self::Asset => HookSet::of(PluginHook::ResolveId)
+                .with(PluginHook::Load)
+                .with(PluginHook::GenerateBundle)
+                .with(PluginHook::WriteBundle)
+                .with(PluginHook::TransformIndexHtml),
+        }
+    }
+
+    /// The descriptor the container places.
+    ///
+    /// Every built-in applies to both `uf build` and `uf dev`: the two differ in
+    /// what a stage emits, not in whether it runs.
+    pub fn descriptor(self) -> PluginDescriptor {
+        PluginDescriptor::builtin(self.name(), self.order(), self.hooks())
+    }
+}
+
+/// Which built-ins a project's config switches on.
+///
+/// A bitset rather than a struct of flags, so "is the router in this pipeline?"
+/// is one AND and the whole selection fits in a byte.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BuiltinSet(u8);
+
+impl BuiltinSet {
+    /// No built-ins.
+    pub const EMPTY: Self = Self(0);
+
+    /// Every built-in.
+    pub const ALL: Self = Self((1u8 << BuiltinPlugin::COUNT) - 1);
+
+    /// A set holding exactly `plugin`.
+    pub const fn of(plugin: BuiltinPlugin) -> Self {
+        Self(plugin.bit())
+    }
+
+    /// This set plus `plugin`.
+    pub const fn with(self, plugin: BuiltinPlugin) -> Self {
+        Self(self.0 | plugin.bit())
+    }
+
+    /// This set plus `plugin` when `enabled`, unchanged otherwise.
+    pub const fn with_if(self, plugin: BuiltinPlugin, enabled: bool) -> Self {
+        if enabled { self.with(plugin) } else { self }
+    }
+
+    /// This set without `plugin`.
+    pub const fn without(self, plugin: BuiltinPlugin) -> Self {
+        Self(self.0 & !plugin.bit())
+    }
+
+    /// Whether `plugin` is in the set.
+    pub const fn contains(self, plugin: BuiltinPlugin) -> bool {
+        self.0 & plugin.bit() != 0
+    }
+
+    /// Whether the set holds nothing.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// How many built-ins are in the set.
+    pub const fn len(self) -> u32 {
+        self.0.count_ones()
+    }
+
+    /// The raw mask.
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// The built-ins in the set, in [`BuiltinPlugin::ALL`] order.
+    pub fn iter(self) -> impl Iterator<Item = BuiltinPlugin> {
+        BuiltinPlugin::ALL
+            .into_iter()
+            .filter(move |plugin| self.contains(*plugin))
+    }
+
+    /// The built-ins a project's `uf.config.js` switches on.
+    ///
+    /// Flow stripping and asset handling are unconditional: a uf project is
+    /// Flow source that imports assets, so switching either off would not
+    /// produce a working build. The rest follow the config fields users
+    /// already have, which is why there is no second set of plugin toggles.
+    pub fn from_config(config: &UniflowedConfig) -> Self {
+        Self::of(BuiltinPlugin::Flow)
+            .with(BuiltinPlugin::Asset)
+            .with_if(BuiltinPlugin::Router, config.app.router.enabled)
+            .with_if(BuiltinPlugin::Rsc, config.app.rsc)
+            .with_if(
+                BuiltinPlugin::Style,
+                matches!(config.app.builtins.style, StyleEngine::StyleX),
+            )
+            .with_if(
+                BuiltinPlugin::ReactCompiler,
+                config.app.builtins.react_compiler.enabled
+                    && matches!(
+                        config.app.builtins.react_compiler.mode,
+                        ReactCompilerMode::Syntax
+                    ),
+            )
+    }
+
+    /// The descriptors for every built-in in the set, in pipeline order.
+    pub fn descriptors(self) -> Vec<PluginDescriptor> {
+        self.iter().map(BuiltinPlugin::descriptor).collect()
+    }
+}
+
+impl FromIterator<BuiltinPlugin> for BuiltinSet {
+    fn from_iter<I: IntoIterator<Item = BuiltinPlugin>>(iter: I) -> Self {
+        iter.into_iter().fold(Self::EMPTY, Self::with)
+    }
+}
+
+impl Serialize for BuiltinSet {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_seq(self.iter().map(BuiltinPlugin::name))
+    }
+}

--- a/crates/uf_plugin/src/container.rs
+++ b/crates/uf_plugin/src/container.rs
@@ -1,0 +1,320 @@
+//! The container: one deterministic run order, and dispatch that costs a slice
+//! walk per module rather than a search.
+
+use compact_str::CompactString;
+use thiserror::Error;
+use uf_config::{HookOrder, PipelineMode};
+use uf_infra::{FxHashMap, InlineVec};
+
+use crate::descriptor::PluginDescriptor;
+use crate::hook::{HookSet, PluginHook};
+use crate::outcome::{
+    HookFailure, HookOutcome, LoadInput, ModuleCode, ResolveInput, ResolvedId, TransformInput,
+};
+use crate::plugin::{FnPlugin, Plugin};
+
+/// How many plugins one container will hold.
+///
+/// Config is untrusted input and the container indexes plugins with a `u16`, so
+/// the ceiling is explicit rather than "whatever fits in memory".
+pub const MAX_PLUGINS: usize = 1024;
+
+/// Indices into the plugin list for one hook. Eight covers every realistic
+/// pipeline without touching the allocator.
+type HookLane = InlineVec<u16, 8>;
+
+/// Everything that can go wrong before or during dispatch.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ContainerError {
+    /// Two plugins claimed the same name.
+    ///
+    /// Silently letting the second win is how a pipeline ends up not running
+    /// the plugin its config names, so this is an error with both positions.
+    #[error("two plugins are named {name}: entries {first} and {second}")]
+    DuplicateName {
+        /// The contested name.
+        name: CompactString,
+        /// Declaration index of the first plugin with that name.
+        first: usize,
+        /// Declaration index of the second.
+        second: usize,
+    },
+    /// More plugins than the container will hold.
+    #[error("{count} plugins declared, over the ceiling of {limit}")]
+    TooManyPlugins {
+        /// How many were declared.
+        count: usize,
+        /// The ceiling, always [`MAX_PLUGINS`].
+        limit: usize,
+    },
+    /// A plugin failed while running a hook.
+    #[error("plugin {plugin} failed the {hook} hook for {module}")]
+    Hook {
+        /// The plugin that failed.
+        plugin: CompactString,
+        /// The hook it was running.
+        hook: PluginHook,
+        /// The module or specifier it was handed.
+        module: CompactString,
+        /// The plugin's own typed reason.
+        #[source]
+        source: HookFailure,
+    },
+}
+
+/// The resolved pipeline.
+///
+/// Construction does all the work that can be done without running plugin code:
+/// it rejects duplicate names, fixes the run order, and turns each plugin's
+/// [`HookSet`] into a per-hook list of indices. After that a hook dispatch is a
+/// walk over a short slice, with no name comparison, no filtering, and no
+/// allocation unless a plugin actually produces something.
+pub struct PluginContainer {
+    /// In resolved run order.
+    plugins: Vec<Box<dyn Plugin>>,
+    /// Parallel to `plugins`, so the plan can be reported without running it.
+    descriptors: Vec<PluginDescriptor>,
+    mode: PipelineMode,
+    /// Union of the hooks that will actually run in `mode`.
+    active: HookSet,
+    /// For each hook, the plugins that implement it and pass `apply`.
+    lanes: [HookLane; PluginHook::COUNT],
+}
+
+impl PluginContainer {
+    /// Resolve `plugins` into a pipeline for `mode`.
+    ///
+    /// The run order is every [`HookOrder::Pre`] plugin in declaration order,
+    /// then every [`HookOrder::Normal`], then every [`HookOrder::Post`]. The
+    /// sort is stable, so the result is a pure function of the declaration
+    /// list: two machines reading the same `uf.config.js` build in the same
+    /// order.
+    pub fn build(
+        mode: PipelineMode,
+        plugins: Vec<Box<dyn Plugin>>,
+    ) -> Result<Self, ContainerError> {
+        if plugins.len() > MAX_PLUGINS {
+            return Err(ContainerError::TooManyPlugins {
+                count: plugins.len(),
+                limit: MAX_PLUGINS,
+            });
+        }
+
+        let mut seen: FxHashMap<&str, usize> =
+            FxHashMap::with_capacity_and_hasher(plugins.len(), Default::default());
+        for (index, plugin) in plugins.iter().enumerate() {
+            let name = plugin.descriptor().name.as_str();
+            if let Some(&first) = seen.get(name) {
+                return Err(ContainerError::DuplicateName {
+                    name: CompactString::new(name),
+                    first,
+                    second: index,
+                });
+            }
+            seen.insert(name, index);
+        }
+        drop(seen);
+
+        let mut plugins = plugins;
+        plugins.sort_by_key(|plugin| order_rank(plugin.descriptor().order));
+
+        let descriptors = plugins
+            .iter()
+            .map(|plugin| plugin.descriptor().clone())
+            .collect::<Vec<_>>();
+
+        let mut lanes: [HookLane; PluginHook::COUNT] = std::array::from_fn(|_| HookLane::new());
+        let mut active = HookSet::EMPTY;
+        for (index, descriptor) in descriptors.iter().enumerate() {
+            if !descriptor.runs_in(mode) {
+                continue;
+            }
+            for hook in descriptor.hooks.iter() {
+                lanes[hook.index()].push(index as u16);
+                active = active.with(hook);
+            }
+        }
+
+        Ok(Self {
+            plugins,
+            descriptors,
+            mode,
+            active,
+            lanes,
+        })
+    }
+
+    /// Resolve descriptors alone into a pipeline that runs nothing.
+    ///
+    /// `uf inspect --json` reports the plan without executing it, and the same
+    /// ordering and duplicate rules have to apply to that report or it would be
+    /// describing a different pipeline than the one that builds.
+    pub fn from_descriptors(
+        mode: PipelineMode,
+        descriptors: Vec<PluginDescriptor>,
+    ) -> Result<Self, ContainerError> {
+        let plugins = descriptors
+            .into_iter()
+            .map(|descriptor| Box::new(FnPlugin::new(descriptor)) as Box<dyn Plugin>)
+            .collect();
+        Self::build(mode, plugins)
+    }
+
+    /// The resolved plan, in run order.
+    pub fn descriptors(&self) -> &[PluginDescriptor] {
+        &self.descriptors
+    }
+
+    /// Plugin names, in run order.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.descriptors.iter().map(|entry| entry.name.as_str())
+    }
+
+    /// Which pipeline this container was resolved for.
+    pub const fn mode(&self) -> PipelineMode {
+        self.mode
+    }
+
+    /// How many plugins are in the pipeline, including ones filtered out of
+    /// every hook by their apply condition.
+    pub fn len(&self) -> usize {
+        self.descriptors.len()
+    }
+
+    /// Whether the pipeline is empty.
+    pub fn is_empty(&self) -> bool {
+        self.descriptors.is_empty()
+    }
+
+    /// Every hook some plugin will actually run in this mode. One AND.
+    pub const fn active_hooks(&self) -> HookSet {
+        self.active
+    }
+
+    /// Whether any plugin runs `hook` in this mode.
+    pub const fn implements(&self, hook: PluginHook) -> bool {
+        self.active.contains(hook)
+    }
+
+    /// The plugins that run `hook`, in run order.
+    pub fn plugins_for(&self, hook: PluginHook) -> impl Iterator<Item = &PluginDescriptor> {
+        self.lanes[hook.index()]
+            .iter()
+            .map(|&index| &self.descriptors[index as usize])
+    }
+
+    /// Resolve an import specifier. First-wins: the first plugin that answers
+    /// owns the id and no later plugin is asked.
+    pub fn resolve_id(
+        &self,
+        specifier: &str,
+        importer: Option<&str>,
+    ) -> Result<HookOutcome<ResolvedId>, ContainerError> {
+        let input = ResolveInput {
+            specifier,
+            importer,
+        };
+        for &index in &self.lanes[PluginHook::ResolveId.index()] {
+            match self.plugins[index as usize].resolve_id(input) {
+                Ok(HookOutcome::Handled(resolved)) => return Ok(HookOutcome::Handled(resolved)),
+                Ok(HookOutcome::Passthrough) => {}
+                Err(source) => {
+                    return Err(self.hook_error(index, PluginHook::ResolveId, specifier, source));
+                }
+            }
+        }
+        Ok(HookOutcome::Passthrough)
+    }
+
+    /// Load a module's source. First-wins, like [`Self::resolve_id`].
+    pub fn load(&self, id: &str) -> Result<HookOutcome<ModuleCode>, ContainerError> {
+        let input = LoadInput { id };
+        for &index in &self.lanes[PluginHook::Load.index()] {
+            match self.plugins[index as usize].load(input) {
+                Ok(HookOutcome::Handled(code)) => return Ok(HookOutcome::Handled(code)),
+                Ok(HookOutcome::Passthrough) => {}
+                Err(source) => {
+                    return Err(self.hook_error(index, PluginHook::Load, id, source));
+                }
+            }
+        }
+        Ok(HookOutcome::Passthrough)
+    }
+
+    /// Run the transform chain over one module.
+    ///
+    /// Each plugin sees what the previous one produced. When no plugin touches
+    /// the module the result is [`HookOutcome::Passthrough`] and nothing was
+    /// allocated, which is the common case for most modules in a build.
+    ///
+    /// The surviving source map is the last one produced. A plugin that
+    /// rewrites code without producing a map drops the chain's map on purpose:
+    /// a map from an earlier stage describes text that no longer exists.
+    pub fn transform(
+        &self,
+        id: &str,
+        code: &str,
+    ) -> Result<HookOutcome<ModuleCode>, ContainerError> {
+        let mut current: Option<ModuleCode> = None;
+        for &index in &self.lanes[PluginHook::Transform.index()] {
+            let input = TransformInput {
+                id,
+                code: current.as_ref().map_or(code, |held| held.code.as_str()),
+            };
+            match self.plugins[index as usize].transform(input) {
+                Ok(HookOutcome::Handled(produced)) => current = Some(produced),
+                Ok(HookOutcome::Passthrough) => {}
+                Err(source) => {
+                    return Err(self.hook_error(index, PluginHook::Transform, id, source));
+                }
+            }
+        }
+        Ok(current.into())
+    }
+
+    /// Run a broadcast hook. Every plugin that declared it is notified, in run
+    /// order, and the first failure stops the pipeline.
+    pub fn notify(&self, hook: PluginHook) -> Result<(), ContainerError> {
+        for &index in &self.lanes[hook.index()] {
+            if let Err(source) = self.plugins[index as usize].notify(hook) {
+                return Err(self.hook_error(index, hook, hook.as_str(), source));
+            }
+        }
+        Ok(())
+    }
+
+    fn hook_error(
+        &self,
+        index: u16,
+        hook: PluginHook,
+        module: &str,
+        source: HookFailure,
+    ) -> ContainerError {
+        ContainerError::Hook {
+            plugin: self.descriptors[index as usize].name.clone(),
+            hook,
+            module: CompactString::new(module),
+            source,
+        }
+    }
+}
+
+impl std::fmt::Debug for PluginContainer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PluginContainer")
+            .field("mode", &self.mode)
+            .field("descriptors", &self.descriptors)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Sort key for the three bands. Stable sorting on this keeps declaration
+/// order within a band.
+const fn order_rank(order: HookOrder) -> u8 {
+    match order {
+        HookOrder::Pre => 0,
+        HookOrder::Normal => 1,
+        HookOrder::Post => 2,
+    }
+}

--- a/crates/uf_plugin/src/descriptor.rs
+++ b/crates/uf_plugin/src/descriptor.rs
@@ -1,0 +1,152 @@
+//! What the container knows about a plugin before it runs any of it.
+
+use camino::Utf8PathBuf;
+use compact_str::CompactString;
+use serde::Serialize;
+use uf_config::{ApplyCondition, HookOrder, PipelineMode};
+
+use crate::hook::{HookSet, PluginHook};
+
+/// Who put a plugin in the pipeline.
+///
+/// `uf inspect --json` reports this so a developer can tell their own plugin
+/// apart from the ones uf adds, without either being a special case anywhere
+/// else in the container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PluginOrigin {
+    /// Part of uf's own pipeline.
+    Builtin,
+    /// Declared in `plugins: [...]` in `uf.config.js`.
+    Project,
+}
+
+impl PluginOrigin {
+    /// Stable id, used in `uf inspect --json`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+            Self::Project => "project",
+        }
+    }
+}
+
+/// Where a project plugin's code comes from.
+///
+/// The distinction matters because only one of these two is a filesystem
+/// request. A [`PluginSource::Package`] is a specifier the resolver looks up; a
+/// [`PluginSource::ProjectFile`] is a path that has already been checked to sit
+/// inside the project root, and it is stored in that checked form so nothing
+/// downstream re-derives it from the user's original text.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum PluginSource {
+    /// uf's own pipeline; nothing is loaded from disk.
+    Builtin,
+    /// A package specifier such as `@uniflowed/plugin-mdx`.
+    Package {
+        /// The specifier, exactly as declared.
+        specifier: CompactString,
+    },
+    /// A file inside the project, as a checked project-relative path.
+    ProjectFile {
+        /// Normalized, verified to stay under the project root.
+        path: Utf8PathBuf,
+    },
+}
+
+impl PluginSource {
+    /// Stable id for the variant, used in `uf inspect --json`.
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+            Self::Package { .. } => "package",
+            Self::ProjectFile { .. } => "project-file",
+        }
+    }
+}
+
+/// Everything the container needs to place and dispatch one plugin.
+///
+/// A descriptor is data: building one runs no plugin code, so the whole
+/// pipeline can be resolved, ordered, checked for duplicates, and printed by
+/// `uf inspect --json` before anything is executed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginDescriptor {
+    /// Unique within one container. Built-in names use `CompactString`'s inline
+    /// representation, so naming a built-in allocates nothing.
+    pub name: CompactString,
+    /// Who put this plugin in the pipeline.
+    pub origin: PluginOrigin,
+    /// Where the code comes from.
+    pub source: PluginSource,
+    /// Which band the plugin runs in.
+    pub order: HookOrder,
+    /// Which pipelines the plugin takes part in.
+    pub apply: ApplyCondition,
+    /// Which hooks the plugin implements.
+    pub hooks: HookSet,
+}
+
+impl PluginDescriptor {
+    /// A built-in descriptor. `name` is a `&'static str` so no allocation
+    /// happens on the path that builds uf's own pipeline.
+    pub fn builtin(name: &'static str, order: HookOrder, hooks: HookSet) -> Self {
+        Self {
+            name: CompactString::const_new(name),
+            origin: PluginOrigin::Builtin,
+            source: PluginSource::Builtin,
+            order,
+            apply: ApplyCondition::Always,
+            hooks,
+        }
+    }
+
+    /// A descriptor for a plugin declared in `uf.config.js`.
+    pub fn project(
+        name: impl Into<CompactString>,
+        source: PluginSource,
+        order: HookOrder,
+        apply: ApplyCondition,
+        hooks: HookSet,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            origin: PluginOrigin::Project,
+            source,
+            order,
+            apply,
+            hooks,
+        }
+    }
+
+    /// Replace the declared hook set.
+    #[must_use]
+    pub fn with_hooks(mut self, hooks: HookSet) -> Self {
+        self.hooks = hooks;
+        self
+    }
+
+    /// Replace the declared apply condition.
+    #[must_use]
+    pub fn with_apply(mut self, apply: ApplyCondition) -> Self {
+        self.apply = apply;
+        self
+    }
+
+    /// Whether this plugin implements `hook`.
+    pub const fn implements(&self, hook: PluginHook) -> bool {
+        self.hooks.contains(hook)
+    }
+
+    /// Whether this plugin runs at all in `mode`.
+    pub const fn runs_in(&self, mode: PipelineMode) -> bool {
+        self.apply.admits(mode)
+    }
+
+    /// Whether this plugin runs `hook` in `mode`.
+    pub const fn dispatches(&self, hook: PluginHook, mode: PipelineMode) -> bool {
+        self.runs_in(mode) && self.implements(hook)
+    }
+}

--- a/crates/uf_plugin/src/hook.rs
+++ b/crates/uf_plugin/src/hook.rs
@@ -1,0 +1,264 @@
+//! The closed hook vocabulary and the bitset that makes dispatch a mask test.
+
+use serde::{Deserialize, Serialize};
+
+/// Every hook the uf pipeline drives.
+///
+/// The set is closed on purpose. A plugin cannot invent a hook name, the
+/// container cannot be asked for one it does not run, and adding a hook is a
+/// deliberate change to this enum rather than a new string appearing in a
+/// config file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PluginHook {
+    /// Reshape the config before it is resolved.
+    Config,
+    /// Observe the fully resolved config.
+    ConfigResolved,
+    /// A build or dev session is starting.
+    BuildStart,
+    /// Turn an import specifier into a module id.
+    ResolveId,
+    /// Produce the source text for a module id.
+    Load,
+    /// Rewrite a module's source text.
+    Transform,
+    /// Observe a module once its imports and exports are known.
+    ModuleParsed,
+    /// Every module has been processed.
+    BuildEnd,
+    /// Rewrite the code of one output chunk.
+    RenderChunk,
+    /// Inspect or add to the whole output before it is written.
+    GenerateBundle,
+    /// The output has been written to disk.
+    WriteBundle,
+    /// Attach handlers to the dev server.
+    ConfigureServer,
+    /// Decide what a changed file invalidates.
+    HandleHotUpdate,
+    /// Rewrite the HTML document shell.
+    TransformIndexHtml,
+}
+
+impl PluginHook {
+    /// Every hook, in pipeline order.
+    ///
+    /// The order is the order a build drives them, so a table built from this
+    /// array reads top-to-bottom like the build itself.
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::Config,
+        Self::ConfigResolved,
+        Self::BuildStart,
+        Self::ResolveId,
+        Self::Load,
+        Self::Transform,
+        Self::ModuleParsed,
+        Self::BuildEnd,
+        Self::RenderChunk,
+        Self::GenerateBundle,
+        Self::WriteBundle,
+        Self::ConfigureServer,
+        Self::HandleHotUpdate,
+        Self::TransformIndexHtml,
+    ];
+
+    /// How many hooks exist. [`HookSet`] needs at least this many bits.
+    pub const COUNT: usize = 14;
+
+    /// Stable id, used in `uf inspect --json` and in diagnostics.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Config => "config",
+            Self::ConfigResolved => "config-resolved",
+            Self::BuildStart => "build-start",
+            Self::ResolveId => "resolve-id",
+            Self::Load => "load",
+            Self::Transform => "transform",
+            Self::ModuleParsed => "module-parsed",
+            Self::BuildEnd => "build-end",
+            Self::RenderChunk => "render-chunk",
+            Self::GenerateBundle => "generate-bundle",
+            Self::WriteBundle => "write-bundle",
+            Self::ConfigureServer => "configure-server",
+            Self::HandleHotUpdate => "handle-hot-update",
+            Self::TransformIndexHtml => "transform-index-html",
+        }
+    }
+
+    /// Position in [`PluginHook::ALL`], and the bit index in a [`HookSet`].
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Config => 0,
+            Self::ConfigResolved => 1,
+            Self::BuildStart => 2,
+            Self::ResolveId => 3,
+            Self::Load => 4,
+            Self::Transform => 5,
+            Self::ModuleParsed => 6,
+            Self::BuildEnd => 7,
+            Self::RenderChunk => 8,
+            Self::GenerateBundle => 9,
+            Self::WriteBundle => 10,
+            Self::ConfigureServer => 11,
+            Self::HandleHotUpdate => 12,
+            Self::TransformIndexHtml => 13,
+        }
+    }
+
+    /// This hook as a one-bit mask.
+    pub const fn bit(self) -> u16 {
+        1u16 << self.index()
+    }
+
+    /// How the container combines what the plugins return.
+    ///
+    /// This is a property of the hook, not of any plugin, which is why the
+    /// container can guarantee it: a `FirstWins` hook stops at the first
+    /// plugin that answers, and a `Chained` hook feeds each answer to the
+    /// next plugin. See [`crate::HookOutcome`].
+    pub const fn dispatch(self) -> HookDispatch {
+        match self {
+            // Whoever claims a specifier or a module id owns it; asking the
+            // rest afterwards could only produce a second, conflicting answer.
+            Self::ResolveId | Self::Load => HookDispatch::FirstWins,
+            // Each plugin rewrites what the previous one produced.
+            Self::Transform
+            | Self::RenderChunk
+            | Self::TransformIndexHtml
+            | Self::HandleHotUpdate => HookDispatch::Chained,
+            // Notifications: every plugin sees the event, nobody consumes it.
+            Self::Config
+            | Self::ConfigResolved
+            | Self::BuildStart
+            | Self::ModuleParsed
+            | Self::BuildEnd
+            | Self::GenerateBundle
+            | Self::WriteBundle
+            | Self::ConfigureServer => HookDispatch::Broadcast,
+        }
+    }
+}
+
+/// How the container combines the plugins that implement one hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HookDispatch {
+    /// Every plugin runs; nothing is returned.
+    Broadcast,
+    /// The first plugin that answers wins and the rest are skipped.
+    FirstWins,
+    /// Every plugin runs and sees the previous plugin's output.
+    Chained,
+}
+
+impl HookDispatch {
+    /// Stable id, used in `uf inspect --json`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Broadcast => "broadcast",
+            Self::FirstWins => "first-wins",
+            Self::Chained => "chained",
+        }
+    }
+}
+
+/// The set of hooks one plugin implements, as a bitset.
+///
+/// A `Vec<String>` here would put a string compare in the middle of the
+/// per-module loop. A `u16` makes "does this plugin implement `Transform`?" a
+/// single AND, which is what lets the container precompute its dispatch lists
+/// without walking names.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HookSet(u16);
+
+impl HookSet {
+    /// No hooks.
+    pub const EMPTY: Self = Self(0);
+
+    /// Every hook in [`PluginHook::ALL`].
+    pub const ALL: Self = Self((1u16 << PluginHook::COUNT) - 1);
+
+    /// A set holding exactly `hook`.
+    pub const fn of(hook: PluginHook) -> Self {
+        Self(hook.bit())
+    }
+
+    /// This set plus `hook`.
+    pub const fn with(self, hook: PluginHook) -> Self {
+        Self(self.0 | hook.bit())
+    }
+
+    /// This set without `hook`.
+    pub const fn without(self, hook: PluginHook) -> Self {
+        Self(self.0 & !hook.bit())
+    }
+
+    /// Everything in either set.
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Everything in both sets.
+    pub const fn intersection(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
+    /// Whether `hook` is in the set. One AND, no branch.
+    pub const fn contains(self, hook: PluginHook) -> bool {
+        self.0 & hook.bit() != 0
+    }
+
+    /// Whether the set holds nothing.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// How many hooks are in the set.
+    pub const fn len(self) -> u32 {
+        self.0.count_ones()
+    }
+
+    /// The raw mask, for callers that want to store or compare it directly.
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+
+    /// The hooks in the set, in [`PluginHook::ALL`] order.
+    pub fn iter(self) -> impl Iterator<Item = PluginHook> {
+        PluginHook::ALL
+            .into_iter()
+            .filter(move |hook| self.contains(*hook))
+    }
+}
+
+impl FromIterator<PluginHook> for HookSet {
+    fn from_iter<I: IntoIterator<Item = PluginHook>>(iter: I) -> Self {
+        iter.into_iter().fold(Self::EMPTY, Self::with)
+    }
+}
+
+impl IntoIterator for HookSet {
+    type Item = PluginHook;
+    type IntoIter = std::vec::IntoIter<PluginHook>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter().collect::<Vec<_>>().into_iter()
+    }
+}
+
+impl Serialize for HookSet {
+    /// Emitted as the list of hook ids, so `uf inspect --json` shows names
+    /// rather than a number nobody can read.
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_seq(self.iter().map(PluginHook::as_str))
+    }
+}
+
+impl<'de> Deserialize<'de> for HookSet {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Vec::<PluginHook>::deserialize(deserializer)?
+            .into_iter()
+            .collect())
+    }
+}

--- a/crates/uf_plugin/src/inspect.rs
+++ b/crates/uf_plugin/src/inspect.rs
@@ -1,0 +1,109 @@
+//! The `plugins` section of `uf inspect --json`.
+//!
+//! A pipeline nobody can see is a pipeline nobody can debug, so the resolved
+//! order and each plugin's hooks are reportable without running anything. The
+//! report names uf's stages and the project's own plugins and nothing else: the
+//! engines underneath are an implementation detail, and naming them here would
+//! put them in front of users who only ever wrote `uf.config.js`.
+
+use serde::Serialize;
+use uf_config::{ApplyCondition, HookOrder, PipelineMode};
+
+use crate::container::PluginContainer;
+use crate::descriptor::{PluginOrigin, PluginSource};
+use crate::hook::{HookDispatch, HookSet, PluginHook};
+
+/// The resolved pipeline, ready to serialize.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineReport<'a> {
+    /// Which pipeline was resolved.
+    pub mode: PipelineMode,
+    /// How many plugins are in it.
+    pub count: usize,
+    /// The plugins, in the order they run.
+    pub plugins: Vec<PluginReport<'a>>,
+    /// The hooks that any plugin runs, and who runs them.
+    pub hooks: Vec<HookReport<'a>>,
+}
+
+/// One plugin's place in the pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginReport<'a> {
+    /// Zero-based position in the run order.
+    pub position: usize,
+    /// The plugin's name.
+    pub name: &'a str,
+    /// Whether uf or the project put it here.
+    pub origin: PluginOrigin,
+    /// Where its code comes from.
+    pub source: &'a PluginSource,
+    /// Which band it runs in.
+    pub order: HookOrder,
+    /// Which pipelines it takes part in.
+    pub apply: ApplyCondition,
+    /// Which hooks it implements.
+    ///
+    /// Empty for a project plugin whose module has not been read yet: the
+    /// resolver places plugins, it does not load them.
+    pub hooks: HookSet,
+    /// Whether it runs at all in this mode.
+    pub active: bool,
+}
+
+/// One hook, and the plugins that run it here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookReport<'a> {
+    /// The hook.
+    pub hook: PluginHook,
+    /// How the container combines what the plugins return.
+    pub dispatch: HookDispatch,
+    /// The plugins that run it, in run order.
+    pub plugins: Vec<&'a str>,
+}
+
+impl PluginContainer {
+    /// The resolved pipeline as a serializable report.
+    ///
+    /// Only hooks that at least one plugin runs are listed, so the section
+    /// describes this project rather than restating the hook enum.
+    pub fn report(&self) -> PipelineReport<'_> {
+        let plugins = self
+            .descriptors()
+            .iter()
+            .enumerate()
+            .map(|(position, descriptor)| PluginReport {
+                position,
+                name: descriptor.name.as_str(),
+                origin: descriptor.origin,
+                source: &descriptor.source,
+                order: descriptor.order,
+                apply: descriptor.apply,
+                hooks: descriptor.hooks,
+                active: descriptor.runs_in(self.mode()),
+            })
+            .collect();
+
+        let hooks = self
+            .active_hooks()
+            .iter()
+            .map(|hook| HookReport {
+                hook,
+                dispatch: hook.dispatch(),
+                plugins: self
+                    .plugins_for(hook)
+                    .map(|descriptor| descriptor.name.as_str())
+                    .collect(),
+            })
+            .collect();
+
+        PipelineReport {
+            mode: self.mode(),
+            count: self.len(),
+            plugins,
+            hooks,
+        }
+    }
+}

--- a/crates/uf_plugin/src/lib.rs
+++ b/crates/uf_plugin/src/lib.rs
@@ -1,0 +1,79 @@
+#![deny(missing_docs)]
+//! The plugin container that drives every stage of a uf build.
+//!
+//! uf has one plugin mechanism, and its own pipeline is built out of it: Flow
+//! stripping, router codegen, the RSC boundary split, StyleX, the React
+//! compiler, and asset handling are all [`BuiltinPlugin`] descriptors placed in
+//! the same container a project's own plugins go into. There is no second path
+//! and no hardcoded stage, so the run order a developer reads in
+//! `uf inspect --json` is the order that actually runs.
+//!
+//! What the pieces are:
+//!
+//! * [`PluginHook`] is the closed set of hooks uf drives, and [`HookSet`] is
+//!   that set as a bitset, so asking whether a plugin implements a hook is one
+//!   AND rather than a string compare in the per-module loop.
+//! * [`PluginDescriptor`] is what the container knows before running anything:
+//!   a name, an [`origin`](PluginOrigin), a [`source`](PluginSource), a band,
+//!   an apply condition, and the hooks.
+//! * [`PluginContainer`] fixes the run order — every `Pre` in declaration
+//!   order, then every `Normal`, then every `Post` — and owns the dispatch
+//!   loop, so first-wins and chaining are properties of the hook rather than
+//!   something a caller can get wrong. [`HookOutcome`] is how a plugin says it
+//!   produced something without deciding what that means.
+//! * [`resolve_pipeline`] turns a `uf.config.js` into a container, refusing any
+//!   plugin entry that names a path outside the project root.
+//!
+//! Stages delegate rather than duplicate: the transform logic lives in the
+//! crate that owns it, and [`FnPlugin`] is how that crate hands a closure to the
+//! container without this crate depending on it.
+//!
+//! ```
+//! use uf_plugin::{BuiltinSet, PipelineMode, PluginContainer, PluginHook};
+//! use uf_config::UniflowedConfig;
+//!
+//! let config = UniflowedConfig::default();
+//! let container = PluginContainer::from_descriptors(
+//!     PipelineMode::Build,
+//!     BuiltinSet::from_config(&config).descriptors(),
+//! )
+//! .expect("a default project resolves");
+//!
+//! // Flow stripping runs before the React compiler, whatever order the
+//! // descriptors arrived in.
+//! let order = container.names().collect::<Vec<_>>();
+//! assert!(
+//!     order.iter().position(|name| *name == "uf:flow")
+//!         < order.iter().position(|name| *name == "uf:react-compiler")
+//! );
+//! assert!(container.implements(PluginHook::Transform));
+//! ```
+
+pub mod builtin;
+pub mod container;
+pub mod descriptor;
+pub mod hook;
+pub mod inspect;
+pub mod outcome;
+pub mod plugin;
+pub mod resolve;
+
+pub use uf_config::{ApplyCondition, HookOrder, PipelineMode, PluginEntry, PluginSpec};
+
+pub use crate::builtin::{BuiltinPlugin, BuiltinSet};
+pub use crate::container::{ContainerError, MAX_PLUGINS, PluginContainer};
+pub use crate::descriptor::{PluginDescriptor, PluginOrigin, PluginSource};
+pub use crate::hook::{HookDispatch, HookSet, PluginHook};
+pub use crate::inspect::{HookReport, PipelineReport, PluginReport};
+pub use crate::outcome::{
+    HookFailure, HookOutcome, HookResult, LoadInput, ModuleCode, ResolveInput, ResolvedId,
+    ResolvedKind, TransformInput,
+};
+pub use crate::plugin::{FnPlugin, Plugin};
+pub use crate::resolve::{
+    BUILTIN_PREFIX, MAX_PLUGIN_NAME_BYTES, PluginPathError, ResolveError, classify_plugin_name,
+    resolve_entry, resolve_pipeline, resolve_project_plugins,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_plugin/src/outcome.rs
+++ b/crates/uf_plugin/src/outcome.rs
@@ -1,0 +1,218 @@
+//! What a hook is handed, what it may answer, and how it may fail.
+
+use compact_str::CompactString;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::hook::PluginHook;
+
+/// What a plugin did with the value it was handed.
+///
+/// This is the type that makes the container's two combining rules safe. A
+/// plugin never decides whether it "wins": it says only whether it produced
+/// something, and [`PluginHook::dispatch`](crate::PluginHook::dispatch) decides
+/// what that means. A first-wins hook stops at the first `Handled`; a chained
+/// hook feeds each `Handled` to the next plugin and keeps going.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum HookOutcome<T> {
+    /// The plugin produced a value.
+    Handled(T),
+    /// The plugin declined; the input is unchanged and the next plugin runs.
+    Passthrough,
+}
+
+impl<T> HookOutcome<T> {
+    /// Whether the plugin produced a value.
+    pub const fn is_handled(&self) -> bool {
+        matches!(self, Self::Handled(_))
+    }
+
+    /// Whether the plugin declined.
+    pub const fn is_passthrough(&self) -> bool {
+        matches!(self, Self::Passthrough)
+    }
+
+    /// The produced value, if any.
+    pub fn handled(self) -> Option<T> {
+        match self {
+            Self::Handled(value) => Some(value),
+            Self::Passthrough => None,
+        }
+    }
+
+    /// The produced value, or `fallback` when the plugin declined.
+    pub fn unwrap_or(self, fallback: T) -> T {
+        self.handled().unwrap_or(fallback)
+    }
+
+    /// Apply `f` to the produced value, keeping `Passthrough` as it is.
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> HookOutcome<U> {
+        match self {
+            Self::Handled(value) => HookOutcome::Handled(f(value)),
+            Self::Passthrough => HookOutcome::Passthrough,
+        }
+    }
+
+    /// A borrowed view of the produced value.
+    pub fn as_ref(&self) -> HookOutcome<&T> {
+        match self {
+            Self::Handled(value) => HookOutcome::Handled(value),
+            Self::Passthrough => HookOutcome::Passthrough,
+        }
+    }
+}
+
+impl<T> From<Option<T>> for HookOutcome<T> {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(value) => Self::Handled(value),
+            None => Self::Passthrough,
+        }
+    }
+}
+
+/// A hook's answer, or a typed failure.
+pub type HookResult<T> = Result<HookOutcome<T>, HookFailure>;
+
+/// The import specifier a plugin is asked to resolve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolveInput<'a> {
+    /// The specifier exactly as it appeared in the source.
+    pub specifier: &'a str,
+    /// The module that imported it, if this is not an entry point.
+    pub importer: Option<&'a str>,
+}
+
+/// What kind of thing a resolved id names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ResolvedKind {
+    /// A real module that goes into the graph.
+    Bundled,
+    /// Left for the runtime to resolve; never read from disk.
+    External,
+    /// Produced by a plugin's `Load` hook rather than by the filesystem.
+    Virtual,
+}
+
+/// A module id a plugin claimed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedId {
+    /// The id every later hook uses for this module.
+    pub id: CompactString,
+    /// What the id names.
+    pub kind: ResolvedKind,
+}
+
+impl ResolvedId {
+    /// A resolved id for a module that goes into the graph.
+    pub fn bundled(id: impl Into<CompactString>) -> Self {
+        Self {
+            id: id.into(),
+            kind: ResolvedKind::Bundled,
+        }
+    }
+
+    /// A resolved id left for the runtime.
+    pub fn external(id: impl Into<CompactString>) -> Self {
+        Self {
+            id: id.into(),
+            kind: ResolvedKind::External,
+        }
+    }
+
+    /// A resolved id a `Load` hook will supply the source for.
+    pub fn virtual_module(id: impl Into<CompactString>) -> Self {
+        Self {
+            id: id.into(),
+            kind: ResolvedKind::Virtual,
+        }
+    }
+}
+
+/// The module a plugin is asked to load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoadInput<'a> {
+    /// The resolved module id.
+    pub id: &'a str,
+}
+
+/// The module a plugin is asked to transform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransformInput<'a> {
+    /// The resolved module id.
+    pub id: &'a str,
+    /// The source text as the previous plugin left it.
+    pub code: &'a str,
+}
+
+/// Source text a plugin produced, from either `Load` or `Transform`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleCode {
+    /// The module's source text.
+    pub code: String,
+    /// A source map for it, when the plugin produced one.
+    pub source_map: Option<String>,
+}
+
+impl ModuleCode {
+    /// Source text with no map.
+    pub fn new(code: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            source_map: None,
+        }
+    }
+
+    /// Attach a source map.
+    #[must_use]
+    pub fn with_source_map(mut self, source_map: impl Into<String>) -> Self {
+        self.source_map = Some(source_map.into());
+        self
+    }
+}
+
+/// Why a plugin could not complete a hook.
+///
+/// The variants are a closed set with structured fields rather than a message,
+/// so a failure can be matched on, counted, and rendered by the CLI without
+/// anyone parsing prose. `Rejected` carries a `&'static str` rule id for the
+/// general case, matching how the linter names its rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum HookFailure {
+    /// The module's syntax is not something this plugin can process.
+    #[error("unsupported syntax at byte offset {offset}")]
+    UnsupportedSyntax {
+        /// Byte offset into the input the plugin was handed.
+        offset: usize,
+    },
+    /// The plugin needs another hook to have run first.
+    #[error("the {required} hook must run before {hook}")]
+    MissingPrerequisite {
+        /// The hook that has to run first.
+        required: PluginHook,
+        /// The hook that could not run.
+        hook: PluginHook,
+    },
+    /// The input is larger than the plugin is willing to hold in memory.
+    #[error("input is {bytes} bytes, over the {limit} byte ceiling")]
+    InputTooLarge {
+        /// Size of the input.
+        bytes: usize,
+        /// The plugin's ceiling.
+        limit: usize,
+    },
+    /// The plugin refused the module because it breaks a project rule.
+    #[error("rejected by rule {rule}")]
+    Rejected {
+        /// Rule id, in the same `namespace/name` shape the linter uses.
+        rule: &'static str,
+    },
+}
+
+impl std::fmt::Display for PluginHook {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}

--- a/crates/uf_plugin/src/plugin.rs
+++ b/crates/uf_plugin/src/plugin.rs
@@ -1,0 +1,163 @@
+//! The trait a plugin implements, and the adapter that wires an existing crate
+//! into the container without that crate having to know the trait exists.
+
+use crate::descriptor::PluginDescriptor;
+use crate::hook::PluginHook;
+use crate::outcome::{
+    HookFailure, HookOutcome, HookResult, LoadInput, ModuleCode, ResolveInput, ResolvedId,
+    TransformInput,
+};
+
+/// One participant in the pipeline.
+///
+/// Every hook defaults to [`HookOutcome::Passthrough`], so a plugin implements
+/// only what it cares about. The container never calls a hook the plugin's
+/// descriptor did not declare, so the declared [`HookSet`](crate::HookSet) and
+/// the implementation stay in step.
+pub trait Plugin: Send + Sync {
+    /// Name, order, apply condition, and declared hooks.
+    fn descriptor(&self) -> &PluginDescriptor;
+
+    /// Turn an import specifier into a module id. First-wins.
+    fn resolve_id(&self, input: ResolveInput<'_>) -> HookResult<ResolvedId> {
+        let _ = input;
+        Ok(HookOutcome::Passthrough)
+    }
+
+    /// Produce the source text for a module id. First-wins.
+    fn load(&self, input: LoadInput<'_>) -> HookResult<ModuleCode> {
+        let _ = input;
+        Ok(HookOutcome::Passthrough)
+    }
+
+    /// Rewrite a module's source text. Chained.
+    fn transform(&self, input: TransformInput<'_>) -> HookResult<ModuleCode> {
+        let _ = input;
+        Ok(HookOutcome::Passthrough)
+    }
+
+    /// Observe a broadcast hook such as `BuildStart` or `WriteBundle`.
+    fn notify(&self, hook: PluginHook) -> Result<(), HookFailure> {
+        let _ = hook;
+        Ok(())
+    }
+}
+
+type ResolveIdFn = Box<dyn Fn(ResolveInput<'_>) -> HookResult<ResolvedId> + Send + Sync>;
+type LoadFn = Box<dyn Fn(LoadInput<'_>) -> HookResult<ModuleCode> + Send + Sync>;
+type TransformFn = Box<dyn Fn(TransformInput<'_>) -> HookResult<ModuleCode> + Send + Sync>;
+type NotifyFn = Box<dyn Fn(PluginHook) -> Result<(), HookFailure> + Send + Sync>;
+
+/// A plugin assembled from closures.
+///
+/// This is how uf's own stages become plugins without `uf_plugin` growing a
+/// dependency on every crate that owns a transform: the crate that owns the
+/// logic hands over a closure, and the container sees an ordinary [`Plugin`].
+/// Registering a hook also records it in the descriptor, so a wired hook is
+/// always a declared hook.
+pub struct FnPlugin {
+    descriptor: PluginDescriptor,
+    resolve_id: Option<ResolveIdFn>,
+    load: Option<LoadFn>,
+    transform: Option<TransformFn>,
+    notify: Option<NotifyFn>,
+}
+
+impl FnPlugin {
+    /// An inert plugin: it occupies its place in the order and runs nothing.
+    pub fn new(descriptor: PluginDescriptor) -> Self {
+        Self {
+            descriptor,
+            resolve_id: None,
+            load: None,
+            transform: None,
+            notify: None,
+        }
+    }
+
+    /// Wire the `ResolveId` hook, declaring it on the descriptor.
+    #[must_use]
+    pub fn on_resolve_id(
+        mut self,
+        hook: impl Fn(ResolveInput<'_>) -> HookResult<ResolvedId> + Send + Sync + 'static,
+    ) -> Self {
+        self.descriptor.hooks = self.descriptor.hooks.with(PluginHook::ResolveId);
+        self.resolve_id = Some(Box::new(hook));
+        self
+    }
+
+    /// Wire the `Load` hook, declaring it on the descriptor.
+    #[must_use]
+    pub fn on_load(
+        mut self,
+        hook: impl Fn(LoadInput<'_>) -> HookResult<ModuleCode> + Send + Sync + 'static,
+    ) -> Self {
+        self.descriptor.hooks = self.descriptor.hooks.with(PluginHook::Load);
+        self.load = Some(Box::new(hook));
+        self
+    }
+
+    /// Wire the `Transform` hook, declaring it on the descriptor.
+    #[must_use]
+    pub fn on_transform(
+        mut self,
+        hook: impl Fn(TransformInput<'_>) -> HookResult<ModuleCode> + Send + Sync + 'static,
+    ) -> Self {
+        self.descriptor.hooks = self.descriptor.hooks.with(PluginHook::Transform);
+        self.transform = Some(Box::new(hook));
+        self
+    }
+
+    /// Wire the broadcast hooks. The hooks themselves stay as declared.
+    #[must_use]
+    pub fn on_notify(
+        mut self,
+        hook: impl Fn(PluginHook) -> Result<(), HookFailure> + Send + Sync + 'static,
+    ) -> Self {
+        self.notify = Some(Box::new(hook));
+        self
+    }
+}
+
+impl std::fmt::Debug for FnPlugin {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FnPlugin")
+            .field("descriptor", &self.descriptor)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Plugin for FnPlugin {
+    fn descriptor(&self) -> &PluginDescriptor {
+        &self.descriptor
+    }
+
+    fn resolve_id(&self, input: ResolveInput<'_>) -> HookResult<ResolvedId> {
+        match &self.resolve_id {
+            Some(hook) => hook(input),
+            None => Ok(HookOutcome::Passthrough),
+        }
+    }
+
+    fn load(&self, input: LoadInput<'_>) -> HookResult<ModuleCode> {
+        match &self.load {
+            Some(hook) => hook(input),
+            None => Ok(HookOutcome::Passthrough),
+        }
+    }
+
+    fn transform(&self, input: TransformInput<'_>) -> HookResult<ModuleCode> {
+        match &self.transform {
+            Some(hook) => hook(input),
+            None => Ok(HookOutcome::Passthrough),
+        }
+    }
+
+    fn notify(&self, hook: PluginHook) -> Result<(), HookFailure> {
+        match &self.notify {
+            Some(notify) => notify(hook),
+            None => Ok(()),
+        }
+    }
+}

--- a/crates/uf_plugin/src/resolve.rs
+++ b/crates/uf_plugin/src/resolve.rs
@@ -1,0 +1,373 @@
+//! Turning `plugins: [...]` into descriptors, and refusing the entries that are
+//! really a request to run code from somewhere else on the machine.
+//!
+//! A plugin name is untrusted input. `uf install` and `uf build` run on freshly
+//! cloned repositories, so a config that can name `../../../.ssh/id_ed25519` or
+//! `/etc/anything` as a plugin is a remote-code-execution primitive, not a
+//! configuration mistake. See `docs/security.md`.
+//!
+//! The grammar below is a closed one, checked in a single byte scan with no
+//! regex, and it is the same on every platform — in particular `\` is a
+//! separator everywhere, never only on Windows, which is the shape of both the
+//! pnpm tarball traversal and the Vite-era dev-server bypasses.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use thiserror::Error;
+use uf_config::{PipelineMode, PluginEntry, UniflowedConfig};
+
+use crate::builtin::BuiltinSet;
+use crate::container::{ContainerError, PluginContainer};
+use crate::descriptor::{PluginDescriptor, PluginSource};
+use crate::hook::HookSet;
+
+/// Longest plugin name the resolver will look at.
+///
+/// Config is attacker-controlled text; every parse in uf has an explicit bound
+/// above it. 256 bytes is longer than any real package specifier or project
+/// path and short enough that a hostile config cannot make the resolver
+/// allocate.
+pub const MAX_PLUGIN_NAME_BYTES: usize = 256;
+
+/// The prefix uf reserves for its own plugins.
+///
+/// A project plugin may not use it, so a config can neither shadow a built-in
+/// nor make `uf inspect --json` claim uf ships something it does not.
+pub const BUILTIN_PREFIX: &str = "uf:";
+
+/// Why a declared plugin name is not usable.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PluginPathError {
+    /// The name is empty.
+    #[error("plugin name is empty")]
+    Empty,
+    /// The name is longer than [`MAX_PLUGIN_NAME_BYTES`].
+    #[error("plugin name is {bytes} bytes, over the {limit} byte ceiling")]
+    TooLong {
+        /// Length of the declared name.
+        bytes: usize,
+        /// The ceiling, always [`MAX_PLUGIN_NAME_BYTES`].
+        limit: usize,
+    },
+    /// The name holds a control byte, which no resolver should ever see.
+    #[error("plugin name {name:?} holds a control byte at offset {offset}")]
+    ControlByte {
+        /// The declared name.
+        name: CompactString,
+        /// Byte offset of the first control byte.
+        offset: usize,
+    },
+    /// The name uses the prefix uf reserves for its own plugins.
+    #[error("plugin name {name:?} uses the reserved {prefix:?} prefix")]
+    ReservedPrefix {
+        /// The declared name.
+        name: CompactString,
+        /// The reserved prefix, always [`BUILTIN_PREFIX`].
+        prefix: &'static str,
+    },
+    /// The name is a URL, or a Windows drive-qualified path.
+    #[error("plugin name {name:?} names a {scheme:?} URL or drive, not a package or project file")]
+    UrlScheme {
+        /// The declared name.
+        name: CompactString,
+        /// The scheme or drive letter found before the colon.
+        scheme: CompactString,
+    },
+    /// The name is relative to the user's home directory.
+    #[error("plugin name {name:?} is home-relative")]
+    HomeRelative {
+        /// The declared name.
+        name: CompactString,
+    },
+    /// The name uses a backslash, which uf treats as a separator everywhere.
+    #[error("plugin name {name:?} holds a path separator `\\` at offset {offset}")]
+    BackslashSeparator {
+        /// The declared name.
+        name: CompactString,
+        /// Byte offset of the first backslash.
+        offset: usize,
+    },
+    /// The name is an absolute path.
+    #[error("plugin name {name:?} is an absolute path")]
+    Absolute {
+        /// The declared name.
+        name: CompactString,
+    },
+    /// The name has an empty path segment, as in `a//b` or a trailing slash.
+    #[error("plugin name {name:?} has an empty path segment at position {position}")]
+    EmptySegment {
+        /// The declared name.
+        name: CompactString,
+        /// Which `/`-separated segment was empty, counting from zero.
+        position: usize,
+    },
+    /// The name walks upwards out of the project.
+    #[error("plugin name {name:?} has a `..` segment at position {position}")]
+    ParentSegment {
+        /// The declared name.
+        name: CompactString,
+        /// Which `/`-separated segment was `..`, counting from zero.
+        position: usize,
+    },
+    /// The name has a `.` segment somewhere other than the front.
+    #[error("plugin name {name:?} has a `.` segment at position {position}")]
+    CurrentSegment {
+        /// The declared name.
+        name: CompactString,
+        /// Which `/`-separated segment was `.`, counting from zero.
+        position: usize,
+    },
+    /// The name resolved to a path outside the project root.
+    ///
+    /// Reached when a symlink inside the project points outwards; the lexical
+    /// grammar cannot see that, so containment is re-checked after resolution.
+    #[error("plugin {name:?} resolves to {resolved}, outside the project root {root}")]
+    OutsideRoot {
+        /// The declared name.
+        name: CompactString,
+        /// Where it actually pointed.
+        resolved: Utf8PathBuf,
+        /// The project root it had to stay inside.
+        root: Utf8PathBuf,
+    },
+    /// The path exists but could not be resolved to a real path.
+    ///
+    /// Containment cannot be proven, so the entry is refused rather than
+    /// admitted on the strength of the lexical check alone.
+    #[error("plugin {name:?} at {path} could not be resolved to a real path")]
+    Unresolvable {
+        /// The declared name.
+        name: CompactString,
+        /// The path that failed to resolve.
+        path: Utf8PathBuf,
+    },
+}
+
+/// Why a project's `plugins: [...]` could not be turned into a pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ResolveError {
+    /// One entry is not a usable plugin name.
+    #[error("plugins[{index}] is not a usable plugin name")]
+    Entry {
+        /// Index into `plugins: [...]`, so the error points at a line.
+        index: usize,
+        /// What was wrong with it.
+        #[source]
+        source: PluginPathError,
+    },
+    /// The resolved plugins do not form a usable pipeline.
+    #[error(transparent)]
+    Container(#[from] ContainerError),
+}
+
+/// Classify a declared plugin name, rejecting anything that reaches outside the
+/// project.
+///
+/// A leading `./` is what makes a name a project file; everything else is a
+/// package specifier, exactly as a module resolver would read it. That means
+/// `plugins/x.js` is looked up as a package and never joined onto a path, so
+/// there is only one way for a config to name a file on disk and only one place
+/// to guard.
+pub fn classify_plugin_name(name: &str, root: &Utf8Path) -> Result<PluginSource, PluginPathError> {
+    if name.is_empty() {
+        return Err(PluginPathError::Empty);
+    }
+    if name.len() > MAX_PLUGIN_NAME_BYTES {
+        return Err(PluginPathError::TooLong {
+            bytes: name.len(),
+            limit: MAX_PLUGIN_NAME_BYTES,
+        });
+    }
+
+    let bytes = name.as_bytes();
+    for (offset, &byte) in bytes.iter().enumerate() {
+        if byte < 0x20 || byte == 0x7f {
+            return Err(PluginPathError::ControlByte {
+                name: CompactString::new(name),
+                offset,
+            });
+        }
+        if byte == b'\\' {
+            return Err(PluginPathError::BackslashSeparator {
+                name: CompactString::new(name),
+                offset,
+            });
+        }
+    }
+
+    if name.starts_with(BUILTIN_PREFIX) {
+        return Err(PluginPathError::ReservedPrefix {
+            name: CompactString::new(name),
+            prefix: BUILTIN_PREFIX,
+        });
+    }
+    if let Some(scheme) = leading_scheme(name) {
+        return Err(PluginPathError::UrlScheme {
+            name: CompactString::new(name),
+            scheme: CompactString::new(scheme),
+        });
+    }
+    if bytes[0] == b'~' {
+        return Err(PluginPathError::HomeRelative {
+            name: CompactString::new(name),
+        });
+    }
+    if bytes[0] == b'/' {
+        return Err(PluginPathError::Absolute {
+            name: CompactString::new(name),
+        });
+    }
+
+    for (position, segment) in name.split('/').enumerate() {
+        match segment {
+            "" => {
+                return Err(PluginPathError::EmptySegment {
+                    name: CompactString::new(name),
+                    position,
+                });
+            }
+            ".." => {
+                return Err(PluginPathError::ParentSegment {
+                    name: CompactString::new(name),
+                    position,
+                });
+            }
+            "." if position > 0 => {
+                return Err(PluginPathError::CurrentSegment {
+                    name: CompactString::new(name),
+                    position,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    if name.starts_with("./") {
+        Ok(PluginSource::ProjectFile {
+            path: resolve_inside_root(name, root)?,
+        })
+    } else {
+        Ok(PluginSource::Package {
+            specifier: CompactString::new(name),
+        })
+    }
+}
+
+/// Join a checked relative name onto the root and prove the result stays inside.
+///
+/// The segment walk above already refuses `..`, so the containment test here is
+/// belt and braces for the lexical case. It earns its keep on the case the
+/// grammar cannot see: a symlink inside the project pointing out of it. When
+/// the target exists, both sides are canonicalized and compared as paths, never
+/// as string prefixes, so `/project-evil` is not treated as living under
+/// `/project`.
+fn resolve_inside_root(name: &str, root: &Utf8Path) -> Result<Utf8PathBuf, PluginPathError> {
+    let mut resolved = root.to_path_buf();
+    for segment in name.split('/') {
+        match segment {
+            "." => {}
+            ".." => {
+                resolved.pop();
+            }
+            other => resolved.push(other),
+        }
+    }
+
+    if !resolved.starts_with(root) {
+        return Err(PluginPathError::OutsideRoot {
+            name: CompactString::new(name),
+            resolved,
+            root: root.to_path_buf(),
+        });
+    }
+
+    if !resolved.exists() {
+        return Ok(resolved);
+    }
+    let Ok(canonical_root) = root.canonicalize_utf8() else {
+        return Ok(resolved);
+    };
+    let canonical = resolved
+        .canonicalize_utf8()
+        .map_err(|_| PluginPathError::Unresolvable {
+            name: CompactString::new(name),
+            path: resolved.clone(),
+        })?;
+    if !canonical.starts_with(&canonical_root) {
+        return Err(PluginPathError::OutsideRoot {
+            name: CompactString::new(name),
+            resolved: canonical,
+            root: canonical_root,
+        });
+    }
+
+    Ok(resolved)
+}
+
+/// Descriptors for the plugins a project declares, in declaration order.
+///
+/// The hook set starts empty: which hooks a project plugin implements is only
+/// known once its module is read, and the resolver reads nothing. A loader
+/// fills it in with [`PluginDescriptor::with_hooks`].
+pub fn resolve_project_plugins(
+    config: &UniflowedConfig,
+    root: &Utf8Path,
+) -> Result<Vec<PluginDescriptor>, ResolveError> {
+    config
+        .plugins
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            resolve_entry(entry, root).map_err(|source| ResolveError::Entry { index, source })
+        })
+        .collect()
+}
+
+/// Turn one declared entry into a descriptor.
+pub fn resolve_entry(
+    entry: &PluginEntry,
+    root: &Utf8Path,
+) -> Result<PluginDescriptor, PluginPathError> {
+    let name = entry.name();
+    let source = classify_plugin_name(name, root)?;
+    Ok(PluginDescriptor::project(
+        name,
+        source,
+        entry.order(),
+        entry.apply(),
+        HookSet::EMPTY,
+    ))
+}
+
+/// The whole pipeline for a project: uf's built-ins plus whatever the config
+/// declares, resolved into one container.
+///
+/// Built-ins come first so a project plugin with the same band still runs after
+/// them, and so a duplicate name collides against the built-in rather than
+/// quietly replacing it.
+pub fn resolve_pipeline(
+    config: &UniflowedConfig,
+    root: &Utf8Path,
+    mode: PipelineMode,
+) -> Result<PluginContainer, ResolveError> {
+    let mut descriptors = BuiltinSet::from_config(config).descriptors();
+    descriptors.extend(resolve_project_plugins(config, root)?);
+    Ok(PluginContainer::from_descriptors(mode, descriptors)?)
+}
+
+/// The `scheme` of `scheme:rest`, when the prefix is a valid URL scheme.
+///
+/// A single Windows drive letter matches too, which is deliberate: `C:/x` is an
+/// absolute path wearing a scheme's clothes, and both are refused here.
+fn leading_scheme(name: &str) -> Option<&str> {
+    let colon = name.find(':')?;
+    let scheme = &name[..colon];
+    let mut bytes = scheme.bytes();
+    let first = bytes.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    bytes
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+        .then_some(scheme)
+}

--- a/crates/uf_plugin/src/tests/builtin.rs
+++ b/crates/uf_plugin/src/tests/builtin.rs
@@ -1,0 +1,251 @@
+//! uf's own pipeline stages.
+
+use uf_config::{HookOrder, PipelineMode, StyleEngine, UniflowedConfig};
+
+use crate::builtin::{BuiltinPlugin, BuiltinSet};
+use crate::container::PluginContainer;
+use crate::descriptor::{PluginOrigin, PluginSource};
+use crate::hook::{HookSet, PluginHook};
+use crate::resolve::BUILTIN_PREFIX;
+
+fn pipeline(config: &UniflowedConfig) -> PluginContainer {
+    PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        BuiltinSet::from_config(config).descriptors(),
+    )
+    .expect("uf's own pipeline always resolves")
+}
+
+#[test]
+fn all_holds_every_builtin_exactly_once() {
+    let mut seen = BuiltinSet::EMPTY;
+    for plugin in BuiltinPlugin::ALL {
+        assert!(!seen.contains(plugin), "{plugin:?} appears twice");
+        seen = seen.with(plugin);
+    }
+    assert_eq!(seen, BuiltinSet::ALL);
+    assert_eq!(BuiltinPlugin::ALL.len(), BuiltinPlugin::COUNT);
+}
+
+#[test]
+fn every_builtin_has_a_unique_index_and_bit() {
+    let mut mask = 0u8;
+    for (position, plugin) in BuiltinPlugin::ALL.into_iter().enumerate() {
+        assert_eq!(plugin.index(), position, "{plugin:?}");
+        assert_eq!(plugin.bit().count_ones(), 1, "{plugin:?}");
+        assert_eq!(mask & plugin.bit(), 0, "{plugin:?} reuses a bit");
+        mask |= plugin.bit();
+    }
+    assert_eq!(mask, BuiltinSet::ALL.bits());
+}
+
+#[test]
+fn every_builtin_has_a_unique_reserved_name() {
+    let mut names = BuiltinPlugin::ALL.map(BuiltinPlugin::name).to_vec();
+    for name in &names {
+        assert!(name.starts_with(BUILTIN_PREFIX), "{name}");
+        assert!(name.len() > BUILTIN_PREFIX.len(), "{name}");
+    }
+    names.sort_unstable();
+    let count = names.len();
+    names.dedup();
+    assert_eq!(names.len(), count, "two built-ins share a name");
+}
+
+#[test]
+fn every_builtin_implements_at_least_one_hook() {
+    for plugin in BuiltinPlugin::ALL {
+        assert!(!plugin.hooks().is_empty(), "{plugin:?}");
+    }
+}
+
+#[test]
+fn flow_stripping_and_route_generation_run_first() {
+    assert_eq!(BuiltinPlugin::Flow.order(), HookOrder::Pre);
+    assert_eq!(BuiltinPlugin::Router.order(), HookOrder::Pre);
+}
+
+#[test]
+fn the_react_compiler_runs_last() {
+    assert_eq!(BuiltinPlugin::ReactCompiler.order(), HookOrder::Post);
+
+    let names = pipeline(&UniflowedConfig::default())
+        .names()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        names.last().map(String::as_str),
+        Some(BuiltinPlugin::ReactCompiler.name())
+    );
+}
+
+#[test]
+fn flow_stripping_runs_before_every_other_transform() {
+    let container = pipeline(&UniflowedConfig::default());
+    let transformers = container
+        .plugins_for(PluginHook::Transform)
+        .map(|plugin| plugin.name.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(transformers.first(), Some(&BuiltinPlugin::Flow.name()));
+    assert!(transformers.len() > 1);
+}
+
+#[test]
+fn a_builtin_descriptor_is_marked_builtin() {
+    for plugin in BuiltinPlugin::ALL {
+        let descriptor = plugin.descriptor();
+        assert_eq!(descriptor.origin, PluginOrigin::Builtin);
+        assert_eq!(descriptor.source, PluginSource::Builtin);
+        assert_eq!(descriptor.name, plugin.name());
+        assert_eq!(descriptor.hooks, plugin.hooks());
+    }
+}
+
+#[test]
+fn a_default_project_switches_on_every_builtin() {
+    let set = BuiltinSet::from_config(&UniflowedConfig::default());
+
+    assert_eq!(set, BuiltinSet::ALL);
+    assert_eq!(set.len() as usize, BuiltinPlugin::COUNT);
+}
+
+#[test]
+fn turning_off_the_router_drops_its_plugin() {
+    let mut config = UniflowedConfig::default();
+    config.app.router.enabled = false;
+
+    let set = BuiltinSet::from_config(&config);
+
+    assert!(!set.contains(BuiltinPlugin::Router));
+    assert_eq!(set, BuiltinSet::ALL.without(BuiltinPlugin::Router));
+}
+
+#[test]
+fn turning_off_rsc_drops_its_plugin() {
+    let mut config = UniflowedConfig::default();
+    config.app.rsc = false;
+
+    assert!(!BuiltinSet::from_config(&config).contains(BuiltinPlugin::Rsc));
+}
+
+#[test]
+fn turning_off_the_react_compiler_drops_its_plugin() {
+    let mut config = UniflowedConfig::default();
+    config.app.builtins.react_compiler.enabled = false;
+
+    let set = BuiltinSet::from_config(&config);
+
+    assert!(!set.contains(BuiltinPlugin::ReactCompiler));
+    assert!(set.contains(BuiltinPlugin::Flow), "the rest stay");
+}
+
+#[test]
+fn the_style_engine_selects_the_style_plugin() {
+    let mut config = UniflowedConfig::default();
+    config.app.builtins.style = StyleEngine::StyleX;
+
+    assert!(BuiltinSet::from_config(&config).contains(BuiltinPlugin::Style));
+}
+
+#[test]
+fn flow_and_asset_handling_cannot_be_switched_off() {
+    let mut config = UniflowedConfig::default();
+    config.app.router.enabled = false;
+    config.app.rsc = false;
+    config.app.builtins.react_compiler.enabled = false;
+
+    let set = BuiltinSet::from_config(&config);
+
+    assert!(set.contains(BuiltinPlugin::Flow));
+    assert!(set.contains(BuiltinPlugin::Asset));
+}
+
+#[test]
+fn an_empty_set_produces_no_descriptors() {
+    assert!(BuiltinSet::EMPTY.is_empty());
+    assert_eq!(BuiltinSet::EMPTY.len(), 0);
+    assert!(BuiltinSet::EMPTY.descriptors().is_empty());
+}
+
+#[test]
+fn a_set_iterates_in_pipeline_order() {
+    let set = BuiltinSet::of(BuiltinPlugin::Asset).with(BuiltinPlugin::Flow);
+
+    assert_eq!(
+        set.iter().collect::<Vec<_>>(),
+        vec![BuiltinPlugin::Flow, BuiltinPlugin::Asset]
+    );
+}
+
+#[test]
+fn with_if_only_adds_when_asked() {
+    let set = BuiltinSet::EMPTY
+        .with_if(BuiltinPlugin::Flow, true)
+        .with_if(BuiltinPlugin::Rsc, false);
+
+    assert_eq!(set, BuiltinSet::of(BuiltinPlugin::Flow));
+}
+
+#[test]
+fn collecting_builtins_deduplicates_them() {
+    let set: BuiltinSet = [BuiltinPlugin::Flow, BuiltinPlugin::Flow, BuiltinPlugin::Rsc]
+        .into_iter()
+        .collect();
+
+    assert_eq!(set.len(), 2);
+}
+
+#[test]
+fn a_set_serializes_as_plugin_names() {
+    let set = BuiltinSet::of(BuiltinPlugin::Flow).with(BuiltinPlugin::Rsc);
+
+    assert_eq!(
+        serde_json::to_value(set).expect("serializes"),
+        serde_json::json!(["uf:flow", "uf:rsc"])
+    );
+}
+
+#[test]
+fn uf_s_own_pipeline_has_no_duplicate_names() {
+    let container = pipeline(&UniflowedConfig::default());
+
+    assert_eq!(container.len(), BuiltinPlugin::COUNT);
+}
+
+#[test]
+fn every_builtin_takes_part_in_both_pipelines() {
+    for mode in PipelineMode::ALL {
+        let container = PluginContainer::from_descriptors(mode, BuiltinSet::ALL.descriptors())
+            .expect("container");
+
+        assert!(
+            container
+                .report()
+                .plugins
+                .iter()
+                .all(|plugin| plugin.active),
+            "{mode:?}"
+        );
+    }
+}
+
+#[test]
+fn the_pipeline_covers_the_hooks_a_build_needs() {
+    let container = pipeline(&UniflowedConfig::default());
+
+    for hook in [
+        PluginHook::ResolveId,
+        PluginHook::Load,
+        PluginHook::Transform,
+        PluginHook::GenerateBundle,
+        PluginHook::WriteBundle,
+    ] {
+        assert!(container.implements(hook), "{hook}");
+    }
+    assert!(
+        container.active_hooks().intersection(HookSet::ALL) == container.active_hooks(),
+        "every active hook is a real hook"
+    );
+}

--- a/crates/uf_plugin/src/tests/chain.rs
+++ b/crates/uf_plugin/src/tests/chain.rs
@@ -1,0 +1,448 @@
+//! Chained dispatch, `apply` filtering, broadcast, and failure mid-chain.
+
+use uf_config::{ApplyCondition, HookOrder, PipelineMode};
+
+use crate::container::{ContainerError, PluginContainer};
+use crate::hook::{HookSet, PluginHook};
+use crate::outcome::{HookFailure, HookOutcome, ModuleCode};
+use crate::plugin::{FnPlugin, Plugin};
+
+use super::{appender, descriptor, failing, passthrough, resolver};
+
+fn build(plugins: Vec<Box<dyn Plugin>>) -> PluginContainer {
+    PluginContainer::build(PipelineMode::Build, plugins).expect("container")
+}
+
+#[test]
+fn transform_runs_every_plugin_in_order() {
+    let container = build(vec![
+        appender("post", HookOrder::Post, "3"),
+        appender("normal", HookOrder::Normal, "2"),
+        appender("pre", HookOrder::Pre, "1"),
+    ]);
+
+    assert_eq!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .handled()
+            .expect("handled")
+            .code,
+        "src123"
+    );
+}
+
+#[test]
+fn transform_feeds_each_plugin_what_the_previous_one_produced() {
+    let container = build(vec![
+        appender("a", HookOrder::Pre, "-a"),
+        Box::new(
+            FnPlugin::new(descriptor("assert", HookOrder::Normal, HookSet::EMPTY)).on_transform(
+                |input| {
+                    assert_eq!(input.code, "src-a");
+                    assert_eq!(input.id, "a.js");
+                    Ok(HookOutcome::Handled(ModuleCode::new("final")))
+                },
+            ),
+        ),
+    ]);
+
+    assert_eq!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .handled()
+            .expect("handled")
+            .code,
+        "final"
+    );
+}
+
+#[test]
+fn transform_passes_through_when_no_plugin_touches_the_module() {
+    let container = build(vec![
+        passthrough("a", HookOrder::Pre),
+        passthrough("b", HookOrder::Normal),
+        passthrough("c", HookOrder::Post),
+    ]);
+
+    assert!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .is_passthrough(),
+        "a module nobody rewrites must not be copied"
+    );
+}
+
+#[test]
+fn transform_passes_through_when_no_plugin_implements_it() {
+    let container = build(vec![resolver("a", HookOrder::Normal, "x")]);
+
+    assert!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .is_passthrough()
+    );
+}
+
+#[test]
+fn a_declining_plugin_in_the_middle_does_not_break_the_chain() {
+    let container = build(vec![
+        appender("a", HookOrder::Pre, "1"),
+        passthrough("skip", HookOrder::Normal),
+        appender("b", HookOrder::Post, "2"),
+    ]);
+
+    assert_eq!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .handled()
+            .expect("handled")
+            .code,
+        "src12"
+    );
+}
+
+#[test]
+fn the_surviving_source_map_is_the_last_one_produced() {
+    let container = build(vec![
+        Box::new(
+            FnPlugin::new(descriptor("first", HookOrder::Pre, HookSet::EMPTY)).on_transform(|_| {
+                Ok(HookOutcome::Handled(
+                    ModuleCode::new("one").with_source_map("first-map"),
+                ))
+            }),
+        ),
+        Box::new(
+            FnPlugin::new(descriptor("second", HookOrder::Post, HookSet::EMPTY)).on_transform(
+                |_| {
+                    Ok(HookOutcome::Handled(
+                        ModuleCode::new("two").with_source_map("second-map"),
+                    ))
+                },
+            ),
+        ),
+    ]);
+
+    assert_eq!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .handled()
+            .expect("handled")
+            .source_map
+            .as_deref(),
+        Some("second-map")
+    );
+}
+
+#[test]
+fn a_transform_without_a_map_drops_the_stale_one() {
+    let container = build(vec![
+        Box::new(
+            FnPlugin::new(descriptor("mapped", HookOrder::Pre, HookSet::EMPTY)).on_transform(
+                |_| {
+                    Ok(HookOutcome::Handled(
+                        ModuleCode::new("one").with_source_map("stale"),
+                    ))
+                },
+            ),
+        ),
+        appender("unmapped", HookOrder::Post, "!"),
+    ]);
+
+    assert_eq!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .handled()
+            .expect("handled")
+            .source_map,
+        None,
+        "a map pointing at text that no longer exists is worse than none"
+    );
+}
+
+#[test]
+fn a_plugin_that_fails_mid_chain_stops_the_pipeline() {
+    let container = build(vec![
+        appender("first", HookOrder::Pre, "1"),
+        failing(
+            "broken",
+            HookOrder::Normal,
+            HookFailure::UnsupportedSyntax { offset: 12 },
+        ),
+        Box::new(
+            FnPlugin::new(descriptor("never", HookOrder::Post, HookSet::EMPTY))
+                .on_transform(|_| panic!("the chain must stop at the failure")),
+        ),
+    ]);
+
+    let error = container
+        .transform("app/page.js", "src")
+        .expect_err("the failure propagates");
+
+    assert_eq!(
+        error,
+        ContainerError::Hook {
+            plugin: "broken".into(),
+            hook: PluginHook::Transform,
+            module: "app/page.js".into(),
+            source: HookFailure::UnsupportedSyntax { offset: 12 },
+        }
+    );
+}
+
+#[test]
+fn a_hook_error_names_the_plugin_the_hook_and_the_module() {
+    let container = build(vec![failing(
+        "broken",
+        HookOrder::Normal,
+        HookFailure::Rejected {
+            rule: "server/no-client-secret",
+        },
+    )]);
+
+    let error = container
+        .transform("app/page.js", "src")
+        .expect_err("the failure propagates");
+
+    assert_eq!(
+        error.to_string(),
+        "plugin broken failed the transform hook for app/page.js"
+    );
+    assert_eq!(
+        std::error::Error::source(&error).map(ToString::to_string),
+        Some("rejected by rule server/no-client-secret".to_string())
+    );
+}
+
+#[test]
+fn a_resolve_failure_names_the_specifier_it_was_handed() {
+    let container = build(vec![Box::new(
+        FnPlugin::new(descriptor("broken", HookOrder::Normal, HookSet::EMPTY))
+            .on_resolve_id(|_| Err(HookFailure::InputTooLarge { bytes: 9, limit: 4 })),
+    )]);
+
+    let error = container
+        .resolve_id("@scope/pkg", None)
+        .expect_err("the failure propagates");
+
+    assert_eq!(
+        error,
+        ContainerError::Hook {
+            plugin: "broken".into(),
+            hook: PluginHook::ResolveId,
+            module: "@scope/pkg".into(),
+            source: HookFailure::InputTooLarge { bytes: 9, limit: 4 },
+        }
+    );
+}
+
+#[test]
+fn a_load_failure_propagates() {
+    let container = build(vec![Box::new(
+        FnPlugin::new(descriptor("broken", HookOrder::Normal, HookSet::EMPTY)).on_load(|_| {
+            Err(HookFailure::MissingPrerequisite {
+                required: PluginHook::ResolveId,
+                hook: PluginHook::Load,
+            })
+        }),
+    )]);
+
+    let error = container.load("x").expect_err("the failure propagates");
+
+    assert!(matches!(
+        error,
+        ContainerError::Hook {
+            hook: PluginHook::Load,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn hook_failures_render_their_structured_fields() {
+    assert_eq!(
+        HookFailure::UnsupportedSyntax { offset: 3 }.to_string(),
+        "unsupported syntax at byte offset 3"
+    );
+    assert_eq!(
+        HookFailure::MissingPrerequisite {
+            required: PluginHook::Load,
+            hook: PluginHook::Transform,
+        }
+        .to_string(),
+        "the load hook must run before transform"
+    );
+    assert_eq!(
+        HookFailure::InputTooLarge {
+            bytes: 10,
+            limit: 4
+        }
+        .to_string(),
+        "input is 10 bytes, over the 4 byte ceiling"
+    );
+}
+
+#[test]
+fn a_build_only_plugin_never_runs_while_serving() {
+    let plugin = Box::new(
+        FnPlugin::new(
+            descriptor("build-only", HookOrder::Normal, HookSet::EMPTY)
+                .with_apply(ApplyCondition::Build),
+        )
+        .on_transform(|_| panic!("a build-only plugin must not run while serving")),
+    ) as Box<dyn Plugin>;
+    let container = PluginContainer::build(PipelineMode::Serve, vec![plugin]).expect("container");
+
+    assert!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .is_passthrough()
+    );
+}
+
+#[test]
+fn a_serve_only_plugin_never_runs_in_a_build() {
+    let plugin = Box::new(
+        FnPlugin::new(
+            descriptor("serve-only", HookOrder::Normal, HookSet::EMPTY)
+                .with_apply(ApplyCondition::Serve),
+        )
+        .on_transform(|_| panic!("a serve-only plugin must not run in a build")),
+    ) as Box<dyn Plugin>;
+    let container = build(vec![plugin]);
+
+    assert!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .is_passthrough()
+    );
+}
+
+#[test]
+fn apply_filtering_leaves_the_rest_of_the_chain_intact() {
+    let filtered = Box::new(
+        FnPlugin::new(
+            descriptor("serve-only", HookOrder::Pre, HookSet::EMPTY)
+                .with_apply(ApplyCondition::Serve),
+        )
+        .on_transform(|_| Ok(HookOutcome::Handled(ModuleCode::new("wrong")))),
+    ) as Box<dyn Plugin>;
+    let container = build(vec![filtered, appender("kept", HookOrder::Normal, "!")]);
+
+    assert_eq!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .handled()
+            .expect("handled")
+            .code,
+        "src!"
+    );
+}
+
+#[test]
+fn notify_reaches_only_the_plugins_that_declared_the_hook() {
+    static STARTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let container = PluginContainer::build(
+        PipelineMode::Build,
+        vec![
+            Box::new(
+                FnPlugin::new(super::declaring("a", PluginHook::BuildStart)).on_notify(|hook| {
+                    assert_eq!(hook, PluginHook::BuildStart);
+                    STARTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Ok(())
+                }),
+            ),
+            Box::new(
+                FnPlugin::new(super::declaring("b", PluginHook::BuildEnd)).on_notify(|_| {
+                    panic!("a plugin that declared BuildEnd must not see BuildStart")
+                }),
+            ),
+        ],
+    )
+    .expect("container");
+
+    container.notify(PluginHook::BuildStart).expect("notifies");
+
+    assert_eq!(STARTS.load(std::sync::atomic::Ordering::Relaxed), 1);
+    assert_eq!(
+        container
+            .plugins_for(PluginHook::BuildStart)
+            .map(|plugin| plugin.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a"]
+    );
+}
+
+#[test]
+fn notify_stops_at_the_first_failure() {
+    let container = PluginContainer::build(
+        PipelineMode::Build,
+        vec![
+            Box::new(
+                FnPlugin::new(super::declaring("broken", PluginHook::BuildStart))
+                    .on_notify(|_| Err(HookFailure::Rejected { rule: "uf/example" })),
+            ),
+            Box::new(
+                FnPlugin::new(super::declaring("never", PluginHook::BuildStart))
+                    .on_notify(|_| panic!("notification must stop at the failure")),
+            ),
+        ],
+    )
+    .expect("container");
+
+    let error = container
+        .notify(PluginHook::BuildStart)
+        .expect_err("the failure propagates");
+
+    assert!(matches!(
+        error,
+        ContainerError::Hook {
+            hook: PluginHook::BuildStart,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn a_hook_a_plugin_did_not_declare_is_never_called() {
+    let plugin = Box::new(
+        FnPlugin::new(descriptor("a", HookOrder::Normal, HookSet::EMPTY))
+            .on_transform(|_| Ok(HookOutcome::Handled(ModuleCode::new("x")))),
+    ) as Box<dyn Plugin>;
+    let container = build(vec![plugin]);
+
+    // `on_transform` declared `Transform` and nothing else, so `Load` has no lane.
+    assert!(container.implements(PluginHook::Transform));
+    assert!(!container.implements(PluginHook::Load));
+    assert!(container.load("a.js").expect("loads").is_passthrough());
+}
+
+#[test]
+fn a_declared_hook_with_nothing_wired_passes_through() {
+    let container = PluginContainer::build(
+        PipelineMode::Build,
+        vec![Box::new(FnPlugin::new(descriptor(
+            "inert",
+            HookOrder::Normal,
+            HookSet::of(PluginHook::Transform),
+        )))],
+    )
+    .expect("container");
+
+    assert!(container.implements(PluginHook::Transform));
+    assert!(
+        container
+            .transform("a.js", "src")
+            .expect("transforms")
+            .is_passthrough()
+    );
+}

--- a/crates/uf_plugin/src/tests/config.rs
+++ b/crates/uf_plugin/src/tests/config.rs
@@ -1,0 +1,208 @@
+//! What a user can write in `plugins: [...]`, read back through `uf.config.js`.
+
+use uf_config::{
+    ApplyCondition, HookOrder, PluginEntry, PluginSpec, UniflowedConfig, extract_config_object,
+};
+
+fn parse(source: &str) -> UniflowedConfig {
+    let object = extract_config_object(source).expect("a config object");
+    json5::from_str(&object).expect("a config")
+}
+
+#[test]
+fn a_project_with_no_plugins_field_has_no_plugins() {
+    assert!(parse("export default defineConfig({});").plugins.is_empty());
+}
+
+#[test]
+fn an_empty_list_is_no_plugins() {
+    assert!(
+        parse("export default defineConfig({ plugins: [] });")
+            .plugins
+            .is_empty()
+    );
+}
+
+#[test]
+fn a_string_entry_takes_the_defaults() {
+    let config = parse(r#"export default defineConfig({ plugins: ["@uniflowed/plugin-mdx"] });"#);
+
+    assert_eq!(
+        config.plugins,
+        vec![PluginEntry::Name("@uniflowed/plugin-mdx".into())]
+    );
+    assert_eq!(config.plugins[0].name(), "@uniflowed/plugin-mdx");
+    assert_eq!(config.plugins[0].order(), HookOrder::Normal);
+    assert_eq!(config.plugins[0].apply(), ApplyCondition::Always);
+}
+
+#[test]
+fn an_object_entry_carries_its_order_and_apply() {
+    let config = parse(
+        r#"
+export default defineConfig({
+  plugins: [{ name: "./plugins/metrics.js", order: "post", apply: "build" }],
+});
+"#,
+    );
+
+    assert_eq!(
+        config.plugins,
+        vec![PluginEntry::Spec(
+            PluginSpec::new("./plugins/metrics.js")
+                .with_order(HookOrder::Post)
+                .with_apply(ApplyCondition::Build)
+        )]
+    );
+    assert_eq!(config.plugins[0].order(), HookOrder::Post);
+    assert_eq!(config.plugins[0].apply(), ApplyCondition::Build);
+}
+
+#[test]
+fn an_object_entry_may_leave_both_knobs_out() {
+    let config = parse(r#"export default defineConfig({ plugins: [{ name: "mdx" }] });"#);
+
+    assert_eq!(config.plugins[0].name(), "mdx");
+    assert_eq!(config.plugins[0].order(), HookOrder::Normal);
+    assert_eq!(config.plugins[0].apply(), ApplyCondition::Always);
+}
+
+#[test]
+fn the_two_spellings_mix_in_one_list() {
+    let config = parse(
+        r#"
+export default defineConfig({
+  plugins: [
+    "a",
+    { name: "b", order: "pre" },
+    "c",
+    { name: "d", apply: "serve" },
+  ],
+});
+"#,
+    );
+
+    assert_eq!(
+        config
+            .plugins
+            .iter()
+            .map(|entry| (entry.name(), entry.order(), entry.apply()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("a", HookOrder::Normal, ApplyCondition::Always),
+            ("b", HookOrder::Pre, ApplyCondition::Always),
+            ("c", HookOrder::Normal, ApplyCondition::Always),
+            ("d", HookOrder::Normal, ApplyCondition::Serve),
+        ]
+    );
+}
+
+#[test]
+fn every_order_spelling_parses() {
+    for (value, expected) in [
+        ("pre", HookOrder::Pre),
+        ("normal", HookOrder::Normal),
+        ("post", HookOrder::Post),
+    ] {
+        let config = parse(&format!(
+            r#"export default defineConfig({{ plugins: [{{ name: "a", order: "{value}" }}] }});"#
+        ));
+
+        assert_eq!(config.plugins[0].order(), expected, "{value}");
+    }
+}
+
+#[test]
+fn every_apply_spelling_parses() {
+    for (value, expected) in [
+        ("build", ApplyCondition::Build),
+        ("serve", ApplyCondition::Serve),
+        ("always", ApplyCondition::Always),
+    ] {
+        let config = parse(&format!(
+            r#"export default defineConfig({{ plugins: [{{ name: "a", apply: "{value}" }}] }});"#
+        ));
+
+        assert_eq!(config.plugins[0].apply(), expected, "{value}");
+    }
+}
+
+#[test]
+fn an_unknown_order_is_refused() {
+    let object = extract_config_object(
+        r#"export default defineConfig({ plugins: [{ name: "a", order: "first" }] });"#,
+    )
+    .expect("a config object");
+
+    assert!(json5::from_str::<UniflowedConfig>(&object).is_err());
+}
+
+#[test]
+fn an_unknown_apply_condition_is_refused() {
+    let object = extract_config_object(
+        r#"export default defineConfig({ plugins: [{ name: "a", apply: "sometimes" }] });"#,
+    )
+    .expect("a config object");
+
+    assert!(json5::from_str::<UniflowedConfig>(&object).is_err());
+}
+
+#[test]
+fn plugins_round_trip_through_json() {
+    let config = parse(
+        r#"
+export default defineConfig({
+  plugins: ["a", { name: "b", order: "pre", apply: "serve" }],
+});
+"#,
+    );
+
+    let json = serde_json::to_string(&config.plugins).expect("serializes");
+    let back: Vec<PluginEntry> = serde_json::from_str(&json).expect("deserializes");
+
+    assert_eq!(back, config.plugins);
+}
+
+#[test]
+fn a_spec_converts_into_an_entry() {
+    let spec = PluginSpec::new("a")
+        .with_order(HookOrder::Pre)
+        .with_apply(ApplyCondition::Build);
+
+    assert_eq!(PluginEntry::from(spec.clone()), PluginEntry::Spec(spec));
+}
+
+#[test]
+fn a_spec_builder_only_changes_what_it_is_asked_to() {
+    let spec = PluginSpec::new("a");
+
+    assert_eq!(spec.name, "a");
+    assert_eq!(spec.order, HookOrder::Normal);
+    assert_eq!(spec.apply, ApplyCondition::Always);
+    assert_eq!(spec.clone().with_order(HookOrder::Post).name, "a");
+    assert_eq!(
+        spec.with_apply(ApplyCondition::Serve).order,
+        HookOrder::Normal
+    );
+}
+
+#[test]
+fn a_spec_defaults_to_an_unnamed_normal_always_plugin() {
+    let spec = PluginSpec::default();
+
+    assert!(spec.name.is_empty());
+    assert_eq!(spec.order, HookOrder::Normal);
+    assert_eq!(spec.apply, ApplyCondition::Always);
+}
+
+#[test]
+fn a_plugin_name_with_a_traversal_survives_parsing_and_is_caught_at_resolution() {
+    // Parsing is not the guard: the config layer stores whatever was written,
+    // and `uf_plugin` is the single place that decides whether it is usable.
+    let config = parse(r#"export default defineConfig({ plugins: ["../../evil.js"] });"#);
+
+    assert_eq!(config.plugins[0].name(), "../../evil.js");
+    assert!(
+        crate::classify_plugin_name("../../evil.js", camino::Utf8Path::new("/workspace")).is_err()
+    );
+}

--- a/crates/uf_plugin/src/tests/container.rs
+++ b/crates/uf_plugin/src/tests/container.rs
@@ -1,0 +1,329 @@
+//! Run order, duplicate names, and the ceilings.
+
+use uf_config::{ApplyCondition, HookOrder, PipelineMode};
+
+use crate::container::{ContainerError, MAX_PLUGINS, PluginContainer};
+use crate::descriptor::PluginDescriptor;
+use crate::hook::{HookSet, PluginHook};
+use crate::plugin::{FnPlugin, Plugin};
+
+use super::{descriptor, inert};
+
+fn build(plugins: Vec<Box<dyn Plugin>>) -> PluginContainer {
+    PluginContainer::build(PipelineMode::Build, plugins).expect("container")
+}
+
+#[test]
+fn pre_runs_first_then_normal_then_post() {
+    let container = build(vec![
+        inert("post", HookOrder::Post),
+        inert("normal", HookOrder::Normal),
+        inert("pre", HookOrder::Pre),
+    ]);
+
+    assert_eq!(
+        container.names().collect::<Vec<_>>(),
+        vec!["pre", "normal", "post"]
+    );
+}
+
+#[test]
+fn declaration_order_is_kept_inside_a_band() {
+    let container = build(vec![
+        inert("pre-a", HookOrder::Pre),
+        inert("normal-a", HookOrder::Normal),
+        inert("pre-b", HookOrder::Pre),
+        inert("normal-b", HookOrder::Normal),
+        inert("pre-c", HookOrder::Pre),
+    ]);
+
+    assert_eq!(
+        container.names().collect::<Vec<_>>(),
+        vec!["pre-a", "pre-b", "pre-c", "normal-a", "normal-b"]
+    );
+}
+
+#[test]
+fn the_run_order_does_not_depend_on_the_declaration_order_of_bands() {
+    let forwards = build(vec![
+        inert("a", HookOrder::Pre),
+        inert("b", HookOrder::Normal),
+        inert("c", HookOrder::Post),
+    ]);
+    let backwards = build(vec![
+        inert("c", HookOrder::Post),
+        inert("b", HookOrder::Normal),
+        inert("a", HookOrder::Pre),
+    ]);
+
+    assert_eq!(
+        forwards.names().collect::<Vec<_>>(),
+        backwards.names().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn an_empty_container_runs_nothing() {
+    let container = build(Vec::new());
+
+    assert!(container.is_empty());
+    assert_eq!(container.len(), 0);
+    assert_eq!(container.active_hooks(), HookSet::EMPTY);
+    for hook in PluginHook::ALL {
+        assert!(!container.implements(hook), "{hook}");
+    }
+}
+
+#[test]
+fn two_plugins_with_one_name_is_an_error() {
+    let error = PluginContainer::build(
+        PipelineMode::Build,
+        vec![
+            inert("first", HookOrder::Normal),
+            inert("other", HookOrder::Normal),
+            inert("first", HookOrder::Normal),
+        ],
+    )
+    .expect_err("a duplicate name is refused");
+
+    assert_eq!(
+        error,
+        ContainerError::DuplicateName {
+            name: "first".into(),
+            first: 0,
+            second: 2,
+        }
+    );
+}
+
+#[test]
+fn a_duplicate_is_reported_at_its_declared_position_not_its_sorted_one() {
+    let error = PluginContainer::build(
+        PipelineMode::Build,
+        vec![
+            inert("post", HookOrder::Post),
+            inert("dupe", HookOrder::Pre),
+            inert("dupe", HookOrder::Post),
+        ],
+    )
+    .expect_err("a duplicate name is refused");
+
+    // Sorting would have moved `dupe`/Pre to the front; the message points at
+    // the lines the user actually wrote.
+    assert_eq!(
+        error,
+        ContainerError::DuplicateName {
+            name: "dupe".into(),
+            first: 1,
+            second: 2,
+        }
+    );
+}
+
+#[test]
+fn a_project_plugin_cannot_take_a_builtin_name() {
+    let error = PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        vec![
+            PluginDescriptor::builtin("uf:flow", HookOrder::Pre, HookSet::EMPTY),
+            descriptor("uf:flow", HookOrder::Post, HookSet::EMPTY),
+        ],
+    )
+    .expect_err("a shadowed built-in is refused");
+
+    assert!(matches!(error, ContainerError::DuplicateName { .. }));
+}
+
+#[test]
+fn a_duplicate_error_names_the_plugin() {
+    let error = ContainerError::DuplicateName {
+        name: "mdx".into(),
+        first: 1,
+        second: 4,
+    };
+
+    assert_eq!(
+        error.to_string(),
+        "two plugins are named mdx: entries 1 and 4"
+    );
+}
+
+#[test]
+fn more_plugins_than_the_ceiling_is_an_error() {
+    let plugins = (0..=MAX_PLUGINS)
+        .map(|index| inert(&format!("p{index}"), HookOrder::Normal))
+        .collect::<Vec<_>>();
+    let count = plugins.len();
+
+    let error =
+        PluginContainer::build(PipelineMode::Build, plugins).expect_err("the ceiling is enforced");
+
+    assert_eq!(
+        error,
+        ContainerError::TooManyPlugins {
+            count,
+            limit: MAX_PLUGINS,
+        }
+    );
+}
+
+#[test]
+fn exactly_the_ceiling_is_accepted() {
+    let plugins = (0..MAX_PLUGINS)
+        .map(|index| inert(&format!("p{index}"), HookOrder::Normal))
+        .collect::<Vec<_>>();
+
+    let container = build(plugins);
+
+    assert_eq!(container.len(), MAX_PLUGINS);
+}
+
+#[test]
+fn the_plan_lists_plugins_that_this_mode_filters_out() {
+    let container = PluginContainer::from_descriptors(
+        PipelineMode::Serve,
+        vec![
+            descriptor(
+                "build-only",
+                HookOrder::Normal,
+                HookSet::of(PluginHook::Transform),
+            )
+            .with_apply(ApplyCondition::Build),
+        ],
+    )
+    .expect("container");
+
+    assert_eq!(container.len(), 1);
+    assert_eq!(container.names().collect::<Vec<_>>(), vec!["build-only"]);
+    assert!(!container.implements(PluginHook::Transform));
+}
+
+#[test]
+fn active_hooks_is_the_union_of_what_will_run() {
+    let container = PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        vec![
+            descriptor("a", HookOrder::Normal, HookSet::of(PluginHook::Load)),
+            descriptor("b", HookOrder::Normal, HookSet::of(PluginHook::Transform)),
+            descriptor("c", HookOrder::Normal, HookSet::of(PluginHook::Load)),
+        ],
+    )
+    .expect("container");
+
+    assert_eq!(
+        container.active_hooks(),
+        HookSet::of(PluginHook::Load).with(PluginHook::Transform)
+    );
+}
+
+#[test]
+fn active_hooks_skips_a_plugin_this_mode_filters_out() {
+    let container = PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        vec![
+            descriptor(
+                "serve",
+                HookOrder::Normal,
+                HookSet::of(PluginHook::ConfigureServer),
+            )
+            .with_apply(ApplyCondition::Serve),
+        ],
+    )
+    .expect("container");
+
+    assert_eq!(container.active_hooks(), HookSet::EMPTY);
+}
+
+#[test]
+fn plugins_for_lists_only_the_plugins_in_that_lane() {
+    let container = PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        vec![
+            descriptor("loader", HookOrder::Normal, HookSet::of(PluginHook::Load)),
+            descriptor(
+                "transformer",
+                HookOrder::Normal,
+                HookSet::of(PluginHook::Transform),
+            ),
+            descriptor(
+                "both",
+                HookOrder::Post,
+                HookSet::of(PluginHook::Load).with(PluginHook::Transform),
+            ),
+        ],
+    )
+    .expect("container");
+
+    assert_eq!(
+        container
+            .plugins_for(PluginHook::Load)
+            .map(|plugin| plugin.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["loader", "both"]
+    );
+    assert_eq!(container.plugins_for(PluginHook::BuildEnd).count(), 0);
+}
+
+#[test]
+fn the_container_remembers_which_mode_it_resolved_for() {
+    let container =
+        PluginContainer::from_descriptors(PipelineMode::Serve, Vec::new()).expect("container");
+
+    assert_eq!(container.mode(), PipelineMode::Serve);
+}
+
+#[test]
+fn wiring_a_hook_also_declares_it() {
+    let plugin =
+        FnPlugin::new(descriptor("a", HookOrder::Normal, HookSet::EMPTY)).on_transform(|_| {
+            Ok(crate::outcome::HookOutcome::Handled(
+                crate::outcome::ModuleCode::new(""),
+            ))
+        });
+
+    assert!(plugin.descriptor().implements(PluginHook::Transform));
+}
+
+#[test]
+fn the_report_describes_the_resolved_pipeline() {
+    let container = PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        vec![
+            descriptor("late", HookOrder::Post, HookSet::of(PluginHook::Transform)),
+            descriptor("early", HookOrder::Pre, HookSet::of(PluginHook::Transform)),
+        ],
+    )
+    .expect("container");
+
+    let report = container.report();
+
+    assert_eq!(report.count, 2);
+    assert_eq!(report.mode, PipelineMode::Build);
+    assert_eq!(report.plugins[0].name, "early");
+    assert_eq!(report.plugins[0].position, 0);
+    assert!(report.plugins[0].active);
+    assert_eq!(report.hooks.len(), 1);
+    assert_eq!(report.hooks[0].hook, PluginHook::Transform);
+    assert_eq!(report.hooks[0].plugins, vec!["early", "late"]);
+}
+
+#[test]
+fn the_report_marks_a_plugin_this_mode_filters_out_as_inactive() {
+    let container = PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        vec![
+            descriptor(
+                "serve-only",
+                HookOrder::Normal,
+                HookSet::of(PluginHook::ConfigureServer),
+            )
+            .with_apply(ApplyCondition::Serve),
+        ],
+    )
+    .expect("container");
+
+    let report = container.report();
+
+    assert!(!report.plugins[0].active);
+    assert!(report.hooks.is_empty());
+}

--- a/crates/uf_plugin/src/tests/descriptor.rs
+++ b/crates/uf_plugin/src/tests/descriptor.rs
@@ -1,0 +1,247 @@
+//! The descriptor, and the `apply` condition it carries.
+
+use uf_config::{ApplyCondition, HookOrder, PipelineMode};
+
+use crate::descriptor::{PluginDescriptor, PluginOrigin, PluginSource};
+use crate::hook::{HookSet, PluginHook};
+use crate::outcome::HookOutcome;
+
+use super::descriptor;
+
+#[test]
+fn a_builtin_descriptor_applies_to_both_pipelines() {
+    let plugin = PluginDescriptor::builtin(
+        "uf:example",
+        HookOrder::Pre,
+        HookSet::of(PluginHook::Transform),
+    );
+
+    assert_eq!(plugin.origin, PluginOrigin::Builtin);
+    assert_eq!(plugin.source, PluginSource::Builtin);
+    assert_eq!(plugin.apply, ApplyCondition::Always);
+    assert_eq!(plugin.order, HookOrder::Pre);
+}
+
+#[test]
+fn a_project_descriptor_keeps_the_source_it_was_given() {
+    let plugin = descriptor("mdx", HookOrder::Post, HookSet::of(PluginHook::Load));
+
+    assert_eq!(plugin.origin, PluginOrigin::Project);
+    assert_eq!(
+        plugin.source,
+        PluginSource::Package {
+            specifier: "mdx".into()
+        }
+    );
+    assert_eq!(plugin.source.kind(), "package");
+}
+
+#[test]
+fn with_hooks_replaces_the_declared_set() {
+    let plugin = descriptor("a", HookOrder::Normal, HookSet::of(PluginHook::Load))
+        .with_hooks(HookSet::of(PluginHook::Transform));
+
+    assert!(plugin.implements(PluginHook::Transform));
+    assert!(!plugin.implements(PluginHook::Load));
+}
+
+#[test]
+fn with_apply_replaces_the_condition() {
+    let plugin =
+        descriptor("a", HookOrder::Normal, HookSet::EMPTY).with_apply(ApplyCondition::Build);
+
+    assert_eq!(plugin.apply, ApplyCondition::Build);
+}
+
+#[test]
+fn implements_matches_the_declared_set() {
+    let plugin = descriptor(
+        "a",
+        HookOrder::Normal,
+        HookSet::of(PluginHook::Load).with(PluginHook::Transform),
+    );
+
+    assert!(plugin.implements(PluginHook::Load));
+    assert!(plugin.implements(PluginHook::Transform));
+    assert!(!plugin.implements(PluginHook::ResolveId));
+}
+
+#[test]
+fn apply_admits_exactly_the_matching_mode() {
+    let table = [
+        (ApplyCondition::Always, PipelineMode::Build, true),
+        (ApplyCondition::Always, PipelineMode::Serve, true),
+        (ApplyCondition::Build, PipelineMode::Build, true),
+        (ApplyCondition::Build, PipelineMode::Serve, false),
+        (ApplyCondition::Serve, PipelineMode::Build, false),
+        (ApplyCondition::Serve, PipelineMode::Serve, true),
+    ];
+
+    for (apply, mode, expected) in table {
+        assert_eq!(apply.admits(mode), expected, "{apply:?} in {mode:?}");
+    }
+    assert_eq!(
+        table.len(),
+        ApplyCondition::ALL.len() * PipelineMode::ALL.len(),
+        "the table has to stay exhaustive"
+    );
+}
+
+#[test]
+fn runs_in_follows_the_apply_condition() {
+    let build_only =
+        descriptor("a", HookOrder::Normal, HookSet::EMPTY).with_apply(ApplyCondition::Build);
+
+    assert!(build_only.runs_in(PipelineMode::Build));
+    assert!(!build_only.runs_in(PipelineMode::Serve));
+}
+
+#[test]
+fn dispatches_needs_both_the_hook_and_the_mode() {
+    let plugin = descriptor("a", HookOrder::Normal, HookSet::of(PluginHook::Transform))
+        .with_apply(ApplyCondition::Serve);
+
+    assert!(plugin.dispatches(PluginHook::Transform, PipelineMode::Serve));
+    assert!(!plugin.dispatches(PluginHook::Transform, PipelineMode::Build));
+    assert!(!plugin.dispatches(PluginHook::Load, PipelineMode::Serve));
+}
+
+#[test]
+fn a_descriptor_serializes_its_hooks_by_name() {
+    let plugin = PluginDescriptor::builtin(
+        "uf:example",
+        HookOrder::Pre,
+        HookSet::of(PluginHook::Transform),
+    );
+
+    assert_eq!(
+        serde_json::to_value(&plugin).expect("serializes"),
+        serde_json::json!({
+            "name": "uf:example",
+            "origin": "builtin",
+            "source": { "kind": "builtin" },
+            "order": "pre",
+            "apply": "always",
+            "hooks": ["transform"],
+        })
+    );
+}
+
+#[test]
+fn plugin_origin_ids_are_stable() {
+    assert_eq!(PluginOrigin::Builtin.as_str(), "builtin");
+    assert_eq!(PluginOrigin::Project.as_str(), "project");
+}
+
+#[test]
+fn plugin_source_kinds_are_stable() {
+    assert_eq!(PluginSource::Builtin.kind(), "builtin");
+    assert_eq!(
+        PluginSource::Package {
+            specifier: "a".into()
+        }
+        .kind(),
+        "package"
+    );
+    assert_eq!(
+        PluginSource::ProjectFile {
+            path: "/tmp/a.js".into()
+        }
+        .kind(),
+        "project-file"
+    );
+}
+
+#[test]
+fn a_source_serializes_under_the_same_kind_it_reports() {
+    for source in [
+        PluginSource::Builtin,
+        PluginSource::Package {
+            specifier: "a".into(),
+        },
+        PluginSource::ProjectFile {
+            path: "/tmp/a.js".into(),
+        },
+    ] {
+        let value = serde_json::to_value(&source).expect("serializes");
+
+        assert_eq!(
+            value.get("kind").and_then(serde_json::Value::as_str),
+            Some(source.kind()),
+            "{source:?}"
+        );
+    }
+}
+
+#[test]
+fn a_project_file_source_serializes_its_checked_path() {
+    assert_eq!(
+        serde_json::to_value(PluginSource::ProjectFile {
+            path: "/workspace/app/plugins/metrics.js".into(),
+        })
+        .expect("serializes"),
+        serde_json::json!({
+            "kind": "project-file",
+            "path": "/workspace/app/plugins/metrics.js",
+        })
+    );
+}
+
+#[test]
+fn order_and_apply_ids_are_stable() {
+    assert_eq!(HookOrder::Pre.as_str(), "pre");
+    assert_eq!(HookOrder::Normal.as_str(), "normal");
+    assert_eq!(HookOrder::Post.as_str(), "post");
+    assert_eq!(ApplyCondition::Build.as_str(), "build");
+    assert_eq!(ApplyCondition::Serve.as_str(), "serve");
+    assert_eq!(ApplyCondition::Always.as_str(), "always");
+    assert_eq!(PipelineMode::Build.as_str(), "build");
+    assert_eq!(PipelineMode::Serve.as_str(), "serve");
+}
+
+#[test]
+fn order_defaults_to_normal_and_apply_to_always() {
+    assert_eq!(HookOrder::default(), HookOrder::Normal);
+    assert_eq!(ApplyCondition::default(), ApplyCondition::Always);
+}
+
+#[test]
+fn an_outcome_reports_whether_it_produced_a_value() {
+    let handled = HookOutcome::Handled(7u8);
+    let declined: HookOutcome<u8> = HookOutcome::Passthrough;
+
+    assert!(handled.is_handled());
+    assert!(!handled.is_passthrough());
+    assert!(declined.is_passthrough());
+    assert!(!declined.is_handled());
+    assert_eq!(handled.handled(), Some(7));
+    assert_eq!(declined.handled(), None);
+    assert_eq!(declined.unwrap_or(3), 3);
+    assert_eq!(handled.unwrap_or(3), 7);
+}
+
+#[test]
+fn mapping_an_outcome_keeps_passthrough() {
+    assert_eq!(
+        HookOutcome::Handled(2u8).map(|v| v * 2),
+        HookOutcome::Handled(4)
+    );
+    assert_eq!(
+        HookOutcome::<u8>::Passthrough.map(|v| v * 2),
+        HookOutcome::Passthrough
+    );
+}
+
+#[test]
+fn an_option_converts_into_an_outcome() {
+    assert_eq!(HookOutcome::from(Some(1u8)), HookOutcome::Handled(1));
+    assert_eq!(HookOutcome::from(None::<u8>), HookOutcome::Passthrough);
+}
+
+#[test]
+fn as_ref_borrows_without_consuming() {
+    let outcome = HookOutcome::Handled(String::from("kept"));
+
+    assert_eq!(outcome.as_ref().handled().map(String::as_str), Some("kept"));
+    assert!(outcome.is_handled());
+}

--- a/crates/uf_plugin/src/tests/dispatch.rs
+++ b/crates/uf_plugin/src/tests/dispatch.rs
@@ -1,0 +1,191 @@
+//! First-wins dispatch: `ResolveId` and `Load`.
+
+use uf_config::{HookOrder, PipelineMode};
+
+use crate::container::PluginContainer;
+use crate::hook::HookSet;
+use crate::outcome::{HookOutcome, ModuleCode, ResolvedId, ResolvedKind};
+use crate::plugin::{FnPlugin, Plugin};
+
+use super::{appender, descriptor, passthrough, resolver};
+
+fn build(plugins: Vec<Box<dyn Plugin>>) -> PluginContainer {
+    PluginContainer::build(PipelineMode::Build, plugins).expect("container")
+}
+
+#[test]
+fn resolve_id_takes_the_first_answer() {
+    let container = build(vec![
+        resolver("first", HookOrder::Normal, "first-id"),
+        resolver("second", HookOrder::Normal, "second-id"),
+    ]);
+
+    let resolved = container
+        .resolve_id("./a.js", None)
+        .expect("resolves")
+        .handled()
+        .expect("someone answered");
+
+    assert_eq!(resolved.id, "first-id");
+    assert_eq!(resolved.kind, ResolvedKind::Bundled);
+}
+
+#[test]
+fn resolve_id_never_asks_a_plugin_after_one_answered() {
+    let container = build(vec![
+        resolver("winner", HookOrder::Normal, "won"),
+        Box::new(
+            FnPlugin::new(descriptor("never", HookOrder::Post, HookSet::EMPTY))
+                .on_resolve_id(|_| panic!("a later plugin must not be asked")),
+        ),
+    ]);
+
+    assert!(
+        container
+            .resolve_id("x", None)
+            .expect("resolves")
+            .is_handled()
+    );
+}
+
+#[test]
+fn the_pre_band_wins_resolve_id_whatever_the_declaration_order() {
+    let container = build(vec![
+        resolver("normal", HookOrder::Normal, "normal-id"),
+        resolver("pre", HookOrder::Pre, "pre-id"),
+    ]);
+
+    assert_eq!(
+        container
+            .resolve_id("x", None)
+            .expect("resolves")
+            .handled()
+            .expect("answered")
+            .id,
+        "pre-id"
+    );
+}
+
+#[test]
+fn resolve_id_passes_through_when_nobody_answers() {
+    let container = build(vec![
+        passthrough("a", HookOrder::Normal),
+        passthrough("b", HookOrder::Normal),
+    ]);
+
+    assert!(
+        container
+            .resolve_id("./a.js", Some("./b.js"))
+            .expect("resolves")
+            .is_passthrough()
+    );
+}
+
+#[test]
+fn resolve_id_passes_through_when_no_plugin_implements_it() {
+    let container = build(vec![appender("a", HookOrder::Normal, "!")]);
+
+    assert!(
+        container
+            .resolve_id("x", None)
+            .expect("resolves")
+            .is_passthrough()
+    );
+}
+
+#[test]
+fn resolve_id_hands_the_importer_to_the_plugin() {
+    let container = build(vec![Box::new(
+        FnPlugin::new(descriptor("echo", HookOrder::Normal, HookSet::EMPTY)).on_resolve_id(
+            |input| {
+                Ok(HookOutcome::Handled(ResolvedId::bundled(format!(
+                    "{}<-{}",
+                    input.specifier,
+                    input.importer.unwrap_or("entry")
+                ))))
+            },
+        ),
+    )]);
+
+    assert_eq!(
+        container
+            .resolve_id("./a.js", Some("./b.js"))
+            .expect("resolves")
+            .handled()
+            .expect("answered")
+            .id,
+        "./a.js<-./b.js"
+    );
+    assert_eq!(
+        container
+            .resolve_id("./a.js", None)
+            .expect("resolves")
+            .handled()
+            .expect("answered")
+            .id,
+        "./a.js<-entry"
+    );
+}
+
+#[test]
+fn a_resolved_id_records_what_it_names() {
+    assert_eq!(ResolvedId::bundled("a").kind, ResolvedKind::Bundled);
+    assert_eq!(ResolvedId::external("react").kind, ResolvedKind::External);
+    assert_eq!(
+        ResolvedId::virtual_module("\0uf:router").kind,
+        ResolvedKind::Virtual
+    );
+}
+
+#[test]
+fn load_takes_the_first_answer() {
+    let container = build(vec![
+        Box::new(
+            FnPlugin::new(descriptor("first", HookOrder::Normal, HookSet::EMPTY))
+                .on_load(|_| Ok(HookOutcome::Handled(ModuleCode::new("first")))),
+        ),
+        Box::new(
+            FnPlugin::new(descriptor("second", HookOrder::Normal, HookSet::EMPTY))
+                .on_load(|_| Ok(HookOutcome::Handled(ModuleCode::new("second")))),
+        ),
+    ]);
+
+    assert_eq!(
+        container
+            .load("x")
+            .expect("loads")
+            .handled()
+            .expect("answered")
+            .code,
+        "first"
+    );
+}
+
+#[test]
+fn load_passes_through_when_nobody_answers() {
+    let container = build(vec![passthrough("a", HookOrder::Normal)]);
+
+    assert!(container.load("x").expect("loads").is_passthrough());
+}
+
+#[test]
+fn load_carries_a_source_map_when_the_plugin_makes_one() {
+    let container = build(vec![Box::new(
+        FnPlugin::new(descriptor("a", HookOrder::Normal, HookSet::EMPTY)).on_load(|_| {
+            Ok(HookOutcome::Handled(
+                ModuleCode::new("code").with_source_map("{\"version\":3}"),
+            ))
+        }),
+    )]);
+
+    assert_eq!(
+        container
+            .load("x")
+            .expect("loads")
+            .handled()
+            .expect("answered")
+            .source_map
+            .as_deref(),
+        Some("{\"version\":3}")
+    );
+}

--- a/crates/uf_plugin/src/tests/hook.rs
+++ b/crates/uf_plugin/src/tests/hook.rs
@@ -1,0 +1,252 @@
+//! The hook vocabulary and the bitset built on it.
+
+use crate::hook::{HookDispatch, HookSet, PluginHook};
+
+#[test]
+fn all_holds_every_hook_exactly_once() {
+    let mut seen = HookSet::EMPTY;
+    for hook in PluginHook::ALL {
+        assert!(!seen.contains(hook), "{hook} appears twice in ALL");
+        seen = seen.with(hook);
+    }
+    assert_eq!(seen, HookSet::ALL);
+    assert_eq!(PluginHook::ALL.len(), PluginHook::COUNT);
+}
+
+#[test]
+fn every_hook_has_a_unique_index() {
+    for (position, hook) in PluginHook::ALL.into_iter().enumerate() {
+        assert_eq!(hook.index(), position, "{hook} is out of position");
+    }
+}
+
+#[test]
+fn every_hook_has_a_unique_id() {
+    let mut ids = PluginHook::ALL.map(PluginHook::as_str).to_vec();
+    ids.sort_unstable();
+    let count = ids.len();
+    ids.dedup();
+    assert_eq!(ids.len(), count, "two hooks share an id");
+}
+
+#[test]
+fn hook_ids_are_kebab_case() {
+    for hook in PluginHook::ALL {
+        let id = hook.as_str();
+        assert!(!id.is_empty());
+        assert!(
+            id.bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte == b'-'),
+            "{id} is not kebab-case"
+        );
+        assert!(!id.starts_with('-') && !id.ends_with('-'), "{id}");
+    }
+}
+
+#[test]
+fn every_hook_bit_fits_a_u16_and_is_unique() {
+    let mut mask = 0u16;
+    for hook in PluginHook::ALL {
+        assert_eq!(hook.bit().count_ones(), 1, "{hook} is not a single bit");
+        assert_eq!(mask & hook.bit(), 0, "{hook} reuses a bit");
+        mask |= hook.bit();
+    }
+    assert_eq!(mask, HookSet::ALL.bits());
+}
+
+#[test]
+fn resolve_id_and_load_are_first_wins() {
+    assert_eq!(PluginHook::ResolveId.dispatch(), HookDispatch::FirstWins);
+    assert_eq!(PluginHook::Load.dispatch(), HookDispatch::FirstWins);
+}
+
+#[test]
+fn transform_and_the_other_rewriting_hooks_chain() {
+    for hook in [
+        PluginHook::Transform,
+        PluginHook::RenderChunk,
+        PluginHook::TransformIndexHtml,
+        PluginHook::HandleHotUpdate,
+    ] {
+        assert_eq!(hook.dispatch(), HookDispatch::Chained, "{hook}");
+    }
+}
+
+#[test]
+fn lifecycle_hooks_broadcast() {
+    for hook in [
+        PluginHook::Config,
+        PluginHook::ConfigResolved,
+        PluginHook::BuildStart,
+        PluginHook::ModuleParsed,
+        PluginHook::BuildEnd,
+        PluginHook::GenerateBundle,
+        PluginHook::WriteBundle,
+        PluginHook::ConfigureServer,
+    ] {
+        assert_eq!(hook.dispatch(), HookDispatch::Broadcast, "{hook}");
+    }
+}
+
+#[test]
+fn dispatch_ids_are_stable() {
+    assert_eq!(HookDispatch::Broadcast.as_str(), "broadcast");
+    assert_eq!(HookDispatch::FirstWins.as_str(), "first-wins");
+    assert_eq!(HookDispatch::Chained.as_str(), "chained");
+}
+
+#[test]
+fn hook_display_matches_its_id() {
+    for hook in PluginHook::ALL {
+        assert_eq!(hook.to_string(), hook.as_str());
+    }
+}
+
+#[test]
+fn an_empty_set_contains_nothing() {
+    let set = HookSet::EMPTY;
+    assert!(set.is_empty());
+    assert_eq!(set.len(), 0);
+    assert_eq!(set.iter().count(), 0);
+    for hook in PluginHook::ALL {
+        assert!(!set.contains(hook), "{hook}");
+    }
+}
+
+#[test]
+fn a_full_set_contains_every_hook() {
+    let set = HookSet::ALL;
+    assert!(!set.is_empty());
+    assert_eq!(set.len() as usize, PluginHook::COUNT);
+    for hook in PluginHook::ALL {
+        assert!(set.contains(hook), "{hook}");
+    }
+}
+
+#[test]
+fn adding_a_hook_twice_changes_nothing() {
+    let once = HookSet::of(PluginHook::Transform);
+    let twice = once.with(PluginHook::Transform);
+
+    assert_eq!(once, twice);
+    assert_eq!(twice.len(), 1);
+}
+
+#[test]
+fn removing_a_hook_leaves_the_rest() {
+    let set = HookSet::ALL.without(PluginHook::Transform);
+
+    assert!(!set.contains(PluginHook::Transform));
+    assert_eq!(set.len() as usize, PluginHook::COUNT - 1);
+    assert_eq!(set.with(PluginHook::Transform), HookSet::ALL);
+}
+
+#[test]
+fn removing_an_absent_hook_changes_nothing() {
+    let set = HookSet::of(PluginHook::Load);
+
+    assert_eq!(set.without(PluginHook::Transform), set);
+}
+
+#[test]
+fn union_and_intersection_agree_with_membership() {
+    let left = HookSet::of(PluginHook::Load).with(PluginHook::Transform);
+    let right = HookSet::of(PluginHook::Transform).with(PluginHook::BuildEnd);
+
+    assert_eq!(left.union(right).len(), 3);
+    assert_eq!(left.intersection(right), HookSet::of(PluginHook::Transform));
+    assert_eq!(left.intersection(HookSet::EMPTY), HookSet::EMPTY);
+    assert_eq!(left.union(HookSet::ALL), HookSet::ALL);
+}
+
+#[test]
+fn a_set_iterates_in_pipeline_order() {
+    let set = HookSet::of(PluginHook::WriteBundle)
+        .with(PluginHook::Config)
+        .with(PluginHook::Transform);
+
+    assert_eq!(
+        set.iter().collect::<Vec<_>>(),
+        vec![
+            PluginHook::Config,
+            PluginHook::Transform,
+            PluginHook::WriteBundle
+        ]
+    );
+}
+
+#[test]
+fn collecting_hooks_deduplicates_them() {
+    let set: HookSet = [
+        PluginHook::Load,
+        PluginHook::Load,
+        PluginHook::Transform,
+        PluginHook::Load,
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(set.len(), 2);
+    assert_eq!(
+        set,
+        HookSet::of(PluginHook::Load).with(PluginHook::Transform)
+    );
+}
+
+#[test]
+fn collecting_nothing_gives_the_empty_set() {
+    let set: HookSet = std::iter::empty().collect();
+
+    assert_eq!(set, HookSet::EMPTY);
+}
+
+#[test]
+fn a_set_serializes_as_hook_ids() {
+    let set = HookSet::of(PluginHook::Transform).with(PluginHook::ResolveId);
+
+    assert_eq!(
+        serde_json::to_value(set).expect("serializes"),
+        serde_json::json!(["resolve-id", "transform"])
+    );
+}
+
+#[test]
+fn an_empty_set_serializes_as_an_empty_list() {
+    assert_eq!(
+        serde_json::to_string(&HookSet::EMPTY).expect("serializes"),
+        "[]"
+    );
+}
+
+#[test]
+fn a_set_round_trips_through_json() {
+    for set in [
+        HookSet::EMPTY,
+        HookSet::ALL,
+        HookSet::of(PluginHook::Load).with(PluginHook::WriteBundle),
+    ] {
+        let json = serde_json::to_string(&set).expect("serializes");
+        let back: HookSet = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, set, "{json}");
+    }
+}
+
+#[test]
+fn a_hook_round_trips_through_json() {
+    for hook in PluginHook::ALL {
+        let json = serde_json::to_string(&hook).expect("serializes");
+        assert_eq!(json, format!("\"{}\"", hook.as_str()));
+        let back: PluginHook = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, hook);
+    }
+}
+
+#[test]
+fn into_iterator_matches_iter() {
+    let set = HookSet::ALL.without(PluginHook::Config);
+
+    assert_eq!(
+        set.into_iter().collect::<Vec<_>>(),
+        set.iter().collect::<Vec<_>>()
+    );
+}

--- a/crates/uf_plugin/src/tests/mod.rs
+++ b/crates/uf_plugin/src/tests/mod.rs
@@ -1,0 +1,93 @@
+//! Tests for the plugin container.
+//!
+//! Split by concern so each file stays readable: the hook vocabulary, the
+//! descriptor, the container's ordering rules, its dispatch rules, the
+//! built-in pipeline, config resolution and its path guard, and the check that
+//! no engine name reaches a user.
+
+mod builtin;
+mod chain;
+mod config;
+mod container;
+mod descriptor;
+mod dispatch;
+mod hook;
+mod naming;
+mod path_guard;
+mod resolve;
+
+use camino::Utf8PathBuf;
+use uf_config::{ApplyCondition, HookOrder};
+
+use crate::descriptor::{PluginDescriptor, PluginSource};
+use crate::hook::{HookSet, PluginHook};
+use crate::outcome::{HookOutcome, HookResult, ModuleCode, ResolvedId, TransformInput};
+use crate::plugin::{FnPlugin, Plugin};
+
+/// A project plugin that implements nothing, for ordering tests.
+fn inert(name: &str, order: HookOrder) -> Box<dyn Plugin> {
+    Box::new(FnPlugin::new(descriptor(name, order, HookSet::EMPTY)))
+}
+
+/// A descriptor for a project plugin with no filesystem source.
+fn descriptor(name: &str, order: HookOrder, hooks: HookSet) -> PluginDescriptor {
+    PluginDescriptor::project(
+        name,
+        PluginSource::Package {
+            specifier: name.into(),
+        },
+        order,
+        ApplyCondition::Always,
+        hooks,
+    )
+}
+
+/// A plugin whose `Transform` hook appends `mark` to whatever it is handed.
+fn appender(name: &str, order: HookOrder, mark: &'static str) -> Box<dyn Plugin> {
+    Box::new(
+        FnPlugin::new(descriptor(name, order, HookSet::EMPTY)).on_transform(
+            move |input: TransformInput<'_>| {
+                Ok(HookOutcome::Handled(ModuleCode::new(format!(
+                    "{}{mark}",
+                    input.code
+                ))))
+            },
+        ),
+    )
+}
+
+/// A plugin that claims every specifier, answering with `id`.
+fn resolver(name: &str, order: HookOrder, id: &'static str) -> Box<dyn Plugin> {
+    Box::new(
+        FnPlugin::new(descriptor(name, order, HookSet::EMPTY))
+            .on_resolve_id(move |_| Ok(HookOutcome::Handled(ResolvedId::bundled(id)))),
+    )
+}
+
+/// A plugin that declines every hook it is asked.
+fn passthrough(name: &str, order: HookOrder) -> Box<dyn Plugin> {
+    Box::new(
+        FnPlugin::new(descriptor(name, order, HookSet::EMPTY))
+            .on_resolve_id(|_| Ok(HookOutcome::Passthrough))
+            .on_load(|_| Ok(HookOutcome::Passthrough))
+            .on_transform(|_| Ok(HookOutcome::Passthrough)),
+    )
+}
+
+/// A plugin whose `Transform` hook always fails with `failure`.
+fn failing(name: &str, order: HookOrder, failure: crate::outcome::HookFailure) -> Box<dyn Plugin> {
+    Box::new(
+        FnPlugin::new(descriptor(name, order, HookSet::EMPTY))
+            .on_transform(move |_| -> HookResult<ModuleCode> { Err(failure) }),
+    )
+}
+
+/// A descriptor that declares `hook` without wiring anything to it.
+fn declaring(name: &str, hook: PluginHook) -> PluginDescriptor {
+    descriptor(name, HookOrder::Normal, HookSet::of(hook))
+}
+
+/// A temporary directory as a UTF-8 path.
+fn temp_root(dir: &tempfile::TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("temp dir is UTF-8")
+}

--- a/crates/uf_plugin/src/tests/naming.rs
+++ b/crates/uf_plugin/src/tests/naming.rs
@@ -1,0 +1,202 @@
+//! uf borrows the plugin *semantics* of the existing ecosystem so those plugins
+//! keep working. It does not borrow the names.
+//!
+//! A developer using uf writes `uf.config.js` and `.js` files with `// @flow`.
+//! They never chose an underlying bundler, so no id, no diagnostic, no report
+//! field, and no generated file may hand them one to reason about. These tests
+//! read this crate's own sources and the project templates and fail if an
+//! engine name appears anywhere a user could see it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use camino::Utf8PathBuf;
+use uf_config::{HookOrder, PipelineMode, UniflowedConfig};
+
+use crate::builtin::{BuiltinPlugin, BuiltinSet};
+use crate::container::PluginContainer;
+use crate::descriptor::{PluginOrigin, PluginSource};
+use crate::hook::{HookDispatch, PluginHook};
+
+/// The engines uf drives internally and never names to a user.
+const ENGINE_NAMES: [&str; 3] = ["vite", "rolldown", "rollup"];
+
+/// Source trees whose user-visible strings are checked.
+///
+/// This crate, because every id it invents ends up in `uf inspect --json`, and
+/// the project templates, because they become the files in someone's
+/// repository.
+const CHECKED_TREES: [&str; 3] = ["src", "benches", "../uf_project/src"];
+
+fn crate_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Collect the `.rs` files under `dir` that end up in a shipped binary.
+///
+/// `#[cfg(test)]` trees are skipped: they are the one place the engines have to
+/// be named, because a test for "this name never reaches a user" has to say the
+/// name to look for it, and none of that code is ever compiled into `uf`.
+fn rust_sources(dir: &Path, into: &mut Vec<PathBuf>) {
+    if dir.file_name().is_some_and(|name| name == "tests") {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, into);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            into.push(path);
+        }
+    }
+}
+
+/// Strip `//` line comments, keeping everything a user could see.
+///
+/// Comments are where the engines *should* be named: this crate has to explain
+/// which semantics it matches, and that explanation is for people reading the
+/// code, not for people running `uf`.
+fn without_line_comments(source: &str) -> String {
+    source
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(index) => &line[..index],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn no_user_visible_string_names_the_underlying_engines() {
+    let root = crate_dir();
+    let mut sources = Vec::new();
+    for tree in CHECKED_TREES {
+        rust_sources(&root.join(tree), &mut sources);
+    }
+    assert!(
+        sources.len() > 8,
+        "the grep found almost nothing, so it is not actually checking anything: {sources:?}"
+    );
+
+    let mut leaks = Vec::new();
+    for path in sources {
+        let source = fs::read_to_string(&path).expect("readable source");
+        let checked = without_line_comments(&source).to_ascii_lowercase();
+        for engine in ENGINE_NAMES {
+            for (line_number, line) in checked.lines().enumerate() {
+                if line.contains(engine) {
+                    leaks.push(format!("{}:{}: {engine}", path.display(), line_number + 1));
+                }
+            }
+        }
+    }
+
+    assert!(
+        leaks.is_empty(),
+        "an engine name reached a user-visible string:\n{}",
+        leaks.join("\n")
+    );
+}
+
+#[test]
+fn no_builtin_plugin_names_an_engine() {
+    for plugin in BuiltinPlugin::ALL {
+        let name = plugin.name().to_ascii_lowercase();
+        for engine in ENGINE_NAMES {
+            assert!(!name.contains(engine), "{name} names {engine}");
+        }
+    }
+}
+
+#[test]
+fn no_hook_id_names_an_engine() {
+    for hook in PluginHook::ALL {
+        let id = hook.as_str().to_ascii_lowercase();
+        for engine in ENGINE_NAMES {
+            assert!(!id.contains(engine), "{id} names {engine}");
+        }
+    }
+}
+
+#[test]
+fn no_enum_id_in_the_public_vocabulary_names_an_engine() {
+    let mut ids = Vec::new();
+    ids.extend(HookOrder::ALL.map(HookOrder::as_str));
+    ids.extend(uf_config::ApplyCondition::ALL.map(uf_config::ApplyCondition::as_str));
+    ids.extend(PipelineMode::ALL.map(PipelineMode::as_str));
+    ids.extend([
+        HookDispatch::Broadcast.as_str(),
+        HookDispatch::FirstWins.as_str(),
+        HookDispatch::Chained.as_str(),
+        PluginOrigin::Builtin.as_str(),
+        PluginOrigin::Project.as_str(),
+        PluginSource::Builtin.kind(),
+    ]);
+
+    for id in ids {
+        let lowered = id.to_ascii_lowercase();
+        for engine in ENGINE_NAMES {
+            assert!(!lowered.contains(engine), "{id} names {engine}");
+        }
+    }
+}
+
+#[test]
+fn the_inspect_report_never_names_an_engine() {
+    let config = UniflowedConfig::default();
+    let container = PluginContainer::from_descriptors(
+        PipelineMode::Build,
+        BuiltinSet::from_config(&config).descriptors(),
+    )
+    .expect("container");
+
+    let json = serde_json::to_string(&container.report())
+        .expect("serializes")
+        .to_ascii_lowercase();
+
+    for engine in ENGINE_NAMES {
+        assert!(!json.contains(engine), "the report names {engine}: {json}");
+    }
+}
+
+#[test]
+fn a_resolved_project_pipeline_never_names_an_engine() {
+    let mut config = UniflowedConfig::default();
+    config.plugins = vec![
+        uf_config::PluginEntry::Name("@uniflowed/plugin-mdx".into()),
+        uf_config::PluginEntry::Spec(
+            uf_config::PluginSpec::new("./plugins/metrics.js")
+                .with_order(HookOrder::Post)
+                .with_apply(uf_config::ApplyCondition::Build),
+        ),
+    ];
+    let root = Utf8PathBuf::from("/workspace/app");
+
+    let container = crate::resolve_pipeline(&config, &root, PipelineMode::Build).expect("resolves");
+    let json = serde_json::to_string(&container.report())
+        .expect("serializes")
+        .to_ascii_lowercase();
+
+    for engine in ENGINE_NAMES {
+        assert!(!json.contains(engine), "the report names {engine}");
+    }
+}
+
+#[test]
+fn the_grep_would_notice_a_leak() {
+    // Without this the test above could be passing because it reads nothing.
+    let leaky = "let backend = \"rolldown\"; // rollup\n";
+
+    assert!(
+        without_line_comments(leaky).contains("rolldown"),
+        "the grep must see code"
+    );
+    assert!(
+        !without_line_comments(leaky).contains("rollup"),
+        "the grep must not see line comments"
+    );
+}

--- a/crates/uf_plugin/src/tests/path_guard.rs
+++ b/crates/uf_plugin/src/tests/path_guard.rs
@@ -1,0 +1,424 @@
+//! The grammar that decides whether a declared plugin name may name code on
+//! disk at all.
+//!
+//! Every case below is a way a config could try to reach outside the project.
+//! See `docs/security.md` for the failures each one is modelled on.
+
+use camino::Utf8PathBuf;
+
+use crate::builtin::BuiltinPlugin;
+use crate::descriptor::PluginSource;
+use crate::resolve::{
+    BUILTIN_PREFIX, MAX_PLUGIN_NAME_BYTES, PluginPathError, classify_plugin_name,
+};
+
+use super::temp_root;
+
+/// A root that does not exist, so the lexical grammar is what is under test.
+const ROOT: &str = "/workspace/app";
+
+fn classify(name: &str) -> Result<PluginSource, PluginPathError> {
+    classify_plugin_name(name, Utf8PathBuf::from(ROOT).as_path())
+}
+
+fn rejected(name: &str) -> PluginPathError {
+    classify(name).expect_err(&format!("{name:?} must be refused"))
+}
+
+#[test]
+fn a_bare_package_specifier_is_a_package() {
+    assert_eq!(
+        classify("mdx").expect("accepted"),
+        PluginSource::Package {
+            specifier: "mdx".into()
+        }
+    );
+}
+
+#[test]
+fn a_scoped_package_specifier_is_a_package() {
+    assert_eq!(
+        classify("@uniflowed/plugin-mdx").expect("accepted"),
+        PluginSource::Package {
+            specifier: "@uniflowed/plugin-mdx".into()
+        }
+    );
+}
+
+#[test]
+fn a_package_subpath_is_a_package() {
+    assert_eq!(
+        classify("@scope/pkg/dist/plugin.js").expect("accepted"),
+        PluginSource::Package {
+            specifier: "@scope/pkg/dist/plugin.js".into()
+        }
+    );
+}
+
+#[test]
+fn a_bare_path_shaped_name_is_still_a_package_and_never_joined_onto_the_root() {
+    // Only a leading `./` makes a name a file, exactly as a module resolver
+    // reads it. Anything else goes to the package resolver and never becomes a
+    // path, so there is one guard rather than two.
+    assert!(matches!(
+        classify("plugins/metrics.js").expect("accepted"),
+        PluginSource::Package { .. }
+    ));
+}
+
+#[test]
+fn a_dot_slash_name_is_a_project_file_under_the_root() {
+    assert_eq!(
+        classify("./plugins/metrics.js").expect("accepted"),
+        PluginSource::ProjectFile {
+            path: Utf8PathBuf::from("/workspace/app/plugins/metrics.js"),
+        }
+    );
+}
+
+#[test]
+fn a_project_file_keeps_its_nested_directories() {
+    assert_eq!(
+        classify("./a/b/c/plugin.js").expect("accepted"),
+        PluginSource::ProjectFile {
+            path: Utf8PathBuf::from("/workspace/app/a/b/c/plugin.js"),
+        }
+    );
+}
+
+#[test]
+fn an_absolute_path_is_refused() {
+    assert_eq!(
+        rejected("/etc/passwd"),
+        PluginPathError::Absolute {
+            name: "/etc/passwd".into()
+        }
+    );
+}
+
+#[test]
+fn a_root_slash_alone_is_refused() {
+    assert!(matches!(rejected("/"), PluginPathError::Absolute { .. }));
+}
+
+#[test]
+fn a_parent_segment_is_refused() {
+    assert_eq!(
+        rejected("../evil.js"),
+        PluginPathError::ParentSegment {
+            name: "../evil.js".into(),
+            position: 0,
+        }
+    );
+}
+
+#[test]
+fn a_parent_segment_after_a_dot_slash_is_refused() {
+    assert_eq!(
+        rejected("./../../.ssh/id_ed25519"),
+        PluginPathError::ParentSegment {
+            name: "./../../.ssh/id_ed25519".into(),
+            position: 1,
+        }
+    );
+}
+
+#[test]
+fn a_parent_segment_buried_deep_in_the_path_is_refused() {
+    assert!(matches!(
+        rejected("./a/b/c/../../../../../../etc/passwd"),
+        PluginPathError::ParentSegment { .. }
+    ));
+}
+
+#[test]
+fn a_parent_segment_inside_a_package_specifier_is_refused() {
+    assert!(matches!(
+        rejected("@scope/../../../etc/passwd"),
+        PluginPathError::ParentSegment { .. }
+    ));
+}
+
+#[test]
+fn a_dotdot_that_is_only_part_of_a_name_is_allowed() {
+    // `..foo` is a legal file name; only a whole `..` segment walks upwards.
+    assert!(classify("./a/..foo.js").is_ok());
+    assert!(classify("./a/foo...js").is_ok());
+}
+
+#[test]
+fn a_backslash_is_a_separator_on_every_platform() {
+    // The pnpm tarball traversal and the Vite-era dev-server bypass were both
+    // "the deny check treated `\` as an ordinary character off Windows".
+    assert_eq!(
+        rejected("..\\..\\evil.js"),
+        PluginPathError::BackslashSeparator {
+            name: "..\\..\\evil.js".into(),
+            offset: 2,
+        }
+    );
+}
+
+#[test]
+fn a_unc_path_is_refused() {
+    assert!(matches!(
+        rejected("\\\\server\\share\\evil.js"),
+        PluginPathError::BackslashSeparator { offset: 0, .. }
+    ));
+}
+
+#[test]
+fn a_windows_drive_path_is_refused() {
+    assert_eq!(
+        rejected("C:/Windows/System32/evil.js"),
+        PluginPathError::UrlScheme {
+            name: "C:/Windows/System32/evil.js".into(),
+            scheme: "C".into(),
+        }
+    );
+}
+
+#[test]
+fn a_file_url_is_refused() {
+    assert!(matches!(
+        rejected("file:///etc/passwd"),
+        PluginPathError::UrlScheme { .. }
+    ));
+}
+
+#[test]
+fn a_remote_url_is_refused() {
+    for name in [
+        "http://example.test/plugin.js",
+        "https://example.test/plugin.js",
+        "data:text/javascript,alert(1)",
+        "node:fs",
+    ] {
+        assert!(
+            matches!(rejected(name), PluginPathError::UrlScheme { .. }),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn a_protocol_relative_url_is_refused() {
+    assert!(matches!(
+        rejected("//example.test/plugin.js"),
+        PluginPathError::Absolute { .. }
+    ));
+}
+
+#[test]
+fn a_home_relative_path_is_refused() {
+    assert_eq!(
+        rejected("~/.ssh/id_ed25519"),
+        PluginPathError::HomeRelative {
+            name: "~/.ssh/id_ed25519".into()
+        }
+    );
+}
+
+#[test]
+fn an_empty_name_is_refused() {
+    assert_eq!(rejected(""), PluginPathError::Empty);
+}
+
+#[test]
+fn an_oversized_name_is_refused() {
+    let name = "a".repeat(MAX_PLUGIN_NAME_BYTES + 1);
+
+    assert_eq!(
+        rejected(&name),
+        PluginPathError::TooLong {
+            bytes: MAX_PLUGIN_NAME_BYTES + 1,
+            limit: MAX_PLUGIN_NAME_BYTES,
+        }
+    );
+}
+
+#[test]
+fn a_name_at_exactly_the_ceiling_is_accepted() {
+    let name = "a".repeat(MAX_PLUGIN_NAME_BYTES);
+
+    assert!(classify(&name).is_ok());
+}
+
+#[test]
+fn a_nul_byte_is_refused() {
+    assert_eq!(
+        rejected("plugin\0.js"),
+        PluginPathError::ControlByte {
+            name: "plugin\0.js".into(),
+            offset: 6,
+        }
+    );
+}
+
+#[test]
+fn a_newline_or_tab_is_refused() {
+    assert!(matches!(
+        rejected("plugin\n.js"),
+        PluginPathError::ControlByte { offset: 6, .. }
+    ));
+    assert!(matches!(
+        rejected("\tplugin"),
+        PluginPathError::ControlByte { offset: 0, .. }
+    ));
+}
+
+#[test]
+fn a_delete_byte_is_refused() {
+    assert!(matches!(
+        rejected("plugin\u{7f}"),
+        PluginPathError::ControlByte { .. }
+    ));
+}
+
+#[test]
+fn the_builtin_prefix_is_reserved() {
+    assert_eq!(
+        rejected("uf:flow"),
+        PluginPathError::ReservedPrefix {
+            name: "uf:flow".into(),
+            prefix: BUILTIN_PREFIX,
+        }
+    );
+    for plugin in BuiltinPlugin::ALL {
+        assert!(
+            matches!(
+                rejected(plugin.name()),
+                PluginPathError::ReservedPrefix { .. }
+            ),
+            "{}",
+            plugin.name()
+        );
+    }
+}
+
+#[test]
+fn an_empty_segment_is_refused() {
+    assert_eq!(
+        rejected("./a//b.js"),
+        PluginPathError::EmptySegment {
+            name: "./a//b.js".into(),
+            position: 2,
+        }
+    );
+}
+
+#[test]
+fn a_trailing_slash_is_refused() {
+    assert!(matches!(
+        rejected("./plugins/"),
+        PluginPathError::EmptySegment { .. }
+    ));
+}
+
+#[test]
+fn a_dot_segment_away_from_the_front_is_refused() {
+    assert_eq!(
+        rejected("./a/./b.js"),
+        PluginPathError::CurrentSegment {
+            name: "./a/./b.js".into(),
+            position: 2,
+        }
+    );
+}
+
+#[test]
+fn a_lone_dot_is_accepted_as_a_package_name() {
+    // Position zero is the `./` form; a bare `.` is not a path and goes to the
+    // package resolver, which will simply not find it.
+    assert!(matches!(
+        classify(".").expect("accepted"),
+        PluginSource::Package { .. }
+    ));
+}
+
+#[test]
+fn a_non_ascii_package_name_is_accepted() {
+    assert!(classify("@scope/plugin-café").is_ok());
+    assert!(classify("./plugins/日本語.js").is_ok());
+}
+
+#[test]
+fn a_symlink_pointing_out_of_the_project_is_refused() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        let outside = tempfile::tempdir().expect("temp dir");
+        let project = tempfile::tempdir().expect("temp dir");
+        let outside_root = temp_root(&outside);
+        let root = temp_root(&project);
+        std::fs::write(outside_root.join("evil.js"), "// @flow\n").expect("write");
+        std::os::unix::fs::symlink(outside_root.join("evil.js"), root.join("plugin.js"))
+            .expect("symlink");
+
+        let error = classify_plugin_name("./plugin.js", &root)
+            .expect_err("a symlink out of the project is refused");
+
+        assert!(
+            matches!(error, PluginPathError::OutsideRoot { .. }),
+            "{error:?}"
+        );
+    }
+}
+
+#[test]
+fn a_symlink_that_stays_inside_the_project_is_accepted() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        let project = tempfile::tempdir().expect("temp dir");
+        let root = temp_root(&project);
+        std::fs::create_dir_all(root.join("real")).expect("dir");
+        std::fs::write(root.join("real/plugin.js"), "// @flow\n").expect("write");
+        std::os::unix::fs::symlink(root.join("real/plugin.js"), root.join("plugin.js"))
+            .expect("symlink");
+
+        assert!(classify_plugin_name("./plugin.js", &root).is_ok());
+    }
+}
+
+#[test]
+fn a_sibling_directory_sharing_a_prefix_is_not_inside_the_root() {
+    // Containment is decided on path components, so `/workspace/app-evil` is
+    // not treated as living under `/workspace/app`.
+    let root = Utf8PathBuf::from("/workspace/app");
+    let sibling = Utf8PathBuf::from("/workspace/app-evil/plugin.js");
+
+    assert!(!sibling.starts_with(&root));
+}
+
+#[test]
+fn a_real_file_inside_the_project_resolves_to_its_checked_path() {
+    let project = tempfile::tempdir().expect("temp dir");
+    let root = temp_root(&project);
+    std::fs::create_dir_all(root.join("plugins")).expect("dir");
+    std::fs::write(root.join("plugins/metrics.js"), "// @flow\n").expect("write");
+
+    assert_eq!(
+        classify_plugin_name("./plugins/metrics.js", &root).expect("accepted"),
+        PluginSource::ProjectFile {
+            path: root.join("plugins/metrics.js"),
+        }
+    );
+}
+
+#[test]
+fn path_errors_say_what_was_wrong() {
+    assert_eq!(
+        rejected("/etc/passwd").to_string(),
+        "plugin name \"/etc/passwd\" is an absolute path"
+    );
+    assert_eq!(
+        rejected("~/x").to_string(),
+        "plugin name \"~/x\" is home-relative"
+    );
+    assert_eq!(PluginPathError::Empty.to_string(), "plugin name is empty");
+}

--- a/crates/uf_plugin/src/tests/resolve.rs
+++ b/crates/uf_plugin/src/tests/resolve.rs
@@ -1,0 +1,208 @@
+//! Turning a project's `plugins: [...]` into a pipeline.
+
+use camino::Utf8PathBuf;
+use uf_config::{
+    ApplyCondition, HookOrder, PipelineMode, PluginEntry, PluginSpec, UniflowedConfig,
+};
+
+use crate::builtin::BuiltinPlugin;
+use crate::descriptor::PluginOrigin;
+use crate::hook::HookSet;
+use crate::resolve::{PluginPathError, ResolveError, resolve_pipeline, resolve_project_plugins};
+
+const ROOT: &str = "/workspace/app";
+
+fn config_with(entries: Vec<PluginEntry>) -> UniflowedConfig {
+    let mut config = UniflowedConfig::default();
+    config.plugins = entries;
+    config
+}
+
+#[test]
+fn plugins_default_to_none() {
+    assert!(UniflowedConfig::default().plugins.is_empty());
+    assert!(
+        resolve_project_plugins(
+            &UniflowedConfig::default(),
+            Utf8PathBuf::from(ROOT).as_path()
+        )
+        .expect("resolves")
+        .is_empty()
+    );
+}
+
+#[test]
+fn resolving_keeps_declaration_order() {
+    let config = config_with(vec![
+        PluginEntry::Name("a".into()),
+        PluginEntry::Name("b".into()),
+        PluginEntry::Name("c".into()),
+    ]);
+
+    let resolved =
+        resolve_project_plugins(&config, Utf8PathBuf::from(ROOT).as_path()).expect("resolves");
+
+    assert_eq!(
+        resolved
+            .iter()
+            .map(|plugin| plugin.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b", "c"]
+    );
+}
+
+#[test]
+fn a_resolved_entry_carries_its_declared_order_and_apply() {
+    let config = config_with(vec![PluginEntry::Spec(
+        PluginSpec::new("metrics")
+            .with_order(HookOrder::Post)
+            .with_apply(ApplyCondition::Build),
+    )]);
+
+    let resolved =
+        resolve_project_plugins(&config, Utf8PathBuf::from(ROOT).as_path()).expect("resolves");
+
+    assert_eq!(resolved[0].order, HookOrder::Post);
+    assert_eq!(resolved[0].apply, ApplyCondition::Build);
+    assert_eq!(resolved[0].origin, PluginOrigin::Project);
+}
+
+#[test]
+fn a_resolved_entry_starts_with_no_hooks() {
+    let config = config_with(vec![PluginEntry::Name("metrics".into())]);
+
+    let resolved =
+        resolve_project_plugins(&config, Utf8PathBuf::from(ROOT).as_path()).expect("resolves");
+
+    assert_eq!(
+        resolved[0].hooks,
+        HookSet::EMPTY,
+        "the resolver places plugins, it does not read them"
+    );
+}
+
+#[test]
+fn a_bad_entry_is_reported_with_its_index() {
+    let config = config_with(vec![
+        PluginEntry::Name("fine".into()),
+        PluginEntry::Name("../../etc/passwd".into()),
+    ]);
+
+    let error = resolve_project_plugins(&config, Utf8PathBuf::from(ROOT).as_path())
+        .expect_err("the escape is refused");
+
+    assert!(matches!(
+        error,
+        ResolveError::Entry {
+            index: 1,
+            source: PluginPathError::ParentSegment { .. },
+        }
+    ));
+    assert_eq!(error.to_string(), "plugins[1] is not a usable plugin name");
+}
+
+#[test]
+fn one_bad_entry_refuses_the_whole_pipeline() {
+    let config = config_with(vec![PluginEntry::Name("/etc/passwd".into())]);
+
+    assert!(
+        resolve_pipeline(
+            &config,
+            Utf8PathBuf::from(ROOT).as_path(),
+            PipelineMode::Build
+        )
+        .is_err(),
+        "a config that names code outside the project must not build at all"
+    );
+}
+
+#[test]
+fn the_pipeline_puts_the_builtins_before_a_normal_project_plugin() {
+    let config = config_with(vec![PluginEntry::Name("mdx".into())]);
+
+    let container = resolve_pipeline(
+        &config,
+        Utf8PathBuf::from(ROOT).as_path(),
+        PipelineMode::Build,
+    )
+    .expect("resolves");
+    let names = container.names().collect::<Vec<_>>();
+    let mdx = names
+        .iter()
+        .position(|name| *name == "mdx")
+        .expect("placed");
+
+    assert_eq!(names.len(), BuiltinPlugin::COUNT + 1);
+    for plugin in BuiltinPlugin::ALL {
+        let builtin = names
+            .iter()
+            .position(|name| *name == plugin.name())
+            .expect("placed");
+        match plugin.order() {
+            // A default project plugin is Normal, so it runs after every
+            // built-in that asked for no position and before the ones that
+            // asked to be last.
+            HookOrder::Pre | HookOrder::Normal => assert!(builtin < mdx, "{plugin:?}"),
+            HookOrder::Post => assert!(builtin > mdx, "{plugin:?}"),
+        }
+    }
+}
+
+#[test]
+fn a_project_plugin_can_ask_to_run_before_the_builtins_in_its_band() {
+    let config = config_with(vec![PluginEntry::Spec(
+        PluginSpec::new("mdx").with_order(HookOrder::Pre),
+    )]);
+
+    let container = resolve_pipeline(
+        &config,
+        Utf8PathBuf::from(ROOT).as_path(),
+        PipelineMode::Build,
+    )
+    .expect("resolves");
+    let names = container.names().collect::<Vec<_>>();
+
+    // Still after the built-in `Pre` plugins, because built-ins are placed
+    // first and the sort inside a band is stable.
+    assert_eq!(
+        names.iter().position(|name| *name == "mdx"),
+        Some(2),
+        "{names:?}"
+    );
+}
+
+#[test]
+fn a_project_plugin_that_shadows_a_builtin_name_is_refused_before_it_can_run() {
+    // The reserved prefix stops this at classification, so the container never
+    // has to choose between two plugins called `uf:flow`.
+    let config = config_with(vec![PluginEntry::Name("uf:flow".into())]);
+
+    assert!(matches!(
+        resolve_pipeline(
+            &config,
+            Utf8PathBuf::from(ROOT).as_path(),
+            PipelineMode::Build
+        ),
+        Err(ResolveError::Entry {
+            index: 0,
+            source: PluginPathError::ReservedPrefix { .. },
+        })
+    ));
+}
+
+#[test]
+fn two_project_plugins_with_one_name_are_refused() {
+    let config = config_with(vec![
+        PluginEntry::Name("mdx".into()),
+        PluginEntry::Name("mdx".into()),
+    ]);
+
+    assert!(matches!(
+        resolve_pipeline(
+            &config,
+            Utf8PathBuf::from(ROOT).as_path(),
+            PipelineMode::Build
+        ),
+        Err(ResolveError::Container(_))
+    ));
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,6 +79,20 @@ defaulting to `*`.
 | Shell injection through the `packageManager` field | Parsed by a hand-written single-pass parser with no regex (ReDoS), and `Invocation.program` comes only from a fixed program table, so no manifest text can name a program or inject an argument | `uf_pm::detect` |
 | Prototype-pollution keys in manifest JSON | `__proto__`, `constructor`, and `prototype` are reported and dropped wherever manifest JSON becomes a map | `uf_pm::detect` |
 
+## Config and plugins
+
+`uf.config.js` is checked into the repository a developer just cloned, so every
+value in it is hostile input. A plugin entry is the sharpest one: it decides
+what code the toolchain executes.
+
+| Past failure | Structural decision in `uf` | Test |
+| --- | --- | --- |
+| A config naming a plugin outside the project (`../../evil.js`, `/etc/…`, `~/…`, `file://…`) loads arbitrary code from the developer's machine | Plugin names are a closed grammar checked in one pass with no regex. Only a leading `./` names a file at all; absolute paths, URL schemes, drive letters, `~`, and `..` segments are typed errors, so there is exactly one place a config can reach the filesystem and it is guarded | `uf_plugin::resolve` |
+| Windows-only separator handling lets `..\..\evil.js` through a check that only understood `/` | `\` is refused as a path separator on **every** platform, never only on Windows | `uf_plugin::resolve` |
+| A symlink inside the project pointing out of it defeats a purely lexical containment check | The joined path is resolved and containment is re-checked against the canonical root, compared as path components rather than string prefixes | `uf_plugin::resolve` |
+| Unbounded config text as a denial-of-service or allocation vector | Plugin names have an explicit byte ceiling and control bytes are refused, so no config text reaches a resolver as a NUL- or newline-bearing string | `uf_plugin::resolve` |
+| A config plugin shadowing a built-in stage, silently replacing part of the toolchain | The `uf:` prefix is reserved, and two plugins with one name is a typed error that names both positions rather than a silent override | `uf_plugin::resolve` |
+
 ## Parser, formatter, linter, and test runner
 
 These read attacker-authored source text. The failure mode is denial of service


### PR DESCRIPTION
`uf` reaches the existing plugin ecosystem by using its hook semantics
internally, but a uf project only ever sees `uf.config.js`. This adds the
container that makes both halves true, and moves uf's own pipeline into it so
there is one mechanism rather than a set of hardcoded call sites in `uf build`.

## The hook contract

`PluginHook` is the closed set of the fourteen hooks uf drives. `HookSet` is
that set as a `u16` bitset, so "does this plugin implement `Transform`?" is one
AND rather than a string compare in the per-module loop.

`PluginHook::dispatch` decides how answers combine — `FirstWins` for
`ResolveId` and `Load`, `Chained` for `Transform`, `Broadcast` for the
lifecycle hooks. That makes the combining rule a property of the hook rather
than something a caller can get wrong: a plugin only ever says
`HookOutcome::Handled` or `Passthrough`, and the container owns the loop.

`PluginContainer::build` fixes the run order — every `Pre` in declaration
order, then `Normal`, then `Post` — and precomputes a per-hook lane of indices
from the bitsets, so a dispatch is a walk over a short `SmallVec` with no
filtering and no name comparison. Two plugins with one name is a typed error
naming both declaration positions, never a silent override. There is a
`MAX_PLUGINS` ceiling, because config is untrusted input.

## Built-ins

Flow stripping, router codegen, the RSC boundary split, StyleX, the React
compiler, and asset handling ship as `BuiltinPlugin` descriptors with their
band and apply condition set — Flow and the router `Pre` because everything
downstream expects plain JavaScript and importable route modules, the React
compiler `Post` because anything that rewrites JavaScript after it would
invalidate the memoization it just proved sound.

The transforms themselves stay in the crates that own them. `FnPlugin` is how
such a crate hands a closure to the container, which is why `uf_plugin` depends
on none of `uf_router`, `uf_rsc`, or `uf_fmt` and reimplements nothing.
`BuiltinSet::from_config` reads the config fields users already have, so there
is no second set of plugin toggles.

## `uf.config.js`

`uf_config` gains `plugins: [...]`, accepting either a bare name or
`{ name, order, apply }`.

A plugin name is untrusted input, because a name that names a file decides what
code the toolchain executes on a machine that just cloned a repository. The
grammar is closed and checked in a single byte scan with no regex. Only a
leading `./` names a file at all — everything else goes to the package
resolver and never becomes a path, so there is exactly one place to guard.
Absolute paths, URL schemes, drive letters, `~`, `..` and `.` segments, empty
segments, control bytes, and over-long names are typed errors. `\` is refused
as a separator on **every** platform, not only on Windows, which is the shape
of both the pnpm tarball traversal and the Vite-era dev-server bypasses. The
joined path is then resolved and containment re-checked against the canonical
root, comparing path components rather than string prefixes, so a symlink
inside the project pointing out of it is refused too. `uf:` is reserved, so a
config cannot shadow a built-in. `docs/security.md` gains the rows.

## `uf inspect --json`

A `plugins` section lists the resolved order, each plugin's origin and source,
which hooks it implements, and which plugins run each hook with that hook's
dispatch rule — without naming the engines underneath.

## Numbers

`crates/uf_plugin/benches/container.rs`, 100 000 modules through 20 plugins,
measured on an M-series Mac at `--sample-size 10`:

| Case | Total | Per module |
| --- | --- | --- |
| Every plugin declines (the common case) | 4.09 ms | **40.9 ns**, zero allocation |
| All twenty rewrite the module | 194 ms | 1.94 us |
| Resolve a specifier, 19 decline then one answers | 10.2 ms | 102 ns |
| `implements(hook)` mask test | — | 476 ps |

## Tests

181 unit tests plus a doctest in `uf_plugin`; the workspace is at 1129 across 83
targets. `no_user_visible_string_names_the_underlying_engines` greps this
crate's own sources and `uf_project`'s templates for "vite", "rolldown", and
"rollup" outside `//` comments, and `the_grep_would_notice_a_leak` proves the
grep is not vacuously passing.

`Cargo Semver Checks` fails here, as it does on every branch including the two
that just merged (#22, #24): the baseline checkout under
`target/semver-checks/git-*` has no `upstream/flow` submodule, so `flow_parser`'s
path dependency cannot be read. Unrelated to this change.

## Deliberately left out

- **Wiring the built-in transforms.** The descriptors and the ordering are real;
  connecting `uf:flow` to `uf_flow` and `uf:router` to `uf_router` means changing
  `uf build`'s call sites. `FnPlugin` is the seam, and this PR keeps its
  `uf_cli` change to the single `inspect --json` section — one import and four
  lines in `commands/inspect.rs` — so it stays out of the way of the output
  rewrite in #24. The human-readable `uf inspect` view is untouched.
- **A project plugin's hook set.** It resolves to `HookSet::EMPTY`, because
  which hooks a plugin implements is only known once its module is read and the
  resolver reads nothing. `PluginDescriptor::with_hooks` is where a loader
  fills it in.
- **The engine names that already leak elsewhere.** Still present on `main`
  after #24, all outside this crate:

  | Where | What a user sees |
  | --- | --- |
  | `uf_cli/src/commands/build.rs:44` | `"bundlerCompatibility": ["vite", "rolldown"]` in the build manifest |
  | `uf_cli/src/commands/dev.rs:33` | `"viteCompatibility"` / `"rolldownCompatibility"` in `.uf/dev-server.json` |
  | `uf_cli/src/commands/inspect.rs:212` | `engines.build` = `"vite-compatible/rolldown"`, `engines.devServer` = `"vite-compatible"` |
  | `uf_cli/src/commands/task.rs:80` | `failed to run task … through uf Vite Task runner` |
  | `uf_config/src/lib.rs:1517` | `TaskRunnerEngine::ViteTask`, serialized as `"vite-task"` |
  | `uf_lib/lib/core/config.js:242` | `+engine?: "vite-task"` in the Flow type users read |

  Each is a real breach of the same product rule, but renaming a config enum
  changes the `uf.config.js` surface and the CLI strings belong to the output
  work, so this PR reports them rather than widening its own blast radius. The
  grep test is scoped to `uf_plugin` and the templates and would catch a
  regression there; pointing it at `uf_cli` and `uf_config` is the follow-up
  that goes with fixing the rows above.

## File sizes

Every source file is under 400 lines. Two test files run slightly over
(`tests/chain.rs` at 448, `tests/path_guard.rs` at 424) — both are flat lists
of independent `#[test]` fns, which is the table-shaped case the guideline
allows. Tests live in a `src/tests/` module tree declared from `lib.rs`,
following the `crates/uf_lint` pattern the brief pointed at; happy to move them
to the per-module `foo/tests.rs` shape that `uf_rsc`, `uf_pm`, and now `uf_cli`
use if that is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
