### PR TITLE
docs: correct the claim that the Flow type checker cannot build

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,14 +75,24 @@ Measured against `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`:
   *stable since 1.100.0-nightly*. When the toolchain pin reaches 1.100 stable,
   `upstream-parser` becomes the default with no nightly involved — a one-line
   change to `uf_flow`'s default features.
-- **The type checker does not build at all, and this is upstream's problem to
-  solve.** 23 crates in the port, including `flow_common` and everything under
-  `flow_typing*`, declare `#![feature(box_patterns)]`. That feature has been
-  *removed* from the compiler, not merely left unstable, so those crates fail on
-  today's nightly and on every nightly from here. `uf check` cannot run Flow's
-  own inference until upstream migrates off it. There is no workaround on our
-  side worth having: pinning a nightly old enough to still accept `box_patterns`
-  would freeze the whole toolchain on a compiler that is going stale.
+- **The type checker builds and runs, on a pinned nightly.** 23 crates in the
+  port, including `flow_common` and everything under `flow_typing*`, declare
+  `#![feature(box_patterns)]`, and that feature was *removed* from the compiler
+  around the 2026-09-01 nightly — so the typing crates fail on the floating
+  `nightly` channel. They compile on `nightly-2026-08-01` (rustc 1.99.0-nightly),
+  which is what the type-check feature pins.
+
+  Measured on that toolchain: Flow's builtin library definitions merge into a
+  master context in **68 ms** (once, then cached), and checking a file costs
+  about **4 ms**. Assigning a string to a `number`, passing a `string` where a
+  `number` is declared, and dereferencing a `?string` are each reported; a
+  well-typed file reports nothing.
+
+  Two things an embedder has to know, neither of them documented upstream:
+  `flow_parser::file_key::{set_project_root, set_flowlib_root}` are
+  process-global and panic on first use if unset, and
+  `flow_parsing::docblock_parser::Docblock` is private, so the context metadata
+  has to be computed where the docblock is parsed rather than carried around.
 
 `flow_flowlib` embeds Flow's library definitions with `include_str!` paths that
 reach outside `rust_port` into `lib/`, `prelude/`, and `tslib/`, so

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -24,8 +24,9 @@
       submodule and Meta's official Flow Rust port.
 - [ ] Make `upstream-parser` the default once `never_type` reaches stable Rust.
 - [ ] Integrate Flow typecheck diagnostics without requiring `.flowconfig`.
-      Blocked upstream: the port's typing crates need `box_patterns`, which the
-      compiler has removed. See docs/architecture.md.
+      The port's typing crates need `box_patterns`, removed from the floating
+      nightly channel, so the feature pins `nightly-2026-08-01`. Proven to run:
+      68 ms to merge builtins, ~4 ms per file. See docs/architecture.md.
 - [ ] Replace whitespace formatter with a Flow AST printer.
 - [x] Default formatter settings to double quotes and semicolons.
 - [ ] Add large-project file discovery tests with ignored directories and non-UTF8 guardrails.


### PR DESCRIPTION
## Summary

I wrote in #20 that the port's typing crates *"fail on today's nightly and on
every nightly from here"*, and that pinning an older one was not worth having.
The first half was right about the wrong thing; the second half was a guess.

`box_patterns` was removed around the **2026-09-01** nightly, so those crates
fail on the *floating* channel. They compile on **`nightly-2026-08-01`**
(rustc 1.99.0-nightly), and on that toolchain **Flow's own inference runs**:

```
builtins merged in 67.9ms (cold)
  clean.js                 errors=0   expected=none    14.0ms  OK
  string-to-number.js      errors=1   expected=some     3.6ms  OK
  bad-argument.js          errors=1   expected=some     3.9ms  OK
  unhandled-null.js        errors=2   expected=some     3.8ms  OK
```

Assigning a string to a `number`, passing a `string` where a `number` is
declared, and dereferencing a `?string` are each reported; a well-typed file
reports nothing. Builtin merge is **68 ms once** and then cached; per-file check
is about **4 ms**.

A pinned nightly for one opt-in feature is not "freezing the toolchain" — the
release binary stays on 1.98.0, exactly as it does for `upstream-parser` today.

## Two things an embedder has to know

Neither is documented upstream; both were found by hitting them:

- `flow_parser::file_key::{set_project_root, set_flowlib_root}` are
  **process-global** and **panic on first use if unset**. The port chooses to
  crash rather than default, which is reasonable for a long-lived server and a
  trap for an embedder.
- `flow_parsing::docblock_parser::Docblock` is **private**, so the context
  metadata has to be computed where the docblock is parsed rather than carried
  around in a struct.

## Verification

The measurements above come from a standalone probe that links
`flow_typing`, `flow_typing_context`, `flow_typing_builtins`, `flow_type_sig`,
`flow_flowlib`, `flow_parsing` and `flow_parser_utils` against the pinned
submodule and reproduces `flow_dot_js_wasm`'s check path. Documentation only; no
Rust in this repository changed.

Wiring it into `uf check` is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790924110&installation_model_id=422833&pr_number=32&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F32&signature=21b4ce8ce2071d52ad38296578473ed7c87b19d40c3f9efe90138fc3b0661ab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->