### PR TITLE
fix: make GitHub flake distribution self-contained

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "flow": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788312499,
+        "narHash": "sha256-AJs2lY1BSuQHAng5AVSlWQEPXmXMyaNpM4xPw/ibJ6M=",
+        "owner": "facebook",
+        "repo": "flow",
+        "rev": "81b0c2a3dd591c66c51167aac341d851932bd9c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "facebook",
+        "repo": "flow",
+        "rev": "81b0c2a3dd591c66c51167aac341d851932bd9c5",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1788179007,
@@ -34,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "flow": "flow",
         "nixpkgs": "nixpkgs",
         "nixpkgs-x86_64-darwin": "nixpkgs-x86_64-darwin",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,17 @@
   description = "uniflowed: Unified Toolchain for Flow (React)";
 
   inputs = {
+    flow = {
+      url = "github:facebook/flow/81b0c2a3dd591c66c51167aac341d851932bd9c5";
+      flake = false;
+    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-x86_64-darwin.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-x86_64-darwin, rust-overlay }:
+  outputs = { self, flow, nixpkgs, nixpkgs-x86_64-darwin, rust-overlay }:
     let
       systems = [
         "aarch64-darwin"
@@ -25,6 +29,7 @@
         nixpkgs.lib.genAttrs systems (system: f system (pkgsFor system));
       workspace = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       version = workspace.workspace.package.version;
+      sourceRoot = toString ./.;
     in
     {
       packages = forAllSystems (system: pkgs:
@@ -44,14 +49,30 @@
               src = ./.;
               filter = path: type:
                 let
-                  base = baseNameOf path;
+                  relPath = pkgs.lib.removePrefix "${sourceRoot}/" (toString path);
+                  excludedDirectories = [
+                    ".direnv"
+                    ".git"
+                    "dist"
+                    "docs/dist"
+                    "infra/cloudflare/.terraform"
+                    "node_modules"
+                    "target"
+                  ];
+                  isInExcludedDirectory = directory:
+                    relPath == directory || pkgs.lib.hasPrefix "${directory}/" relPath;
                 in
-                  !(base == "target"
-                    || base == "dist"
-                    || base == ".git"
-                    || base == ".direnv"
-                    || base == ".terraform");
+                  !(pkgs.lib.any isInExcludedDirectory excludedDirectories
+                    || relPath == "docs/router.js"
+                    || pkgs.lib.hasSuffix ".tfstate" relPath
+                    || pkgs.lib.hasInfix ".tfstate." relPath);
             };
+
+            postPatch = ''
+              rm -rf upstream/flow
+              mkdir -p upstream
+              ln -s ${flow} upstream/flow
+            '';
 
             cargoLock.lockFile = ./Cargo.lock;
             cargoBuildFlags = [ "--package" "uf_cli" "--bins" ];


### PR DESCRIPTION
## Summary
- pin the Flow upstream source as a flake input so GitHub flake builds do not depend on Git submodules
- narrow the Nix source filter to root generated directories so source modules named target are preserved

## Validation
- cargo test --workspace
- nix run nixpkgs#nixpkgs-fmt -- --check flake.nix
- nix build path:/Users/nishimura/Code/github.com/ubugeeei-prod/uf#uf --no-link
- nix run path:/Users/nishimura/Code/github.com/ubugeeei-prod/uf#uf -- --version

## Notes
- cargo +nightly test --workspace --all-features is not runnable with the local nightly because it is rustc 1.97.0-nightly while this workspace requires Rust 1.98

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790923594&installation_model_id=422833&pr_number=31&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F31&signature=176c0e0745c4993d6f986d0a4ec1f0bb357bd8105a36627242b3581bad9bdcf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->