### PR TITLE
feat(devserver): give `uf dev` an access-control layer it cannot skip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "tempfile",
  "uf_bundle",
  "uf_config",
+ "uf_devserver",
  "uf_effect",
  "uf_flow",
  "uf_fmt",
@@ -1499,6 +1500,20 @@ dependencies = [
  "tempfile",
  "thiserror",
  "uf_bundle",
+]
+
+[[package]]
+name = "uf_devserver"
+version = "0.1.0"
+dependencies = [
+ "camino",
+ "compact_str",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "uf_config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/uf_bundle",
   "crates/uf_cli",
   "crates/uf_config",
+  "crates/uf_devserver",
   "crates/uf_effect",
   "crates/uf_fetch",
   "crates/uf_flow",

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -26,6 +26,7 @@ camino.workspace = true
 clap.workspace = true
 uf_bundle = { path = "../uf_bundle" }
 uf_config = { path = "../uf_config" }
+uf_devserver = { path = "../uf_devserver" }
 uf_effect = { path = "../uf_effect" }
 uf_flow = { path = "../uf_flow" }
 uf_fmt = { path = "../uf_fmt" }

--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -41,6 +41,10 @@ pub(crate) enum Commands {
         command: CreateCommand,
     },
     Dev {
+        /// Bind a routable address instead of loopback. Requires a non-empty
+        /// `dev.allowedHosts` in `uf.config.js`; see `docs/security.md`.
+        #[arg(long, value_name = "HOST")]
+        host: Option<String>,
         #[arg(long, hide = true)]
         once: bool,
     },

--- a/crates/uf_cli/src/commands/dev.rs
+++ b/crates/uf_cli/src/commands/dev.rs
@@ -1,43 +1,59 @@
 //! `uf dev` and `uf lsp`: the two commands that hold a socket or a protocol.
 
-use std::fs;
 use std::io::{IsTerminal, Read, Write};
-use std::net::{TcpListener, TcpStream};
 
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use serde_json::json;
 use uf_config::load_config;
+use uf_devserver::{DevServer, Exposure, HEALTH_TARGET};
 use uf_router::write_router_manifest;
 use uf_term::{KeyValue, Status, Tone};
 
-use crate::support::{project_label, write_json_file};
+use crate::support::project_label;
 use crate::ui::Ui;
 
-pub(crate) fn dev(cwd: &Utf8Path, ui: &mut Ui, once: bool) -> Result<()> {
+/// Start the access-controlled dev server.
+///
+/// Serving a file — request-target validation, path resolution, the deny/allow
+/// decision — belongs entirely to `uf_devserver`, so this command has no way to
+/// reach the filesystem on a request's behalf and no guard here to forget.
+pub(crate) fn dev(cwd: &Utf8Path, ui: &mut Ui, host: Option<&str>, once: bool) -> Result<()> {
     let resolved = load_config(cwd)?;
-    let listener = bind_dev_listener(
-        resolved.config.dev.host.as_str(),
-        resolved.config.dev.port,
-        resolved.config.dev.strict_port,
-    )?;
-    let address = listener.local_addr()?;
-    let state_dir = resolved.root.join(".uf");
-    fs::create_dir_all(&state_dir).with_context(|| format!("failed to create {state_dir}"))?;
-    write_json_file(
-        &state_dir.join("dev-server.json"),
-        &json!({
-            "host": address.ip().to_string(),
-            "port": address.port(),
-            "engine": "uf-native",
-            "pluginContract": "uf-plugin-v1",
-            "health": "/__uf/health",
-        }),
-    )?;
+    let mut config = resolved.config.dev.clone();
+    if let Some(host) = host {
+        config.host = host.into();
+    }
+
+    let server = DevServer::bind(&resolved.root, &config).with_context(|| {
+        if host.is_some() {
+            "failed to start `uf dev --host`: exposing the dev server needs an explicit \
+             dev.allowedHosts list in uf.config.js"
+        } else {
+            "failed to start the dev server"
+        }
+    })?;
+    server.write_state(&resolved.root)?;
     let _ = write_router_manifest(&resolved.root, &resolved.config)?;
 
+    let address = server.address();
     let url = format!("http://{}:{}", address.ip(), address.port());
-    let health = format!("{url}/__uf/health");
+    let health = format!("{url}{HEALTH_TARGET}");
+    let network = server.network_policy();
+    let (exposure, exposure_tone) = match network.exposure() {
+        Exposure::Loopback => ("loopback", Tone::Muted),
+        // An exposed dev server is reachable from the network. Say so loudly.
+        Exposure::Exposed => ("exposed", Tone::Warn),
+    };
+    let access = format!(
+        "{} host{}, {} origin{}, {} root{}",
+        network.allowed_hosts().count(),
+        plural(network.allowed_hosts().count()),
+        network.allowed_origins().count(),
+        plural(network.allowed_origins().count()),
+        server.fs_policy().roots().len(),
+        plural(server.fs_policy().roots().len()),
+    );
     ui.render(|renderer, out| {
         renderer.banner(out, "uf dev", Some(project_label(&resolved.root)));
         renderer.blank(out);
@@ -48,6 +64,8 @@ pub(crate) fn dev(cwd: &Utf8Path, ui: &mut Ui, once: bool) -> Result<()> {
                 KeyValue::toned("local", &url, Tone::Accent),
                 KeyValue::toned("health", &health, Tone::Muted),
                 KeyValue::new("engine", "uf-native"),
+                KeyValue::toned("exposure", exposure, exposure_tone),
+                KeyValue::toned("allowed", &access, Tone::Muted),
             ],
         );
         renderer.blank(out);
@@ -58,49 +76,12 @@ pub(crate) fn dev(cwd: &Utf8Path, ui: &mut Ui, once: bool) -> Result<()> {
         return Ok(());
     }
 
-    for stream in listener.incoming() {
-        let stream = stream.with_context(|| "failed to accept dev server connection")?;
-        serve_dev_request(stream)?;
-    }
+    server.serve_forever()?;
     Ok(())
 }
 
-fn bind_dev_listener(host: &str, port: u16, strict_port: bool) -> Result<TcpListener> {
-    match TcpListener::bind((host, port)) {
-        Ok(listener) => Ok(listener),
-        Err(_) if !strict_port => TcpListener::bind((host, 0)).with_context(|| {
-            format!("failed to bind requested port {host}:{port} and fallback port")
-        }),
-        Err(error) => Err(error).with_context(|| format!("failed to bind {host}:{port}")),
-    }
-}
-
-fn serve_dev_request(mut stream: TcpStream) -> Result<()> {
-    let mut buffer = [0u8; 2048];
-    let bytes = stream
-        .read(&mut buffer)
-        .with_context(|| "failed to read dev server request")?;
-    let request = String::from_utf8_lossy(&buffer[..bytes]);
-    let path = request
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .unwrap_or("/");
-    let (content_type, body) = if path == "/__uf/health" {
-        (
-            "application/json",
-            r#"{"status":"ok","engine":"uf-native"}"#,
-        )
-    } else {
-        ("text/plain; charset=utf-8", "uf dev server\n")
-    };
-    let response = format!(
-        "HTTP/1.1 200 OK\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    stream
-        .write_all(response.as_bytes())
-        .with_context(|| "failed to write dev server response")
+fn plural(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
 }
 
 /// `uf lsp` speaks JSON-RPC on stdout, so nothing else may be written there.
@@ -171,21 +152,14 @@ mod tests {
         assert_eq!(json_rpc_id("{\"jsonrpc\":\"2.0\"}"), None);
     }
 
-    #[test]
-    fn a_non_strict_port_falls_back_to_an_ephemeral_one() {
-        let held = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let port = held.local_addr().unwrap().port();
-
-        let listener = bind_dev_listener("127.0.0.1", port, false).unwrap();
-        assert!(listener.local_addr().unwrap().port() > 0);
-    }
+    // Port binding now belongs to `uf_devserver::server`, and is covered by
+    // `falls_back_to_an_ephemeral_port_unless_strict` and
+    // `a_strict_port_that_is_taken_is_a_bind_error` there.
 
     #[test]
-    fn a_strict_port_reports_the_conflict() {
-        let held = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let port = held.local_addr().unwrap().port();
-
-        let error = bind_dev_listener("127.0.0.1", port, true).unwrap_err();
-        assert!(error.to_string().contains("failed to bind"));
+    fn counts_are_pluralized() {
+        assert_eq!(plural(0), "s");
+        assert_eq!(plural(1), "");
+        assert_eq!(plural(2), "s");
     }
 }

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -81,7 +81,7 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
             commands::lint::lint_command(&cwd, ui, commands::lint::LintCommand::Check, json)
         }
         Commands::Create { command } => commands::create::create(&cwd, ui, command),
-        Commands::Dev { once } => commands::dev::dev(&cwd, ui, once),
+        Commands::Dev { host, once } => commands::dev::dev(&cwd, ui, host.as_deref(), once),
         Commands::Env { command } => commands::env::env(&cwd, ui, command),
         Commands::Exec { package, args } => commands::task::exec_package(&cwd, ui, &package, &args),
         Commands::Fmt { check } => commands::fmt::fmt(&cwd, ui, check),

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -254,6 +254,76 @@ fn dev_once_writes_native_server_state() {
             .unwrap();
     assert_eq!(state["engine"], serde_json::json!("uf-native"));
     assert!(state["port"].as_u64().unwrap() > 0);
+
+    // The access-control posture is part of the reported state, and the default
+    // is loopback with no allowlists. See `docs/security.md`.
+    assert!(stdout.contains("exposure"), "{stdout}");
+    assert!(stdout.contains("loopback"), "{stdout}");
+    assert!(stdout.contains("0 hosts, 0 origins, 1 root"), "{stdout}");
+    assert_eq!(state["exposure"], serde_json::json!("loopback"));
+    assert_eq!(state["allowedHosts"], serde_json::json!([]));
+    assert_eq!(state["allowedOrigins"], serde_json::json!([]));
+    assert!(
+        state["fsDeny"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!(".env*"))
+    );
+}
+
+#[test]
+fn dev_host_without_an_allowed_hosts_list_refuses_to_start() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              dev: { port: 0 },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["dev", "--host", "0.0.0.0", "--once"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("allowedHosts"), "{stderr}");
+}
+
+#[test]
+fn dev_host_with_an_allowed_hosts_list_starts_exposed() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              dev: { port: 0, allowedHosts: ["dev.internal"] },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["dev", "--host", "0.0.0.0", "--once"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("exposed"), "{stdout}");
+    assert!(stdout.contains("1 host, 0 origins, 1 root"), "{stdout}");
 }
 
 #[test]

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -728,6 +728,9 @@ pub struct DevConfig {
     pub host: CompactString,
     pub port: u16,
     pub strict_port: bool,
+    pub fs: DevFsConfig,
+    pub allowed_hosts: Vec<CompactString>,
+    pub allowed_origins: Vec<CompactString>,
 }
 
 impl Default for DevConfig {
@@ -736,8 +739,26 @@ impl Default for DevConfig {
             host: CompactString::const_new("127.0.0.1"),
             port: 5173,
             strict_port: false,
+            fs: DevFsConfig::default(),
+            allowed_hosts: Vec::new(),
+            allowed_origins: Vec::new(),
         }
     }
+}
+
+/// Which files the dev server may serve.
+///
+/// `allow` names extra roots beyond the project root, which is always allowed.
+/// `deny` is a glob list evaluated on the canonical path, and deny wins over
+/// allow. Entries are *added* to `uf_devserver`'s built-in deny list — which
+/// already covers `.env*`, `**/.git/**`, `*.pem`, `*.key`, `*.crt`, and
+/// `**/.uf/**` — and cannot remove one. See `docs/security.md`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct DevFsConfig {
+    pub allow: Vec<CompactString>,
+    pub deny: Vec<CompactString>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/uf_config/src/tests.rs
+++ b/crates/uf_config/src/tests.rs
@@ -200,6 +200,43 @@ fn zero_config_defaults_to_flow_react_app_stack() {
 }
 
 #[test]
+fn parses_the_dev_server_access_control_surface() {
+    let source = r#"
+        export default defineConfig({
+          dev: {
+            port: 5173,
+            fs: {
+              allow: ["../shared"],
+              deny: ["*.secret"],
+            },
+            allowedHosts: ["dev.internal"],
+            allowedOrigins: ["http://dev.internal:5173"],
+          },
+        });
+    "#;
+
+    let object = extract_config_object(source).expect("object");
+    let parsed: UniflowedConfig = json5::from_str(&object).expect("config");
+
+    assert_eq!(parsed.dev.fs.allow, vec!["../shared"]);
+    assert_eq!(parsed.dev.fs.deny, vec!["*.secret"]);
+    assert_eq!(parsed.dev.allowed_hosts, vec!["dev.internal"]);
+    assert_eq!(parsed.dev.allowed_origins, vec!["http://dev.internal:5173"]);
+}
+
+#[test]
+fn dev_server_access_control_defaults_to_nothing_extra() {
+    // The built-in deny list lives in `uf_devserver`, not here: configuring
+    // `dev.fs.deny` adds to it and cannot shrink it.
+    let dev = DevConfig::default();
+    assert_eq!(dev.host, "127.0.0.1");
+    assert!(dev.fs.allow.is_empty());
+    assert!(dev.fs.deny.is_empty());
+    assert!(dev.allowed_hosts.is_empty());
+    assert!(dev.allowed_origins.is_empty());
+}
+
+#[test]
 fn extracts_vite_style_define_config_object() {
     let source = r#"
         // @flow

--- a/crates/uf_devserver/Cargo.toml
+++ b/crates/uf_devserver/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "uf_devserver"
+description = "Access-controlled development HTTP server for the Unified Toolchain for Flow (React)."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+uf_config = { path = "../uf_config" }
+camino.workspace = true
+compact_str.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+smallvec.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/uf_devserver/src/http.rs
+++ b/crates/uf_devserver/src/http.rs
@@ -1,0 +1,404 @@
+//! The HTTP surface: parse a request head, decide, write a response.
+//!
+//! # Threat model
+//!
+//! [CVE-2025-29927] was an inbound header (`x-middleware-subrequest`) that
+//! selected a dispatch path, so sending it skipped the middleware that did the
+//! authorization. The lesson is not "validate that header better"; it is that
+//! **no inbound header may participate in routing, dispatch, or authorization.**
+//!
+//! [`RequestHead`] enforces that structurally. Parsing keeps the method, the
+//! request target, and exactly two header values — `Host` and `Origin` — and
+//! drops every other header as it scans past it. There is no header map to
+//! consult, so no future handler can grow a dependency on one. The two headers
+//! that are kept can only ever turn a served request into a refusal
+//! ([`crate::network`]); neither can select a root, a loader, a handler, or a
+//! path.
+//!
+//! Everything else here is bounded on purpose: the request head has a byte
+//! ceiling, the method is a closed enum, and the response body is a `Vec<u8>`
+//! that came from a [`ResolvedFile`] whose size was already checked.
+//!
+//! [CVE-2025-29927]: https://nvd.nist.gov/vuln/detail/CVE-2025-29927
+
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::network::{NetworkDenial, NetworkPolicy};
+use crate::policy::{FsPolicy, PolicyDenial};
+use crate::resolve::{AccessDenied, resolve_with_policy};
+use crate::target::RequestTarget;
+
+#[cfg(test)]
+mod tests;
+
+/// Largest request head this server will buffer, in bytes.
+pub const MAX_REQUEST_HEAD_BYTES: usize = 8 * 1024;
+
+/// Most header lines this server will scan past.
+pub const MAX_HEADER_LINES: usize = 128;
+
+/// The health endpoint, matched as an exact request target.
+pub const HEALTH_TARGET: &str = "/__uf/health";
+
+/// The methods this server implements.
+///
+/// A closed enum: an unknown method becomes a `405`, never a string that some
+/// later `match` might treat as familiar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Method {
+    /// `GET`.
+    Get,
+    /// `HEAD`.
+    Head,
+    /// `OPTIONS`, including CORS preflights.
+    Options,
+}
+
+impl Method {
+    /// Parse a method token.
+    pub fn parse(token: &str) -> Option<Self> {
+        match token {
+            "GET" => Some(Self::Get),
+            "HEAD" => Some(Self::Head),
+            "OPTIONS" => Some(Self::Options),
+            _ => None,
+        }
+    }
+
+    /// Whether this is a simple, side-effect-free request in the CORS sense.
+    pub fn is_simple(self) -> bool {
+        matches!(self, Self::Get | Self::Head)
+    }
+
+    /// Whether a response to this method carries a body.
+    pub fn wants_body(self) -> bool {
+        matches!(self, Self::Get)
+    }
+}
+
+/// Why a request head could not be parsed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum HttpError {
+    /// The head exceeded [`MAX_REQUEST_HEAD_BYTES`].
+    #[error("request head is larger than {MAX_REQUEST_HEAD_BYTES} bytes")]
+    HeadTooLarge,
+    /// The head is not valid UTF-8.
+    #[error("request head is not valid UTF-8")]
+    NonUtf8,
+    /// The request line is not `METHOD SP TARGET SP VERSION`.
+    #[error("malformed request line")]
+    MalformedRequestLine,
+    /// The method is not one this server implements.
+    #[error("unsupported method")]
+    UnsupportedMethod,
+    /// The version token is not `HTTP/1.0` or `HTTP/1.1`.
+    #[error("unsupported HTTP version")]
+    UnsupportedVersion,
+    /// More than [`MAX_HEADER_LINES`] header lines arrived.
+    #[error("request carries more than {MAX_HEADER_LINES} header lines")]
+    TooManyHeaders,
+    /// A header line has no `:`.
+    #[error("malformed header line")]
+    MalformedHeader,
+    /// `Host` or `Origin` appeared twice, which is request smuggling bait.
+    #[error("duplicate {name} header")]
+    DuplicateHeader {
+        /// The header that repeated.
+        name: &'static str,
+    },
+}
+
+/// A parsed request head, reduced to the only four things that may matter.
+///
+/// Note what this struct does *not* have: a header map. Dropping every other
+/// header during the scan is what makes "no inbound header influences routing"
+/// a property of the type rather than a convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestHead<'a> {
+    method: Method,
+    target: &'a str,
+    host: Option<&'a str>,
+    origin: Option<&'a str>,
+}
+
+impl<'a> RequestHead<'a> {
+    /// Parse the bytes up to and including the blank line that ends the head.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HttpError`] for a head that is too large, not UTF-8, or not
+    /// shaped like an HTTP/1.x request head.
+    pub fn parse(raw: &'a [u8]) -> Result<Self, HttpError> {
+        if raw.len() > MAX_REQUEST_HEAD_BYTES {
+            return Err(HttpError::HeadTooLarge);
+        }
+        let text = std::str::from_utf8(raw).map_err(|_| HttpError::NonUtf8)?;
+        let mut lines = text.split("\r\n");
+        let request_line = lines.next().ok_or(HttpError::MalformedRequestLine)?;
+
+        let mut parts = request_line.split(' ');
+        let method = parts.next().ok_or(HttpError::MalformedRequestLine)?;
+        let target = parts.next().ok_or(HttpError::MalformedRequestLine)?;
+        let version = parts.next().ok_or(HttpError::MalformedRequestLine)?;
+        if parts.next().is_some() || target.is_empty() {
+            return Err(HttpError::MalformedRequestLine);
+        }
+        if version != "HTTP/1.1" && version != "HTTP/1.0" {
+            return Err(HttpError::UnsupportedVersion);
+        }
+        let method = Method::parse(method).ok_or(HttpError::UnsupportedMethod)?;
+
+        let mut host = None;
+        let mut origin = None;
+        let mut seen = 0usize;
+        for line in lines {
+            if line.is_empty() {
+                break;
+            }
+            seen += 1;
+            if seen > MAX_HEADER_LINES {
+                return Err(HttpError::TooManyHeaders);
+            }
+            let (name, value) = line.split_once(':').ok_or(HttpError::MalformedHeader)?;
+            let value = value.trim();
+            // Everything not named here is read past and forgotten. That is the
+            // guard, not an optimization.
+            if name.eq_ignore_ascii_case("host") {
+                if host.replace(value).is_some() {
+                    return Err(HttpError::DuplicateHeader { name: "Host" });
+                }
+            } else if name.eq_ignore_ascii_case("origin") && origin.replace(value).is_some() {
+                return Err(HttpError::DuplicateHeader { name: "Origin" });
+            }
+        }
+
+        Ok(Self {
+            method,
+            target,
+            host,
+            origin,
+        })
+    }
+
+    /// The request method.
+    pub fn method(&self) -> Method {
+        self.method
+    }
+
+    /// The raw, still-unvalidated request target.
+    pub fn target(&self) -> &'a str {
+        self.target
+    }
+
+    /// The `Host` header value, if one arrived.
+    pub fn host(&self) -> Option<&'a str> {
+        self.host
+    }
+
+    /// The `Origin` header value, if one arrived.
+    pub fn origin(&self) -> Option<&'a str> {
+        self.origin
+    }
+}
+
+/// The status codes this server emits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Status {
+    /// The request was served.
+    Ok,
+    /// The request was not a request this server can parse.
+    BadRequest,
+    /// The request was understood and refused.
+    Forbidden,
+    /// Nothing is served at that path.
+    NotFound,
+    /// The method is not implemented.
+    MethodNotAllowed,
+    /// The file is over the size ceiling.
+    PayloadTooLarge,
+    /// The filesystem failed in a way that is not the client's business.
+    InternalServerError,
+}
+
+impl Status {
+    /// The numeric code.
+    pub const fn code(self) -> u16 {
+        match self {
+            Self::Ok => 200,
+            Self::BadRequest => 400,
+            Self::Forbidden => 403,
+            Self::NotFound => 404,
+            Self::MethodNotAllowed => 405,
+            Self::PayloadTooLarge => 413,
+            Self::InternalServerError => 500,
+        }
+    }
+
+    /// The reason phrase.
+    pub const fn reason(self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::BadRequest => "Bad Request",
+            Self::Forbidden => "Forbidden",
+            Self::NotFound => "Not Found",
+            Self::MethodNotAllowed => "Method Not Allowed",
+            Self::PayloadTooLarge => "Payload Too Large",
+            Self::InternalServerError => "Internal Server Error",
+        }
+    }
+
+    /// Whether the request was served.
+    pub const fn is_success(self) -> bool {
+        matches!(self, Self::Ok)
+    }
+}
+
+impl fmt::Display for Status {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} {}", self.code(), self.reason())
+    }
+}
+
+/// A response, built entirely from server-controlled values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Response {
+    /// The status to send.
+    pub status: Status,
+    /// The `Content-Type` header value.
+    pub content_type: &'static str,
+    /// The `x-uf-loader` header value: which closed-enum loader was selected.
+    ///
+    /// A response header only. Nothing in this crate reads a loader from an
+    /// inbound header.
+    pub loader: &'static str,
+    /// The body, empty for `HEAD` and for refusals.
+    pub body: Vec<u8>,
+}
+
+impl Response {
+    /// A refusal carrying only its status.
+    pub fn refusal(status: Status) -> Self {
+        Self {
+            status,
+            content_type: "text/plain; charset=utf-8",
+            loader: "none",
+            body: Vec::new(),
+        }
+    }
+
+    /// Serialize the response as HTTP/1.1 bytes.
+    ///
+    /// Nothing from the request reaches the head: no reflected path, no
+    /// reflected origin, no reflected header. `nosniff` is unconditional so a
+    /// project file can never be re-interpreted as HTML by the browser.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.body.len() + 256);
+        out.extend_from_slice(
+            format!(
+                "HTTP/1.1 {} {}\r\ncontent-type: {}\r\ncontent-length: {}\r\nx-uf-loader: {}\r\nx-content-type-options: nosniff\r\ncache-control: no-store\r\nconnection: close\r\n\r\n",
+                self.status.code(),
+                self.status.reason(),
+                self.content_type,
+                self.body.len(),
+                self.loader,
+            )
+            .as_bytes(),
+        );
+        out.extend_from_slice(&self.body);
+        out
+    }
+}
+
+/// Map a refusal onto the status the client sees.
+///
+/// A denied path and a missing path both answer with as little as possible:
+/// [`AccessDenied::Denied`] is a flat `403` and never says which pattern
+/// matched, and a resolution failure is a flat `404`.
+pub fn status_for(denied: &AccessDenied) -> Status {
+    match denied {
+        AccessDenied::InvalidTarget(_)
+        | AccessDenied::InvalidPercentEncoding { .. }
+        | AccessDenied::DoubleEncoded
+        | AccessDenied::NonUtf8
+        | AccessDenied::ForbiddenByte { .. }
+        | AccessDenied::TooDeep => Status::BadRequest,
+        AccessDenied::Escape
+        | AccessDenied::FilesystemPrefix
+        | AccessDenied::Denied(PolicyDenial::DeniedByPattern { .. })
+        | AccessDenied::Denied(PolicyDenial::OutsideAllowedRoots { .. }) => Status::Forbidden,
+        AccessDenied::NotFound | AccessDenied::NotARegularFile { .. } => Status::NotFound,
+        AccessDenied::TooLarge { .. } => Status::PayloadTooLarge,
+        AccessDenied::Io { .. } => Status::InternalServerError,
+    }
+}
+
+/// Map a network refusal onto a status.
+pub fn status_for_network(denial: &NetworkDenial) -> Status {
+    match denial {
+        NetworkDenial::MissingHost | NetworkDenial::MalformedHost => Status::BadRequest,
+        NetworkDenial::HostNotAllowed { .. }
+        | NetworkDenial::MissingOrigin
+        | NetworkDenial::OriginNotAllowed { .. } => Status::Forbidden,
+    }
+}
+
+/// Run one request through the whole pipeline.
+///
+/// The order is fixed and is itself part of the guard: network allowlists, then
+/// the request-target grammar, then the health route, then resolution. Nothing
+/// downstream can be reached by a request that failed an earlier stage.
+pub fn respond(head: &RequestHead<'_>, fs: &FsPolicy, network: &NetworkPolicy) -> Response {
+    if let Err(denial) = network.check_host(head.host()) {
+        return Response::refusal(status_for_network(&denial));
+    }
+    if let Err(denial) = network.check_origin(head.method(), head.origin()) {
+        return Response::refusal(status_for_network(&denial));
+    }
+    if head.method() == Method::Options {
+        // A preflight that got this far named an allowed origin, but this server
+        // has no non-simple endpoints to preflight for, so it advertises none.
+        return Response::refusal(Status::MethodNotAllowed);
+    }
+
+    let target = match RequestTarget::parse(head.target()) {
+        Ok(target) => target,
+        Err(error) => return Response::refusal(status_for(&AccessDenied::from(error))),
+    };
+
+    if target.path() == HEALTH_TARGET && target.query().is_none() {
+        let body = br#"{"status":"ok","engine":"uf-native"}"#.to_vec();
+        return Response {
+            status: Status::Ok,
+            content_type: "application/json",
+            loader: "none",
+            body: if head.method().wants_body() {
+                body
+            } else {
+                Vec::new()
+            },
+        };
+    }
+
+    match resolve_with_policy(fs, &target) {
+        Ok(file) => {
+            let content_type = file.media_type().as_str();
+            let loader = file.loader().as_str();
+            match file.read() {
+                Ok(body) => Response {
+                    status: Status::Ok,
+                    content_type,
+                    loader,
+                    body: if head.method().wants_body() {
+                        body
+                    } else {
+                        Vec::new()
+                    },
+                },
+                Err(_) => Response::refusal(Status::InternalServerError),
+            }
+        }
+        Err(denied) => Response::refusal(status_for(&denied)),
+    }
+}

--- a/crates/uf_devserver/src/http/tests.rs
+++ b/crates/uf_devserver/src/http/tests.rs
@@ -1,0 +1,411 @@
+use super::*;
+
+use camino::Utf8PathBuf;
+
+use crate::network::Exposure;
+use crate::target::TargetError;
+
+fn head(raw: &str) -> Result<RequestHead<'_>, HttpError> {
+    RequestHead::parse(raw.as_bytes())
+}
+
+// --- request head parsing ---------------------------------------------------
+
+#[test]
+fn parses_a_minimal_request() {
+    let request = head("GET /app/main.js HTTP/1.1\r\nhost: localhost:5173\r\n\r\n").unwrap();
+    assert_eq!(request.method(), Method::Get);
+    assert_eq!(request.target(), "/app/main.js");
+    assert_eq!(request.host(), Some("localhost:5173"));
+    assert_eq!(request.origin(), None);
+}
+
+#[test]
+fn header_names_are_case_insensitive() {
+    let request =
+        head("GET / HTTP/1.1\r\nHOST: localhost\r\nOrIgIn: http://a.test\r\n\r\n").unwrap();
+    assert_eq!(request.host(), Some("localhost"));
+    assert_eq!(request.origin(), Some("http://a.test"));
+}
+
+#[test]
+fn keeps_only_host_and_origin() {
+    // The guard is that there is nowhere else for a header to go. This asserts
+    // the shape rather than the absence: `RequestHead` has four fields, and two
+    // of them are headers.
+    let request = head(concat!(
+        "GET /a.js HTTP/1.1\r\n",
+        "host: localhost\r\n",
+        "x-middleware-subrequest: middleware\r\n",
+        "x-forwarded-host: evil.test\r\n",
+        "x-rewrite-url: /.env\r\n",
+        "x-original-url: /.env\r\n",
+        "origin: http://localhost\r\n",
+        "\r\n"
+    ))
+    .unwrap();
+    assert_eq!(request.target(), "/a.js");
+    assert_eq!(request.host(), Some("localhost"));
+    assert_eq!(request.origin(), Some("http://localhost"));
+}
+
+#[test]
+fn rejects_a_duplicate_host_header() {
+    assert_eq!(
+        head("GET / HTTP/1.1\r\nhost: localhost\r\nhost: evil.test\r\n\r\n").unwrap_err(),
+        HttpError::DuplicateHeader { name: "Host" }
+    );
+}
+
+#[test]
+fn rejects_a_duplicate_origin_header() {
+    assert_eq!(
+        head(
+            "OPTIONS / HTTP/1.1\r\nhost: localhost\r\norigin: http://a\r\norigin: http://b\r\n\r\n"
+        )
+        .unwrap_err(),
+        HttpError::DuplicateHeader { name: "Origin" }
+    );
+}
+
+#[test]
+fn rejects_a_malformed_request_line() {
+    for raw in [
+        "GET\r\n\r\n",
+        "GET /\r\n\r\n",
+        "GET / HTTP/1.1 extra\r\n\r\n",
+        "GET  HTTP/1.1\r\n\r\n",
+    ] {
+        assert!(
+            matches!(
+                head(raw).unwrap_err(),
+                HttpError::MalformedRequestLine | HttpError::UnsupportedVersion
+            ),
+            "{raw:?} was accepted"
+        );
+    }
+}
+
+#[test]
+fn rejects_an_unsupported_version() {
+    assert_eq!(
+        head("GET / HTTP/2\r\n\r\n").unwrap_err(),
+        HttpError::UnsupportedVersion
+    );
+}
+
+#[test]
+fn rejects_an_unsupported_method() {
+    for method in ["POST", "PUT", "DELETE", "PATCH", "TRACE", "CONNECT", "get"] {
+        assert_eq!(
+            head(&format!("{method} / HTTP/1.1\r\n\r\n")).unwrap_err(),
+            HttpError::UnsupportedMethod,
+            "{method} was accepted"
+        );
+    }
+}
+
+#[test]
+fn rejects_a_head_over_the_byte_ceiling() {
+    let raw = format!(
+        "GET / HTTP/1.1\r\nhost: localhost\r\nx-pad: {}\r\n\r\n",
+        "a".repeat(MAX_REQUEST_HEAD_BYTES)
+    );
+    assert_eq!(head(&raw).unwrap_err(), HttpError::HeadTooLarge);
+}
+
+#[test]
+fn rejects_more_header_lines_than_the_ceiling() {
+    let mut raw = String::from("GET / HTTP/1.1\r\n");
+    for index in 0..=MAX_HEADER_LINES {
+        raw.push_str(&format!("x-{index}: v\r\n"));
+    }
+    raw.push_str("\r\n");
+    assert_eq!(head(&raw).unwrap_err(), HttpError::TooManyHeaders);
+}
+
+#[test]
+fn rejects_a_header_line_without_a_colon() {
+    assert_eq!(
+        head("GET / HTTP/1.1\r\nnonsense\r\n\r\n").unwrap_err(),
+        HttpError::MalformedHeader
+    );
+}
+
+#[test]
+fn rejects_a_head_that_is_not_utf8() {
+    assert_eq!(
+        RequestHead::parse(b"GET /\xff HTTP/1.1\r\n\r\n").unwrap_err(),
+        HttpError::NonUtf8
+    );
+}
+
+// --- statuses ---------------------------------------------------------------
+
+#[test]
+fn status_codes_and_reasons_are_stable() {
+    assert_eq!(Status::Ok.code(), 200);
+    assert_eq!(Status::BadRequest.code(), 400);
+    assert_eq!(Status::Forbidden.code(), 403);
+    assert_eq!(Status::NotFound.code(), 404);
+    assert_eq!(Status::MethodNotAllowed.code(), 405);
+    assert_eq!(Status::PayloadTooLarge.code(), 413);
+    assert_eq!(Status::InternalServerError.code(), 500);
+    assert_eq!(Status::Forbidden.to_string(), "403 Forbidden");
+    assert!(Status::Ok.is_success());
+    assert!(!Status::Forbidden.is_success());
+}
+
+#[test]
+fn a_grammar_failure_is_a_bad_request() {
+    assert_eq!(
+        status_for(&AccessDenied::InvalidTarget(TargetError::NotOriginForm)),
+        Status::BadRequest
+    );
+    assert_eq!(status_for(&AccessDenied::DoubleEncoded), Status::BadRequest);
+    assert_eq!(
+        status_for(&AccessDenied::ForbiddenByte { byte: 0 }),
+        Status::BadRequest
+    );
+}
+
+#[test]
+fn a_policy_refusal_is_forbidden() {
+    assert_eq!(status_for(&AccessDenied::Escape), Status::Forbidden);
+    assert_eq!(
+        status_for(&AccessDenied::FilesystemPrefix),
+        Status::Forbidden
+    );
+    assert_eq!(
+        status_for(&AccessDenied::Denied(PolicyDenial::DeniedByPattern {
+            path: Utf8PathBuf::from(".env"),
+            pattern: ".env*".into(),
+        })),
+        Status::Forbidden
+    );
+}
+
+// --- responses --------------------------------------------------------------
+
+#[test]
+fn a_refusal_carries_no_body() {
+    let response = Response::refusal(Status::Forbidden);
+    assert!(response.body.is_empty());
+    assert_eq!(response.loader, "none");
+}
+
+#[test]
+fn a_response_never_reflects_the_request() {
+    let bytes = Response::refusal(Status::Forbidden).to_bytes();
+    let text = String::from_utf8(bytes).unwrap();
+    assert!(text.starts_with("HTTP/1.1 403 Forbidden\r\n"));
+    assert!(text.contains("content-length: 0\r\n"));
+    assert!(text.contains("x-content-type-options: nosniff\r\n"));
+    assert!(text.contains("cache-control: no-store\r\n"));
+    assert!(
+        !text
+            .to_ascii_lowercase()
+            .contains("access-control-allow-origin")
+    );
+}
+
+#[test]
+fn a_body_response_reports_its_own_length() {
+    let response = Response {
+        status: Status::Ok,
+        content_type: "text/plain; charset=utf-8",
+        loader: "module",
+        body: b"hello".to_vec(),
+    };
+    let text = String::from_utf8(response.to_bytes()).unwrap();
+    assert!(text.contains("content-length: 5\r\n"));
+    assert!(text.ends_with("\r\n\r\nhello"));
+}
+
+// --- the whole pipeline -----------------------------------------------------
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    fs: FsPolicy,
+    network: NetworkPolicy,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_network(NetworkPolicy::loopback())
+    }
+
+    fn with_network(network: NetworkPolicy) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
+        std::fs::write(root.join("index.html"), "<!doctype html>\n").unwrap();
+        std::fs::write(root.join("main.js"), "export default 1;\n").unwrap();
+        std::fs::write(root.join(".env"), "SECRET=1\n").unwrap();
+        Self {
+            _dir: dir,
+            fs: FsPolicy::with_defaults(&root).unwrap(),
+            network,
+        }
+    }
+
+    fn request(&self, raw: &str) -> Response {
+        let request = RequestHead::parse(raw.as_bytes()).unwrap();
+        respond(&request, &self.fs, &self.network)
+    }
+
+    fn get(&self, target: &str) -> Response {
+        self.request(&format!(
+            "GET {target} HTTP/1.1\r\nhost: localhost:5173\r\n\r\n"
+        ))
+    }
+}
+
+#[test]
+fn serves_a_project_file() {
+    let fixture = Fixture::new();
+    let response = fixture.get("/main.js");
+    assert_eq!(response.status, Status::Ok);
+    assert_eq!(response.content_type, "text/javascript; charset=utf-8");
+    assert_eq!(response.loader, "module");
+    assert_eq!(response.body, b"export default 1;\n");
+}
+
+#[test]
+fn serves_the_health_endpoint() {
+    let fixture = Fixture::new();
+    let response = fixture.get(HEALTH_TARGET);
+    assert_eq!(response.status, Status::Ok);
+    assert_eq!(response.content_type, "application/json");
+    assert_eq!(response.body, br#"{"status":"ok","engine":"uf-native"}"#);
+}
+
+#[test]
+fn the_health_endpoint_does_not_match_with_a_query() {
+    // A control route that tolerates a query is a control route with a second,
+    // less-tested spelling.
+    let fixture = Fixture::new();
+    assert_eq!(fixture.get("/__uf/health?raw").status, Status::NotFound);
+}
+
+#[test]
+fn a_head_request_gets_the_headers_without_the_body() {
+    let fixture = Fixture::new();
+    let response = fixture.request("HEAD /main.js HTTP/1.1\r\nhost: localhost\r\n\r\n");
+    assert_eq!(response.status, Status::Ok);
+    assert_eq!(response.content_type, "text/javascript; charset=utf-8");
+    assert!(response.body.is_empty());
+}
+
+#[test]
+fn a_denied_file_is_forbidden() {
+    let fixture = Fixture::new();
+    assert_eq!(fixture.get("/.env").status, Status::Forbidden);
+    assert!(fixture.get("/.env").body.is_empty());
+}
+
+#[test]
+fn an_unknown_file_is_not_found() {
+    assert_eq!(Fixture::new().get("/missing.js").status, Status::NotFound);
+}
+
+#[test]
+fn an_invalid_target_is_a_bad_request() {
+    let fixture = Fixture::new();
+    assert_eq!(
+        fixture.get("http://evil.test/.env").status,
+        Status::BadRequest
+    );
+    assert_eq!(fixture.get("*").status, Status::BadRequest);
+}
+
+#[test]
+fn a_rebinding_host_is_refused_before_the_path_is_looked_at() {
+    let fixture = Fixture::new();
+    let response = fixture.request("GET /main.js HTTP/1.1\r\nhost: evil.test\r\n\r\n");
+    assert_eq!(response.status, Status::Forbidden);
+    assert!(response.body.is_empty());
+}
+
+#[test]
+fn a_missing_host_header_is_a_bad_request() {
+    let fixture = Fixture::new();
+    assert_eq!(
+        fixture.request("GET /main.js HTTP/1.1\r\n\r\n").status,
+        Status::BadRequest
+    );
+}
+
+#[test]
+fn a_preflight_from_an_unlisted_origin_is_forbidden() {
+    let fixture = Fixture::new();
+    let response = fixture.request(
+        "OPTIONS /main.js HTTP/1.1\r\nhost: localhost\r\norigin: http://evil.test\r\n\r\n",
+    );
+    assert_eq!(response.status, Status::Forbidden);
+}
+
+#[test]
+fn a_preflight_from_a_listed_origin_still_has_nothing_to_preflight() {
+    let network = NetworkPolicy::new(
+        Exposure::Loopback,
+        Vec::<&str>::new(),
+        ["http://localhost:5173"],
+    )
+    .unwrap();
+    let fixture = Fixture::with_network(network);
+    let response = fixture.request(
+        "OPTIONS /main.js HTTP/1.1\r\nhost: localhost\r\norigin: http://localhost:5173\r\n\r\n",
+    );
+    assert_eq!(response.status, Status::MethodNotAllowed);
+}
+
+#[test]
+fn a_cross_origin_simple_get_is_served_without_cors_headers() {
+    // The browser, not this server, is what stops the other origin reading it.
+    let fixture = Fixture::new();
+    let response = fixture
+        .request("GET /main.js HTTP/1.1\r\nhost: localhost\r\norigin: http://evil.test\r\n\r\n");
+    assert_eq!(response.status, Status::Ok);
+    let text = String::from_utf8(response.to_bytes()).unwrap();
+    assert!(
+        !text
+            .to_ascii_lowercase()
+            .contains("access-control-allow-origin")
+    );
+}
+
+#[test]
+fn no_inbound_header_changes_what_is_served() {
+    // CVE-2025-29927's bug class, asserted end to end: the same target with a
+    // pile of dispatch-flavoured headers produces byte-identical responses.
+    let fixture = Fixture::new();
+    let plain = fixture.request("GET /main.js HTTP/1.1\r\nhost: localhost\r\n\r\n");
+    let loaded = fixture.request(concat!(
+        "GET /main.js HTTP/1.1\r\n",
+        "host: localhost\r\n",
+        "x-middleware-subrequest: middleware:middleware:middleware\r\n",
+        "x-forwarded-host: evil.test\r\n",
+        "x-forwarded-proto: https\r\n",
+        "x-original-url: /.env\r\n",
+        "x-rewrite-url: /.env\r\n",
+        "x-uf-loader: raw\r\n",
+        "x-http-method-override: POST\r\n",
+        "authorization: Bearer nonsense\r\n",
+        "\r\n"
+    ));
+    assert_eq!(plain, loaded);
+}
+
+#[test]
+fn a_dispatch_header_cannot_reach_a_denied_file() {
+    let fixture = Fixture::new();
+    let response = fixture.request(concat!(
+        "GET /main.js HTTP/1.1\r\n",
+        "host: localhost\r\n",
+        "x-original-url: /.env\r\n",
+        "x-rewrite-url: /.env\r\n",
+        "\r\n"
+    ));
+    assert_eq!(response.status, Status::Ok);
+    assert_eq!(response.body, b"export default 1;\n");
+}

--- a/crates/uf_devserver/src/lib.rs
+++ b/crates/uf_devserver/src/lib.rs
@@ -1,0 +1,89 @@
+#![deny(missing_docs)]
+//! The `uf dev` HTTP server and its access-control layer.
+//!
+//! # Why this is its own crate
+//!
+//! The Vite dev server was bypassed four separate ways in a single year —
+//! [CVE-2025-30208], [CVE-2025-31125], [CVE-2025-32395] and [CVE-2025-62522] —
+//! and all four are one bug: **the access decision ran against a string that
+//! was not the path that was eventually opened.** A query suffix survived the
+//! check and changed the open; a second decode round happened after the check;
+//! an unparseable target was repaired into a different path than the one that
+//! was validated; a separator was normalized on one platform and not another.
+//!
+//! Defending against that with a helper function inside the CLI would leave the
+//! guard optional: any future handler could reach `std::fs` on its own and skip
+//! it. So the dev server lives here instead, and the only way to obtain a file
+//! is [`resolve_request`], which returns a [`ResolvedFile`] — an already-open
+//! handle whose approved path is not exposed as a path type. There is no
+//! "resolve without checking" entry point to forget to call.
+//!
+//! # Pipeline
+//!
+//! ```text
+//! bytes ─▶ RequestHead::parse   only the method, target, Host and Origin survive
+//!       ─▶ NetworkPolicy        Host and Origin may refuse; they never route
+//!       ─▶ RequestTarget::parse origin-form or 400 — never a repaired target
+//!       ─▶ resolve_with_policy  decode once ▸ normalize ▸ canonicalize
+//!                               ▸ FsPolicy::decide ▸ open the checked path
+//!       ─▶ Response             server-controlled bytes only
+//! ```
+//!
+//! Each stage is a module: [`http`], [`network`], [`target`], [`resolve`],
+//! [`policy`], and [`media`], with [`server`] holding the socket. Each module's
+//! documentation names the failure it exists to prevent.
+//!
+//! # Defaults
+//!
+//! Loopback bind, no exposed hosts, no allowed origins, and a deny list
+//! covering `.env*`, `**/.git/**`, `*.pem`, `*.key`, `*.crt` and `**/.uf/**`.
+//! There is no `*` anywhere, and [`NetworkPolicy::new`] refuses one.
+//!
+//! ```no_run
+//! use camino::Utf8Path;
+//! use uf_devserver::{DevServer, DevConfig};
+//!
+//! let root = Utf8Path::new(".");
+//! let server = DevServer::bind(root, &DevConfig::default())?;
+//! server.write_state(root)?;
+//! server.serve_forever()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! [CVE-2025-30208]: https://github.com/advisories/GHSA-x574-m823-4x7w
+//! [CVE-2025-31125]: https://nvd.nist.gov/vuln/detail/CVE-2025-31125
+//! [CVE-2025-32395]: https://nvd.nist.gov/vuln/detail/CVE-2025-32395
+//! [CVE-2025-62522]: https://nvd.nist.gov/vuln/detail/CVE-2025-62522
+
+pub mod http;
+pub mod media;
+pub mod network;
+pub mod policy;
+pub mod resolve;
+pub mod server;
+pub mod target;
+
+pub use uf_config::DevConfig;
+
+pub use http::{
+    HEALTH_TARGET, HttpError, MAX_HEADER_LINES, MAX_REQUEST_HEAD_BYTES, Method, RequestHead,
+    Response, Status, respond, status_for, status_for_network,
+};
+pub use media::MediaType;
+pub use network::{
+    Exposure, LOOPBACK_HOSTS, MAX_ALLOWLIST_ENTRIES, MAX_AUTHORITY_BYTES, NetworkDenial,
+    NetworkPolicy, NetworkPolicyError,
+};
+pub use policy::{
+    DEFAULT_DENY, FsPolicy, MAX_ALLOW_ROOTS, MAX_DENY_PATTERNS, MAX_PATTERN_BYTES, PolicyDenial,
+    PolicyError,
+};
+pub use resolve::{
+    AccessDenied, CheckedPath, DIRECTORY_INDEX, FILESYSTEM_PREFIX, MAX_FILE_BYTES,
+    MAX_PATH_SEGMENTS, ResolvedFile, resolve_request, resolve_with_policy,
+};
+pub use server::{
+    CONNECTION_TIMEOUT, DevServer, DevServerError, DevServerState, ENGINE, PLUGIN_CONTRACT,
+    STATE_DIR, STATE_FILE,
+};
+pub use target::{Loader, MAX_TARGET_BYTES, RequestTarget, TargetError};

--- a/crates/uf_devserver/src/media.rs
+++ b/crates/uf_devserver/src/media.rs
@@ -1,0 +1,77 @@
+//! The closed extension-to-media-type table.
+//!
+//! # Threat model
+//!
+//! A `Content-Type` derived from attacker-influenced text is an XSS primitive:
+//! upload or name a file so the browser is told to treat it as HTML, and the
+//! page runs in the dev server's origin. So the mapping is a fixed table of
+//! `&'static str` pairs, an unknown extension falls through to
+//! `application/octet-stream` rather than being guessed, and every response
+//! carries `X-Content-Type-Options: nosniff` so the browser does not guess
+//! either.
+//!
+//! The extension is read from the *canonical* path — the file that was actually
+//! opened — not from the request, for the same reason every other decision in
+//! this crate is made on the canonical path.
+
+/// A media type this server is willing to name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum MediaType {
+    /// Anything not on the table.
+    #[default]
+    Binary,
+    /// A known type, held as its full header value.
+    Known(&'static str),
+}
+
+impl MediaType {
+    /// The `Content-Type` header value.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Binary => "application/octet-stream",
+            Self::Known(value) => value,
+        }
+    }
+
+    /// Look up the media type for a file extension, case-insensitively.
+    pub fn for_extension(extension: Option<&str>) -> Self {
+        let Some(extension) = extension else {
+            return Self::Binary;
+        };
+        if extension.len() > MAX_EXTENSION_BYTES {
+            return Self::Binary;
+        }
+        MEDIA_TYPES
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(extension))
+            .map_or(Self::Binary, |(_, value)| Self::Known(value))
+    }
+}
+
+/// Longest extension worth a table scan.
+const MAX_EXTENSION_BYTES: usize = 16;
+
+/// Extensions the dev server will name a type for. Sorted for readability; the
+/// lookup is a linear scan because the table is small and the comparison is
+/// case-insensitive.
+const MEDIA_TYPES: &[(&str, &str)] = &[
+    ("avif", "image/avif"),
+    ("css", "text/css; charset=utf-8"),
+    ("gif", "image/gif"),
+    ("htm", "text/html; charset=utf-8"),
+    ("html", "text/html; charset=utf-8"),
+    ("ico", "image/x-icon"),
+    ("jpeg", "image/jpeg"),
+    ("jpg", "image/jpeg"),
+    ("js", "text/javascript; charset=utf-8"),
+    ("json", "application/json"),
+    ("map", "application/json"),
+    ("mjs", "text/javascript; charset=utf-8"),
+    ("png", "image/png"),
+    ("svg", "image/svg+xml"),
+    ("txt", "text/plain; charset=utf-8"),
+    ("wasm", "application/wasm"),
+    ("webp", "image/webp"),
+    ("woff", "font/woff"),
+    ("woff2", "font/woff2"),
+];

--- a/crates/uf_devserver/src/network.rs
+++ b/crates/uf_devserver/src/network.rs
@@ -1,0 +1,335 @@
+//! Network exposure: which hosts and origins may talk to the dev server.
+//!
+//! # Threat model
+//!
+//! A dev server holds the developer's source tree, so reaching it from another
+//! machine or another origin is the whole attack. Two mechanisms matter:
+//!
+//! * **DNS rebinding.** An attacker's page resolves `evil.test` to `127.0.0.1`
+//!   and then talks to the dev server as same-origin. The defence is the `Host`
+//!   header: a request arriving as `Host: evil.test` is not a request for this
+//!   server, whatever the socket says, and is refused.
+//! * **Cross-origin writes.** A page on another origin can always *send* a
+//!   simple `GET`; what it must not do is anything with side effects. Non-simple
+//!   methods therefore require an `Origin` on an explicit list.
+//!
+//! # No wildcards, ever
+//!
+//! There is no `*` default and no accepted `*` entry: [`NetworkPolicy::new`]
+//! rejects the literal wildcard in either list. Binding a non-loopback address
+//! is only possible with a non-empty [`allowed_hosts`](NetworkPolicy::allowed_hosts)
+//! list — that is a construction-time error, not a warning, so an exposed
+//! server with no allowlist cannot exist.
+//!
+//! # Headers are used to refuse, never to route
+//!
+//! `Host` and `Origin` are the only inbound headers this crate retains, and the
+//! only thing either can do is turn an otherwise-served request into a refusal.
+//! Neither selects a handler, a root, a loader, or a path. That is the
+//! [CVE-2025-29927] bug class — a header (`x-middleware-subrequest`) that
+//! *chose* a dispatch path and so could be spoofed into skipping authorization.
+//!
+//! [CVE-2025-29927]: https://nvd.nist.gov/vuln/detail/CVE-2025-29927
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+use thiserror::Error;
+
+use crate::http::Method;
+
+#[cfg(test)]
+mod tests;
+
+/// Host names accepted without configuration when bound to loopback.
+pub const LOOPBACK_HOSTS: &[&str] = &["localhost", "127.0.0.1", "[::1]"];
+
+/// Most entries either allowlist may hold.
+pub const MAX_ALLOWLIST_ENTRIES: usize = 64;
+
+/// Longest accepted `Host` or `Origin` header value, in bytes.
+pub const MAX_AUTHORITY_BYTES: usize = 255;
+
+/// Where the listening socket is reachable from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Exposure {
+    /// Bound to a loopback address. [`LOOPBACK_HOSTS`] are implicitly allowed.
+    #[default]
+    Loopback,
+    /// Bound to a routable address. Every acceptable host must be listed.
+    Exposed,
+}
+
+/// Why a network policy could not be built.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NetworkPolicyError {
+    /// A non-loopback bind was requested without an allowed-hosts list.
+    #[error("exposing the dev server requires a non-empty dev.allowedHosts list")]
+    ExposedWithoutAllowedHosts,
+    /// An allowlist contained `*`.
+    #[error("`*` is not an accepted {list} entry; list the hosts or origins explicitly")]
+    Wildcard {
+        /// Which list held it.
+        list: &'static str,
+    },
+    /// An allowlist entry is empty or over [`MAX_AUTHORITY_BYTES`].
+    #[error("{list} entry is empty or longer than {MAX_AUTHORITY_BYTES} bytes")]
+    InvalidEntry {
+        /// Which list held it.
+        list: &'static str,
+    },
+    /// An allowlist has more than [`MAX_ALLOWLIST_ENTRIES`] entries.
+    #[error("{list} may hold at most {MAX_ALLOWLIST_ENTRIES} entries, got {count}")]
+    TooManyEntries {
+        /// Which list held it.
+        list: &'static str,
+        /// How many were configured.
+        count: usize,
+    },
+}
+
+/// Why a request was refused before it reached the filesystem.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NetworkDenial {
+    /// HTTP/1.1 requires a `Host`, and this server will not guess one.
+    #[error("request has no Host header")]
+    MissingHost,
+    /// The `Host` value is not a plausible authority.
+    #[error("Host header is not a valid authority")]
+    MalformedHost,
+    /// The `Host` name is not on the allowlist.
+    #[error("host {host} is not in dev.allowedHosts")]
+    HostNotAllowed {
+        /// The rejected name, port removed.
+        host: CompactString,
+    },
+    /// A non-simple request arrived without an `Origin`.
+    #[error("a non-simple request must carry an Origin header")]
+    MissingOrigin,
+    /// The `Origin` is not on the allowlist.
+    #[error("origin {origin} is not in dev.allowedOrigins")]
+    OriginNotAllowed {
+        /// The rejected origin.
+        origin: CompactString,
+    },
+}
+
+/// The host and origin allowlists for one dev server.
+#[derive(Debug, Clone)]
+pub struct NetworkPolicy {
+    exposure: Exposure,
+    allowed_hosts: SmallVec<[CompactString; 4]>,
+    allowed_origins: SmallVec<[CompactString; 4]>,
+}
+
+impl NetworkPolicy {
+    /// Build a policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NetworkPolicyError`] for an exposed bind with no allowed
+    /// hosts, for a `*` entry, and for anything over the configured bounds.
+    pub fn new<H, O>(
+        exposure: Exposure,
+        allowed_hosts: H,
+        allowed_origins: O,
+    ) -> Result<Self, NetworkPolicyError>
+    where
+        H: IntoIterator,
+        H::Item: AsRef<str>,
+        O: IntoIterator,
+        O::Item: AsRef<str>,
+    {
+        let allowed_hosts = collect_list("dev.allowedHosts", allowed_hosts, normalize_host)?;
+        let allowed_origins =
+            collect_list("dev.allowedOrigins", allowed_origins, normalize_origin)?;
+        if exposure == Exposure::Exposed && allowed_hosts.is_empty() {
+            return Err(NetworkPolicyError::ExposedWithoutAllowedHosts);
+        }
+        Ok(Self {
+            exposure,
+            allowed_hosts,
+            allowed_origins,
+        })
+    }
+
+    /// A loopback policy with no extra hosts and no allowed origins.
+    ///
+    /// This is the default posture: reachable only as `localhost`, `127.0.0.1`
+    /// or `[::1]`, and no cross-origin request with side effects is accepted.
+    pub fn loopback() -> Self {
+        Self {
+            exposure: Exposure::Loopback,
+            allowed_hosts: SmallVec::new(),
+            allowed_origins: SmallVec::new(),
+        }
+    }
+
+    /// Where the socket is reachable from.
+    pub fn exposure(&self) -> Exposure {
+        self.exposure
+    }
+
+    /// The configured host allowlist, without the implicit loopback names.
+    pub fn allowed_hosts(&self) -> impl Iterator<Item = &str> {
+        self.allowed_hosts.iter().map(CompactString::as_str)
+    }
+
+    /// The configured origin allowlist.
+    pub fn allowed_origins(&self) -> impl Iterator<Item = &str> {
+        self.allowed_origins.iter().map(CompactString::as_str)
+    }
+
+    /// Check a request's `Host` header.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NetworkDenial`] when the header is absent, malformed, or names
+    /// a host that is not allowed.
+    pub fn check_host(&self, host: Option<&str>) -> Result<(), NetworkDenial> {
+        let Some(host) = host else {
+            return Err(NetworkDenial::MissingHost);
+        };
+        let name = host_name(host).ok_or(NetworkDenial::MalformedHost)?;
+        let allowed = self
+            .allowed_hosts
+            .iter()
+            .any(|entry| entry.eq_ignore_ascii_case(name))
+            || (self.exposure == Exposure::Loopback
+                && LOOPBACK_HOSTS
+                    .iter()
+                    .any(|entry| entry.eq_ignore_ascii_case(name)));
+        if allowed {
+            Ok(())
+        } else {
+            Err(NetworkDenial::HostNotAllowed {
+                host: CompactString::new(name),
+            })
+        }
+    }
+
+    /// Check a request's `Origin` header.
+    ///
+    /// A simple `GET` or `HEAD` is always permitted: a browser can send one
+    /// cross-origin no matter what the server says, and this server emits no
+    /// `Access-Control-Allow-Origin`, so the response stays unreadable to the
+    /// other origin. Everything else needs an allowlisted `Origin`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NetworkDenial`] when a non-simple request has no `Origin` or
+    /// an `Origin` that is not allowed.
+    pub fn check_origin(&self, method: Method, origin: Option<&str>) -> Result<(), NetworkDenial> {
+        if method.is_simple() {
+            return Ok(());
+        }
+        let Some(origin) = origin else {
+            return Err(NetworkDenial::MissingOrigin);
+        };
+        let candidate = origin.trim_end_matches('/');
+        if candidate.len() <= MAX_AUTHORITY_BYTES
+            && self
+                .allowed_origins
+                .iter()
+                .any(|entry| entry.eq_ignore_ascii_case(candidate))
+        {
+            Ok(())
+        } else {
+            Err(NetworkDenial::OriginNotAllowed {
+                origin: CompactString::new(origin),
+            })
+        }
+    }
+}
+
+fn collect_list<I>(
+    list: &'static str,
+    entries: I,
+    normalize: fn(&str) -> Option<CompactString>,
+) -> Result<SmallVec<[CompactString; 4]>, NetworkPolicyError>
+where
+    I: IntoIterator,
+    I::Item: AsRef<str>,
+{
+    let mut out: SmallVec<[CompactString; 4]> = SmallVec::new();
+    for entry in entries {
+        let entry = entry.as_ref().trim();
+        if entry == "*" {
+            return Err(NetworkPolicyError::Wildcard { list });
+        }
+        if entry.is_empty() || entry.len() > MAX_AUTHORITY_BYTES {
+            return Err(NetworkPolicyError::InvalidEntry { list });
+        }
+        let value = normalize(entry).ok_or(NetworkPolicyError::InvalidEntry { list })?;
+        if !out.contains(&value) {
+            out.push(value);
+        }
+        if out.len() > MAX_ALLOWLIST_ENTRIES {
+            return Err(NetworkPolicyError::TooManyEntries {
+                list,
+                count: out.len(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn normalize_host(entry: &str) -> Option<CompactString> {
+    host_name(entry).map(CompactString::new)
+}
+
+fn normalize_origin(entry: &str) -> Option<CompactString> {
+    let trimmed = entry.trim_end_matches('/');
+    // An origin is a scheme plus an authority. `null` and bare host names are
+    // refused so a configuration typo cannot widen the allowlist.
+    let (scheme, rest) = trimmed.split_once("://")?;
+    if scheme.is_empty() || rest.is_empty() || rest.contains('/') {
+        return None;
+    }
+    host_name(rest)?;
+    Some(CompactString::new(trimmed))
+}
+
+/// Strip the port from an authority and validate what is left.
+///
+/// Returns `None` for anything that is not a plausible host, so a `Host` header
+/// carrying a path, userinfo, or whitespace is refused rather than truncated
+/// into something that happens to match.
+fn host_name(authority: &str) -> Option<&str> {
+    if authority.is_empty() || authority.len() > MAX_AUTHORITY_BYTES {
+        return None;
+    }
+    let (name, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let close = rest.find(']')?;
+        let inner = &rest[..close];
+        if inner.is_empty()
+            || !inner
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() || byte == b':' || byte == b'.')
+        {
+            return None;
+        }
+        (&authority[..close + 2], &rest[close + 1..])
+    } else {
+        match authority.split_once(':') {
+            Some((name, port)) => (name, port),
+            None => (authority, ""),
+        }
+    };
+    if !port.is_empty() {
+        let digits = port.strip_prefix(':').unwrap_or(port);
+        if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+    }
+    if name.is_empty() {
+        return None;
+    }
+    // A bracketed literal was already validated character by character above.
+    let valid = name.starts_with('[')
+        || name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'.');
+    valid.then_some(name)
+}

--- a/crates/uf_devserver/src/network/tests.rs
+++ b/crates/uf_devserver/src/network/tests.rs
@@ -1,0 +1,281 @@
+use super::*;
+
+fn loopback() -> NetworkPolicy {
+    NetworkPolicy::loopback()
+}
+
+fn exposed(hosts: &[&str], origins: &[&str]) -> NetworkPolicy {
+    NetworkPolicy::new(
+        Exposure::Exposed,
+        hosts.iter().copied(),
+        origins.iter().copied(),
+    )
+    .unwrap()
+}
+
+// --- host checks ------------------------------------------------------------
+
+#[test]
+fn a_loopback_server_accepts_the_loopback_names() {
+    let policy = loopback();
+    for host in [
+        "localhost",
+        "localhost:5173",
+        "127.0.0.1",
+        "127.0.0.1:5173",
+        "[::1]",
+        "[::1]:5173",
+        "LOCALHOST",
+    ] {
+        assert_eq!(policy.check_host(Some(host)), Ok(()), "{host} was refused");
+    }
+}
+
+#[test]
+fn a_loopback_server_refuses_a_rebinding_host() {
+    // DNS rebinding: the socket says 127.0.0.1, the Host header says otherwise,
+    // and the Host header is the one that describes what the browser thinks it
+    // is talking to.
+    let policy = loopback();
+    for host in ["evil.test", "evil.test:5173", "attacker.example.com"] {
+        assert!(
+            matches!(
+                policy.check_host(Some(host)).unwrap_err(),
+                NetworkDenial::HostNotAllowed { .. }
+            ),
+            "{host} was accepted"
+        );
+    }
+}
+
+#[test]
+fn a_missing_host_header_is_refused() {
+    assert_eq!(
+        loopback().check_host(None).unwrap_err(),
+        NetworkDenial::MissingHost
+    );
+}
+
+#[test]
+fn a_malformed_host_header_is_refused_not_truncated() {
+    let policy = loopback();
+    for host in [
+        "",
+        "localhost:notaport",
+        "localhost:80:80",
+        "user@localhost",
+        "localhost/../",
+        "local host",
+        "[::1",
+        "[]",
+        "[zz::1]",
+    ] {
+        assert_eq!(
+            policy.check_host(Some(host)).unwrap_err(),
+            NetworkDenial::MalformedHost,
+            "{host:?} was not refused as malformed"
+        );
+    }
+}
+
+#[test]
+fn a_host_over_the_byte_ceiling_is_refused() {
+    let host = "a".repeat(MAX_AUTHORITY_BYTES + 1);
+    assert_eq!(
+        loopback().check_host(Some(&host)).unwrap_err(),
+        NetworkDenial::MalformedHost
+    );
+}
+
+#[test]
+fn an_exposed_server_accepts_only_listed_hosts() {
+    let policy = exposed(&["dev.internal"], &[]);
+    assert_eq!(policy.check_host(Some("dev.internal:5173")), Ok(()));
+    assert!(matches!(
+        policy.check_host(Some("evil.test")).unwrap_err(),
+        NetworkDenial::HostNotAllowed { .. }
+    ));
+}
+
+#[test]
+fn an_exposed_server_does_not_implicitly_allow_loopback() {
+    // The implicit loopback names exist because a loopback socket is only
+    // reachable from the machine itself. An exposed socket has no such excuse.
+    let policy = exposed(&["dev.internal"], &[]);
+    assert!(matches!(
+        policy.check_host(Some("localhost")).unwrap_err(),
+        NetworkDenial::HostNotAllowed { .. }
+    ));
+}
+
+#[test]
+fn a_loopback_server_also_honours_configured_hosts() {
+    let policy =
+        NetworkPolicy::new(Exposure::Loopback, ["dev.internal"], Vec::<&str>::new()).unwrap();
+    assert_eq!(policy.check_host(Some("dev.internal")), Ok(()));
+    assert_eq!(policy.check_host(Some("localhost")), Ok(()));
+}
+
+// --- origin checks ----------------------------------------------------------
+
+#[test]
+fn a_simple_get_needs_no_origin() {
+    let policy = loopback();
+    assert_eq!(policy.check_origin(Method::Get, None), Ok(()));
+    assert_eq!(policy.check_origin(Method::Head, None), Ok(()));
+    assert_eq!(
+        policy.check_origin(Method::Get, Some("http://evil.test")),
+        Ok(())
+    );
+}
+
+#[test]
+fn a_preflight_without_an_origin_is_refused() {
+    assert_eq!(
+        loopback().check_origin(Method::Options, None).unwrap_err(),
+        NetworkDenial::MissingOrigin
+    );
+}
+
+#[test]
+fn a_preflight_from_an_unlisted_origin_is_refused() {
+    let policy = loopback();
+    assert!(matches!(
+        policy
+            .check_origin(Method::Options, Some("http://evil.test"))
+            .unwrap_err(),
+        NetworkDenial::OriginNotAllowed { .. }
+    ));
+}
+
+#[test]
+fn the_default_origin_allowlist_is_empty() {
+    // No `*`, and no implicit entry either: by default nothing non-simple is
+    // accepted from anywhere.
+    assert_eq!(loopback().allowed_origins().count(), 0);
+    assert!(
+        loopback()
+            .check_origin(Method::Options, Some("http://localhost:5173"))
+            .is_err()
+    );
+}
+
+#[test]
+fn a_preflight_from_a_listed_origin_passes_the_origin_check() {
+    let policy = exposed(&["dev.internal"], &["http://dev.internal:5173"]);
+    assert_eq!(
+        policy.check_origin(Method::Options, Some("http://dev.internal:5173")),
+        Ok(())
+    );
+    assert_eq!(
+        policy.check_origin(Method::Options, Some("http://dev.internal:5173/")),
+        Ok(())
+    );
+}
+
+#[test]
+fn origin_matching_ignores_ascii_case_but_not_the_host() {
+    let policy = exposed(&["dev.internal"], &["http://dev.internal:5173"]);
+    assert_eq!(
+        policy.check_origin(Method::Options, Some("HTTP://DEV.INTERNAL:5173")),
+        Ok(())
+    );
+    assert!(
+        policy
+            .check_origin(Method::Options, Some("http://dev.internal.evil.test:5173"))
+            .is_err()
+    );
+}
+
+#[test]
+fn a_null_origin_is_refused() {
+    let policy = exposed(&["dev.internal"], &["http://dev.internal:5173"]);
+    assert!(matches!(
+        policy
+            .check_origin(Method::Options, Some("null"))
+            .unwrap_err(),
+        NetworkDenial::OriginNotAllowed { .. }
+    ));
+}
+
+// --- construction -----------------------------------------------------------
+
+#[test]
+fn exposing_without_an_allowed_hosts_list_is_a_startup_error() {
+    assert_eq!(
+        NetworkPolicy::new(Exposure::Exposed, Vec::<&str>::new(), Vec::<&str>::new()).unwrap_err(),
+        NetworkPolicyError::ExposedWithoutAllowedHosts
+    );
+}
+
+#[test]
+fn a_wildcard_host_is_refused() {
+    assert_eq!(
+        NetworkPolicy::new(Exposure::Exposed, ["*"], Vec::<&str>::new()).unwrap_err(),
+        NetworkPolicyError::Wildcard {
+            list: "dev.allowedHosts"
+        }
+    );
+}
+
+#[test]
+fn a_wildcard_origin_is_refused() {
+    assert_eq!(
+        NetworkPolicy::new(Exposure::Loopback, Vec::<&str>::new(), ["*"]).unwrap_err(),
+        NetworkPolicyError::Wildcard {
+            list: "dev.allowedOrigins"
+        }
+    );
+}
+
+#[test]
+fn an_origin_without_a_scheme_is_refused_at_startup() {
+    for entry in ["dev.internal", "null", "http://", "http://a/b", "://x"] {
+        assert!(
+            NetworkPolicy::new(Exposure::Loopback, Vec::<&str>::new(), [entry]).is_err(),
+            "{entry} was accepted as an origin"
+        );
+    }
+}
+
+#[test]
+fn a_malformed_host_entry_is_refused_at_startup() {
+    for entry in ["", "  ", "host name", "http://dev.internal"] {
+        assert!(
+            NetworkPolicy::new(Exposure::Exposed, [entry], Vec::<&str>::new()).is_err(),
+            "{entry:?} was accepted as a host"
+        );
+    }
+}
+
+#[test]
+fn duplicate_entries_are_stored_once() {
+    let policy = exposed(&["dev.internal", "dev.internal:5173"], &[]);
+    assert_eq!(
+        policy.allowed_hosts().collect::<Vec<_>>(),
+        vec!["dev.internal"]
+    );
+}
+
+#[test]
+fn rejects_more_entries_than_the_ceiling() {
+    let hosts: Vec<String> = (0..=MAX_ALLOWLIST_ENTRIES)
+        .map(|n| format!("h{n}.test"))
+        .collect();
+    assert!(matches!(
+        NetworkPolicy::new(Exposure::Exposed, hosts, Vec::<&str>::new()).unwrap_err(),
+        NetworkPolicyError::TooManyEntries { .. }
+    ));
+}
+
+#[test]
+fn exposure_serializes_in_kebab_case() {
+    assert_eq!(
+        serde_json::to_string(&Exposure::Loopback).unwrap(),
+        "\"loopback\""
+    );
+    assert_eq!(
+        serde_json::to_string(&Exposure::Exposed).unwrap(),
+        "\"exposed\""
+    );
+}

--- a/crates/uf_devserver/src/policy.rs
+++ b/crates/uf_devserver/src/policy.rs
@@ -1,0 +1,416 @@
+//! The allow/deny decision, evaluated on canonical paths only.
+//!
+//! # Threat model
+//!
+//! A deny list is only as good as the string it is matched against. Every dev
+//! server bypass in `docs/security.md` shares one shape: the deny list was
+//! consulted with a value that was not the path the server went on to open —
+//! a raw request string, a half-decoded URL, a path with the query still glued
+//! to the end. This module therefore takes an already-canonical [`Utf8Path`]
+//! and nothing else. It cannot be handed a request string, because it does not
+//! accept one.
+//!
+//! Three rules, in this order:
+//!
+//! 1. **Deny wins.** A path matching any deny pattern is refused even when it
+//!    sits inside an allowed root. There is no allow entry that overrides a
+//!    deny entry.
+//! 2. **[`DEFAULT_DENY`] is not removable.** A project's configured patterns
+//!    are *added* to the built-in list, never substituted for it. A deny list
+//!    that a config typo can shrink is a deny list that will one day be shrunk;
+//!    there is no dev-server request for `.env` that is worth serving.
+//! 3. **Allow by table.** What survives the deny pass must live under one of a
+//!    fixed list of roots. The list comes from configuration at startup and is
+//!    never extended by anything a request carries.
+//!
+//! # Matching
+//!
+//! Patterns are matched by a hand-written two-pointer globber with a single
+//! backtrack point, at both the segment and the character level. It is `O(n*m)`
+//! in the worst case and allocates nothing per comparison. Rule 5 of the threat
+//! model forbids a backtracking regex on untrusted input; a naively recursive
+//! glob has exactly the same exponential blow-up, so it is avoided the same way.
+//!
+//! A pattern containing no `/` is matched against the whole relative path *and*
+//! against every individual segment, so `.env*` denies `config/.env.local` and
+//! `*.pem` denies `certs/server.pem`. This only ever adds denials.
+//!
+//! Root containment uses [`Utf8Path::starts_with`], which compares whole
+//! components. A textual prefix test would let `/srv/project-secrets` pass as
+//! being "inside" `/srv/project`.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use smallvec::SmallVec;
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+/// Patterns denied by every policy, whatever a project configures.
+pub const DEFAULT_DENY: &[&str] = &[
+    ".env*",
+    "**/.git/**",
+    "*.pem",
+    "*.key",
+    "*.crt",
+    "**/.uf/**",
+];
+
+/// Most allow roots a policy will accept.
+pub const MAX_ALLOW_ROOTS: usize = 32;
+
+/// Most deny patterns a policy will accept.
+pub const MAX_DENY_PATTERNS: usize = 256;
+
+/// Longest accepted deny pattern, in bytes.
+pub const MAX_PATTERN_BYTES: usize = 512;
+
+/// Why a policy could not be built.
+///
+/// These are startup failures. A misconfigured allow root is a hard error
+/// rather than a silently dropped entry, because a dropped allow root looks
+/// exactly like a working one until the day it does not.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PolicyError {
+    /// An allow root does not exist or could not be canonicalized.
+    #[error("allow root {root} could not be resolved: {message}")]
+    UnresolvableRoot {
+        /// The configured root.
+        root: Utf8PathBuf,
+        /// The underlying I/O failure.
+        message: CompactString,
+    },
+    /// An allow root canonicalized to a non-UTF-8 path.
+    #[error("allow root {root} resolved to a non-UTF-8 path")]
+    NonUtf8Root {
+        /// The configured root.
+        root: Utf8PathBuf,
+    },
+    /// More than [`MAX_ALLOW_ROOTS`] roots were configured.
+    #[error("at most {MAX_ALLOW_ROOTS} allow roots are supported, got {count}")]
+    TooManyRoots {
+        /// How many were configured.
+        count: usize,
+    },
+    /// More than [`MAX_DENY_PATTERNS`] patterns were configured.
+    #[error("at most {MAX_DENY_PATTERNS} deny patterns are supported, got {count}")]
+    TooManyPatterns {
+        /// How many were configured.
+        count: usize,
+    },
+    /// A deny pattern is longer than [`MAX_PATTERN_BYTES`].
+    #[error("deny pattern is longer than {MAX_PATTERN_BYTES} bytes: {len}")]
+    PatternTooLong {
+        /// Length that was supplied.
+        len: usize,
+    },
+}
+
+/// Why the policy refused a canonical path.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PolicyDenial {
+    /// The path resolved outside every allowed root.
+    #[error("{path} is outside every allowed root")]
+    OutsideAllowedRoots {
+        /// The canonical path that was checked.
+        path: Utf8PathBuf,
+    },
+    /// The path matched a deny pattern.
+    #[error("{path} matches the deny pattern {pattern}")]
+    DeniedByPattern {
+        /// The path the deny list was evaluated against: the canonical path
+        /// from [`FsPolicy::decide`], or the normalized relative path when the
+        /// caller ran the monotone pre-filesystem pass.
+        path: Utf8PathBuf,
+        /// The pattern that matched.
+        pattern: CompactString,
+    },
+}
+
+/// One compiled deny pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DenyGlob {
+    source: CompactString,
+    segments: SmallVec<[GlobSegment; 4]>,
+    rooted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GlobSegment {
+    /// A `**` segment: matches zero or more whole path segments.
+    AnyDepth,
+    /// A literal segment, possibly containing `*` and `?`.
+    Pattern(CompactString),
+}
+
+impl DenyGlob {
+    fn compile(source: &str) -> Result<Self, PolicyError> {
+        if source.len() > MAX_PATTERN_BYTES {
+            return Err(PolicyError::PatternTooLong { len: source.len() });
+        }
+        // A pattern may be written with either separator; both mean the same
+        // thing here for the same reason `\` is a separator in a request path.
+        let normalized = source.replace('\\', "/");
+        let rooted = normalized.contains('/');
+        let segments = normalized
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .map(|segment| {
+                if segment == "**" {
+                    GlobSegment::AnyDepth
+                } else {
+                    GlobSegment::Pattern(CompactString::new(segment))
+                }
+            })
+            .collect();
+        Ok(Self {
+            source: CompactString::new(source),
+            segments,
+            rooted,
+        })
+    }
+
+    fn matches(&self, relative: &Utf8Path) -> bool {
+        let segments: SmallVec<[&str; 16]> = relative.as_str().split('/').collect();
+        if match_segments(&self.segments, &segments) {
+            return true;
+        }
+        // An unrooted pattern also applies to each individual segment, so
+        // `.env*` reaches `config/.env.local` and `*.pem` reaches `certs/a.pem`.
+        match self.segments.as_slice() {
+            [GlobSegment::Pattern(pattern)] if !self.rooted => segments
+                .iter()
+                .any(|segment| match_one_segment(pattern, segment)),
+            _ => false,
+        }
+    }
+}
+
+/// The access decision for one dev server.
+///
+/// Built once at startup from configuration, then consulted per request. It
+/// holds canonical roots so that a request-time check never has to touch the
+/// filesystem to know what "inside the project" means.
+#[derive(Debug, Clone)]
+pub struct FsPolicy {
+    roots: SmallVec<[Utf8PathBuf; 2]>,
+    deny: SmallVec<[DenyGlob; 8]>,
+}
+
+impl FsPolicy {
+    /// Build a policy over `root` with `extra` additional allow roots and
+    /// `deny` patterns *on top of* [`DEFAULT_DENY`].
+    ///
+    /// Every root is canonicalized here, once, so no request-time code path
+    /// ever has to.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError`] when a root cannot be resolved or a bound is
+    /// exceeded.
+    pub fn new<E, D>(root: &Utf8Path, extra: E, deny: D) -> Result<Self, PolicyError>
+    where
+        E: IntoIterator,
+        E::Item: AsRef<str>,
+        D: IntoIterator,
+        D::Item: AsRef<str>,
+    {
+        let mut roots: SmallVec<[Utf8PathBuf; 2]> = SmallVec::new();
+        roots.push(canonical_root(root)?);
+        for entry in extra {
+            let entry = entry.as_ref();
+            let joined = if Utf8Path::new(entry).is_absolute() {
+                Utf8PathBuf::from(entry)
+            } else {
+                root.join(entry)
+            };
+            let resolved = canonical_root(&joined)?;
+            if !roots.contains(&resolved) {
+                roots.push(resolved);
+            }
+            if roots.len() > MAX_ALLOW_ROOTS {
+                return Err(PolicyError::TooManyRoots { count: roots.len() });
+            }
+        }
+
+        // The built-ins go in first and are never consulted for removal: a
+        // configured list can only make the policy stricter.
+        let mut patterns: SmallVec<[DenyGlob; 8]> = SmallVec::new();
+        for pattern in DEFAULT_DENY {
+            patterns.push(DenyGlob::compile(pattern)?);
+        }
+        for pattern in deny {
+            let compiled = DenyGlob::compile(pattern.as_ref())?;
+            if !patterns.contains(&compiled) {
+                patterns.push(compiled);
+            }
+            if patterns.len() > MAX_DENY_PATTERNS {
+                return Err(PolicyError::TooManyPatterns {
+                    count: patterns.len(),
+                });
+            }
+        }
+
+        Ok(Self {
+            roots,
+            deny: patterns,
+        })
+    }
+
+    /// Build a policy over `root` with only the built-in deny list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError`] when `root` cannot be resolved.
+    pub fn with_defaults(root: &Utf8Path) -> Result<Self, PolicyError> {
+        Self::new(root, Vec::<&str>::new(), Vec::<&str>::new())
+    }
+
+    /// The canonical allow roots, project root first.
+    pub fn roots(&self) -> &[Utf8PathBuf] {
+        &self.roots
+    }
+
+    /// The configured deny patterns, in order.
+    pub fn deny_patterns(&self) -> impl Iterator<Item = &str> {
+        self.deny.iter().map(|glob| glob.source.as_str())
+    }
+
+    /// Decide whether `canonical` may be served.
+    ///
+    /// `canonical` must already be a real, symlink-free path — the contract
+    /// this whole crate is built to keep. Deny patterns are evaluated first and
+    /// cannot be overridden.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyDenial`] when a deny pattern matches or the path lies
+    /// outside every allowed root.
+    pub fn decide(&self, canonical: &Utf8Path) -> Result<(), PolicyDenial> {
+        let Some(root) = self
+            .roots
+            .iter()
+            .find(|root| canonical.starts_with(root.as_path()))
+        else {
+            return Err(PolicyDenial::OutsideAllowedRoots {
+                path: canonical.to_owned(),
+            });
+        };
+        let relative = canonical.strip_prefix(root).unwrap_or(canonical);
+        if let Some(pattern) = self.deny_pattern_for(relative) {
+            return Err(PolicyDenial::DeniedByPattern {
+                path: canonical.to_owned(),
+                pattern: CompactString::new(pattern),
+            });
+        }
+        Ok(())
+    }
+
+    /// The deny pattern matching `relative`, if any.
+    ///
+    /// Exposed so the request pipeline can run the deny list *before* touching
+    /// the filesystem, on the lexically normalized relative path. That early
+    /// pass is monotone: it can only add denials, never remove one, so it
+    /// cannot reintroduce the "checked one string, opened another" bug. Its
+    /// purpose is to keep a denied name from becoming an existence oracle —
+    /// `/.env` must answer the same way whether or not `.env` is there.
+    pub fn deny_pattern_for(&self, relative: &Utf8Path) -> Option<&str> {
+        self.deny
+            .iter()
+            .find(|glob| glob.matches(relative))
+            .map(|glob| glob.source.as_str())
+    }
+}
+
+fn canonical_root(root: &Utf8Path) -> Result<Utf8PathBuf, PolicyError> {
+    let resolved = std::fs::canonicalize(root).map_err(|error| PolicyError::UnresolvableRoot {
+        root: root.to_owned(),
+        message: CompactString::new(error.to_string()),
+    })?;
+    Utf8PathBuf::from_path_buf(resolved).map_err(|_| PolicyError::NonUtf8Root {
+        root: root.to_owned(),
+    })
+}
+
+/// Segment-level wildcard match with a single backtrack point.
+fn match_segments(pattern: &[GlobSegment], path: &[&str]) -> bool {
+    let (mut pi, mut si) = (0usize, 0usize);
+    let mut star: Option<(usize, usize)> = None;
+    while si < path.len() {
+        if pi < pattern.len() {
+            match &pattern[pi] {
+                GlobSegment::AnyDepth => {
+                    star = Some((pi + 1, si));
+                    pi += 1;
+                    continue;
+                }
+                GlobSegment::Pattern(segment) if match_one_segment(segment, path[si]) => {
+                    pi += 1;
+                    si += 1;
+                    continue;
+                }
+                GlobSegment::Pattern(_) => {}
+            }
+        }
+        match star {
+            Some((resume, consumed)) => {
+                pi = resume;
+                si = consumed + 1;
+                star = Some((resume, consumed + 1));
+            }
+            None => return false,
+        }
+    }
+    while pi < pattern.len() && matches!(pattern[pi], GlobSegment::AnyDepth) {
+        pi += 1;
+    }
+    pi == pattern.len()
+}
+
+/// Character-level wildcard match with a single backtrack point.
+///
+/// Operates on `char`s rather than bytes so `?` consumes one character of a
+/// non-ASCII name instead of one byte of it. A `?` that splits a multi-byte
+/// character would make a deny pattern quietly fail to match, which is the
+/// dangerous direction for a deny list.
+fn match_one_segment(pattern: &str, text: &str) -> bool {
+    let pattern: SmallVec<[char; 32]> = pattern.chars().collect();
+    let text: SmallVec<[char; 32]> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let mut star: Option<(usize, usize)> = None;
+    while ti < text.len() {
+        if pi < pattern.len() {
+            match pattern[pi] {
+                '*' => {
+                    star = Some((pi + 1, ti));
+                    pi += 1;
+                    continue;
+                }
+                '?' => {
+                    pi += 1;
+                    ti += 1;
+                    continue;
+                }
+                candidate if candidate == text[ti] => {
+                    pi += 1;
+                    ti += 1;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        match star {
+            Some((resume, consumed)) => {
+                pi = resume;
+                ti = consumed + 1;
+                star = Some((resume, consumed + 1));
+            }
+            None => return false,
+        }
+    }
+    while pi < pattern.len() && pattern[pi] == '*' {
+        pi += 1;
+    }
+    pi == pattern.len()
+}

--- a/crates/uf_devserver/src/policy/tests.rs
+++ b/crates/uf_devserver/src/policy/tests.rs
@@ -1,0 +1,245 @@
+use super::*;
+
+fn glob(pattern: &str) -> DenyGlob {
+    DenyGlob::compile(pattern).unwrap()
+}
+
+fn denies(pattern: &str, path: &str) -> bool {
+    glob(pattern).matches(Utf8Path::new(path))
+}
+
+#[test]
+fn a_literal_pattern_matches_only_itself() {
+    assert!(denies("index.html", "index.html"));
+    assert!(!denies("index.html", "index.htm"));
+    assert!(!denies("index.html", "app/index.html.bak"));
+}
+
+#[test]
+fn a_star_does_not_cross_a_separator() {
+    assert!(denies("*.pem", "server.pem"));
+    assert!(!denies("app/*.pem", "app/nested/server.pem"));
+}
+
+#[test]
+fn an_unrooted_pattern_reaches_every_segment() {
+    // `.env*` must deny `config/.env.local`, not only a root-level `.env`.
+    assert!(denies(".env*", ".env"));
+    assert!(denies(".env*", "config/.env.local"));
+    assert!(denies("*.pem", "certs/deep/server.pem"));
+}
+
+#[test]
+fn a_rooted_pattern_is_anchored() {
+    assert!(denies("app/secret.js", "app/secret.js"));
+    assert!(!denies("app/secret.js", "vendor/app/secret.js"));
+}
+
+#[test]
+fn double_star_spans_any_number_of_segments() {
+    assert!(denies("**/.git/**", ".git/config"));
+    assert!(denies("**/.git/**", "a/b/.git/objects/ab/cd"));
+    assert!(denies("**/.git/**", "a/.git"));
+    assert!(!denies("**/.git/**", "a/git/config"));
+}
+
+#[test]
+fn a_question_mark_matches_one_character() {
+    assert!(denies("a?c.js", "abc.js"));
+    assert!(!denies("a?c.js", "ac.js"));
+    assert!(!denies("a?c.js", "abbc.js"));
+}
+
+#[test]
+fn a_question_mark_matches_one_non_ascii_character() {
+    // Byte-wise matching would split the two-byte `é` and quietly fail to deny.
+    assert!(denies("caf?.key", "café.key"));
+}
+
+#[test]
+fn a_backslash_in_a_pattern_is_a_separator() {
+    assert!(denies("**\\.git\\**", "a/.git/config"));
+}
+
+#[test]
+fn a_pathological_pattern_terminates() {
+    // A backtracking matcher would go exponential here. This one is O(n*m).
+    let pattern = "*".repeat(40) + "b";
+    let text = "a".repeat(4000);
+    assert!(!denies(&pattern, &text));
+}
+
+#[test]
+fn rejects_a_pattern_over_the_byte_ceiling() {
+    let pattern = "a".repeat(MAX_PATTERN_BYTES + 1);
+    assert!(matches!(
+        DenyGlob::compile(&pattern).unwrap_err(),
+        PolicyError::PatternTooLong { .. }
+    ));
+}
+
+fn project() -> (tempfile::TempDir, Utf8PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
+    (dir, root)
+}
+
+#[test]
+fn the_project_root_is_always_the_first_allow_root() {
+    let (_guard, root) = project();
+    let policy = FsPolicy::with_defaults(&root).unwrap();
+    assert_eq!(policy.roots(), &[root]);
+}
+
+#[test]
+fn allows_a_file_inside_the_root() {
+    let (_guard, root) = project();
+    std::fs::write(root.join("index.html"), "<!doctype html>").unwrap();
+    let policy = FsPolicy::with_defaults(&root).unwrap();
+    assert_eq!(policy.decide(&root.join("index.html")), Ok(()));
+}
+
+#[test]
+fn denies_a_path_outside_every_root() {
+    let (_guard, root) = project();
+    let policy = FsPolicy::with_defaults(&root).unwrap();
+    assert!(matches!(
+        policy.decide(Utf8Path::new("/etc/passwd")).unwrap_err(),
+        PolicyDenial::OutsideAllowedRoots { .. }
+    ));
+}
+
+#[test]
+fn root_containment_compares_whole_components() {
+    // A textual prefix test would let a sibling directory whose name merely
+    // starts with the root's name pass as "inside" it.
+    let (_guard, root) = project();
+    let policy = FsPolicy::with_defaults(&root).unwrap();
+    let sibling = Utf8PathBuf::from(format!("{root}-secrets/key.txt"));
+    assert!(matches!(
+        policy.decide(&sibling).unwrap_err(),
+        PolicyDenial::OutsideAllowedRoots { .. }
+    ));
+}
+
+#[test]
+fn deny_wins_over_a_path_inside_the_root() {
+    let (_guard, root) = project();
+    let policy = FsPolicy::with_defaults(&root).unwrap();
+    assert!(matches!(
+        policy.decide(&root.join(".env")).unwrap_err(),
+        PolicyDenial::DeniedByPattern { .. }
+    ));
+}
+
+#[test]
+fn deny_wins_over_an_explicitly_allowed_extra_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
+    let extra = root.join("shared");
+    std::fs::create_dir(&extra).unwrap();
+    std::fs::write(extra.join(".env"), "SECRET=1").unwrap();
+
+    let policy = FsPolicy::new(&root, ["shared"], Vec::<&str>::new()).unwrap();
+    assert!(matches!(
+        policy.decide(&extra.join(".env")).unwrap_err(),
+        PolicyDenial::DeniedByPattern { .. }
+    ));
+}
+
+#[test]
+fn an_extra_allow_root_widens_the_allowed_set() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
+    let project_root = root.join("app");
+    let shared = root.join("shared");
+    std::fs::create_dir(&project_root).unwrap();
+    std::fs::create_dir(&shared).unwrap();
+
+    let strict = FsPolicy::with_defaults(&project_root).unwrap();
+    assert!(strict.decide(&shared.join("lib.js")).is_err());
+
+    let relaxed = FsPolicy::new(&project_root, ["../shared"], Vec::<&str>::new()).unwrap();
+    assert_eq!(relaxed.decide(&shared.join("lib.js")), Ok(()));
+}
+
+#[test]
+fn an_unresolvable_allow_root_is_a_startup_error() {
+    let (_guard, root) = project();
+    assert!(matches!(
+        FsPolicy::new(&root, ["does-not-exist"], Vec::<&str>::new()).unwrap_err(),
+        PolicyError::UnresolvableRoot { .. }
+    ));
+}
+
+#[test]
+fn rejects_more_patterns_than_the_ceiling() {
+    let (_guard, root) = project();
+    let patterns: Vec<String> = (0..=MAX_DENY_PATTERNS).map(|n| format!("p{n}")).collect();
+    assert!(matches!(
+        FsPolicy::new(&root, Vec::<&str>::new(), patterns).unwrap_err(),
+        PolicyError::TooManyPatterns { .. }
+    ));
+}
+
+#[test]
+fn the_default_deny_list_covers_the_documented_classes() {
+    let (_guard, root) = project();
+    let policy = FsPolicy::with_defaults(&root).unwrap();
+    for relative in [
+        ".env",
+        ".env.local",
+        ".env.production",
+        "config/.env",
+        ".git/config",
+        "vendor/.git/HEAD",
+        "certs/server.pem",
+        "certs/server.key",
+        "certs/server.crt",
+        ".uf/dev-server.json",
+    ] {
+        assert!(
+            policy.deny_pattern_for(Utf8Path::new(relative)).is_some(),
+            "{relative} was not denied"
+        );
+    }
+}
+
+#[test]
+fn the_default_deny_list_leaves_ordinary_files_alone() {
+    let (_guard, root) = project();
+    let policy = FsPolicy::with_defaults(&root).unwrap();
+    for relative in [
+        "index.html",
+        "app/main.js",
+        "src/components/Button.js",
+        "assets/logo.svg",
+        "environment.js",
+        "docs/git.md",
+    ] {
+        assert_eq!(
+            policy.deny_pattern_for(Utf8Path::new(relative)),
+            None,
+            "{relative} was denied"
+        );
+    }
+}
+
+#[test]
+fn a_project_can_only_add_to_the_deny_list() {
+    let (_guard, root) = project();
+    let policy = FsPolicy::new(&root, Vec::<&str>::new(), ["*.secret"]).unwrap();
+    assert!(policy.deny_pattern_for(Utf8Path::new("a.secret")).is_some());
+    // The built-ins survive a project-supplied list.
+    assert!(policy.deny_pattern_for(Utf8Path::new(".env")).is_some());
+    let patterns: Vec<&str> = policy.deny_patterns().collect();
+    assert_eq!(patterns.len(), DEFAULT_DENY.len() + 1);
+    assert_eq!(patterns.last(), Some(&"*.secret"));
+}
+
+#[test]
+fn a_duplicate_of_a_built_in_pattern_is_not_stored_twice() {
+    let (_guard, root) = project();
+    let policy = FsPolicy::new(&root, Vec::<&str>::new(), [".env*"]).unwrap();
+    assert_eq!(policy.deny_patterns().count(), DEFAULT_DENY.len());
+}

--- a/crates/uf_devserver/src/resolve.rs
+++ b/crates/uf_devserver/src/resolve.rs
@@ -1,0 +1,402 @@
+//! One canonicalization, one decision, one open.
+//!
+//! # Threat model
+//!
+//! [CVE-2025-30208], [CVE-2025-31125], [CVE-2025-32395] and [CVE-2025-62522]
+//! are four bugs with one cause: **the access decision ran against a string
+//! that was not the path that was eventually opened.** Each fix closed one
+//! spelling of the gap — a query suffix, an extra decode round, a repaired
+//! target, a Windows-only separator — and the next spelling arrived a few weeks
+//! later.
+//!
+//! This module removes the gap instead of the spellings. A request path goes
+//! through exactly one pipeline, in exactly this order, and there is no other
+//! way into the filesystem in this crate:
+//!
+//! 1. **Percent-decode once.** Never in a loop, never "until stable". A decoded
+//!    result that still contains `%` followed by two hex digits is rejected as
+//!    a double-encoding attempt rather than decoded again (`/%252e%252e/.env`).
+//! 2. **Reject what decoding revealed.** A NUL byte or any other control
+//!    character in the decoded path is refused, not stripped — `%00` truncation
+//!    is how `/.env%00.js` gets a suffix check to see `.js` and an `open(2)` to
+//!    see `.env`.
+//! 3. **Normalize lexically.** `/` and `\` are both separators, on every
+//!    platform, because CVE-2025-62522 was a `\` that only one platform's
+//!    normalizer recognized. `.` is dropped, `..` pops, and a `..` with nothing
+//!    to pop is an error rather than a clamp — clamping is a repair, and
+//!    repairs are what this crate refuses to do.
+//! 4. **Resolve symlinks.** [`std::fs::canonicalize`] produces the real path.
+//! 5. **Decide on the real path.** [`FsPolicy::decide`] sees the canonical path
+//!    and nothing else.
+//! 6. **Open that exact path**, and hand the caller the open handle.
+//!
+//! # Why the caller cannot re-derive a path
+//!
+//! [`ResolvedFile`] owns the [`File`] that was opened from the path the policy
+//! approved, and its bytes are reachable only through
+//! [`ResolvedFile::read`], which consumes it. The approved path is exposed
+//! only as a [`CheckedPath`], which implements [`fmt::Display`] and nothing
+//! else: no `Deref`, no `AsRef<Path>`, no accessor handing back a `Utf8Path`.
+//! A caller therefore has no path-typed value to open, join, or re-check, so
+//! "checked one path, opened another" is not an available mistake at the call
+//! site — it is missing from the type.
+//!
+//! [CVE-2025-30208]: https://github.com/advisories/GHSA-x574-m823-4x7w
+//! [CVE-2025-31125]: https://nvd.nist.gov/vuln/detail/CVE-2025-31125
+//! [CVE-2025-32395]: https://nvd.nist.gov/vuln/detail/CVE-2025-32395
+//! [CVE-2025-62522]: https://nvd.nist.gov/vuln/detail/CVE-2025-62522
+
+use std::fmt;
+use std::fs::File;
+use std::io::{ErrorKind, Read};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use smallvec::SmallVec;
+use thiserror::Error;
+
+use crate::media::MediaType;
+use crate::policy::{FsPolicy, PolicyDenial};
+use crate::target::{Loader, RequestTarget, TargetError};
+
+#[cfg(test)]
+mod tests;
+
+/// Largest file the dev server will read into memory.
+///
+/// Rule 4 of the threat model: no unbounded allocation. A dev server that
+/// `read_to_end`s whatever the client names is a one-request OOM.
+pub const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Most path segments a request may contain after normalization.
+pub const MAX_PATH_SEGMENTS: usize = 64;
+
+/// The file served when a request names a directory root.
+pub const DIRECTORY_INDEX: &str = "index.html";
+
+/// The first path segment Vite reserves for "serve this absolute filesystem
+/// path", and the entry point every dev server bypass in the threat model went
+/// through. `uf` has no such escape hatch, and says so with a typed refusal
+/// rather than by happening not to implement it.
+pub const FILESYSTEM_PREFIX: &str = "@fs";
+
+/// A canonical path an access decision was made about.
+///
+/// Intentionally *not* a path type. It exists so denials and logs can name the
+/// file that was checked without handing anyone a value they could open. See
+/// the module docs for why that matters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedPath(Utf8PathBuf);
+
+impl fmt::Display for CheckedPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+/// A file that passed the whole pipeline, with the handle that was opened.
+///
+/// The only way to obtain one is [`resolve_request`] or
+/// [`resolve_with_policy`], so possession of a `ResolvedFile` *is* the proof
+/// that the access decision ran, on this path, before this handle existed.
+#[derive(Debug)]
+pub struct ResolvedFile {
+    file: File,
+    loader: Loader,
+    media_type: MediaType,
+    len: u64,
+    path: CheckedPath,
+}
+
+impl ResolvedFile {
+    /// The loader the request selected.
+    pub fn loader(&self) -> Loader {
+        self.loader
+    }
+
+    /// The media type, taken from the canonical path's extension.
+    pub fn media_type(&self) -> MediaType {
+        self.media_type
+    }
+
+    /// The size of the opened file, in bytes, as reported by the handle.
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Whether the opened file is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The canonical path the policy approved, for logging and diagnostics.
+    pub fn checked_path(&self) -> &CheckedPath {
+        &self.path
+    }
+
+    /// Read the whole file from the handle that was opened during resolution.
+    ///
+    /// Consumes the value: after this there is no handle left to re-read and no
+    /// path to re-open.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying I/O error if the read fails.
+    pub fn read(mut self) -> std::io::Result<Vec<u8>> {
+        let mut bytes = Vec::with_capacity(self.len as usize);
+        self.file.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    }
+}
+
+/// Why a request was refused.
+///
+/// Every variant is a refusal. There is deliberately no variant that means
+/// "accepted after repair".
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AccessDenied {
+    /// The request target is not valid origin-form.
+    #[error("invalid request target: {0}")]
+    InvalidTarget(#[from] TargetError),
+    /// A `%` was not followed by two hexadecimal digits.
+    #[error("invalid percent-encoding at byte {index}")]
+    InvalidPercentEncoding {
+        /// Where the bad escape starts.
+        index: usize,
+    },
+    /// Decoding once produced something that is still percent-encoded.
+    #[error("request path is percent-encoded more than once")]
+    DoubleEncoded,
+    /// The decoded path is not valid UTF-8.
+    #[error("request path is not valid UTF-8 once decoded")]
+    NonUtf8,
+    /// The decoded path contains a control character or NUL.
+    #[error("decoded request path contains a forbidden byte {byte:#04x}")]
+    ForbiddenByte {
+        /// The offending byte.
+        byte: u8,
+    },
+    /// A `..` segment climbed above the project root.
+    #[error("request path climbs above the project root")]
+    Escape,
+    /// The request used the `/@fs/` absolute-path prefix.
+    #[error("the /{FILESYSTEM_PREFIX}/ prefix is not served")]
+    FilesystemPrefix,
+    /// The path has more segments than [`MAX_PATH_SEGMENTS`].
+    #[error("request path has more than {MAX_PATH_SEGMENTS} segments")]
+    TooDeep,
+    /// The policy refused the canonical path.
+    #[error(transparent)]
+    Denied(#[from] PolicyDenial),
+    /// Nothing exists at the resolved path.
+    #[error("no file at the requested path")]
+    NotFound,
+    /// The resolved path is a directory, device, socket, or fifo.
+    #[error("{path} is not a regular file")]
+    NotARegularFile {
+        /// The canonical path that was checked.
+        path: CheckedPath,
+    },
+    /// The file is larger than [`MAX_FILE_BYTES`].
+    #[error("{path} is {len} bytes, over the {MAX_FILE_BYTES} byte limit")]
+    TooLarge {
+        /// The canonical path that was checked.
+        path: CheckedPath,
+        /// The size that was reported.
+        len: u64,
+    },
+    /// The filesystem refused the operation.
+    #[error("failed to resolve the requested path: {message}")]
+    Io {
+        /// The underlying failure.
+        message: CompactString,
+    },
+}
+
+/// Resolve a raw request target against `root` with the default policy.
+///
+/// This is the crate's narrow waist: it takes the target exactly as it arrived
+/// on the wire, so validation cannot be skipped by a caller that already has a
+/// "clean" string.
+///
+/// # Errors
+///
+/// Returns [`AccessDenied`] for every rejection, from a malformed target to a
+/// deny-list match.
+pub fn resolve_request(root: &Utf8Path, target: &str) -> Result<ResolvedFile, AccessDenied> {
+    let policy = FsPolicy::with_defaults(root).map_err(|error| AccessDenied::Io {
+        message: CompactString::new(error.to_string()),
+    })?;
+    let parsed = RequestTarget::parse(target)?;
+    resolve_with_policy(&policy, &parsed)
+}
+
+/// Resolve a validated target against a prepared policy.
+///
+/// # Errors
+///
+/// Returns [`AccessDenied`] for every rejection.
+pub fn resolve_with_policy(
+    policy: &FsPolicy,
+    target: &RequestTarget<'_>,
+) -> Result<ResolvedFile, AccessDenied> {
+    let decoded = percent_decode_once(target.path())?;
+    let relative = normalize(&decoded)?;
+
+    // Monotone pre-pass: a denied *name* answers the same way whether or not it
+    // exists, so the deny list never doubles as an existence oracle. This can
+    // only add denials; the authoritative decision below still runs on the
+    // canonical path.
+    if let Some(pattern) = policy.deny_pattern_for(&relative) {
+        return Err(AccessDenied::Denied(PolicyDenial::DeniedByPattern {
+            path: relative.clone(),
+            pattern: CompactString::new(pattern),
+        }));
+    }
+
+    let project_root = policy
+        .roots()
+        .first()
+        .expect("a policy always has a project root");
+    let candidate = project_root.join(&relative);
+    let canonical = canonicalize(&candidate)?;
+
+    policy.decide(&canonical)?;
+
+    let media_type = MediaType::for_extension(canonical.extension());
+    let path = CheckedPath(canonical);
+    let file = File::open(&path.0).map_err(|error| map_io(&error))?;
+    // Metadata comes from the handle, not from the path: it describes the object
+    // this `ResolvedFile` will actually read.
+    let metadata = file.metadata().map_err(|error| map_io(&error))?;
+    if !metadata.is_file() {
+        return Err(AccessDenied::NotARegularFile { path });
+    }
+    let len = metadata.len();
+    if len > MAX_FILE_BYTES {
+        return Err(AccessDenied::TooLarge { path, len });
+    }
+
+    Ok(ResolvedFile {
+        file,
+        loader: target.loader(),
+        media_type,
+        len,
+        path,
+    })
+}
+
+/// Percent-decode `encoded` exactly once.
+///
+/// # Errors
+///
+/// Rejects a malformed escape, a result that is still encoded, a result that is
+/// not UTF-8, and any control byte the decode revealed.
+fn percent_decode_once(encoded: &str) -> Result<String, AccessDenied> {
+    let bytes = encoded.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let Some(value) = hex_pair(bytes, index + 1) else {
+                return Err(AccessDenied::InvalidPercentEncoding { index });
+            };
+            out.push(value);
+            index += 3;
+        } else {
+            out.push(bytes[index]);
+            index += 1;
+        }
+    }
+
+    let decoded = String::from_utf8(out).map_err(|_| AccessDenied::NonUtf8)?;
+
+    // A second layer of encoding means the sender is trying to make two stages
+    // disagree about what the path is. There is no legitimate request that
+    // needs it, so this rejects rather than decodes again. The cost is that a
+    // file genuinely named `50%AB.js` is unreachable; that is the right trade.
+    let raw = decoded.as_bytes();
+    for index in 0..raw.len() {
+        if raw[index] == b'%' && hex_pair(raw, index + 1).is_some() {
+            return Err(AccessDenied::DoubleEncoded);
+        }
+    }
+    for &byte in raw {
+        if byte < 0x20 || byte == 0x7f {
+            return Err(AccessDenied::ForbiddenByte { byte });
+        }
+    }
+
+    Ok(decoded)
+}
+
+fn hex_pair(bytes: &[u8], index: usize) -> Option<u8> {
+    let high = hex_digit(*bytes.get(index)?)?;
+    let low = hex_digit(*bytes.get(index + 1)?)?;
+    Some(high << 4 | low)
+}
+
+fn hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Normalize a decoded path into a relative path with no `.` or `..` left.
+///
+/// `\` is a separator here on every platform. A file whose name genuinely
+/// contains a backslash is therefore unreachable through the dev server, which
+/// is the deliberate trade CVE-2025-62522 argues for: one separator rule
+/// everywhere beats a rule that changes with the host OS.
+fn normalize(decoded: &str) -> Result<Utf8PathBuf, AccessDenied> {
+    let mut segments: SmallVec<[&str; 16]> = SmallVec::new();
+    for segment in decoded.split(['/', '\\']) {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                if segments.pop().is_none() {
+                    return Err(AccessDenied::Escape);
+                }
+            }
+            other => {
+                if segments.len() == MAX_PATH_SEGMENTS {
+                    return Err(AccessDenied::TooDeep);
+                }
+                segments.push(other);
+            }
+        }
+    }
+    // Checked after normalization rather than on the raw string, so `/./@fs/…`
+    // and `/x/../@fs/…` cannot spell their way past it.
+    if segments.first() == Some(&FILESYSTEM_PREFIX) {
+        return Err(AccessDenied::FilesystemPrefix);
+    }
+    if segments.is_empty() {
+        return Ok(Utf8PathBuf::from(DIRECTORY_INDEX));
+    }
+    Ok(Utf8PathBuf::from(segments.join("/")))
+}
+
+fn canonicalize(candidate: &Utf8Path) -> Result<Utf8PathBuf, AccessDenied> {
+    let resolved = std::fs::canonicalize(candidate).map_err(|error| map_io(&error))?;
+    Utf8PathBuf::from_path_buf(resolved).map_err(|_| AccessDenied::Io {
+        message: CompactString::const_new("resolved path is not valid UTF-8"),
+    })
+}
+
+fn map_io(error: &std::io::Error) -> AccessDenied {
+    match error.kind() {
+        // "Missing", "a component is not a directory", and "you may not look"
+        // all answer identically. Distinguishing them turns the resolver into
+        // an oracle for the shape of the filesystem above the project root.
+        ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::NotADirectory => {
+            AccessDenied::NotFound
+        }
+        _ => AccessDenied::Io {
+            message: CompactString::new(error.to_string()),
+        },
+    }
+}

--- a/crates/uf_devserver/src/resolve/tests.rs
+++ b/crates/uf_devserver/src/resolve/tests.rs
@@ -1,0 +1,326 @@
+use super::*;
+
+mod decision;
+
+/// A throwaway project root with a few files in it.
+struct Project {
+    _dir: tempfile::TempDir,
+    root: Utf8PathBuf,
+}
+
+impl Project {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        // The temp directory is itself behind a symlink on macOS, so canonicalize
+        // once here; every assertion below then compares real paths to real paths.
+        let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
+        Self { _dir: dir, root }
+    }
+
+    fn write(&self, relative: &str, contents: &str) -> Utf8PathBuf {
+        let path = self.root.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    fn resolve(&self, target: &str) -> Result<ResolvedFile, AccessDenied> {
+        resolve_request(&self.root, target)
+    }
+
+    fn body(&self, target: &str) -> String {
+        String::from_utf8(self.resolve(target).unwrap().read().unwrap()).unwrap()
+    }
+}
+
+// --- the positive path ------------------------------------------------------
+
+#[test]
+fn serves_an_ordinary_file() {
+    let project = Project::new();
+    project.write("app/main.js", "export default 1;\n");
+    assert_eq!(project.body("/app/main.js"), "export default 1;\n");
+}
+
+#[test]
+fn serves_the_directory_index_for_the_root() {
+    let project = Project::new();
+    project.write("index.html", "<!doctype html>\n");
+    assert_eq!(project.body("/"), "<!doctype html>\n");
+}
+
+#[test]
+fn serves_a_file_whose_name_contains_a_space() {
+    let project = Project::new();
+    project.write("a file.js", "spaced\n");
+    assert_eq!(project.body("/a%20file.js"), "spaced\n");
+}
+
+#[test]
+fn serves_a_file_with_a_non_ascii_name() {
+    let project = Project::new();
+    project.write("café/naïve.js", "unicode\n");
+    assert_eq!(project.body("/caf%C3%A9/na%C3%AFve.js"), "unicode\n");
+}
+
+#[test]
+fn serves_a_file_through_a_legitimate_import_query() {
+    let project = Project::new();
+    project.write("app/main.js", "export default 1;\n");
+    let resolved = project.resolve("/app/main.js?import&t=1700000000").unwrap();
+    assert_eq!(resolved.loader(), Loader::Module);
+    assert_eq!(resolved.read().unwrap(), b"export default 1;\n");
+}
+
+#[test]
+fn carries_the_selected_loader_onto_the_resolved_file() {
+    let project = Project::new();
+    project.write("app/logo.svg", "<svg/>\n");
+    assert_eq!(
+        project.resolve("/app/logo.svg?raw").unwrap().loader(),
+        Loader::Raw
+    );
+}
+
+#[test]
+fn reports_the_media_type_from_the_canonical_extension() {
+    let project = Project::new();
+    project.write("app/main.js", "x\n");
+    project.write("app/data.json", "{}\n");
+    project.write("app/blob.unknown", "x\n");
+    assert_eq!(
+        project
+            .resolve("/app/main.js")
+            .unwrap()
+            .media_type()
+            .as_str(),
+        "text/javascript; charset=utf-8"
+    );
+    assert_eq!(
+        project
+            .resolve("/app/data.json")
+            .unwrap()
+            .media_type()
+            .as_str(),
+        "application/json"
+    );
+    assert_eq!(
+        project
+            .resolve("/app/blob.unknown")
+            .unwrap()
+            .media_type()
+            .as_str(),
+        "application/octet-stream"
+    );
+}
+
+#[test]
+fn collapses_redundant_separators_and_dot_segments() {
+    let project = Project::new();
+    project.write("app/main.js", "ok\n");
+    assert_eq!(project.body("/app//main.js"), "ok\n");
+    assert_eq!(project.body("/./app/./main.js"), "ok\n");
+    assert_eq!(project.body("/app/nested/../main.js"), "ok\n");
+}
+
+#[test]
+fn reports_the_length_from_the_open_handle() {
+    let project = Project::new();
+    project.write("app/main.js", "1234567890");
+    let resolved = project.resolve("/app/main.js").unwrap();
+    assert_eq!(resolved.len(), 10);
+    assert!(!resolved.is_empty());
+}
+
+#[test]
+fn an_empty_file_is_reported_as_empty() {
+    let project = Project::new();
+    project.write("app/empty.js", "");
+    assert!(project.resolve("/app/empty.js").unwrap().is_empty());
+}
+
+#[test]
+fn the_checked_path_displays_the_canonical_path() {
+    let project = Project::new();
+    let written = project.write("app/main.js", "ok\n");
+    let resolved = project.resolve("/app/main.js").unwrap();
+    assert_eq!(resolved.checked_path().to_string(), written.to_string());
+}
+
+// --- percent decoding -------------------------------------------------------
+
+#[test]
+fn decodes_exactly_once() {
+    let project = Project::new();
+    project.write("a b.js", "ok\n");
+    assert_eq!(project.body("/a%20b.js"), "ok\n");
+}
+
+#[test]
+fn rejects_a_double_encoded_path() {
+    // `%252e` decodes once to `%2e`. Decoding again is what turns a checked
+    // string into a different opened path.
+    let project = Project::new();
+    assert_eq!(
+        project.resolve("/%252e%252e/.env").unwrap_err(),
+        AccessDenied::DoubleEncoded
+    );
+    assert_eq!(
+        project.resolve("/app/%25%36%31.js").unwrap_err(),
+        AccessDenied::DoubleEncoded
+    );
+}
+
+#[test]
+fn a_literal_percent_that_is_not_an_escape_is_allowed_through() {
+    let project = Project::new();
+    project.write("100%.js", "ok\n");
+    assert_eq!(project.body("/100%25.js"), "ok\n");
+}
+
+#[test]
+fn rejects_a_truncated_percent_escape() {
+    let project = Project::new();
+    assert!(matches!(
+        project.resolve("/a%2").unwrap_err(),
+        AccessDenied::InvalidPercentEncoding { .. }
+    ));
+    assert!(matches!(
+        project.resolve("/a%zz.js").unwrap_err(),
+        AccessDenied::InvalidPercentEncoding { .. }
+    ));
+    assert!(matches!(
+        project.resolve("/a%").unwrap_err(),
+        AccessDenied::InvalidPercentEncoding { .. }
+    ));
+}
+
+#[test]
+fn rejects_an_encoded_nul_byte() {
+    // Poisoned NUL: a suffix check sees `.js`, `open(2)` sees `.env`.
+    let project = Project::new();
+    assert_eq!(
+        project.resolve("/.env%00.js").unwrap_err(),
+        AccessDenied::ForbiddenByte { byte: 0 }
+    );
+}
+
+#[test]
+fn rejects_encoded_control_characters() {
+    let project = Project::new();
+    for target in ["/a%0d%0ab.js", "/a%09b.js", "/a%7f.js"] {
+        assert!(
+            matches!(
+                project.resolve(target).unwrap_err(),
+                AccessDenied::ForbiddenByte { .. }
+            ),
+            "{target} was accepted"
+        );
+    }
+}
+
+#[test]
+fn rejects_a_path_that_is_not_utf8_once_decoded() {
+    let project = Project::new();
+    assert_eq!(
+        project.resolve("/%ff%fe.js").unwrap_err(),
+        AccessDenied::NonUtf8
+    );
+}
+
+#[test]
+fn rejects_an_encoded_lone_surrogate() {
+    let project = Project::new();
+    assert_eq!(
+        project.resolve("/%ed%a0%80.js").unwrap_err(),
+        AccessDenied::NonUtf8
+    );
+}
+
+// --- normalization ----------------------------------------------------------
+
+#[test]
+fn rejects_a_traversal_above_the_root() {
+    let project = Project::new();
+    for target in [
+        "/../.env",
+        "/../../etc/passwd",
+        "/app/../../.env",
+        "/..%2f..%2f.env",
+        "/%2e%2e/%2e%2e/.env",
+        "/..%5c..%5c.env",
+    ] {
+        assert_eq!(
+            project.resolve(target).unwrap_err(),
+            AccessDenied::Escape,
+            "{target} was not treated as an escape"
+        );
+    }
+}
+
+#[test]
+fn does_not_clamp_a_traversal_back_to_the_root() {
+    // Clamping `..` to the root is a repair; the request asked for something
+    // outside, and the answer is a refusal, not a substitution.
+    let project = Project::new();
+    project.write("index.html", "<!doctype html>\n");
+    assert_eq!(
+        project.resolve("/../index.html").unwrap_err(),
+        AccessDenied::Escape
+    );
+}
+
+#[test]
+fn treats_a_backslash_as_a_separator_on_every_platform() {
+    // CVE-2025-62522. `app\main.js` must reach the same file `app/main.js` does,
+    // and `\` must never survive into a file name the deny list cannot see.
+    let project = Project::new();
+    project.write("app/main.js", "ok\n");
+    assert_eq!(project.body("/app%5Cmain.js"), "ok\n");
+    assert_eq!(project.body("/app/main.js%5C"), "ok\n");
+}
+
+#[test]
+fn four_dots_are_a_literal_segment_not_a_traversal() {
+    // `/....//` is only a traversal to a normalizer that rewrites it into one.
+    let project = Project::new();
+    project.write("..../inside.js", "inside\n");
+    project.write(".env", "SECRET=1\n");
+    // It reaches the literal `....` directory, and never the parent.
+    assert_eq!(project.body("/....//inside.js"), "inside\n");
+    assert_eq!(
+        project.resolve("/....//nope.js").unwrap_err(),
+        AccessDenied::NotFound
+    );
+    assert!(matches!(
+        project.resolve("/....//.env").unwrap_err(),
+        AccessDenied::Denied(PolicyDenial::DeniedByPattern { .. })
+    ));
+}
+
+#[test]
+fn rejects_the_filesystem_prefix() {
+    let project = Project::new();
+    for target in [
+        "/@fs/etc/passwd",
+        "/@fs/",
+        "/./@fs/etc/passwd",
+        "/app/../@fs/etc/passwd",
+        "/@fs%2Fetc%2Fpasswd",
+    ] {
+        assert_eq!(
+            project.resolve(target).unwrap_err(),
+            AccessDenied::FilesystemPrefix,
+            "{target} was not refused"
+        );
+    }
+}
+
+#[test]
+fn rejects_a_path_deeper_than_the_segment_ceiling() {
+    let project = Project::new();
+    let deep = format!("/{}", "a/".repeat(MAX_PATH_SEGMENTS + 2));
+    assert_eq!(project.resolve(&deep).unwrap_err(), AccessDenied::TooDeep);
+}

--- a/crates/uf_devserver/src/resolve/tests/decision.rs
+++ b/crates/uf_devserver/src/resolve/tests/decision.rs
@@ -1,0 +1,183 @@
+//! The access decision itself: deny patterns, allow roots, and symlinks.
+
+use super::*;
+
+#[test]
+fn denies_a_dotenv_file_however_it_is_spelled() {
+    let project = Project::new();
+    project.write(".env", "SECRET=1\n");
+    for target in [
+        "/.env",
+        "/.env?raw",
+        "/.env?raw??",
+        "/.env?import&raw??",
+        "/.env?inline",
+        "/.env%5C",
+        "/.env/",
+        "/./.env",
+        "/app/../.env",
+    ] {
+        assert!(
+            matches!(
+                project.resolve(target).unwrap_err(),
+                AccessDenied::Denied(PolicyDenial::DeniedByPattern { .. })
+            ),
+            "{target} was not denied"
+        );
+    }
+}
+
+#[test]
+fn a_denied_name_answers_the_same_whether_or_not_it_exists() {
+    // Otherwise the deny list is an existence oracle for the project's secrets.
+    let present = Project::new();
+    present.write(".env", "SECRET=1\n");
+    let absent = Project::new();
+    assert_eq!(
+        present.resolve("/.env").unwrap_err(),
+        absent.resolve("/.env").unwrap_err()
+    );
+}
+
+#[test]
+fn denies_git_metadata() {
+    let project = Project::new();
+    project.write(".git/config", "[core]\n");
+    assert!(matches!(
+        project.resolve("/.git/config").unwrap_err(),
+        AccessDenied::Denied(PolicyDenial::DeniedByPattern { .. })
+    ));
+}
+
+#[test]
+fn denies_key_material() {
+    let project = Project::new();
+    project.write("certs/server.pem", "-----BEGIN\n");
+    assert!(matches!(
+        project.resolve("/certs/server.pem").unwrap_err(),
+        AccessDenied::Denied(PolicyDenial::DeniedByPattern { .. })
+    ));
+}
+
+#[test]
+fn denies_the_dev_server_state_directory() {
+    let project = Project::new();
+    project.write(".uf/dev-server.json", "{}\n");
+    assert!(matches!(
+        project.resolve("/.uf/dev-server.json").unwrap_err(),
+        AccessDenied::Denied(PolicyDenial::DeniedByPattern { .. })
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn denies_a_symlink_that_points_out_of_the_root() {
+    // Lexical normalization alone cannot see this: every segment is innocent,
+    // and only `canonicalize` reveals where the path lands.
+    let project = Project::new();
+    std::os::unix::fs::symlink("/etc/passwd", project.root.join("passwd.js")).unwrap();
+    assert!(matches!(
+        project.resolve("/passwd.js").unwrap_err(),
+        AccessDenied::Denied(PolicyDenial::OutsideAllowedRoots { .. })
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn denies_a_symlinked_directory_that_points_out_of_the_root() {
+    let outside = Project::new();
+    outside.write("secret.js", "leaked\n");
+    let project = Project::new();
+    std::os::unix::fs::symlink(outside.root.as_std_path(), project.root.join("escape")).unwrap();
+    assert!(matches!(
+        project.resolve("/escape/secret.js").unwrap_err(),
+        AccessDenied::Denied(PolicyDenial::OutsideAllowedRoots { .. })
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn allows_a_symlink_that_stays_inside_the_root() {
+    let project = Project::new();
+    project.write("app/main.js", "ok\n");
+    std::os::unix::fs::symlink("app/main.js", project.root.join("alias.js")).unwrap();
+    assert_eq!(project.body("/alias.js"), "ok\n");
+}
+
+#[test]
+#[cfg(unix)]
+fn denies_a_symlink_whose_target_matches_the_deny_list() {
+    // The decision runs on the canonical path, so the deny list follows the
+    // link rather than being fooled by the innocent-looking link name.
+    let project = Project::new();
+    project.write(".env", "SECRET=1\n");
+    std::os::unix::fs::symlink(".env", project.root.join("config.js")).unwrap();
+    assert!(matches!(
+        project.resolve("/config.js").unwrap_err(),
+        AccessDenied::Denied(PolicyDenial::DeniedByPattern { .. })
+    ));
+}
+
+#[test]
+fn a_missing_file_is_not_found() {
+    let project = Project::new();
+    assert_eq!(
+        project.resolve("/app/missing.js").unwrap_err(),
+        AccessDenied::NotFound
+    );
+}
+
+#[test]
+fn a_directory_is_not_a_regular_file() {
+    let project = Project::new();
+    project.write("app/main.js", "ok\n");
+    assert!(matches!(
+        project.resolve("/app").unwrap_err(),
+        AccessDenied::NotARegularFile { .. }
+    ));
+}
+
+#[test]
+fn a_path_through_a_file_is_not_found() {
+    let project = Project::new();
+    project.write("app/main.js", "ok\n");
+    assert_eq!(
+        project.resolve("/app/main.js/extra").unwrap_err(),
+        AccessDenied::NotFound
+    );
+}
+
+#[test]
+fn an_invalid_target_never_reaches_the_filesystem() {
+    let project = Project::new();
+    project.write("index.html", "<!doctype html>\n");
+    assert!(matches!(
+        project.resolve("http://evil.test/index.html").unwrap_err(),
+        AccessDenied::InvalidTarget(TargetError::NotOriginForm)
+    ));
+    assert!(matches!(
+        project.resolve("*").unwrap_err(),
+        AccessDenied::InvalidTarget(TargetError::AsteriskForm)
+    ));
+}
+
+#[test]
+fn a_prepared_policy_and_the_convenience_entry_point_agree() {
+    let project = Project::new();
+    project.write("app/main.js", "ok\n");
+    project.write(".env", "SECRET=1\n");
+    let policy = FsPolicy::with_defaults(&project.root).unwrap();
+    for target in ["/app/main.js", "/.env", "/../.env", "/@fs/etc/passwd"] {
+        let parsed = RequestTarget::parse(target).unwrap();
+        let direct = resolve_with_policy(&policy, &parsed);
+        let convenience = project.resolve(target);
+        assert_eq!(
+            direct.is_ok(),
+            convenience.is_ok(),
+            "{target} disagreed between entry points"
+        );
+        if let (Err(left), Err(right)) = (direct, convenience) {
+            assert_eq!(left, right, "{target} produced different refusals");
+        }
+    }
+}

--- a/crates/uf_devserver/src/server.rs
+++ b/crates/uf_devserver/src/server.rs
@@ -1,0 +1,310 @@
+//! Binding, state, and the accept loop.
+//!
+//! # Threat model
+//!
+//! Two properties are decided here and nowhere else.
+//!
+//! **Exposure is read from the socket, not from the configuration string.**
+//! [`DevServer::bind`] classifies the server by asking the *bound address*
+//! whether it is loopback. A config that says `127.0.0.1` but resolves to a
+//! routable interface is treated as exposed, because the socket is the truth.
+//! An exposed bind with no `dev.allowedHosts` list fails to start.
+//!
+//! **Every connection is bounded.** Read and write timeouts, a ceiling on the
+//! request head, and a single response per connection. A dev server that can be
+//! held open by a slow client is a dev server an attacker can wedge.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::time::Duration;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uf_config::DevConfig;
+
+use crate::http::{MAX_REQUEST_HEAD_BYTES, RequestHead, Response, Status, respond};
+use crate::network::{Exposure, NetworkPolicy, NetworkPolicyError};
+use crate::policy::{FsPolicy, PolicyError};
+
+#[cfg(test)]
+mod tests;
+
+/// Directory, relative to the project root, holding dev server state.
+pub const STATE_DIR: &str = ".uf";
+
+/// File, inside [`STATE_DIR`], describing the running server.
+pub const STATE_FILE: &str = "dev-server.json";
+
+/// The engine name reported in the state file.
+pub const ENGINE: &str = "uf-native";
+
+/// The plugin contract this server implements.
+pub const PLUGIN_CONTRACT: &str = "uf-plugin-v1";
+
+/// How long a single connection may take to send its head or read its body.
+pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Why the dev server could not start or could not serve.
+#[derive(Debug, Error)]
+pub enum DevServerError {
+    /// The listener could not be bound.
+    #[error("failed to bind {host}:{port}: {message}")]
+    Bind {
+        /// The requested host.
+        host: CompactString,
+        /// The requested port.
+        port: u16,
+        /// The underlying failure.
+        message: CompactString,
+    },
+    /// The filesystem policy is invalid.
+    #[error(transparent)]
+    Policy(#[from] PolicyError),
+    /// The network policy is invalid.
+    #[error(transparent)]
+    Network(#[from] NetworkPolicyError),
+    /// The state file could not be written.
+    #[error("failed to write {path}: {message}")]
+    State {
+        /// The file that could not be written.
+        path: Utf8PathBuf,
+        /// The underlying failure.
+        message: CompactString,
+    },
+    /// The listener failed.
+    #[error("dev server listener failed: {message}")]
+    Listener {
+        /// The underlying failure.
+        message: CompactString,
+    },
+}
+
+/// The contents of `.uf/dev-server.json`.
+///
+/// The access-control posture is part of the state file on purpose: a developer
+/// who wants to know what their dev server will serve should be able to read it
+/// rather than infer it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DevServerState {
+    /// The bound address.
+    pub host: CompactString,
+    /// The bound port.
+    pub port: u16,
+    /// Always `uf-native`.
+    pub engine: CompactString,
+    /// The plugin contract this server implements.
+    pub plugin_contract: CompactString,
+    /// The health endpoint.
+    pub health: CompactString,
+    /// Whether the socket is reachable beyond loopback.
+    pub exposure: Exposure,
+    /// The configured host allowlist.
+    pub allowed_hosts: Vec<CompactString>,
+    /// The configured origin allowlist.
+    pub allowed_origins: Vec<CompactString>,
+    /// The canonical roots that may be served.
+    pub fs_allow: Vec<Utf8PathBuf>,
+    /// The deny patterns applied to every canonical path.
+    pub fs_deny: Vec<CompactString>,
+}
+
+/// A bound, access-controlled development server.
+#[derive(Debug)]
+pub struct DevServer {
+    listener: TcpListener,
+    address: SocketAddr,
+    fs: FsPolicy,
+    network: NetworkPolicy,
+}
+
+impl DevServer {
+    /// Bind a dev server for `root` using `config`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DevServerError`] when the socket cannot be bound, when the
+    /// filesystem policy is invalid, or when an exposed bind has no allowed
+    /// hosts.
+    pub fn bind(root: &Utf8Path, config: &DevConfig) -> Result<Self, DevServerError> {
+        let listener = bind_listener(config.host.as_str(), config.port, config.strict_port)?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| DevServerError::Bind {
+                host: config.host.clone(),
+                port: config.port,
+                message: CompactString::new(error.to_string()),
+            })?;
+
+        let fs = FsPolicy::new(root, &config.fs.allow, &config.fs.deny)?;
+        let exposure = if address.ip().is_loopback() {
+            Exposure::Loopback
+        } else {
+            Exposure::Exposed
+        };
+        let network = NetworkPolicy::new(exposure, &config.allowed_hosts, &config.allowed_origins)?;
+
+        Ok(Self {
+            listener,
+            address,
+            fs,
+            network,
+        })
+    }
+
+    /// The address the listener actually bound.
+    pub fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    /// The filesystem policy in force.
+    pub fn fs_policy(&self) -> &FsPolicy {
+        &self.fs
+    }
+
+    /// The network policy in force.
+    pub fn network_policy(&self) -> &NetworkPolicy {
+        &self.network
+    }
+
+    /// Describe the running server.
+    pub fn state(&self) -> DevServerState {
+        DevServerState {
+            host: CompactString::new(self.address.ip().to_string()),
+            port: self.address.port(),
+            engine: CompactString::const_new(ENGINE),
+            plugin_contract: CompactString::const_new(PLUGIN_CONTRACT),
+            health: CompactString::const_new(crate::http::HEALTH_TARGET),
+            exposure: self.network.exposure(),
+            allowed_hosts: self
+                .network
+                .allowed_hosts()
+                .map(CompactString::new)
+                .collect(),
+            allowed_origins: self
+                .network
+                .allowed_origins()
+                .map(CompactString::new)
+                .collect(),
+            fs_allow: self.fs.roots().to_vec(),
+            fs_deny: self.fs.deny_patterns().map(CompactString::new).collect(),
+        }
+    }
+
+    /// Write `.uf/dev-server.json` under `root` and return its path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DevServerError::State`] if the directory or file cannot be
+    /// written.
+    pub fn write_state(&self, root: &Utf8Path) -> Result<Utf8PathBuf, DevServerError> {
+        let directory = root.join(STATE_DIR);
+        let path = directory.join(STATE_FILE);
+        std::fs::create_dir_all(&directory).map_err(|error| DevServerError::State {
+            path: directory.clone(),
+            message: CompactString::new(error.to_string()),
+        })?;
+        let mut json =
+            serde_json::to_string_pretty(&self.state()).map_err(|error| DevServerError::State {
+                path: path.clone(),
+                message: CompactString::new(error.to_string()),
+            })?;
+        json.push('\n');
+        std::fs::write(&path, json).map_err(|error| DevServerError::State {
+            path: path.clone(),
+            message: CompactString::new(error.to_string()),
+        })?;
+        Ok(path)
+    }
+
+    /// Accept one connection, answer it, and return the status that was sent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DevServerError::Listener`] only when `accept` itself fails. A
+    /// connection that misbehaves gets a refusal, not a server shutdown.
+    pub fn serve_next(&self) -> Result<Status, DevServerError> {
+        let (stream, _) = self
+            .listener
+            .accept()
+            .map_err(|error| DevServerError::Listener {
+                message: CompactString::new(error.to_string()),
+            })?;
+        Ok(self.serve_connection(stream))
+    }
+
+    /// Serve until the listener fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DevServerError::Listener`] when `accept` fails.
+    pub fn serve_forever(&self) -> Result<(), DevServerError> {
+        loop {
+            self.serve_next()?;
+        }
+    }
+
+    fn serve_connection(&self, mut stream: TcpStream) -> Status {
+        let _ = stream.set_read_timeout(Some(CONNECTION_TIMEOUT));
+        let _ = stream.set_write_timeout(Some(CONNECTION_TIMEOUT));
+        let response = match read_head(&mut stream) {
+            Ok(head) => match RequestHead::parse(&head) {
+                Ok(request) => respond(&request, &self.fs, &self.network),
+                Err(_) => Response::refusal(Status::BadRequest),
+            },
+            Err(status) => Response::refusal(status),
+        };
+        let status = response.status;
+        let _ = stream.write_all(&response.to_bytes());
+        let _ = stream.flush();
+        status
+    }
+}
+
+fn bind_listener(host: &str, port: u16, strict_port: bool) -> Result<TcpListener, DevServerError> {
+    match TcpListener::bind((host, port)) {
+        Ok(listener) => Ok(listener),
+        Err(_) if !strict_port => {
+            TcpListener::bind((host, 0)).map_err(|error| DevServerError::Bind {
+                host: CompactString::new(host),
+                port,
+                message: CompactString::new(error.to_string()),
+            })
+        }
+        Err(error) => Err(DevServerError::Bind {
+            host: CompactString::new(host),
+            port,
+            message: CompactString::new(error.to_string()),
+        }),
+    }
+}
+
+/// Read up to the blank line that ends the request head.
+///
+/// Bounded twice over: the buffer stops growing at [`MAX_REQUEST_HEAD_BYTES`],
+/// and the socket has a read timeout, so neither a large head nor a slow one
+/// can hold the accept loop.
+fn read_head(stream: &mut TcpStream) -> Result<Vec<u8>, Status> {
+    let mut buffer = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    loop {
+        if let Some(end) = find_head_end(&buffer) {
+            buffer.truncate(end);
+            return Ok(buffer);
+        }
+        if buffer.len() >= MAX_REQUEST_HEAD_BYTES {
+            return Err(Status::BadRequest);
+        }
+        match stream.read(&mut chunk) {
+            Ok(0) => return Err(Status::BadRequest),
+            Ok(read) => buffer.extend_from_slice(&chunk[..read]),
+            Err(_) => return Err(Status::BadRequest),
+        }
+    }
+}
+
+fn find_head_end(buffer: &[u8]) -> Option<usize> {
+    buffer.windows(4).position(|window| window == b"\r\n\r\n")
+}

--- a/crates/uf_devserver/src/server/tests.rs
+++ b/crates/uf_devserver/src/server/tests.rs
@@ -1,0 +1,232 @@
+use super::*;
+
+use compact_str::CompactString;
+
+fn project() -> (tempfile::TempDir, Utf8PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
+    std::fs::write(root.join("index.html"), "<!doctype html>\n").unwrap();
+    std::fs::write(root.join(".env"), "SECRET=1\n").unwrap();
+    (dir, root)
+}
+
+/// `DevConfig` and `DevFsConfig` are `#[non_exhaustive]`, so tests adjust a
+/// default rather than spelling out every field.
+fn config(adjust: impl FnOnce(&mut DevConfig)) -> DevConfig {
+    let mut config = DevConfig::default();
+    config.port = 0;
+    adjust(&mut config);
+    config
+}
+
+fn ephemeral() -> DevConfig {
+    config(|_| {})
+}
+
+#[test]
+fn binds_loopback_by_default() {
+    let (_guard, root) = project();
+    let server = DevServer::bind(&root, &ephemeral()).unwrap();
+    assert!(server.address().ip().is_loopback());
+    assert_eq!(server.network_policy().exposure(), Exposure::Loopback);
+}
+
+#[test]
+fn falls_back_to_an_ephemeral_port_unless_strict() {
+    let (_guard, root) = project();
+    let first = DevServer::bind(&root, &ephemeral()).unwrap();
+    let taken = config(|config| {
+        config.port = first.address().port();
+        config.strict_port = false;
+    });
+    let second = DevServer::bind(&root, &taken).unwrap();
+    assert_ne!(second.address().port(), 0);
+}
+
+#[test]
+fn a_strict_port_that_is_taken_is_a_bind_error() {
+    let (_guard, root) = project();
+    let first = DevServer::bind(&root, &ephemeral()).unwrap();
+    let taken = config(|config| {
+        config.port = first.address().port();
+        config.strict_port = true;
+    });
+    assert!(matches!(
+        DevServer::bind(&root, &taken).unwrap_err(),
+        DevServerError::Bind { .. }
+    ));
+}
+
+/// Whether this machine will let a test bind a routable address at all. Some
+/// sandboxes will not, and that is an environment limit, not a regression.
+fn can_bind_wildcard() -> bool {
+    std::net::TcpListener::bind(("0.0.0.0", 0)).is_ok()
+}
+
+#[test]
+fn exposure_is_read_from_the_bound_socket() {
+    // A routable bind with no allowed hosts must fail to start, whatever the
+    // configuration file claims about the posture.
+    if !can_bind_wildcard() {
+        return;
+    }
+    let (_guard, root) = project();
+    let exposed = config(|config| config.host = CompactString::const_new("0.0.0.0"));
+    assert!(matches!(
+        DevServer::bind(&root, &exposed).unwrap_err(),
+        DevServerError::Network(NetworkPolicyError::ExposedWithoutAllowedHosts)
+    ));
+}
+
+#[test]
+fn an_exposed_bind_with_an_allowlist_starts() {
+    if !can_bind_wildcard() {
+        return;
+    }
+    let (_guard, root) = project();
+    let exposed = config(|config| {
+        config.host = CompactString::const_new("0.0.0.0");
+        config.allowed_hosts = vec![CompactString::const_new("dev.internal")];
+    });
+    let server = DevServer::bind(&root, &exposed).unwrap();
+    assert_eq!(server.network_policy().exposure(), Exposure::Exposed);
+}
+
+#[test]
+fn a_bad_allow_root_is_a_startup_error() {
+    let (_guard, root) = project();
+    let config = config(|config| config.fs.allow = vec![CompactString::const_new("nowhere")]);
+    assert!(matches!(
+        DevServer::bind(&root, &config).unwrap_err(),
+        DevServerError::Policy(_)
+    ));
+}
+
+#[test]
+fn configured_deny_patterns_are_added_to_the_built_ins() {
+    let (_guard, root) = project();
+    let config = config(|config| config.fs.deny = vec![CompactString::const_new("*.secret")]);
+    let server = DevServer::bind(&root, &config).unwrap();
+    let patterns: Vec<&str> = server.fs_policy().deny_patterns().collect();
+    assert!(patterns.contains(&".env*"));
+    assert!(patterns.contains(&"*.secret"));
+}
+
+#[test]
+fn the_state_file_describes_the_access_control_posture() {
+    let (_guard, root) = project();
+    let server = DevServer::bind(&root, &ephemeral()).unwrap();
+    let path = server.write_state(&root).unwrap();
+    assert_eq!(path, root.join(STATE_DIR).join(STATE_FILE));
+
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(written["engine"], "uf-native");
+    assert_eq!(written["health"], crate::http::HEALTH_TARGET);
+    assert_eq!(written["exposure"], "loopback");
+    assert_eq!(written["pluginContract"], PLUGIN_CONTRACT);
+    assert!(written["port"].as_u64().unwrap() > 0);
+    assert_eq!(written["allowedHosts"], serde_json::json!([]));
+    assert_eq!(written["allowedOrigins"], serde_json::json!([]));
+    assert_eq!(written["fsAllow"], serde_json::json!([root.as_str()]));
+    assert!(
+        written["fsDeny"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!(".env*"))
+    );
+}
+
+#[test]
+fn the_state_file_round_trips() {
+    let (_guard, root) = project();
+    let server = DevServer::bind(&root, &ephemeral()).unwrap();
+    let path = server.write_state(&root).unwrap();
+    let parsed: DevServerState =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(parsed, server.state());
+}
+
+#[test]
+fn finds_the_end_of_a_request_head() {
+    assert_eq!(find_head_end(b"GET / HTTP/1.1\r\n\r\n"), Some(14));
+    assert_eq!(find_head_end(b"GET / HTTP/1.1\r\n"), None);
+    assert_eq!(find_head_end(b""), None);
+}
+
+/// Drive a real socket end to end. `serve_next` blocks, so the request is
+/// written from a worker thread while the test thread serves it.
+fn round_trip(server: &DevServer, request: String) -> (Status, String) {
+    use std::io::{Read, Write};
+
+    let address = server.address();
+    let client = std::thread::spawn(move || {
+        let mut stream = std::net::TcpStream::connect(address).unwrap();
+        // Writes are best-effort: an over-long head makes the server stop
+        // reading and close, which the client sees as a reset mid-write. That
+        // is the server behaving correctly, not a failure to reproduce.
+        let _ = stream.write_all(request.as_bytes());
+        let _ = stream.flush();
+        // Half-close so a request with no head terminator ends promptly rather
+        // than waiting out the connection timeout.
+        let _ = stream.shutdown(std::net::Shutdown::Write);
+        let mut response = String::new();
+        let _ = stream.read_to_string(&mut response);
+        response
+    });
+    let status = server.serve_next().unwrap();
+    (status, client.join().unwrap())
+}
+
+#[test]
+fn serves_a_file_over_a_real_socket() {
+    let (_guard, root) = project();
+    let server = DevServer::bind(&root, &ephemeral()).unwrap();
+    let (status, response) = round_trip(
+        &server,
+        format!(
+            "GET /index.html HTTP/1.1\r\nhost: {}\r\n\r\n",
+            server.address()
+        ),
+    );
+    assert_eq!(status, Status::Ok);
+    assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+    assert!(response.ends_with("<!doctype html>\n"));
+}
+
+#[test]
+fn refuses_a_denied_file_over_a_real_socket() {
+    let (_guard, root) = project();
+    let server = DevServer::bind(&root, &ephemeral()).unwrap();
+    let (status, response) = round_trip(
+        &server,
+        format!("GET /.env HTTP/1.1\r\nhost: {}\r\n\r\n", server.address()),
+    );
+    assert_eq!(status, Status::Forbidden);
+    assert!(response.starts_with("HTTP/1.1 403 Forbidden\r\n"));
+    assert!(!response.contains("SECRET"));
+}
+
+#[test]
+fn refuses_a_request_with_no_head_terminator() {
+    let (_guard, root) = project();
+    let server = DevServer::bind(&root, &ephemeral()).unwrap();
+    let (status, response) = round_trip(&server, "GET /index.html HTTP/1.1\r\n".to_string());
+    assert_eq!(status, Status::BadRequest);
+    assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+}
+
+#[test]
+fn refuses_a_head_larger_than_the_ceiling_over_a_real_socket() {
+    let (_guard, root) = project();
+    let server = DevServer::bind(&root, &ephemeral()).unwrap();
+    let padding = "a".repeat(MAX_REQUEST_HEAD_BYTES);
+    let (status, _) = round_trip(
+        &server,
+        format!(
+            "GET /index.html HTTP/1.1\r\nhost: {}\r\nx-pad: {padding}\r\n\r\n",
+            server.address()
+        ),
+    );
+    assert_eq!(status, Status::BadRequest);
+}

--- a/crates/uf_devserver/src/target.rs
+++ b/crates/uf_devserver/src/target.rs
@@ -1,0 +1,273 @@
+//! Request-target validation: the grammar gate in front of every other stage.
+//!
+//! # Threat model
+//!
+//! [CVE-2025-32395] was a dev server that accepted a request target it could not
+//! parse, "fixed it up" into something path-shaped, and then served whatever the
+//! fix-up produced. The repair step was the vulnerability: the string the access
+//! check later ran against was manufactured by the server, not sent by the
+//! client, so no amount of care in the check could make it describe the request.
+//!
+//! This module therefore has exactly one job and one failure mode. A byte string
+//! either *is* a valid origin-form request target, in which case it becomes a
+//! [`RequestTarget`], or it is not, in which case it becomes a [`TargetError`]
+//! and the connection gets a `400` — never a repaired path. There is no code
+//! path in this crate that turns a rejected target into an accepted one.
+//!
+//! # The grammar
+//!
+//! RFC 9112 gives a request target four forms. A file-serving dev server needs
+//! precisely one of them, so the other three are rejected outright:
+//!
+//! | Form | Example | Handling |
+//! | --- | --- | --- |
+//! | origin-form | `/app/main.js?import` | the only accepted form |
+//! | absolute-form | `http://evil.test/.env` | rejected |
+//! | authority-form | `evil.test:443` | rejected |
+//! | asterisk-form | `*` | rejected |
+//!
+//! On top of the form, every accepted target is plain visible ASCII: no C0
+//! controls, no space, no `DEL`, no high bytes, no NUL. A fragment is rejected
+//! rather than stripped, because origin-form has no fragment and stripping one
+//! is the same "repair the client's input" move that produced CVE-2025-32395.
+//!
+//! # Loaders
+//!
+//! [`Loader`] is a closed enum chosen by exact match against a fixed table of
+//! `&'static str` keys parsed out of the query. It is never chosen by a suffix
+//! match on the raw target: [CVE-2025-30208] slipped `?raw??` past a suffix
+//! match, and [CVE-2025-31125] did the same with `?import` and `?inline`. Under
+//! exact matching `raw??` is simply not the key `raw`, so it selects nothing.
+//!
+//! The query is matched as raw bytes and is never percent-decoded. Decoding it
+//! would re-introduce the mismatch this crate exists to prevent — a decoded
+//! `%72aw` that matches the table while the enforcement stage sees something
+//! else. A loader flag is an exact ASCII token or it is not a loader flag.
+//!
+//! [CVE-2025-30208]: https://github.com/advisories/GHSA-x574-m823-4x7w
+//! [CVE-2025-31125]: https://nvd.nist.gov/vuln/detail/CVE-2025-31125
+//! [CVE-2025-32395]: https://nvd.nist.gov/vuln/detail/CVE-2025-32395
+
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+/// Longest accepted request target, in bytes.
+///
+/// Rule 4 of the threat model: every read has an explicit bound. A target
+/// longer than this is rejected before any allocation happens.
+pub const MAX_TARGET_BYTES: usize = 4096;
+
+/// How a resolved file is meant to be delivered to the client.
+///
+/// This is deliberately a closed enum with no `Other(String)` variant. Untrusted
+/// query text can select *among* these, and can never name a new one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Loader {
+    /// Serve as an ES module. The default when the query names no loader.
+    #[default]
+    Module,
+    /// Serve the bytes as a default-exported string (`?raw`).
+    Raw,
+    /// Serve as an inlined `data:` URL (`?inline`).
+    Inline,
+    /// Serve the resolved URL as a string (`?url`).
+    Url,
+    /// Serve as a worker entry point (`?worker`).
+    Worker,
+}
+
+impl Loader {
+    /// The stable kebab-case name of this loader.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Module => "module",
+            Self::Raw => "raw",
+            Self::Inline => "inline",
+            Self::Url => "url",
+            Self::Worker => "worker",
+        }
+    }
+}
+
+/// The only query keys that select a loader.
+///
+/// Exhaustive and `&'static str`: no request text ever reaches a position where
+/// it could name a loader that is not on this list.
+const LOADER_KEYS: &[(&str, Loader)] = &[
+    ("inline", Loader::Inline),
+    ("raw", Loader::Raw),
+    ("url", Loader::Url),
+    ("worker", Loader::Worker),
+];
+
+/// Query keys that are recognized, carry no loader meaning, and are ignored.
+///
+/// `?import` is the module-graph marker a bundler appends to its own rewritten
+/// specifiers; it selects [`Loader::Module`], which is also the default.
+const NEUTRAL_KEYS: &[&str] = &["import", "t", "v"];
+
+/// Why a request target was rejected.
+///
+/// Every variant is a `400`. None of them is recoverable, and none of them has
+/// a "repair" counterpart anywhere in this crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum TargetError {
+    /// The target was empty.
+    #[error("request target is empty")]
+    Empty,
+    /// The target is longer than [`MAX_TARGET_BYTES`].
+    #[error("request target is longer than {MAX_TARGET_BYTES} bytes: {len}")]
+    TooLong {
+        /// Length that was supplied.
+        len: usize,
+    },
+    /// The target is the asterisk-form (`*`), which only `OPTIONS` may use.
+    #[error("asterisk-form request target is not served")]
+    AsteriskForm,
+    /// The target is absolute-form or authority-form: it does not begin with a
+    /// single `/`.
+    #[error("request target is not origin-form")]
+    NotOriginForm,
+    /// The target begins with `//`, a network-path reference that some parsers
+    /// read as an authority.
+    #[error("request target starts with a network-path reference")]
+    NetworkPathReference,
+    /// The target contains a byte outside printable US-ASCII.
+    #[error("request target contains a forbidden byte {byte:#04x} at index {index}")]
+    ForbiddenByte {
+        /// The offending byte.
+        byte: u8,
+        /// Where it was found.
+        index: usize,
+    },
+    /// The target contains a `#`, which origin-form has no room for.
+    #[error("request target contains a fragment")]
+    Fragment,
+    /// Two different loader keys appeared in one query.
+    #[error("query names conflicting loaders {first} and {second}")]
+    ConflictingLoaders {
+        /// The loader named first.
+        first: &'static str,
+        /// The loader that contradicted it.
+        second: &'static str,
+    },
+}
+
+/// A request target that has passed the origin-form grammar gate.
+///
+/// The path is still percent-encoded here: decoding is [`crate::resolve`]'s job
+/// and happens exactly once. Holding an un-decoded path in this type is
+/// deliberate — it means no stage can decode twice by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestTarget<'a> {
+    path: &'a str,
+    query: Option<&'a str>,
+    loader: Loader,
+}
+
+impl<'a> RequestTarget<'a> {
+    /// Validate `raw` as an origin-form request target.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TargetError`] for anything that is not origin-form. The
+    /// caller's only correct response is a `400`; there is no repaired value to
+    /// fall back to.
+    pub fn parse(raw: &'a str) -> Result<Self, TargetError> {
+        if raw.is_empty() {
+            return Err(TargetError::Empty);
+        }
+        if raw.len() > MAX_TARGET_BYTES {
+            return Err(TargetError::TooLong { len: raw.len() });
+        }
+        if raw == "*" {
+            return Err(TargetError::AsteriskForm);
+        }
+
+        // Byte gate first, so later stages never see a control character, a NUL,
+        // a raw space, or a high byte. Non-ASCII must arrive percent-encoded.
+        for (index, byte) in raw.bytes().enumerate() {
+            if byte == b'#' {
+                return Err(TargetError::Fragment);
+            }
+            if !(0x21..=0x7e).contains(&byte) {
+                return Err(TargetError::ForbiddenByte { byte, index });
+            }
+        }
+
+        if !raw.starts_with('/') {
+            return Err(TargetError::NotOriginForm);
+        }
+        if raw.starts_with("//") {
+            return Err(TargetError::NetworkPathReference);
+        }
+
+        let (path, query) = match raw.find('?') {
+            Some(index) => (&raw[..index], Some(&raw[index + 1..])),
+            None => (raw, None),
+        };
+        let loader = parse_loader(query)?;
+
+        Ok(Self {
+            path,
+            query,
+            loader,
+        })
+    }
+
+    /// The still-encoded path, guaranteed to start with `/` and to contain no
+    /// `?`, `#`, or non-printable byte.
+    pub fn path(&self) -> &'a str {
+        self.path
+    }
+
+    /// The raw query, if the target had one, with the `?` removed.
+    pub fn query(&self) -> Option<&'a str> {
+        self.query
+    }
+
+    /// The loader this target selected.
+    pub fn loader(&self) -> Loader {
+        self.loader
+    }
+}
+
+/// Choose a loader by exact key match over [`LOADER_KEYS`].
+///
+/// Ambiguity is an error rather than a precedence rule. Picking a winner from
+/// two loader keys is how a request ends up served under a loader the access
+/// decision did not model, which is the shape of CVE-2025-30208.
+fn parse_loader(query: Option<&str>) -> Result<Loader, TargetError> {
+    let Some(query) = query else {
+        return Ok(Loader::Module);
+    };
+    let mut chosen: Option<Loader> = None;
+    for pair in query.split('&') {
+        let key = match pair.find('=') {
+            Some(index) => &pair[..index],
+            None => pair,
+        };
+        if key.is_empty() || NEUTRAL_KEYS.contains(&key) {
+            continue;
+        }
+        let Some(&(_, loader)) = LOADER_KEYS.iter().find(|(name, _)| *name == key) else {
+            // Unrecognized keys are inert. `raw??` lands here, and inertness is
+            // the whole point: it selects nothing rather than fuzzily matching
+            // `raw`.
+            continue;
+        };
+        match chosen {
+            None => chosen = Some(loader),
+            Some(first) if first == loader => {}
+            Some(first) => {
+                return Err(TargetError::ConflictingLoaders {
+                    first: first.as_str(),
+                    second: loader.as_str(),
+                });
+            }
+        }
+    }
+    Ok(chosen.unwrap_or_default())
+}

--- a/crates/uf_devserver/src/target/tests.rs
+++ b/crates/uf_devserver/src/target/tests.rs
@@ -1,0 +1,218 @@
+use super::*;
+
+fn parse(raw: &str) -> Result<RequestTarget<'_>, TargetError> {
+    RequestTarget::parse(raw)
+}
+
+#[test]
+fn accepts_a_plain_origin_form_path() {
+    let target = parse("/app/main.js").unwrap();
+    assert_eq!(target.path(), "/app/main.js");
+    assert_eq!(target.query(), None);
+    assert_eq!(target.loader(), Loader::Module);
+}
+
+#[test]
+fn accepts_a_root_target() {
+    assert_eq!(parse("/").unwrap().path(), "/");
+}
+
+#[test]
+fn splits_the_query_off_the_path() {
+    let target = parse("/app/main.js?import&t=1700000000").unwrap();
+    assert_eq!(target.path(), "/app/main.js");
+    assert_eq!(target.query(), Some("import&t=1700000000"));
+}
+
+#[test]
+fn keeps_the_path_percent_encoded() {
+    // Decoding is `resolve`'s job and happens exactly once, there.
+    assert_eq!(parse("/caf%C3%A9.js").unwrap().path(), "/caf%C3%A9.js");
+}
+
+#[test]
+fn rejects_an_empty_target() {
+    assert_eq!(parse("").unwrap_err(), TargetError::Empty);
+}
+
+#[test]
+fn rejects_a_target_over_the_byte_ceiling() {
+    let raw = format!("/{}", "a".repeat(MAX_TARGET_BYTES));
+    assert!(matches!(
+        parse(&raw).unwrap_err(),
+        TargetError::TooLong { .. }
+    ));
+}
+
+#[test]
+fn rejects_the_asterisk_form() {
+    assert_eq!(parse("*").unwrap_err(), TargetError::AsteriskForm);
+}
+
+#[test]
+fn rejects_an_absolute_form_target() {
+    // CVE-2025-32395: an absolute-form target that a server "fixes up" into a
+    // path is a path the access check never saw.
+    assert_eq!(
+        parse("http://evil.test/.env").unwrap_err(),
+        TargetError::NotOriginForm
+    );
+    assert_eq!(
+        parse("https://evil.test/.env").unwrap_err(),
+        TargetError::NotOriginForm
+    );
+}
+
+#[test]
+fn rejects_an_authority_form_target() {
+    assert_eq!(
+        parse("evil.test:443").unwrap_err(),
+        TargetError::NotOriginForm
+    );
+}
+
+#[test]
+fn rejects_a_network_path_reference() {
+    assert_eq!(
+        parse("//evil.test/.env").unwrap_err(),
+        TargetError::NetworkPathReference
+    );
+}
+
+#[test]
+fn rejects_a_bare_relative_target() {
+    assert_eq!(parse(".env").unwrap_err(), TargetError::NotOriginForm);
+}
+
+#[test]
+fn rejects_an_embedded_nul() {
+    assert!(matches!(
+        parse("/.env\0.js").unwrap_err(),
+        TargetError::ForbiddenByte { byte: 0, .. }
+    ));
+}
+
+#[test]
+fn rejects_control_characters() {
+    for raw in ["/a\rb", "/a\nb", "/a\tb", "/a\x0bb", "/a\x7fb"] {
+        assert!(
+            matches!(parse(raw).unwrap_err(), TargetError::ForbiddenByte { .. }),
+            "{raw:?} was accepted"
+        );
+    }
+}
+
+#[test]
+fn rejects_a_raw_space() {
+    assert!(matches!(
+        parse("/a file.js").unwrap_err(),
+        TargetError::ForbiddenByte { byte: 0x20, .. }
+    ));
+}
+
+#[test]
+fn rejects_a_raw_non_ascii_byte() {
+    assert!(matches!(
+        parse("/café.js").unwrap_err(),
+        TargetError::ForbiddenByte { .. }
+    ));
+}
+
+#[test]
+fn rejects_a_fragment_rather_than_stripping_it() {
+    // Stripping is a repair, and repairs are how the checked string stops
+    // describing the opened path.
+    assert_eq!(
+        parse("/app.js#/../.env").unwrap_err(),
+        TargetError::Fragment
+    );
+}
+
+#[test]
+fn treats_a_backslash_as_an_ordinary_target_byte() {
+    // The separator decision belongs to `resolve`, on the decoded path. The
+    // grammar gate must not reject it, or the CVE-2025-62522 case never reaches
+    // the normalizer that proves it is handled.
+    assert_eq!(parse("/.env\\").unwrap().path(), "/.env\\");
+}
+
+#[test]
+fn defaults_to_the_module_loader() {
+    assert_eq!(parse("/a.js").unwrap().loader(), Loader::Module);
+    assert_eq!(parse("/a.js?").unwrap().loader(), Loader::Module);
+    assert_eq!(parse("/a.js?t=1").unwrap().loader(), Loader::Module);
+}
+
+#[test]
+fn selects_each_loader_by_exact_key() {
+    assert_eq!(parse("/a.js?raw").unwrap().loader(), Loader::Raw);
+    assert_eq!(parse("/a.js?inline").unwrap().loader(), Loader::Inline);
+    assert_eq!(parse("/a.js?url").unwrap().loader(), Loader::Url);
+    assert_eq!(parse("/a.js?worker").unwrap().loader(), Loader::Worker);
+}
+
+#[test]
+fn treats_import_as_neutral() {
+    assert_eq!(parse("/a.js?import").unwrap().loader(), Loader::Module);
+    assert_eq!(parse("/a.js?import&raw").unwrap().loader(), Loader::Raw);
+}
+
+#[test]
+fn does_not_match_a_loader_by_suffix() {
+    // CVE-2025-30208 in one assertion: `raw??` is not the key `raw`, and a
+    // closed-table lookup cannot be talked into thinking otherwise.
+    assert_eq!(parse("/a.js?raw??").unwrap().loader(), Loader::Module);
+    assert_eq!(parse("/a.js?rawx").unwrap().loader(), Loader::Module);
+    assert_eq!(parse("/a.js?xraw").unwrap().loader(), Loader::Module);
+    assert_eq!(parse("/a.js?raw.js").unwrap().loader(), Loader::Module);
+    assert_eq!(
+        parse("/a.js?import&raw??").unwrap().loader(),
+        Loader::Module
+    );
+}
+
+#[test]
+fn does_not_percent_decode_the_query_to_find_a_loader() {
+    // Decoding the query would put a second, differently-spelled decision in
+    // front of the one `resolve` makes.
+    assert_eq!(parse("/a.js?%72aw").unwrap().loader(), Loader::Module);
+}
+
+#[test]
+fn repeating_one_loader_key_is_not_a_conflict() {
+    assert_eq!(parse("/a.js?raw&raw").unwrap().loader(), Loader::Raw);
+}
+
+#[test]
+fn rejects_two_different_loader_keys() {
+    assert_eq!(
+        parse("/a.js?raw&inline").unwrap_err(),
+        TargetError::ConflictingLoaders {
+            first: "raw",
+            second: "inline",
+        }
+    );
+}
+
+#[test]
+fn ignores_a_loader_key_that_carries_a_value() {
+    assert_eq!(parse("/a.js?raw=1").unwrap().loader(), Loader::Raw);
+}
+
+#[test]
+fn loader_names_are_stable() {
+    assert_eq!(Loader::Module.as_str(), "module");
+    assert_eq!(Loader::Raw.as_str(), "raw");
+    assert_eq!(Loader::Inline.as_str(), "inline");
+    assert_eq!(Loader::Url.as_str(), "url");
+    assert_eq!(Loader::Worker.as_str(), "worker");
+}
+
+#[test]
+fn parsing_is_idempotent_on_its_own_output() {
+    for raw in ["/a.js", "/a/b/c.js?import", "/%20.js", "/a.js?raw"] {
+        let once = parse(raw).unwrap();
+        let twice = parse(raw).unwrap();
+        assert_eq!(once, twice);
+    }
+}

--- a/crates/uf_devserver/tests/attack_corpus.rs
+++ b/crates/uf_devserver/tests/attack_corpus.rs
@@ -1,0 +1,413 @@
+//! The dev server attack corpus.
+//!
+//! Every row here is a request that must not produce a file. The table is the
+//! regression test `docs/security.md` points at for its "Dev server and file
+//! serving" rows, and it is meant to grow: when a new bypass is imagined or
+//! published, it becomes a row before it becomes a fix.
+//!
+//! Rows are driven through the whole HTTP surface — request head, network
+//! allowlists, target grammar, resolution, response — so a row proves the
+//! *server* refuses the request, not merely that some function did.
+
+use camino::Utf8PathBuf;
+use uf_devserver::{FsPolicy, Loader, NetworkPolicy, RequestHead, Response, Status, respond};
+
+/// Marker written into every file the server must never serve. If it appears in
+/// a response body, something leaked.
+const SECRET: &str = "uf-devserver-secret-marker";
+
+/// A project laid out to give every attack in the corpus something to aim at.
+///
+/// A denial that happens only because the file is missing proves nothing, so
+/// every denied path in the table exists on disk here.
+struct Fixture {
+    _dir: tempfile::TempDir,
+    root: Utf8PathBuf,
+    fs: FsPolicy,
+    network: NetworkPolicy,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
+
+        for (relative, contents) in [
+            ("index.html", "<!doctype html>\n"),
+            ("app/main.js", "export default 1;\n"),
+            ("app/logo.svg", "<svg/>\n"),
+            ("a file.js", "spaced\n"),
+            ("café.js", "unicode\n"),
+            ("nested/deep/mod.js", "deep\n"),
+            ("environment.js", "not a secret\n"),
+        ] {
+            write(&root, relative, contents);
+        }
+        for relative in [
+            ".env",
+            ".env.local",
+            ".env.",
+            ".env ",
+            "config/.env.local",
+            ".git/config",
+            "certs/server.pem",
+            "certs/server.key",
+            "certs/server.crt",
+            ".uf/dev-server.json",
+            "..../.env",
+        ] {
+            write(&root, relative, &format!("{SECRET}\n"));
+        }
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("/etc/passwd", root.join("passwd.js")).unwrap();
+            std::os::unix::fs::symlink("/etc", root.join("etc")).unwrap();
+            std::os::unix::fs::symlink(".env", root.join("innocent.js")).unwrap();
+        }
+
+        Self {
+            _dir: dir,
+            fs: FsPolicy::with_defaults(&root).unwrap(),
+            network: NetworkPolicy::loopback(),
+            root,
+        }
+    }
+
+    fn request(&self, raw: &str) -> Response {
+        let head = match RequestHead::parse(raw.as_bytes()) {
+            Ok(head) => head,
+            // A head this server cannot parse is a `400`, which is exactly what
+            // the socket loop sends. Modelling it here keeps malformed-head rows
+            // in the same table as everything else.
+            Err(_) => return Response::refusal(Status::BadRequest),
+        };
+        respond(&head, &self.fs, &self.network)
+    }
+
+    fn get(&self, target: &str) -> Response {
+        self.request(&format!(
+            "GET {target} HTTP/1.1\r\nhost: localhost:5173\r\n\r\n"
+        ))
+    }
+}
+
+fn write(root: &Utf8PathBuf, relative: &str, contents: &str) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, contents).unwrap();
+}
+
+/// One attack: the request target, what it is trying, and the status the server
+/// must answer with.
+struct Attack {
+    target: &'static str,
+    trying: &'static str,
+    expect: Status,
+}
+
+const BAD_REQUEST: Status = Status::BadRequest;
+const FORBIDDEN: Status = Status::Forbidden;
+
+/// The corpus.
+///
+/// `400` means the request was refused as ungrammatical before any path work;
+/// `403` means the access decision refused the resolved path. Both are
+/// refusals. The distinction is recorded so that a row silently changing which
+/// guard caught it shows up as a test failure rather than passing quietly.
+///
+/// One row per line on purpose, so the corpus reads as a list of attacks rather
+/// than a wall of struct literals. `rustfmt` is told to leave it alone.
+#[rustfmt::skip]
+const CORPUS: &[Attack] = &[
+    // -- CVE-2025-30208: query suffixes that survived the deny check ---------
+    Attack { target: "/.env",                trying: "the plain denied file",                 expect: FORBIDDEN },
+    Attack { target: "/.env?raw",            trying: "a loader query",                        expect: FORBIDDEN },
+    Attack { target: "/.env?raw??",          trying: "the published `?raw??` bypass",         expect: FORBIDDEN },
+    Attack { target: "/.env?import&raw??",   trying: "the published `?import&raw??` bypass",  expect: FORBIDDEN },
+    Attack { target: "/.env?inline",         trying: "the inline loader",                     expect: FORBIDDEN },
+    Attack { target: "/.env?url",            trying: "the url loader",                        expect: FORBIDDEN },
+    Attack { target: "/.env?worker",         trying: "the worker loader",                     expect: FORBIDDEN },
+    Attack { target: "/.env?t=1&raw??&import", trying: "loaders among cache busters",         expect: FORBIDDEN },
+    Attack { target: "/.env?%72aw",          trying: "a percent-encoded loader key",          expect: FORBIDDEN },
+    Attack { target: "/.env?raw&inline",     trying: "two loaders at once",                   expect: BAD_REQUEST },
+    // -- CVE-2025-31125: traversal wearing a loader query --------------------
+    Attack { target: "/app/../.env?import",  trying: "traversal plus the import marker",      expect: FORBIDDEN },
+    Attack { target: "/app/../.env?raw",     trying: "traversal plus a loader",               expect: FORBIDDEN },
+    Attack { target: "/index.html%2f..%2f.env", trying: "encoded traversal through a file",   expect: FORBIDDEN },
+    // -- traversal, in every spelling ----------------------------------------
+    Attack { target: "/../.env",             trying: "one level up",                          expect: FORBIDDEN },
+    Attack { target: "/../../.env",          trying: "two levels up",                         expect: FORBIDDEN },
+    Attack { target: "/../../../../../../etc/passwd", trying: "climbing to the system",       expect: FORBIDDEN },
+    Attack { target: "/..%2f..%2f.env",      trying: "encoded separators",                    expect: FORBIDDEN },
+    Attack { target: "/%2e%2e/%2e%2e/.env",  trying: "encoded dots",                          expect: FORBIDDEN },
+    Attack { target: "/%2E%2E/%2E%2E/.env",  trying: "encoded dots, uppercase hex",           expect: FORBIDDEN },
+    Attack { target: "/%2e%2e%2f%2e%2e%2fetc%2fpasswd", trying: "everything encoded",         expect: FORBIDDEN },
+    Attack { target: "/..%5c..%5c.env",      trying: "encoded backslash separators",          expect: FORBIDDEN },
+    Attack { target: "/....//.env",          trying: "the `....//` normalizer trick",         expect: FORBIDDEN },
+    Attack { target: "/....\\\\.env",        trying: "`....\\\\` on any platform",            expect: FORBIDDEN },
+    Attack { target: "/....//.env?raw",      trying: "the `....//` trick plus a loader",      expect: FORBIDDEN },
+    Attack { target: "/%252e%252e/.env",     trying: "double encoding",                       expect: BAD_REQUEST },
+    Attack { target: "/%25252e%25252e/.env", trying: "triple encoding",                       expect: BAD_REQUEST },
+    Attack { target: "/%c0%ae%c0%ae/.env",   trying: "overlong UTF-8 dots",                   expect: BAD_REQUEST },
+    // -- CVE-2025-62522: the backslash separator ------------------------------
+    Attack { target: "/.env\\",              trying: "a literal trailing backslash",          expect: FORBIDDEN },
+    Attack { target: "/.env%5C",             trying: "an encoded trailing backslash",         expect: FORBIDDEN },
+    Attack { target: "/.env/",               trying: "a trailing slash",                      expect: FORBIDDEN },
+    Attack { target: "/.env%20",             trying: "a trailing space",                      expect: FORBIDDEN },
+    Attack { target: "/.env.",               trying: "a trailing dot",                        expect: FORBIDDEN },
+    Attack { target: "/config\\.env.local",  trying: "a backslash as a separator",            expect: FORBIDDEN },
+    // -- CVE-2025-32395: request targets that are not origin-form -------------
+    Attack { target: "http://evil.test/.env",  trying: "absolute-form",                       expect: BAD_REQUEST },
+    Attack { target: "https://evil.test/.env", trying: "absolute-form over TLS",              expect: BAD_REQUEST },
+    Attack { target: "//evil.test/.env",     trying: "a network-path reference",              expect: BAD_REQUEST },
+    Attack { target: "evil.test:443",        trying: "authority-form",                        expect: BAD_REQUEST },
+    Attack { target: "*",                    trying: "asterisk-form",                         expect: BAD_REQUEST },
+    Attack { target: ".env",                 trying: "a relative target",                     expect: BAD_REQUEST },
+    Attack { target: "/.env#.js",            trying: "a fragment",                            expect: BAD_REQUEST },
+    // -- byte-level smuggling -------------------------------------------------
+    Attack { target: "/.env%00.js",          trying: "a poisoned NUL byte",                   expect: BAD_REQUEST },
+    Attack { target: "/.env%0d%0aX-Injected:%201", trying: "CRLF injection",                  expect: BAD_REQUEST },
+    Attack { target: "/.env%09",             trying: "an encoded tab",                        expect: BAD_REQUEST },
+    Attack { target: "/%ff%fe.env",          trying: "a non-UTF-8 path",                      expect: BAD_REQUEST },
+    Attack { target: "/%ed%a0%80.env",       trying: "a lone surrogate",                      expect: BAD_REQUEST },
+    Attack { target: "/.env%",               trying: "a truncated escape",                    expect: BAD_REQUEST },
+    Attack { target: "/.env%2",              trying: "a half-written escape",                 expect: BAD_REQUEST },
+    Attack { target: "/.env%zz",             trying: "a non-hex escape",                      expect: BAD_REQUEST },
+    // -- the `/@fs/` escape hatch this server does not have -------------------
+    Attack { target: "/@fs/etc/passwd",      trying: "Vite's absolute-path prefix",           expect: FORBIDDEN },
+    Attack { target: "/@fs//etc/passwd",     trying: "the prefix with a doubled separator",   expect: FORBIDDEN },
+    Attack { target: "/@fs%2Fetc%2Fpasswd",  trying: "the prefix, encoded",                   expect: FORBIDDEN },
+    Attack { target: "/./@fs/etc/passwd",    trying: "the prefix behind a dot segment",       expect: FORBIDDEN },
+    Attack { target: "/app/../@fs/etc/passwd", trying: "the prefix behind a traversal",       expect: FORBIDDEN },
+    Attack { target: "/@fs/C:/Windows/win.ini", trying: "the prefix with a drive letter",     expect: FORBIDDEN },
+    // -- encoded spellings of a denied name -----------------------------------
+    Attack { target: "/.%65nv",              trying: "an encoded letter",                     expect: FORBIDDEN },
+    Attack { target: "/%2eenv",              trying: "an encoded leading dot",                expect: FORBIDDEN },
+    Attack { target: "/.env.local",          trying: "a dotenv variant",                      expect: FORBIDDEN },
+    Attack { target: "/config/.env.local",   trying: "a dotenv in a subdirectory",            expect: FORBIDDEN },
+    Attack { target: "/nested/../config/.env.local", trying: "a nested dotenv via traversal", expect: FORBIDDEN },
+    // -- other denied classes -------------------------------------------------
+    Attack { target: "/.git/config",         trying: "VCS metadata",                          expect: FORBIDDEN },
+    Attack { target: "/.git/../.git/config", trying: "VCS metadata via traversal",            expect: FORBIDDEN },
+    Attack { target: "/certs/server.pem",    trying: "a certificate",                         expect: FORBIDDEN },
+    Attack { target: "/certs/server.key",    trying: "a private key",                         expect: FORBIDDEN },
+    Attack { target: "/certs/server.crt",    trying: "a certificate",                         expect: FORBIDDEN },
+    Attack { target: "/.uf/dev-server.json", trying: "the server's own state",                expect: FORBIDDEN },
+];
+
+#[test]
+fn every_attack_in_the_corpus_is_refused() {
+    let fixture = Fixture::new();
+    for attack in CORPUS {
+        let response = fixture.get(attack.target);
+        assert!(
+            !response.status.is_success(),
+            "{} ({}) was SERVED",
+            attack.target,
+            attack.trying
+        );
+        assert_eq!(
+            response.status, attack.expect,
+            "{} ({}) was refused with the wrong status",
+            attack.target, attack.trying
+        );
+        assert!(
+            response.body.is_empty(),
+            "{} ({}) returned a body",
+            attack.target,
+            attack.trying
+        );
+    }
+}
+
+#[test]
+fn no_attack_in_the_corpus_leaks_the_secret_marker() {
+    let fixture = Fixture::new();
+    for attack in CORPUS {
+        let bytes = fixture.get(attack.target).to_bytes();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(
+            !text.contains(SECRET),
+            "{} ({}) leaked the marker",
+            attack.target,
+            attack.trying
+        );
+    }
+}
+
+#[test]
+fn the_corpus_covers_every_documented_cve_row() {
+    // The four rows in `docs/security.md` each need at least one entry, spelled
+    // exactly as the advisory spells it.
+    for required in [
+        "/.env?raw??",
+        "/.env?import&raw??",
+        "/.env?inline",
+        "http://evil.test/.env",
+        "/.env\\",
+        "/@fs/etc/passwd",
+    ] {
+        assert!(
+            CORPUS.iter().any(|attack| attack.target == required),
+            "the corpus lost its {required} row"
+        );
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn a_symlink_out_of_the_root_is_refused() {
+    let fixture = Fixture::new();
+    for target in ["/passwd.js", "/etc/passwd", "/etc/hosts"] {
+        let response = fixture.get(target);
+        assert_eq!(response.status, Status::Forbidden, "{target} was served");
+        assert!(response.body.is_empty());
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn a_symlink_to_a_denied_file_is_refused() {
+    // The link name is innocent; only the canonical path is not. The decision
+    // runs on the canonical path, so the link does not launder anything.
+    let fixture = Fixture::new();
+    let response = fixture.get("/innocent.js");
+    assert_eq!(response.status, Status::Forbidden);
+    assert!(!String::from_utf8_lossy(&response.to_bytes()).contains(SECRET));
+}
+
+#[test]
+fn a_rebinding_host_header_is_refused() {
+    let fixture = Fixture::new();
+    for host in [
+        "evil.test",
+        "evil.test:5173",
+        "127.0.0.1.evil.test",
+        "localhost.evil.test",
+    ] {
+        let response =
+            fixture.request(&format!("GET /index.html HTTP/1.1\r\nhost: {host}\r\n\r\n"));
+        assert_eq!(response.status, Status::Forbidden, "{host} was accepted");
+        assert!(response.body.is_empty());
+    }
+}
+
+#[test]
+fn a_request_without_a_host_header_is_refused() {
+    let fixture = Fixture::new();
+    let response = fixture.request("GET /index.html HTTP/1.1\r\n\r\n");
+    assert_eq!(response.status, Status::BadRequest);
+}
+
+#[test]
+fn a_preflight_from_a_foreign_origin_is_refused() {
+    let fixture = Fixture::new();
+    for origin in ["http://evil.test", "https://evil.test", "null"] {
+        let response = fixture.request(&format!(
+            "OPTIONS /index.html HTTP/1.1\r\nhost: localhost\r\norigin: {origin}\r\n\r\n"
+        ));
+        assert_eq!(response.status, Status::Forbidden, "{origin} was accepted");
+    }
+}
+
+#[test]
+fn a_foreign_origin_still_cannot_read_a_denied_file() {
+    let fixture = Fixture::new();
+    let response = fixture
+        .request("GET /.env HTTP/1.1\r\nhost: localhost\r\norigin: http://evil.test\r\n\r\n");
+    assert_eq!(response.status, Status::Forbidden);
+    assert!(!String::from_utf8_lossy(&response.to_bytes()).contains(SECRET));
+}
+
+#[test]
+fn no_inbound_header_can_reach_a_denied_file() {
+    // CVE-2025-29927's class: a header that participates in dispatch. None of
+    // these changes anything, because none of them is retained.
+    let fixture = Fixture::new();
+    let plain = fixture.get("/index.html");
+    let loaded = fixture.request(concat!(
+        "GET /index.html HTTP/1.1\r\n",
+        "host: localhost:5173\r\n",
+        "x-middleware-subrequest: middleware:middleware:middleware:middleware:middleware\r\n",
+        "x-forwarded-host: evil.test\r\n",
+        "x-forwarded-proto: https\r\n",
+        "x-forwarded-for: 10.0.0.1\r\n",
+        "x-original-url: /.env\r\n",
+        "x-rewrite-url: /.env\r\n",
+        "x-http-method-override: POST\r\n",
+        "x-uf-loader: raw\r\n",
+        "x-uf-root: /\r\n",
+        "authorization: Bearer nonsense\r\n",
+        "\r\n"
+    ));
+    assert_eq!(plain, loaded);
+    assert_eq!(loaded.status, Status::Ok);
+}
+
+// --- the positive path ------------------------------------------------------
+
+#[test]
+fn ordinary_project_files_are_still_served() {
+    let fixture = Fixture::new();
+    for (target, expected) in [
+        ("/", "<!doctype html>\n"),
+        ("/index.html", "<!doctype html>\n"),
+        ("/app/main.js", "export default 1;\n"),
+        ("/app/main.js?import", "export default 1;\n"),
+        ("/app/main.js?import&t=1700000000", "export default 1;\n"),
+        ("/nested/deep/mod.js", "deep\n"),
+        ("/a%20file.js", "spaced\n"),
+        ("/caf%C3%A9.js", "unicode\n"),
+        ("/environment.js", "not a secret\n"),
+        ("/nested/../app/main.js", "export default 1;\n"),
+        ("/./app/./main.js", "export default 1;\n"),
+        ("/app//main.js", "export default 1;\n"),
+        ("/app%5Cmain.js", "export default 1;\n"),
+    ] {
+        let response = fixture.get(target);
+        assert_eq!(response.status, Status::Ok, "{target} was refused");
+        assert_eq!(
+            response.body,
+            expected.as_bytes(),
+            "{target} served wrongly"
+        );
+    }
+}
+
+#[test]
+fn a_legitimate_loader_query_selects_a_loader_and_still_serves() {
+    let fixture = Fixture::new();
+    let response = fixture.get("/app/logo.svg?raw");
+    assert_eq!(response.status, Status::Ok);
+    assert_eq!(response.loader, Loader::Raw.as_str());
+    assert_eq!(response.body, b"<svg/>\n");
+}
+
+#[test]
+fn the_health_endpoint_answers() {
+    let fixture = Fixture::new();
+    let response = fixture.get("/__uf/health");
+    assert_eq!(response.status, Status::Ok);
+    assert_eq!(response.body, br#"{"status":"ok","engine":"uf-native"}"#);
+}
+
+#[test]
+fn every_denied_fixture_file_is_readable_from_disk() {
+    // Guards the guard: if a corpus row passed only because the file was never
+    // created, this test is what notices.
+    let fixture = Fixture::new();
+    for relative in [
+        ".env",
+        ".env.local",
+        "config/.env.local",
+        ".git/config",
+        "certs/server.pem",
+        "certs/server.key",
+        ".uf/dev-server.json",
+        "..../.env",
+    ] {
+        let contents = std::fs::read_to_string(fixture.root.join(relative)).unwrap();
+        assert!(contents.contains(SECRET), "{relative} was not planted");
+    }
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,14 +40,32 @@ was eventually opened."
 
 | Past failure | Structural decision in `uf` | Test |
 | --- | --- | --- |
-| [CVE-2025-30208](https://github.com/advisories/GHSA-x574-m823-4x7w) — `?raw??` and `?import&raw??` bypass `server.fs.deny` | Query suffixes are stripped and the request is canonicalized to an absolute path *before* any access decision; the decision is made on the resolved path only | todo |
-| [CVE-2025-31125](https://nvd.nist.gov/vuln/detail/CVE-2025-31125) — `?import` / `?inline` / `?raw` traversal | Loader selection is a table lookup over a closed enum, not a string suffix match | todo |
-| [CVE-2025-32395](https://nvd.nist.gov/vuln/detail/CVE-2025-32395) — invalid `request-target` bypass | Requests whose target is not a valid origin-form path are rejected before routing, not normalized into one | todo |
-| [CVE-2025-62522](https://nvd.nist.gov/vuln/detail/CVE-2025-62522) — Windows trailing backslash bypass | `\` is treated as a path separator on every platform when deciding access, never only on Windows | todo |
+| [CVE-2025-30208](https://github.com/advisories/GHSA-x574-m823-4x7w) — `?raw??` and `?import&raw??` bypass `server.fs.deny` | Query suffixes are stripped and the request is canonicalized to an absolute path *before* any access decision; the decision is made on the resolved path only | `uf_devserver::target`, `uf_devserver::resolve`, `attack_corpus` |
+| [CVE-2025-31125](https://nvd.nist.gov/vuln/detail/CVE-2025-31125) — `?import` / `?inline` / `?raw` traversal | Loader selection is a table lookup over a closed enum, not a string suffix match | `uf_devserver::target`, `attack_corpus` |
+| [CVE-2025-32395](https://nvd.nist.gov/vuln/detail/CVE-2025-32395) — invalid `request-target` bypass | Requests whose target is not a valid origin-form path are rejected before routing, not normalized into one | `uf_devserver::target`, `attack_corpus` |
+| [CVE-2025-62522](https://nvd.nist.gov/vuln/detail/CVE-2025-62522) — Windows trailing backslash bypass | `\` is treated as a path separator on every platform when deciding access, never only on Windows | `uf_devserver::resolve`, `attack_corpus` |
+| Traversal, double encoding, poisoned `%00`, and symlinks out of the project root | One pipeline: percent-decode once (a still-encoded result is rejected, not decoded again), normalize lexically, resolve symlinks, decide, then open. `ResolvedFile` carries the open handle and exposes the approved path only as a non-path `CheckedPath`, so a caller has nothing to re-derive | `uf_devserver::resolve`, `attack_corpus` |
+| Vite's `/@fs/` absolute-path prefix, the entry point for the four rows above | There is no such prefix. A request whose first normalized segment is `@fs` is a typed refusal, so the absence is asserted rather than incidental | `uf_devserver::resolve`, `attack_corpus` |
+| A deny list weakened by project configuration | `dev.fs.deny` entries are *added* to a built-in list (`.env*`, `**/.git/**`, `*.pem`, `*.key`, `*.crt`, `**/.uf/**`) and cannot remove one. Patterns are matched by a two-pointer globber with a single backtrack point — no regex, no exponential blow-up | `uf_devserver::policy`, `attack_corpus` |
+| DNS rebinding, and cross-origin requests with side effects | Loopback bind by default; `--host` fails to start without a non-empty `dev.allowedHosts`, with exposure read from the *bound socket* rather than the config string. A `Host` outside the list is refused, and anything that is not a simple `GET`/`HEAD` needs an `Origin` in `dev.allowedOrigins`. `*` is rejected in either list | `uf_devserver::network`, `uf_devserver::server`, `attack_corpus`, `uf_cli` |
+| Inbound headers that steer dispatch — [CVE-2025-29927](https://nvd.nist.gov/vuln/detail/CVE-2025-29927)'s class, at the dev server's own surface | `RequestHead` retains the method, the request target, `Host` and `Origin`, and nothing else: there is no header map for a handler to consult. The two retained headers can only refuse a request, never select a root, loader, handler, or path | `uf_devserver::http`, `attack_corpus` |
 
-The dev server binds loopback by default. Exposing it requires an explicit
-opt-in, and that opt-in must also require an allowed-origin list rather than
-defaulting to `*`.
+`attack_corpus` is `crates/uf_devserver/tests/attack_corpus.rs`: a table of
+request targets that must never produce a file, each row naming the trick it
+plays and the status the server must answer with. Every new bypass anyone
+thinks of becomes a row there before it becomes a fix.
+
+The dev server binds loopback by default. Exposing it requires `uf dev --host`
+*and* a non-empty `dev.allowedHosts`; a cross-origin request with side effects
+additionally requires an `Origin` in `dev.allowedOrigins`. Neither list has a
+default, neither accepts `*`, and a server that cannot name its allowed hosts
+does not start.
+
+What the dev server does today is serve static files under the project root and
+answer `/__uf/health`. The loaders it names (`?raw`, `?inline`, `?url`,
+`?worker`) are selected from the closed enum and reported on the response, but
+do not yet transform the body; when they do, the transform must consume the
+`ResolvedFile` rather than re-open anything.
 
 ## Framework, RSC, and server actions
 


### PR DESCRIPTION
Makes `docs/security.md`'s "Dev server and file serving" section true.

The Vite dev server was bypassed four times in one year — CVE-2025-30208,
CVE-2025-31125, CVE-2025-32395, CVE-2025-62522 — with one underlying bug:
**the access decision ran against a string that was not the path that was
eventually opened.** A query suffix survived the check and changed the open; a
second decode round happened after the check; an unparseable target was
repaired into a different path than the one that was validated; a separator was
normalized on one platform and not another. Each fix closed one spelling of the
gap and the next spelling arrived a few weeks later.

This closes the gap instead of the spellings.

## Moved, not wrapped

The `uf dev` server **moved wholesale** into a new `crates/uf_devserver` rather
than staying in `uf_cli` with a guard bolted alongside it. The old server was
~85 lines (`dev`, `bind_dev_listener`, `serve_dev_request`) and served a stub
response to everything, so moving it was cheap; leaving it in place would have
left the guard *optional*, and the whole point is that a future handler cannot
reach `std::fs` without going through the check. The only way to obtain a file
in this crate is `resolve_request`, which returns an already-open handle.

The cost is a diff against `uf_cli` while two other agents were rewriting it.
That turned out to be the right call anyway: the change to `uf_cli` is a net
deletion plus one call, so both rebases (onto the `uf_term`/`commands/` split
and onto the plugin-contract rename) touched only the small surface I added.

## The six modules

| Module | Owns |
| --- | --- |
| `target` | The origin-form grammar gate and the closed `Loader` enum |
| `resolve` | Decode once, normalize, canonicalize, decide, open |
| `policy` | Allow roots and deny globs, on canonical paths only |
| `network` | Loopback default, `Host`/`Origin` allowlists |
| `http` | Request head, statuses, responses |
| `media` | The closed extension→`Content-Type` table |

Highlights:

- **No repairs.** An invalid request target is a `400`, never a fixed-up path.
  A fragment is rejected rather than stripped; a `..` above the root is an
  error rather than a clamp. Both are the CVE-2025-32395 move.
- **One decode.** A result that still contains `%XX` after decoding is rejected
  as double-encoding rather than decoded again, and control bytes the decode
  revealed (`%00`, `%0d`) are refused, not stripped.
- **Loaders are a closed table.** `?raw??` is not the key `raw`, so it selects
  nothing. The query is never percent-decoded — decoding it would put a second,
  differently-spelled decision in front of the real one.
- **`\` is a separator everywhere**, not only on Windows.
- **`ResolvedFile` carries the open handle.** The approved path is exposed only
  as a `CheckedPath` with `Display` and nothing else — no `Deref`, no
  `AsRef<Path>`, no accessor returning a `Utf8Path`. "Checked one path, opened
  another" is not an available mistake at the call site; it is missing from the
  type.
- **`/@fs/` does not exist**, and says so with a typed refusal rather than by
  happening not to be implemented.
- **The built-in deny list cannot be shrunk.** `dev.fs.deny` entries are added
  to `.env*`, `**/.git/**`, `*.pem`, `*.key`, `*.crt`, `**/.uf/**`. The globber
  is two-pointer with a single backtrack point — no regex, no exponential
  blow-up.
- **A denied name is not an existence oracle.** The deny list also runs before
  the filesystem is touched, on the normalized relative path. That pass is
  monotone — it can only add denials — so it cannot reintroduce the bug.
- **Exposure is read from the bound socket**, not the config string. An exposed
  bind with no `dev.allowedHosts` fails to start. No `*` is accepted in either
  allowlist.
- **`RequestHead` has no header map.** It retains the method, the target,
  `Host` and `Origin`, and drops every other header as it scans past. The two
  it keeps can only refuse a request — never select a root, loader, handler, or
  path. That is CVE-2025-29927's bug class made unrepresentable.

## Tests

`crates/uf_devserver/tests/attack_corpus.rs` is a table of 70 request targets
that must never produce a file, each row naming the trick it plays and the
status the server must answer with, driven through the whole HTTP surface.
Recording the expected status means a row that starts passing for a different
reason fails instead of passing quietly. Every denied file is planted on disk,
and a separate test asserts that, so no row can pass merely because the file
was missing. Alongside it: `Host` and `Origin` rows, a header-trust row that
asserts a pile of dispatch-flavoured headers produces a byte-identical
response, and a positive table (spaces, non-ASCII names, `?import`, `//`, `\`,
`.` and `..` inside the root).

**Both guards were mutation-checked**, because a corpus that passes for free is
worse than no corpus:

- emptying `DEFAULT_DENY` → `/.env (the plain denied file) was SERVED`
- making `\` unix-only → `/..%5c..%5c.env … was refused with the wrong status`

Counts: 158 unit tests in `uf_devserver`, 14 corpus tests, plus new `uf_config`
and `uf_cli` tests. Workspace: 1306 passing, `cargo fmt --all -- --check` and
`cargo clippy --workspace --all-targets -- -D warnings` clean on 1.98.0.

## Config

`dev.fs.allow`, `dev.fs.deny`, `dev.allowedHosts`, `dev.allowedOrigins`. The
brief named these `server.allowedHosts` after Vite's shape, but `server.*` in
`uf.config.js` already means the *production* server (engine, deploy adapters),
so dev-server access control lives under `dev.*`. Flagging the rename since it
diverges from the brief.

## Deliberately not done

- `docs/security.md`'s **CVE-2025-29927 row stays `todo`**. That row is about
  framework *middleware* dispatch, which does not exist yet. What landed here
  is the same bug class at the dev server's own surface, so it got its own row
  in the dev-server table rather than flipping a row it does not cover.
- Loader variants are selected and reported (`x-uf-loader`) but do not yet
  transform the body. Noted in `docs/security.md`; when they do, the transform
  must consume the `ResolvedFile` rather than re-open anything.
- `attack_corpus.rs` is 413 lines, over the 400 guideline, and carries an
  explicit `#[rustfmt::skip]` so the table stays one row per line. It is a
  single `const` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790922482&installation_model_id=422833&pr_number=30&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F30&signature=969e45608888a51ec77650093d8d8735cd91f6c7286e08d350dd52a20388a5a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure development server with file serving, health checks, loader support, and persistent server state.
  * Added `--host` support for binding to routable addresses.
  * Added configurable host, origin, filesystem allowlists, and deny patterns.
  * Added protections against traversal, sensitive-file access, malformed requests, and unauthorized network access.
* **Documentation**
  * Updated security documentation with current development-server protections and exposure requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->