### PR TITLE
ci: exclude uf_flow from cargo-semver-checks

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -25,3 +25,9 @@ jobs:
         with:
           baseline-rev: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           rust-toolchain: "1.98.0"
+          # `uf_flow` optionally path-depends on `upstream/flow`, and
+          # cargo-semver-checks builds its baseline from a copy of the crate at
+          # a different depth, where `../../upstream/...` no longer resolves.
+          # The relative path is not something the crate can fix, so the crate
+          # is excluded rather than the whole gate being turned off.
+          exclude: uf_flow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,12 @@ Measured against `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`:
 reach outside `rust_port` into `lib/`, `prelude/`, and `tslib/`, so
 `tools/upstream/sync.sh` checks those out too and asserts they arrived.
 
+The submodule costs one gate: `cargo-semver-checks` builds its baseline from
+a copy of each crate at a different depth, where `uf_flow`'s relative path to
+`upstream/flow` no longer resolves. `uf_flow` is excluded from that check
+rather than the check being switched off, and it is the crate whose public API
+moves least — the backends sit behind one `validate_source`.
+
 ## Flow And React
 
 The default app preset is Flow-first React. New app templates use Flow component


### PR DESCRIPTION
## Summary

`Cargo Semver Checks` has been failing on **every** branch since the
`upstream/flow` submodule landed:

```
error: running 'cargo update' on crate 'uf_flow' failed with output:
error: failed to get `flow_parser` as a dependency of package
       `uf_flow v0.1.0 (/home/runner/_work/uf/uf/semver-checks/...)`
  No such file or directory (os error 2)
```

cargo-semver-checks builds its baseline from a **copy** of the crate at a
different directory depth, and `uf_flow`'s relative path to
`upstream/flow/rust_port` does not resolve from there. The path is relative
because that is what a path dependency is — the crate cannot fix it, and neither
can the submodule.

This is a regression I introduced with #5, and it has been masking real findings
on other branches since — #16's genuine `constructible_struct_adds_field` was
found before this started, but anything since has been reported as this error
instead.

## Fix

Exclude that one crate rather than switching the gate off. `uf_flow` is also the
crate whose public API moves least — both backends sit behind a single
`validate_source` — so the coverage lost is small, and every other crate stays
gated.

Recorded in `docs/architecture.md` next to the rest of the submodule's costs, so
the trade-off is visible rather than buried in a workflow file.

## Verification

- [x] `exclude` is a documented input of `obi1kenobi/cargo-semver-checks-action@v2`
- [x] Workflow-only change; no Rust code touched
- [ ] `Cargo Semver Checks` passes on this PR — that is the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790920947&installation_model_id=422833&pr_number=26&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F26&signature=877a5df2790dc3c691cb7be50564e0e980165e345a379edb9fec5c56626dd470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->