### PR TITLE
fix(fmt): stop `uf fmt` from rewriting package.json

### DIFF
--- a/crates/uf_cli/src/commands/fmt.rs
+++ b/crates/uf_cli/src/commands/fmt.rs
@@ -14,7 +14,13 @@ use crate::ui::Ui;
 
 pub(crate) fn fmt(cwd: &Utf8Path, ui: &mut Ui, check: bool) -> Result<()> {
     let resolved = load_config(cwd)?;
-    let files = collect_source_files(&resolved.root, &resolved.config)?;
+    // Discovery returns `package.json` too, because the linter reads it. The
+    // formatter must not touch it: it is a JavaScript formatter, and running it
+    // over JSON inserts a statement terminator and leaves the file unparseable.
+    let files = collect_source_files(&resolved.root, &resolved.config)?
+        .into_iter()
+        .filter(|file| file.kind.is_formattable())
+        .collect::<Vec<_>>();
     let scanned = files.len();
     let mut changed = Vec::new();
 
@@ -33,9 +39,10 @@ pub(crate) fn fmt(cwd: &Utf8Path, ui: &mut Ui, check: bool) -> Result<()> {
     let failing = check && !changed.is_empty();
     let summary = if check {
         format!(
-            "{} of {} need formatting",
+            "{} of {} {} formatting",
             plural(changed.len(), "file"),
-            scanned
+            scanned,
+            if changed.len() == 1 { "needs" } else { "need" }
         )
     } else {
         format!("formatted {} of {}", plural(changed.len(), "file"), scanned)

--- a/crates/uf_cli/src/commands/test/watch/tests.rs
+++ b/crates/uf_cli/src/commands/test/watch/tests.rs
@@ -3,8 +3,11 @@
 use super::*;
 
 fn file(path: &str, source: &str) -> ProjectFile {
+    let absolute_path = camino::Utf8PathBuf::from(path);
     ProjectFile {
-        absolute_path: camino::Utf8PathBuf::from(path),
+        kind: uf_project::SourceKind::from_path(&absolute_path)
+            .unwrap_or(uf_project::SourceKind::JavaScript),
+        absolute_path,
         relative_path: path.to_string(),
         source: source.to_string(),
     }

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -364,6 +364,63 @@ fn fmt_reports_an_already_formatted_project() {
     assert!(stdout.contains("✓"));
 }
 
+/// `uf fmt` must not rewrite `package.json`.
+///
+/// Discovery returns it because the linter reads it, and the formatter used to
+/// take the same list — so `uf fmt` inserted a statement terminator after
+/// `"@uniflowed/core": "latest"` and left the manifest unparseable. `uf install`
+/// then failed on a project whose only crime was running `uf fmt`.
+///
+/// A scaffolded project is a real one: this is what `uf create && uf fmt` did.
+#[test]
+fn fmt_leaves_the_package_manifest_byte_identical() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = dir.path().join("app");
+    create_app(&app);
+
+    let manifest = app.join("package.json");
+    let before = fs::read_to_string(&manifest).unwrap();
+    serde_json::from_str::<serde_json::Value>(&before).expect("the scaffold writes valid JSON");
+
+    let output = uf().arg("--cwd").arg(&app).arg("fmt").output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let after = fs::read_to_string(&manifest).unwrap();
+    serde_json::from_str::<serde_json::Value>(&after)
+        .expect("uf fmt must leave package.json parseable");
+    assert_eq!(before, after, "uf fmt rewrote package.json");
+}
+
+/// And `--check` must not claim it needs formatting either, which is how a
+/// green CI job would start failing for a file the formatter must never touch.
+#[test]
+fn fmt_check_ignores_the_package_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = dir.path().join("app");
+    create_app(&app);
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(&app)
+        .args(["fmt", "--check"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        !stdout.contains("package.json"),
+        "uf fmt --check listed package.json:\n{stdout}"
+    );
+    assert!(
+        output.status.success(),
+        "a freshly scaffolded project must pass `uf fmt --check`:\n{stdout}"
+    );
+}
+
 #[test]
 fn env_use_records_the_active_environment() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/uf_project/src/lib.rs
+++ b/crates/uf_project/src/lib.rs
@@ -33,6 +33,49 @@ pub struct ProjectFile {
     pub absolute_path: Utf8PathBuf,
     pub relative_path: String,
     pub source: String,
+    /// What kind of file this is.
+    ///
+    /// The linter reads `package.json` as well as JavaScript, so discovery
+    /// returns both. The formatter must not: it is a JavaScript formatter, and
+    /// running it over JSON inserts statement terminators and destroys the file.
+    /// Recording the kind is what lets each caller say which it wants instead of
+    /// every caller having to remember.
+    pub kind: SourceKind,
+}
+
+/// What a discovered project file is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SourceKind {
+    /// Flow-typed JavaScript: `.js`, `.jsx`, `.mjs`, `.cjs`.
+    JavaScript,
+    /// A `package.json` manifest. Read by the linter, never rewritten.
+    PackageManifest,
+}
+
+impl SourceKind {
+    /// Classify a path, or [`None`] when the project does not own it.
+    #[must_use]
+    pub fn from_path(path: &Utf8Path) -> Option<Self> {
+        if path.file_name() == Some("package.json") {
+            return Some(Self::PackageManifest);
+        }
+        match path.extension() {
+            Some("js" | "jsx" | "mjs" | "cjs") => Some(Self::JavaScript),
+            _ => None,
+        }
+    }
+
+    /// Whether `uf fmt` may rewrite a file of this kind.
+    ///
+    /// A `match` rather than a comparison, so a new kind cannot default into
+    /// being formattable by omission.
+    #[must_use]
+    pub const fn is_formattable(self) -> bool {
+        match self {
+            Self::JavaScript => true,
+            Self::PackageManifest => false,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -98,10 +141,12 @@ pub fn collect_source_files(
             }
         })?;
 
-        if !entry.file_type().is_file() || !is_source_file(&path) || is_ignored(root, &path, config)
-        {
+        if !entry.file_type().is_file() || is_ignored(root, &path, config) {
             continue;
         }
+        let Some(kind) = SourceKind::from_path(&path) else {
+            continue;
+        };
 
         let source = fs::read_to_string(&path).map_err(|source| ProjectError::Read {
             path: path.clone(),
@@ -116,6 +161,7 @@ pub fn collect_source_files(
             absolute_path: path,
             relative_path,
             source,
+            kind,
         });
     }
     files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
@@ -138,14 +184,6 @@ fn write_generated_file(path: &Utf8Path, contents: &str, force: bool) -> Result<
         path: path.to_path_buf(),
         source,
     })
-}
-
-fn is_source_file(path: &Utf8Path) -> bool {
-    matches!(path.file_name(), Some("package.json"))
-        || matches!(
-            path.extension(),
-            Some("flow" | "js" | "jsx" | "mjs" | "cjs")
-        )
 }
 
 fn is_ignored(root: &Utf8Path, path: &Utf8Path, config: &UniflowedConfig) -> bool {


### PR DESCRIPTION
## Summary

Found by running the product end to end. `uf create app react && uf fmt` left
the project **unusable**:

```diff
-    "@uniflowed/core": "latest"
+    "@uniflowed/core": "latest";
```

`uf fmt` inserted a statement terminator into `package.json`, and the manifest
stopped being JSON — `node -e "JSON.parse(...)"` fails on it. `uf install` then
fails on a project whose only crime was running the formatter.

## Cause

`collect_source_files` deliberately returns `package.json`, because `uf lint`
reads it for `package/no-npm-scripts`:

```rust
fn is_source_file(path: &Utf8Path) -> bool {
    matches!(path.file_name(), Some("package.json"))
        || matches!(path.extension(), Some("flow" | "js" | "jsx" | "mjs" | "cjs"))
}
```

`uf fmt` took the same list and ran a **JavaScript** formatter over **JSON**.

## Fix

Discovery now records what each file *is*:

```rust
pub enum SourceKind { JavaScript, PackageManifest }
```

`is_formattable` is a `match` rather than a comparison, so a kind added later
cannot become formattable by omission, and `uf fmt` filters on it. The
classification lives in one place instead of a predicate each caller has to
remember — which is the shape that produced this bug, and the reserved-router-file
one in #15 before it.

(`.flow` also disappears from discovery, matching the decision in #14 that the
product has no `.flow` files.)

## The test that should have caught it

`fmt_reports_an_already_formatted_project` passed the entire time, because it
only asserted that a checkmark appeared — and without `--check`, `uf fmt`
happily reports success while corrupting a file.

Two tests replace that assumption with the actual property:

- after `uf fmt` on a scaffolded project, `package.json` still parses **and is
  byte-identical**;
- `uf fmt --check` neither lists it nor fails.

**Both fail with the filter removed** — verified by removing it and watching
them go red.

Also fixes the "1 file need formatting" verb agreement.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **1703 passed, 0 failed**
- [x] End to end on a real scaffold: `uf fmt --check` now reports
      *"every file is already formatted"*, and `package.json` still parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790927158&installation_model_id=422833&pr_number=36&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F36&signature=98ad0dbbabb6dce63b1af5bed8979aaa4fb4e8a365d69484429749e6ae8bbf15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->