### PR TITLE
feat(check): run Flow's own type inference in `uf check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,5 +107,34 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
+      # The parser, on the *current* nightly. This is the job that tells us when
+      # `never_type` stabilizes and `upstream-parser` can become the default, so
+      # it deliberately tracks the moving channel. `--all-features` would drag in
+      # `upstream-typecheck`, which needs a pinned nightly; that has its own job.
+      - run: cargo clippy --workspace --all-targets --features uf_flow/upstream-parser -- -D warnings
+      - run: cargo test --workspace --features uf_flow/upstream-parser
+
+  upstream-typecheck:
+    name: Upstream Flow Typecheck
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    env:
+      # Flow's typing crates declare `#![feature(box_patterns)]`, which the
+      # compiler *removed* around 2026-09-01. This date is the newest nightly
+      # that still accepts it, so the pin is not a preference — a floating
+      # `nightly` cannot build the type checker at all. Same `RUSTUP_TOOLCHAIN`
+      # trick as above, because `rust-toolchain.toml` overrides `rustup default`.
+      RUSTUP_TOOLCHAIN: nightly-2026-08-01
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: tools/upstream/sync.sh
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-08-01
+          components: clippy
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - run: cargo install wild-linker --version 0.10.0 --locked
+      - run: wild --version
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo test --workspace --all-features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,12 +59,23 @@ cargo bench --workspace --no-run
 ```
 
 The pinned 1.98.0 release toolchain cannot compile the upstream Flow Rust port
-yet, because the port still uses the unstable `!` type. `--all-features` therefore
-runs on nightly, which is also what the `Upstream Flow` CI job does:
+yet, because the port still uses the unstable `!` type. `uf_flow`'s
+`upstream-parser` therefore runs on the current nightly, which is what the
+`Upstream Flow` CI job does:
 
 ```sh
-cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
-cargo +nightly test --workspace --all-features
+cargo +nightly clippy --workspace --all-targets --features uf_flow/upstream-parser -- -D warnings
+cargo +nightly test --workspace --features uf_flow/upstream-parser
+```
+
+`--all-features` additionally turns on `uf_check`'s `upstream-typecheck`, and
+Flow's typing crates declare `#![feature(box_patterns)]` — which the compiler
+*removed* around the 2026-09-01 nightly. That half needs a nightly old enough to
+still accept it, which is the `Upstream Flow Typecheck` CI job:
+
+```sh
+cargo +nightly-2026-08-01 clippy --workspace --all-targets --all-features -- -D warnings
+cargo +nightly-2026-08-01 test --workspace --all-features
 ```
 
 Once `never_type` reaches stable, `uf_flow`'s `upstream-parser` feature becomes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocative"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8cf9afc79c83d514444b55df3935d317da54b1ce3b17a133c646889cc260de8"
+dependencies = [
+ "allocative_derive",
+ "ctor",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614043c56c1173b800acb007b81fd0cbc0a0d7d717b71ba705fc2230d0760a23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "archery"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,10 +180,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bitflags"
@@ -212,6 +284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +340,29 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -371,10 +472,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -400,7 +516,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -420,7 +536,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -438,6 +576,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -465,6 +612,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +636,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dupe"
@@ -551,6 +714,140 @@ dependencies = [
 ]
 
 [[package]]
+name = "flow_aloc"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_packed_locs",
+ "flow_parser",
+ "serde",
+]
+
+[[package]]
+name = "flow_analysis"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_lint_settings",
+ "flow_parser",
+ "vec1",
+]
+
+[[package]]
+name = "flow_common"
+version = "0.0.0"
+dependencies = [
+ "dunce",
+ "dupe",
+ "flow_aloc",
+ "flow_common_leb128",
+ "flow_data_structure_wrapper",
+ "flow_lint_settings",
+ "flow_packed_locs",
+ "flow_parser",
+ "globset",
+ "jwalk",
+ "nix",
+ "regex",
+ "rustix",
+ "serde",
+ "serde_json",
+ "vec1",
+]
+
+[[package]]
+name = "flow_common_cycle_hash"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common_xx",
+ "vec1",
+]
+
+[[package]]
+name = "flow_common_errors"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common",
+ "flow_common_utils",
+ "flow_lint_settings",
+ "flow_parser",
+ "flow_utils_tty",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "flow_common_exit_status"
+version = "0.0.0"
+dependencies = [
+ "flow_common",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "flow_common_leb128"
+version = "0.0.0"
+
+[[package]]
+name = "flow_common_modulename"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "serde",
+ "starlark_map",
+]
+
+[[package]]
+name = "flow_common_tarjan"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common_utils",
+ "vec1",
+]
+
+[[package]]
+name = "flow_common_ty"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "flow_parser_utils_output",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "flow_common_utils"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "flow_common_xx"
+version = "0.0.0"
+dependencies = [
+ "xxhash-rust",
+]
+
+[[package]]
 name = "flow_data_structure_wrapper"
 version = "0.0.0"
 dependencies = [
@@ -564,6 +861,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "flow_env_builder"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_analysis",
+ "flow_common",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "flow_parser_utils",
+ "serde",
+ "vec1",
+]
+
+[[package]]
+name = "flow_env_builder_resolver"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_analysis",
+ "flow_common",
+ "flow_common_tarjan",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_typing_errors",
+ "vec1",
+]
+
+[[package]]
+name = "flow_flowlib"
+version = "0.0.0"
+dependencies = [
+ "flow_common",
+ "flow_common_exit_status",
+ "flow_common_xx",
+ "libc",
+]
+
+[[package]]
+name = "flow_heap"
+version = "0.0.0"
+dependencies = [
+ "arc-swap",
+ "bincode",
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_modulename",
+ "flow_data_structure_wrapper",
+ "flow_heap_serialization",
+ "flow_imports_exports",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_type_sig",
+ "flow_utils_concurrency",
+ "lz4_flex",
+ "parking_lot",
+ "rayon",
+ "serde",
+]
+
+[[package]]
+name = "flow_heap_serialization"
+version = "0.0.0"
+dependencies = [
+ "bincode",
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_imports_exports",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_type_sig",
+ "lz4_flex",
+ "parking_lot",
+]
+
+[[package]]
+name = "flow_hh_logger"
+version = "0.0.0"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "flow_imports_exports"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_type_sig",
+ "serde",
+]
+
+[[package]]
+name = "flow_lazy"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+]
+
+[[package]]
+name = "flow_lint_settings"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_parser",
+ "serde",
+]
+
+[[package]]
+name = "flow_packed_locs"
+version = "0.0.0"
+dependencies = [
+ "flow_common_leb128",
+ "flow_parser",
+]
+
+[[package]]
 name = "flow_parser"
 version = "0.0.0"
 dependencies = [
@@ -573,6 +997,520 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "flow_parser_utils"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_analysis",
+ "flow_common",
+ "flow_common_tarjan",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "regex",
+ "serde",
+ "vec1",
+]
+
+[[package]]
+name = "flow_parser_utils_output"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_server_utils",
+]
+
+[[package]]
+name = "flow_parsing"
+version = "0.0.0"
+dependencies = [
+ "bumpalo",
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_modulename",
+ "flow_data_structure_wrapper",
+ "flow_heap",
+ "flow_hh_logger",
+ "flow_imports_exports",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_services_module",
+ "flow_type_sig",
+ "flow_utils_concurrency",
+ "logos",
+ "regex",
+ "vec1",
+]
+
+[[package]]
+name = "flow_server_utils"
+version = "0.0.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "flow_services_module"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common",
+ "flow_common_modulename",
+ "flow_data_structure_wrapper",
+ "flow_heap",
+ "flow_hh_logger",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_utils_concurrency",
+ "regex",
+ "vec1",
+]
+
+[[package]]
+name = "flow_type_sig"
+version = "0.0.0"
+dependencies = [
+ "bumpalo",
+ "dupe",
+ "flow_analysis",
+ "flow_common",
+ "flow_common_cycle_hash",
+ "flow_data_structure_wrapper",
+ "flow_parser",
+ "flow_parser_utils",
+ "serde",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing"
+version = "0.0.0"
+dependencies = [
+ "bumpalo",
+ "dupe",
+ "flow_aloc",
+ "flow_analysis",
+ "flow_common",
+ "flow_common_ty",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_env_builder_resolver",
+ "flow_hh_logger",
+ "flow_lazy",
+ "flow_lint_settings",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_type_sig",
+ "flow_typing_builtins",
+ "flow_typing_context",
+ "flow_typing_debug",
+ "flow_typing_errors",
+ "flow_typing_exists_check",
+ "flow_typing_flow_common",
+ "flow_typing_flow_js",
+ "flow_typing_loc_env",
+ "flow_typing_statement",
+ "flow_typing_tvar",
+ "flow_typing_ty_normalizer",
+ "flow_typing_type",
+ "flow_typing_utils",
+ "flow_typing_visitors",
+ "flow_utils_concurrency",
+ "flow_utils_union_find",
+ "serde_json",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_builtins"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_lazy",
+ "flow_typing_type",
+]
+
+[[package]]
+name = "flow_typing_context"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_analysis",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_lazy",
+ "flow_lint_settings",
+ "flow_parser",
+ "flow_type_sig",
+ "flow_typing_builtins",
+ "flow_typing_errors",
+ "flow_typing_exists_check",
+ "flow_typing_generics",
+ "flow_typing_loc_env",
+ "flow_typing_spread_cache",
+ "flow_typing_type",
+ "flow_utils_concurrency",
+ "flow_utils_union_find",
+ "regex",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_debug"
+version = "0.0.0"
+dependencies = [
+ "flow_aloc",
+ "flow_common",
+ "flow_lint_settings",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_type_sig",
+ "flow_typing_context",
+ "flow_typing_default",
+ "flow_typing_errors",
+ "flow_typing_generics",
+ "flow_typing_type",
+ "flow_utils_union_find",
+]
+
+[[package]]
+name = "flow_typing_default"
+version = "0.0.0"
+dependencies = [
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_typing_type",
+]
+
+[[package]]
+name = "flow_typing_errors"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_errors",
+ "flow_common_ty",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_lint_settings",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_type_sig",
+ "flow_typing_type",
+ "serde",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_exists_check"
+version = "0.0.0"
+dependencies = [
+ "flow_aloc",
+ "flow_parser",
+]
+
+[[package]]
+name = "flow_typing_flow_common"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_lazy",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_type_sig",
+ "flow_typing_context",
+ "flow_typing_debug",
+ "flow_typing_errors",
+ "flow_typing_flow_js_env",
+ "flow_typing_generics",
+ "flow_typing_tvar",
+ "flow_typing_type",
+ "flow_typing_visitors",
+ "flow_utils_concurrency",
+ "flow_utils_union_find",
+ "regex",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_flow_js"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_lazy",
+ "flow_parser",
+ "flow_typing_context",
+ "flow_typing_debug",
+ "flow_typing_default",
+ "flow_typing_errors",
+ "flow_typing_flow_common",
+ "flow_typing_flow_js_env",
+ "flow_typing_generics",
+ "flow_typing_implicit_instantiation_check",
+ "flow_typing_spread_cache",
+ "flow_typing_tvar",
+ "flow_typing_type",
+ "flow_typing_visitors",
+ "flow_utils_concurrency",
+ "flow_utils_union_find",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_flow_js_env"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_typing_errors",
+ "flow_typing_type",
+]
+
+[[package]]
+name = "flow_typing_generics"
+version = "0.0.0"
+dependencies = [
+ "flow_aloc",
+ "flow_common",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_implicit_instantiation_check"
+version = "0.0.0"
+dependencies = [
+ "flow_aloc",
+ "flow_common",
+ "flow_typing_type",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_key"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common",
+ "flow_data_structure_wrapper",
+]
+
+[[package]]
+name = "flow_typing_loc_env"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_lazy",
+ "flow_parser",
+ "flow_parser_utils_output",
+ "flow_typing_type",
+ "flow_utils_concurrency",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_spread_cache"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_typing_errors",
+ "flow_typing_type",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_statement"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_analysis",
+ "flow_common",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_hh_logger",
+ "flow_lazy",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_typing_context",
+ "flow_typing_debug",
+ "flow_typing_default",
+ "flow_typing_errors",
+ "flow_typing_exists_check",
+ "flow_typing_flow_common",
+ "flow_typing_flow_js",
+ "flow_typing_flow_js_env",
+ "flow_typing_generics",
+ "flow_typing_key",
+ "flow_typing_loc_env",
+ "flow_typing_tvar",
+ "flow_typing_type",
+ "flow_typing_utils",
+ "flow_typing_visitors",
+ "flow_utils_concurrency",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_tvar"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common",
+ "flow_typing_context",
+ "flow_typing_type",
+ "flow_utils_concurrency",
+ "flow_utils_union_find",
+]
+
+[[package]]
+name = "flow_typing_ty_normalizer"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_ty",
+ "flow_data_structure_wrapper",
+ "flow_lazy",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_typing_context",
+ "flow_typing_debug",
+ "flow_typing_flow_common",
+ "flow_typing_type",
+ "flow_utils_concurrency",
+]
+
+[[package]]
+name = "flow_typing_type"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_ty",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_lazy",
+ "flow_parser",
+ "flow_typing_generics",
+ "flow_utils_concurrency",
+ "flow_utils_union_find",
+ "serde",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_utils"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_aloc",
+ "flow_analysis",
+ "flow_common",
+ "flow_data_structure_wrapper",
+ "flow_env_builder",
+ "flow_hh_logger",
+ "flow_lazy",
+ "flow_lint_settings",
+ "flow_parser",
+ "flow_type_sig",
+ "flow_typing_builtins",
+ "flow_typing_context",
+ "flow_typing_debug",
+ "flow_typing_errors",
+ "flow_typing_flow_common",
+ "flow_typing_flow_js",
+ "flow_typing_flow_js_env",
+ "flow_typing_generics",
+ "flow_typing_implicit_instantiation_check",
+ "flow_typing_key",
+ "flow_typing_loc_env",
+ "flow_typing_tvar",
+ "flow_typing_type",
+ "flow_typing_visitors",
+ "flow_utils_concurrency",
+ "flow_utils_union_find",
+ "serde_json",
+ "vec1",
+]
+
+[[package]]
+name = "flow_typing_visitors"
+version = "0.0.0"
+dependencies = [
+ "dupe",
+ "flow_common",
+ "flow_common_utils",
+ "flow_data_structure_wrapper",
+ "flow_typing_context",
+ "flow_typing_type",
+]
+
+[[package]]
+name = "flow_utils_concurrency"
+version = "0.0.0"
+dependencies = [
+ "crossbeam",
+ "dupe",
+ "equivalent",
+ "flow_aloc",
+ "flow_common_utils",
+ "hashbrown 0.17.1",
+ "human_bytes",
+ "itertools 0.15.0",
+ "lock_free_hashtable",
+ "nix",
+ "num_cpus",
+ "parking_lot",
+ "rayon",
+ "starlark_map",
+ "tracing",
+]
+
+[[package]]
+name = "flow_utils_tty"
+version = "0.0.0"
+
+[[package]]
+name = "flow_utils_union_find"
+version = "0.0.0"
+dependencies = [
+ "flow_data_structure_wrapper",
 ]
 
 [[package]]
@@ -591,6 +1529,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -617,6 +1561,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +1588,21 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+ "serde",
 ]
 
 [[package]]
@@ -650,9 +1618,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -661,13 +1645,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
+
+[[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "rayon",
  "serde",
@@ -683,7 +1703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -697,6 +1717,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -729,6 +1758,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +1793,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +1818,22 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "lock_free_hashtable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf3631712f5b790675292ff827af269f5d9f920c920b77dc41d0485e3719612"
+dependencies = [
+ "atomic",
+ "parking_lot",
+]
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "logos"
@@ -801,10 +1868,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mimalloc"
@@ -826,12 +1911,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1024,10 +2132,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -1035,7 +2160,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1065,6 +2190,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1206,7 +2351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1290,10 +2435,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "starlark_map"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234877898fd216af93b2f5798b08cbbdc1a2e8f16a622a258b1db23a61a1c4ba"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.16.1",
+ "serde",
+ "strong_hash",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strong_hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0831334aea34390b6b6ec7af0a27f9ee6324ad3a69463e6b240d83d6b7bce9c9"
+dependencies = [
+ "ref-cast",
+ "strong_hash_derive",
+]
+
+[[package]]
+name = "strong_hash_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace6b48b7c4383a39bd3b966cca41bc999003aab9f690a2f355525c924296928"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "strsim"
@@ -1412,10 +2592,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
 name = "triomphe"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
 name = "typenum"
@@ -1477,6 +2695,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "uf_check"
+version = "0.1.0"
+dependencies = [
+ "compact_str",
+ "dupe",
+ "flow_aloc",
+ "flow_common",
+ "flow_common_errors",
+ "flow_flowlib",
+ "flow_lint_settings",
+ "flow_parser",
+ "flow_parser_utils",
+ "flow_parsing",
+ "flow_type_sig",
+ "flow_typing",
+ "flow_typing_context",
+ "flow_typing_errors",
+ "flow_typing_type",
+ "flow_typing_utils",
+ "flow_utils_concurrency",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "uf_cli"
 version = "0.1.0"
 dependencies = [
@@ -1490,6 +2735,7 @@ dependencies = [
  "tempfile",
  "uf_bundle",
  "uf_bundler",
+ "uf_check",
  "uf_config",
  "uf_devserver",
  "uf_effect",
@@ -1914,16 +3160,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vec1"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -2031,10 +3304,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2050,6 +3376,12 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/uf_browser",
   "crates/uf_bundle",
   "crates/uf_bundler",
+  "crates/uf_check",
   "crates/uf_cli",
   "crates/uf_config",
   "crates/uf_devserver",
@@ -60,7 +61,22 @@ camino = { version = "1.2.1", features = ["serde1"] }
 clap = { version = "4.6.4", features = ["derive", "env"] }
 compact_str = { version = "0.10.0", features = ["serde"] }
 criterion = "0.8.2"
+dupe = "0.9.1"
+flow_aloc = { path = "upstream/flow/rust_port/crates/flow_aloc" }
+flow_common = { path = "upstream/flow/rust_port/crates/flow_common" }
+flow_common_errors = { path = "upstream/flow/rust_port/crates/flow_common_errors" }
+flow_flowlib = { path = "upstream/flow/rust_port/crates/flow_flowlib" }
+flow_lint_settings = { path = "upstream/flow/rust_port/crates/flow_lint_settings" }
 flow_parser = { path = "upstream/flow/rust_port/crates/flow_parser" }
+flow_parser_utils = { path = "upstream/flow/rust_port/crates/flow_parser_utils" }
+flow_parsing = { path = "upstream/flow/rust_port/crates/flow_parsing" }
+flow_type_sig = { path = "upstream/flow/rust_port/crates/flow_type_sig" }
+flow_typing = { path = "upstream/flow/rust_port/crates/flow_typing" }
+flow_typing_context = { path = "upstream/flow/rust_port/crates/flow_typing_context" }
+flow_typing_errors = { path = "upstream/flow/rust_port/crates/flow_typing_errors" }
+flow_typing_type = { path = "upstream/flow/rust_port/crates/flow_typing_type" }
+flow_typing_utils = { path = "upstream/flow/rust_port/crates/flow_typing_utils" }
+flow_utils_concurrency = { path = "upstream/flow/rust_port/crates/flow_utils_concurrency" }
 flate2 = { version = "1.1.10", default-features = false, features = ["rust_backend"] }
 flowjs-parser = "0.0.0-alpha.3"
 ignore = "0.4.25"

--- a/crates/uf_check/Cargo.toml
+++ b/crates/uf_check/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+name = "uf_check"
+description = "Flow type inference for uniflowed, driven by Meta's official Flow Rust port."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[features]
+default = []
+# Run Flow's own type inference from the `upstream/flow` submodule.
+#
+# Off by default: the typing crates in the port declare `#![feature(box_patterns)]`,
+# so they build only on a nightly old enough to still accept it. See
+# `docs/architecture.md` for the pinned date and why it is pinned.
+upstream-typecheck = [
+  "dep:dupe",
+  "dep:flow_aloc",
+  "dep:flow_common",
+  "dep:flow_common_errors",
+  "dep:flow_flowlib",
+  "dep:flow_lint_settings",
+  "dep:flow_parser",
+  "dep:flow_parser_utils",
+  "dep:flow_parsing",
+  "dep:flow_type_sig",
+  "dep:flow_typing",
+  "dep:flow_typing_context",
+  "dep:flow_typing_errors",
+  "dep:flow_typing_type",
+  "dep:flow_typing_utils",
+  "dep:flow_utils_concurrency",
+  "dep:serde_json",
+]
+
+[dependencies]
+compact_str.workspace = true
+serde.workspace = true
+smallvec.workspace = true
+thiserror.workspace = true
+
+dupe = { workspace = true, optional = true }
+flow_aloc = { workspace = true, optional = true }
+flow_common = { workspace = true, optional = true }
+flow_common_errors = { workspace = true, optional = true }
+flow_flowlib = { workspace = true, optional = true }
+flow_lint_settings = { workspace = true, optional = true }
+flow_parser = { workspace = true, optional = true }
+flow_parser_utils = { workspace = true, optional = true }
+flow_parsing = { workspace = true, optional = true }
+flow_type_sig = { workspace = true, optional = true }
+flow_typing = { workspace = true, optional = true }
+flow_typing_context = { workspace = true, optional = true }
+flow_typing_errors = { workspace = true, optional = true }
+flow_typing_type = { workspace = true, optional = true }
+flow_typing_utils = { workspace = true, optional = true }
+flow_utils_concurrency = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/uf_check/src/diagnostic.rs
+++ b/crates/uf_check/src/diagnostic.rs
@@ -1,0 +1,247 @@
+//! The typed shape of a Flow type error.
+//!
+//! Flow does not produce strings. It produces a severity, an error code, a
+//! primary location, an optional root location, a message built from labelled
+//! inline fragments, and a set of referenced locations that the fragments point
+//! at. Flattening that into one line throws away everything an editor, an LSP
+//! server, or a code-frame renderer needs, so nothing here is a rendered
+//! string: [`TypeDiagnostic::message`] keeps the fragments and
+//! [`TypeDiagnostic::related`] keeps the locations they refer to.
+
+use compact_str::CompactString;
+use serde::Serialize;
+use smallvec::SmallVec;
+
+/// Message fragments held inline before spilling to the heap.
+///
+/// Flow's own messages are short; six covers the common
+/// "Cannot assign _ to _ because _ is incompatible with _" shape.
+pub type MessageFeatures = SmallVec<[MessageSegment; 6]>;
+
+/// Related locations held inline before spilling to the heap.
+pub type RelatedLocations = SmallVec<[RelatedLocation; 2]>;
+
+/// Whether a diagnostic fails the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Severity {
+    /// The run fails.
+    Error,
+    /// The run continues.
+    Warning,
+}
+
+impl Severity {
+    /// The stable identifier used in JSON output.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+/// Which stage of Flow produced a diagnostic.
+///
+/// Flow distinguishes these because they are suppressed, sorted, and rendered
+/// differently; collapsing them into "error" loses the distinction between a
+/// checker bug ([`Self::Internal`]), a guard firing
+/// ([`Self::RecursionLimit`]), and a real type error ([`Self::Infer`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticKind {
+    /// The parser rejected the source, or the checker reported as if it had.
+    Parse,
+    /// Type inference found a real error.
+    Infer,
+    /// A lint rule fired inside the checker.
+    Lint,
+    /// The checker hit an internal invariant.
+    Internal,
+    /// Two files claim to provide the same module.
+    DuplicateProvider,
+    /// Inference gave up at [`crate::CheckLimits::recursion_limit`].
+    RecursionLimit,
+}
+
+impl DiagnosticKind {
+    /// The stable identifier used in JSON output.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Parse => "parse",
+            Self::Infer => "infer",
+            Self::Lint => "lint",
+            Self::Internal => "internal",
+            Self::DuplicateProvider => "duplicate-provider",
+            Self::RecursionLimit => "recursion-limit",
+        }
+    }
+}
+
+/// One point in a source file.
+///
+/// Both fields are one-based, matching every other diagnostic surface in `uf`,
+/// and `column` counts **bytes** rather than characters — which is what the
+/// code-frame renderer expects, and what Flow's parser produces before its JSON
+/// layer converts to codepoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct Position {
+    /// One-based line.
+    pub line: u32,
+    /// One-based column, in bytes.
+    pub column: u32,
+}
+
+impl Position {
+    /// A position at the very start of a file.
+    pub const START: Self = Self { line: 1, column: 1 };
+}
+
+/// A half-open range in one source file.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Span {
+    /// The file the range belongs to, as Flow reported it. Library definitions
+    /// baked into the checker report their own synthetic names.
+    pub path: CompactString,
+    /// Inclusive start.
+    pub start: Position,
+    /// Exclusive end.
+    pub end: Position,
+}
+
+impl Span {
+    /// The byte length of the range when it stays on one line.
+    ///
+    /// A caret span is only meaningful within a single rendered line, so a
+    /// multi-line range reports the remainder of its first line as unknown and
+    /// yields [`None`].
+    pub fn single_line_len(&self) -> Option<usize> {
+        (self.start.line == self.end.line)
+            .then(|| self.end.column.saturating_sub(self.start.column).max(1) as usize)
+    }
+}
+
+/// One fragment of a Flow error message.
+///
+/// Flow's messages interleave prose, quoted code, and references to other
+/// locations. Keeping the three apart is what lets a renderer highlight code
+/// and hyperlink references instead of printing one grey sentence.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum MessageSegment {
+    /// Prose.
+    Text {
+        /// The prose itself.
+        text: CompactString,
+    },
+    /// A quoted type, name, or expression.
+    Code {
+        /// The quoted source text.
+        text: CompactString,
+    },
+    /// A pointer at one of [`TypeDiagnostic::related`].
+    Reference {
+        /// The text Flow renders for the reference.
+        text: CompactString,
+        /// Matches [`RelatedLocation::id`].
+        id: u32,
+    },
+}
+
+impl MessageSegment {
+    /// The text this segment contributes to a one-line rendering.
+    pub fn text(&self) -> &str {
+        match self {
+            Self::Text { text } | Self::Code { text } | Self::Reference { text, .. } => text,
+        }
+    }
+}
+
+/// A location one of the message's references points at.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedLocation {
+    /// The reference number Flow used in the message, starting at one.
+    pub id: u32,
+    /// Where the reference points.
+    pub span: Span,
+}
+
+/// One diagnostic from Flow's own type inference.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeDiagnostic {
+    /// Whether the diagnostic fails the run.
+    pub severity: Severity,
+    /// Which stage produced it.
+    pub kind: DiagnosticKind,
+    /// Flow's own error code, such as `incompatible-type` or `prop-missing`.
+    ///
+    /// Borrowed from upstream's table rather than mirrored into a `uf` enum:
+    /// the codes are Flow's public contract, they gain members every release,
+    /// and a copy here would silently drift. [`None`] is Flow reporting an
+    /// error it has not given a code to.
+    pub code: Option<&'static str>,
+    /// Where to put the caret.
+    pub primary: Span,
+    /// The wider range Flow associates with the error, when it has one. Always
+    /// contains [`Self::primary`].
+    pub root: Option<Span>,
+    /// The message, in fragments.
+    pub message: MessageFeatures,
+    /// Every location [`MessageSegment::Reference`] fragments point at.
+    pub related: RelatedLocations,
+}
+
+impl TypeDiagnostic {
+    /// Render the message as one line.
+    ///
+    /// Reference fragments carry a trailing `[n]` marker so a reader can match
+    /// them to [`Self::related`], which is how Flow's own CLI renders them.
+    pub fn message_text(&self) -> String {
+        let mut out = String::with_capacity(
+            self.message
+                .iter()
+                .map(|segment| segment.text().len() + 4)
+                .sum(),
+        );
+        for segment in &self.message {
+            out.push_str(segment.text());
+            if let MessageSegment::Reference { id, .. } = segment {
+                out.push_str(" [");
+                // Reference ids are small; formatting through `Display` here
+                // would allocate a second buffer per fragment.
+                push_u32(&mut out, *id);
+                out.push(']');
+            }
+        }
+        out
+    }
+
+    /// Whether this diagnostic fails the run.
+    pub const fn is_error(&self) -> bool {
+        matches!(self.severity, Severity::Error)
+    }
+}
+
+/// Append a decimal `u32` without going through `format!`.
+fn push_u32(out: &mut String, mut value: u32) {
+    if value == 0 {
+        out.push('0');
+        return;
+    }
+    let mut digits = [0u8; 10];
+    let mut len = 0;
+    while value > 0 {
+        digits[len] = b'0' + (value % 10) as u8;
+        value /= 10;
+        len += 1;
+    }
+    for index in (0..len).rev() {
+        out.push(digits[index] as char);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_check/src/diagnostic/tests.rs
+++ b/crates/uf_check/src/diagnostic/tests.rs
@@ -1,0 +1,215 @@
+use compact_str::CompactString;
+use smallvec::smallvec;
+
+use super::*;
+
+fn span(start: (u32, u32), end: (u32, u32)) -> Span {
+    Span {
+        path: CompactString::const_new("app.js"),
+        start: Position {
+            line: start.0,
+            column: start.1,
+        },
+        end: Position {
+            line: end.0,
+            column: end.1,
+        },
+    }
+}
+
+fn diagnostic(message: MessageFeatures, related: RelatedLocations) -> TypeDiagnostic {
+    TypeDiagnostic {
+        severity: Severity::Error,
+        kind: DiagnosticKind::Infer,
+        code: Some("incompatible-type"),
+        primary: span((2, 19), (2, 33)),
+        root: None,
+        message,
+        related,
+    }
+}
+
+#[test]
+fn severity_ids_are_stable() {
+    assert_eq!(Severity::Error.as_str(), "error");
+    assert_eq!(Severity::Warning.as_str(), "warning");
+}
+
+#[test]
+fn diagnostic_kind_ids_are_stable() {
+    assert_eq!(DiagnosticKind::Parse.as_str(), "parse");
+    assert_eq!(DiagnosticKind::Infer.as_str(), "infer");
+    assert_eq!(DiagnosticKind::Lint.as_str(), "lint");
+    assert_eq!(DiagnosticKind::Internal.as_str(), "internal");
+    assert_eq!(
+        DiagnosticKind::DuplicateProvider.as_str(),
+        "duplicate-provider"
+    );
+    assert_eq!(DiagnosticKind::RecursionLimit.as_str(), "recursion-limit");
+}
+
+#[test]
+fn a_span_on_one_line_reports_its_byte_length() {
+    assert_eq!(span((2, 19), (2, 33)).single_line_len(), Some(14));
+}
+
+#[test]
+fn an_empty_span_still_covers_one_column() {
+    assert_eq!(span((2, 19), (2, 19)).single_line_len(), Some(1));
+}
+
+#[test]
+fn a_multi_line_span_has_no_single_line_length() {
+    assert_eq!(span((2, 19), (5, 3)).single_line_len(), None);
+}
+
+#[test]
+fn a_reversed_span_does_not_underflow() {
+    assert_eq!(span((2, 33), (2, 19)).single_line_len(), Some(1));
+}
+
+#[test]
+fn message_segments_expose_their_text() {
+    assert_eq!(
+        MessageSegment::Text {
+            text: CompactString::const_new("Cannot assign ")
+        }
+        .text(),
+        "Cannot assign "
+    );
+    assert_eq!(
+        MessageSegment::Code {
+            text: CompactString::const_new("string")
+        }
+        .text(),
+        "string"
+    );
+    assert_eq!(
+        MessageSegment::Reference {
+            text: CompactString::const_new("number"),
+            id: 1
+        }
+        .text(),
+        "number"
+    );
+}
+
+#[test]
+fn rendering_a_message_marks_each_reference() {
+    let diagnostic = diagnostic(
+        smallvec![
+            MessageSegment::Text {
+                text: CompactString::const_new("Cannot assign "),
+            },
+            MessageSegment::Code {
+                text: CompactString::const_new("\"x\""),
+            },
+            MessageSegment::Text {
+                text: CompactString::const_new(" to "),
+            },
+            MessageSegment::Reference {
+                text: CompactString::const_new("number"),
+                id: 1,
+            },
+        ],
+        RelatedLocations::new(),
+    );
+
+    assert_eq!(
+        diagnostic.message_text(),
+        "Cannot assign \"x\" to number [1]"
+    );
+}
+
+#[test]
+fn rendering_an_empty_message_yields_an_empty_string() {
+    assert_eq!(
+        diagnostic(MessageFeatures::new(), RelatedLocations::new()).message_text(),
+        ""
+    );
+}
+
+#[test]
+fn rendering_handles_multi_digit_and_zero_reference_ids() {
+    let diagnostic = diagnostic(
+        smallvec![
+            MessageSegment::Reference {
+                text: CompactString::const_new("a"),
+                id: 0,
+            },
+            MessageSegment::Reference {
+                text: CompactString::const_new("b"),
+                id: 1234,
+            },
+        ],
+        RelatedLocations::new(),
+    );
+
+    assert_eq!(diagnostic.message_text(), "a [0]b [1234]");
+}
+
+#[test]
+fn rendering_a_message_is_idempotent() {
+    let diagnostic = diagnostic(
+        smallvec![MessageSegment::Text {
+            text: CompactString::const_new("boom"),
+        }],
+        RelatedLocations::new(),
+    );
+
+    assert_eq!(diagnostic.message_text(), diagnostic.message_text());
+}
+
+#[test]
+fn rendering_keeps_non_ascii_message_text_intact() {
+    let diagnostic = diagnostic(
+        smallvec![MessageSegment::Code {
+            text: CompactString::const_new("\"日本語\""),
+        }],
+        RelatedLocations::new(),
+    );
+
+    assert_eq!(diagnostic.message_text(), "\"日本語\"");
+}
+
+#[test]
+fn only_errors_fail_the_run() {
+    let mut diagnostic = diagnostic(MessageFeatures::new(), RelatedLocations::new());
+    assert!(diagnostic.is_error());
+
+    diagnostic.severity = Severity::Warning;
+    assert!(!diagnostic.is_error());
+}
+
+#[test]
+fn diagnostics_serialize_with_camel_case_keys_and_kebab_case_enums() {
+    let diagnostic = diagnostic(
+        smallvec![MessageSegment::Reference {
+            text: CompactString::const_new("number"),
+            id: 1,
+        }],
+        smallvec![RelatedLocation {
+            id: 1,
+            span: span((3, 1), (3, 7)),
+        }],
+    );
+
+    let json = serde_json::to_value(&diagnostic).expect("serializes");
+
+    assert_eq!(json["severity"], serde_json::json!("error"));
+    assert_eq!(json["kind"], serde_json::json!("infer"));
+    assert_eq!(json["code"], serde_json::json!("incompatible-type"));
+    assert_eq!(json["primary"]["start"]["line"], serde_json::json!(2));
+    assert_eq!(json["message"][0]["kind"], serde_json::json!("reference"));
+    assert_eq!(json["related"][0]["id"], serde_json::json!(1));
+}
+
+#[test]
+fn diagnostics_order_by_severity_then_kind() {
+    let mut error = diagnostic(MessageFeatures::new(), RelatedLocations::new());
+    let mut warning = error.clone();
+    warning.severity = Severity::Warning;
+    error.kind = DiagnosticKind::Infer;
+
+    assert!(error < warning);
+}

--- a/crates/uf_check/src/error.rs
+++ b/crates/uf_check/src/error.rs
@@ -1,0 +1,74 @@
+//! Failures of the checker itself, as opposed to type errors in the source.
+//!
+//! A type error is a [`crate::TypeDiagnostic`]. Everything in this module means
+//! the check did not run to completion, which is a different thing and gets a
+//! different exit path.
+
+use compact_str::CompactString;
+use thiserror::Error;
+
+/// A checker failure.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CheckError {
+    /// The build has no type checker compiled in.
+    #[error(
+        "Flow type inference is not compiled into this build; rebuild uf_check with the \
+         `upstream-typecheck` feature"
+    )]
+    Unavailable,
+    /// The source is larger than [`crate::CheckLimits::max_source_bytes`].
+    ///
+    /// Inference allocates per AST node, so an unbounded file is an unbounded
+    /// allocation. The limit is checked before the parser is handed the text.
+    #[error("{path} is {size} bytes, over the {limit}-byte type-check limit")]
+    SourceTooLarge {
+        /// The file that was rejected.
+        path: CompactString,
+        /// Its size in bytes.
+        size: usize,
+        /// The configured limit.
+        limit: usize,
+    },
+    /// Inference ran out of its wall-clock budget.
+    #[error("type inference for {path} exceeded its {limit_ms}ms budget")]
+    Budget {
+        /// The file being checked.
+        path: CompactString,
+        /// The configured budget.
+        limit_ms: u64,
+    },
+    /// Inference was asked to stop.
+    #[error("type inference for {path} was cancelled")]
+    Cancelled {
+        /// The file being checked.
+        path: CompactString,
+    },
+    /// The builtin library definitions did not merge.
+    ///
+    /// This means the vendored `upstream/flow` submodule and the checker
+    /// disagree, not that anything is wrong with the user's code.
+    #[error("Flow's builtin library definitions failed to load: {detail}")]
+    Builtins {
+        /// What upstream reported.
+        detail: CompactString,
+    },
+    /// The worker thread the check runs on could not be started or died.
+    #[error("the type-check worker failed for {path}: {detail}")]
+    Worker {
+        /// The file being checked.
+        path: CompactString,
+        /// What went wrong.
+        detail: CompactString,
+    },
+}
+
+impl CheckError {
+    /// Whether the failure is the absence of a compiled-in checker rather than
+    /// something going wrong.
+    ///
+    /// Callers use this to stay quiet on a default build instead of reporting a
+    /// failure the user cannot act on.
+    pub const fn is_unavailable(&self) -> bool {
+        matches!(self, Self::Unavailable)
+    }
+}

--- a/crates/uf_check/src/lib.rs
+++ b/crates/uf_check/src/lib.rs
@@ -1,0 +1,129 @@
+//! Flow type inference for `uf`.
+//!
+//! `uf lint` answers "is this file well-formed and idiomatic". This crate
+//! answers the other half — "do the types hold" — by running Flow's own
+//! inference from the `upstream/flow` submodule rather than approximating it.
+//! Nothing here reimplements a typing rule; the crate is an embedding.
+//!
+//! # Why this is a crate and not a feature on `uf_flow`
+//!
+//! `uf_flow` is the parser adapter, and `uf_lint` depends on it, so anything
+//! added there lands in every crate that lints. Inference needs sixteen path
+//! dependencies on the submodule and a nightly old enough to still accept
+//! `#![feature(box_patterns)]`; hanging that off `uf_flow` would put the whole
+//! lint graph behind those constraints, and Cargo resolves path dependencies
+//! even for features that are off. Keeping it here means exactly one crate —
+//! and, through it, `uf_cli` — knows about the typing crates.
+//!
+//! # Availability
+//!
+//! The checker is compiled in only with the `upstream-typecheck` feature. With
+//! it off every entry point returns [`CheckError::Unavailable`], which
+//! [`CheckError::is_unavailable`] distinguishes from a real failure.
+//!
+//! ```
+//! # use uf_check::{CheckLimits, Source, check_sources};
+//! let sources = [Source::new("app.js", "// @flow\nconst n: number = 1;\n")];
+//! match check_sources(&sources, &CheckLimits::default()) {
+//!     Ok(report) => assert_eq!(report.files_checked, 1),
+//!     Err(error) => assert!(error.is_unavailable()),
+//! }
+//! ```
+
+#![deny(missing_docs)]
+
+mod diagnostic;
+mod error;
+mod limits;
+mod report;
+#[cfg(feature = "upstream-typecheck")]
+mod upstream;
+
+pub use crate::diagnostic::{
+    DiagnosticKind, MessageFeatures, MessageSegment, Position, RelatedLocation, RelatedLocations,
+    Severity, Span, TypeDiagnostic,
+};
+pub use crate::error::CheckError;
+pub use crate::limits::{CHECK_STACK_BYTES, CheckLimits};
+pub use crate::report::{BuiltinsTiming, CheckReport, Source};
+
+/// Which type checker a build compiled in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckerBackend {
+    /// Meta's official Flow Rust port, from `upstream/flow/rust_port`.
+    UpstreamRustPort,
+    /// No checker: every entry point reports [`CheckError::Unavailable`].
+    Unavailable,
+}
+
+/// The checker compiled into this build.
+pub const fn active_backend() -> CheckerBackend {
+    #[cfg(feature = "upstream-typecheck")]
+    {
+        CheckerBackend::UpstreamRustPort
+    }
+    #[cfg(not(feature = "upstream-typecheck"))]
+    {
+        CheckerBackend::Unavailable
+    }
+}
+
+/// Whether this build can type check.
+pub const fn is_available() -> bool {
+    matches!(active_backend(), CheckerBackend::UpstreamRustPort)
+}
+
+/// A stable identifier for a backend, for `uf inspect` and the LSP.
+pub const fn backend_name(backend: CheckerBackend) -> &'static str {
+    match backend {
+        CheckerBackend::UpstreamRustPort => "upstream-flow-rust-port",
+        CheckerBackend::Unavailable => "unavailable",
+    }
+}
+
+/// Merge Flow's builtin library definitions, or report that they are already
+/// merged.
+///
+/// Calling this before a batch moves the one-time cost somewhere a caller can
+/// account for it — a progress line, a benchmark — instead of hiding it inside
+/// the first file's timing.
+pub fn prepare_builtins() -> Result<BuiltinsTiming, CheckError> {
+    #[cfg(feature = "upstream-typecheck")]
+    {
+        upstream::prepare_builtins()
+    }
+    #[cfg(not(feature = "upstream-typecheck"))]
+    {
+        Err(CheckError::Unavailable)
+    }
+}
+
+/// Type check one source file.
+pub fn check_source(
+    source: Source<'_>,
+    limits: &CheckLimits,
+) -> Result<Vec<TypeDiagnostic>, CheckError> {
+    check_sources(std::slice::from_ref(&source), limits).map(|report| report.diagnostics)
+}
+
+/// Type check a batch of files against one shared builtin environment.
+///
+/// Files are checked in the order given and diagnostics come back in that
+/// order, so the result is a function of the input alone.
+pub fn check_sources(
+    sources: &[Source<'_>],
+    limits: &CheckLimits,
+) -> Result<CheckReport, CheckError> {
+    #[cfg(feature = "upstream-typecheck")]
+    {
+        upstream::check_sources(sources, limits)
+    }
+    #[cfg(not(feature = "upstream-typecheck"))]
+    {
+        let _ = (sources, limits);
+        Err(CheckError::Unavailable)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_check/src/limits.rs
+++ b/crates/uf_check/src/limits.rs
@@ -1,0 +1,125 @@
+//! What the checker refuses to do.
+//!
+//! Type inference is a fixed-point computation over a graph the user controls,
+//! so every input is a potential denial of service: a deeply nested generic
+//! recurses, a type that expands into itself diverges, and a file large enough
+//! makes the AST alone exhaust memory. Flow already carries the two knobs that
+//! matter — `Options::recursion_limit` and `CheckBudget` — and this type is how
+//! `uf` sets them, plus the one guard Flow has no opinion on: how much text it
+//! is willing to be handed in the first place.
+
+use std::time::Duration;
+
+/// The stack the checker runs on, in bytes.
+///
+/// Both the parser and inference are recursive descent over user-controlled
+/// nesting, so they need far more than a default 2 MiB thread. Giving the
+/// worker a large stack turns "deeply nested input aborts the process" into
+/// "deeply nested input hits `recursion_limit` and reports a diagnostic",
+/// which is the difference between a crash and an error message.
+pub const CHECK_STACK_BYTES: usize = 1024 * 1024 * 1024;
+
+/// A default Rust worker gets 2 MiB. Ten thousand nested generics need three
+/// orders of magnitude more than that in an unoptimized build, so shrinking
+/// this back toward the default would turn a hostile file into an abort.
+const _: () = assert!(CHECK_STACK_BYTES >= 512 * 1024 * 1024);
+
+/// The bounds one type check runs under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckLimits {
+    /// The largest source the checker accepts, in bytes.
+    ///
+    /// Past this the file is rejected with [`crate::CheckError::SourceTooLarge`]
+    /// before a parser sees it.
+    pub max_source_bytes: usize,
+    /// Flow's own limit on how deep inference may recurse.
+    ///
+    /// Reaching it produces a [`crate::DiagnosticKind::RecursionLimit`]
+    /// diagnostic; it does not abort the check.
+    pub recursion_limit: u32,
+    /// How far a type is expanded before Flow stops unfolding it.
+    pub type_expansion_recursion_limit: u32,
+    /// Wall-clock budget for one file, or [`None`] for no budget.
+    ///
+    /// Exhausting it fails with [`crate::CheckError::Budget`].
+    pub file_timeout: Option<Duration>,
+}
+
+impl CheckLimits {
+    /// 4 MiB: comfortably past any hand-written module, and an order of
+    /// magnitude below the point where the AST alone becomes a memory problem.
+    pub const DEFAULT_MAX_SOURCE_BYTES: usize = 4 * 1024 * 1024;
+    /// Flow's own default, and what `flow_dot_js` runs with.
+    pub const DEFAULT_RECURSION_LIMIT: u32 = 10_000;
+    /// Flow's own default.
+    pub const DEFAULT_TYPE_EXPANSION_RECURSION_LIMIT: u32 = 3;
+    /// Long enough that no honest file reaches it, short enough that a
+    /// pathological one does not wedge a build.
+    pub const DEFAULT_FILE_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Limits with no wall-clock budget, for tests that must be deterministic
+    /// on a loaded machine.
+    pub const fn without_timeout(mut self) -> Self {
+        self.file_timeout = None;
+        self
+    }
+
+    /// Replace the source size limit.
+    pub const fn with_max_source_bytes(mut self, bytes: usize) -> Self {
+        self.max_source_bytes = bytes;
+        self
+    }
+
+    /// Replace the wall-clock budget.
+    pub const fn with_file_timeout(mut self, timeout: Duration) -> Self {
+        self.file_timeout = Some(timeout);
+        self
+    }
+}
+
+impl Default for CheckLimits {
+    fn default() -> Self {
+        Self {
+            max_source_bytes: Self::DEFAULT_MAX_SOURCE_BYTES,
+            recursion_limit: Self::DEFAULT_RECURSION_LIMIT,
+            type_expansion_recursion_limit: Self::DEFAULT_TYPE_EXPANSION_RECURSION_LIMIT,
+            file_timeout: Some(Self::DEFAULT_FILE_TIMEOUT),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_limits_reject_a_five_megabyte_file() {
+        assert!(CheckLimits::default().max_source_bytes < 5_000_000);
+    }
+
+    #[test]
+    fn default_limits_accept_a_large_hand_written_module() {
+        assert!(CheckLimits::default().max_source_bytes >= 1_000_000);
+    }
+
+    #[test]
+    fn dropping_the_timeout_keeps_every_other_limit() {
+        let limits = CheckLimits::default();
+
+        let without = limits.without_timeout();
+
+        assert_eq!(without.file_timeout, None);
+        assert_eq!(without.max_source_bytes, limits.max_source_bytes);
+        assert_eq!(without.recursion_limit, limits.recursion_limit);
+    }
+
+    #[test]
+    fn limits_are_overridable_one_at_a_time() {
+        let limits = CheckLimits::default()
+            .with_max_source_bytes(64)
+            .with_file_timeout(Duration::from_millis(5));
+
+        assert_eq!(limits.max_source_bytes, 64);
+        assert_eq!(limits.file_timeout, Some(Duration::from_millis(5)));
+    }
+}

--- a/crates/uf_check/src/report.rs
+++ b/crates/uf_check/src/report.rs
@@ -1,0 +1,90 @@
+//! What goes into a type check, and what comes out of one.
+
+use std::time::Duration;
+
+use compact_str::CompactString;
+
+use crate::diagnostic::{Severity, TypeDiagnostic};
+
+/// One file to check.
+///
+/// `path` is what diagnostics are reported under, so it should be the path the
+/// user recognises — project-relative, in `uf`'s case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Source<'a> {
+    /// The path diagnostics are reported under.
+    pub path: &'a str,
+    /// The file's text.
+    pub source: &'a str,
+}
+
+impl<'a> Source<'a> {
+    /// A source with a path and text.
+    pub const fn new(path: &'a str, source: &'a str) -> Self {
+        Self { path, source }
+    }
+}
+
+/// What one call to [`crate::prepare_builtins`] cost.
+///
+/// The builtin environment is merged once per process and shared, so the first
+/// call pays for it and every later call pays nothing. Both numbers are worth
+/// reporting: the cold cost is the floor on a one-shot `uf check`, and the warm
+/// cost is what a watch mode or an editor session actually sees.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltinsTiming {
+    /// How long this call took.
+    pub elapsed: Duration,
+    /// How long the one-time merge took, whenever in the process it happened.
+    pub cold_elapsed: Duration,
+    /// Whether this call is the one that did the merge.
+    pub cold: bool,
+}
+
+/// The result of checking a batch of files.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckReport {
+    /// Every diagnostic, errors before warnings and ordered within each.
+    pub diagnostics: Vec<TypeDiagnostic>,
+    /// How many files were checked.
+    pub files_checked: usize,
+    /// Module specifiers that resolved to nothing typed, sorted and de-duped.
+    ///
+    /// Every file is checked against Flow's standard library, but not yet
+    /// against the other files in the project: `uf` does not run Flow's merge
+    /// service, so an import of a project module has no signature to check
+    /// against. Flow's answer to a dependency it cannot type is to type the
+    /// import as `any` and carry on, which is what happens here — and this list
+    /// is how a caller says so out loud instead of letting the hole be silent.
+    pub untyped_modules: Vec<CompactString>,
+    /// What the shared builtin environment cost.
+    pub builtins: BuiltinsTiming,
+    /// Wall time spent in inference, excluding the builtin merge.
+    pub elapsed: Duration,
+}
+
+impl CheckReport {
+    /// How many diagnostics have the given severity.
+    pub fn count(&self, severity: Severity) -> usize {
+        self.diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == severity)
+            .count()
+    }
+
+    /// Whether the run should fail.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.is_error())
+    }
+
+    /// Files checked per second, or [`None`] when no measurable time passed.
+    ///
+    /// Reported rather than logged so a benchmark and the CLI agree on what
+    /// throughput means here: inference only, with the builtins already warm.
+    pub fn files_per_second(&self) -> Option<f64> {
+        let seconds = self.elapsed.as_secs_f64();
+        (seconds > 0.0).then(|| self.files_checked as f64 / seconds)
+    }
+}

--- a/crates/uf_check/src/tests.rs
+++ b/crates/uf_check/src/tests.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+const CLEAN: &str = "// @flow\nconst n: number = 1;\n";
+
+#[test]
+fn backend_names_are_stable() {
+    assert_eq!(
+        backend_name(CheckerBackend::UpstreamRustPort),
+        "upstream-flow-rust-port"
+    );
+    assert_eq!(backend_name(CheckerBackend::Unavailable), "unavailable");
+}
+
+#[test]
+fn availability_matches_the_compiled_in_backend() {
+    if is_available() {
+        assert_eq!(active_backend(), CheckerBackend::UpstreamRustPort);
+    } else {
+        assert_eq!(active_backend(), CheckerBackend::Unavailable);
+    }
+}
+
+#[test]
+fn a_build_without_a_checker_says_so_instead_of_failing_opaquely() {
+    if is_available() {
+        return;
+    }
+
+    let error = check_source(Source::new("app.js", CLEAN), &CheckLimits::default())
+        .expect_err("no checker is compiled in");
+
+    assert!(error.is_unavailable());
+    assert_eq!(error, CheckError::Unavailable);
+}
+
+#[test]
+fn only_the_unavailable_error_reports_itself_as_unavailable() {
+    assert!(CheckError::Unavailable.is_unavailable());
+    assert!(
+        !CheckError::SourceTooLarge {
+            path: "app.js".into(),
+            size: 8,
+            limit: 4,
+        }
+        .is_unavailable()
+    );
+}
+
+#[test]
+fn errors_name_the_file_and_the_limit_they_broke() {
+    let error = CheckError::SourceTooLarge {
+        path: "src/app.js".into(),
+        size: 5_000_000,
+        limit: 4_194_304,
+    };
+
+    let rendered = error.to_string();
+
+    assert!(rendered.contains("src/app.js"), "{rendered}");
+    assert!(rendered.contains("5000000"), "{rendered}");
+    assert!(rendered.contains("4194304"), "{rendered}");
+}
+
+#[test]
+fn a_source_keeps_the_path_diagnostics_are_reported_under() {
+    let source = Source::new("src/app.js", CLEAN);
+
+    assert_eq!(source.path, "src/app.js");
+    assert_eq!(source.source, CLEAN);
+}
+
+#[test]
+fn an_empty_batch_is_not_an_error() {
+    match check_sources(&[], &CheckLimits::default()) {
+        Ok(report) => {
+            assert_eq!(report.files_checked, 0);
+            assert!(report.diagnostics.is_empty());
+            assert!(!report.has_errors());
+        }
+        Err(error) => assert!(error.is_unavailable()),
+    }
+}
+
+#[test]
+fn a_report_counts_by_severity() {
+    let report = CheckReport {
+        diagnostics: Vec::new(),
+        files_checked: 3,
+        untyped_modules: Vec::new(),
+        builtins: BuiltinsTiming {
+            elapsed: std::time::Duration::ZERO,
+            cold_elapsed: std::time::Duration::ZERO,
+            cold: false,
+        },
+        elapsed: std::time::Duration::from_millis(10),
+    };
+
+    assert_eq!(report.count(Severity::Error), 0);
+    assert_eq!(report.count(Severity::Warning), 0);
+    assert!(!report.has_errors());
+    assert_eq!(report.files_per_second(), Some(300.0));
+}
+
+#[test]
+fn throughput_is_unknown_when_no_time_passed() {
+    let report = CheckReport {
+        diagnostics: Vec::new(),
+        files_checked: 1,
+        untyped_modules: Vec::new(),
+        builtins: BuiltinsTiming {
+            elapsed: std::time::Duration::ZERO,
+            cold_elapsed: std::time::Duration::ZERO,
+            cold: true,
+        },
+        elapsed: std::time::Duration::ZERO,
+    };
+
+    assert_eq!(report.files_per_second(), None);
+}

--- a/crates/uf_check/src/upstream/builtins.rs
+++ b/crates/uf_check/src/upstream/builtins.rs
@@ -1,0 +1,123 @@
+//! The shared builtin environment.
+//!
+//! Merging Flow's library definitions — the global type environment, plus the
+//! `declare module` blocks for `react` and friends — costs tens of
+//! milliseconds and produces a value that never changes. Doing it per file
+//! would dominate the cost of checking a project, so it happens once per
+//! process and every check borrows the result.
+
+use std::sync::Arc;
+use std::sync::Once;
+use std::sync::OnceLock;
+use std::time::Duration;
+use std::time::Instant;
+
+use compact_str::{CompactString, ToCompactString};
+use dupe::Dupe;
+use flow_common::type_strictness::TypeStrictnessKind;
+use flow_parser::file_key::{FileKey, FileKeyInner};
+use flow_typing::merge;
+use flow_typing_context::MasterContext;
+
+use super::VIRTUAL_ROOT;
+use super::options::{builtin_sig_options, options};
+use super::parse::parse_file;
+use crate::{BuiltinsTiming, CheckError, CheckLimits};
+
+/// The merged builtins and what they cost to build.
+struct Builtins {
+    master_cx: Arc<MasterContext>,
+    cold_elapsed: Duration,
+}
+
+/// Sharing the merged builtins across threads is the entire point of caching
+/// them, so make the requirement a compile error here rather than a confusing
+/// one at the `OnceLock`.
+const _: () = {
+    const fn assert_shareable<T: Send + Sync>() {}
+    assert_shareable::<MasterContext>();
+};
+
+static BUILTINS: OnceLock<Result<Builtins, CompactString>> = OnceLock::new();
+static ROOTS: Once = Once::new();
+
+/// Install the two process-global roots the port reads through statics.
+///
+/// `FileKey::to_absolute` panics on first use when these are unset rather than
+/// defaulting, which is defensible for a long-lived server and a trap for an
+/// embedder. Both are set to [`VIRTUAL_ROOT`], which the error renderer strips
+/// back off; see that constant for why it is not the real project root.
+pub(super) fn ensure_roots() {
+    ROOTS.call_once(|| {
+        flow_parser::file_key::set_project_root(VIRTUAL_ROOT);
+        flow_parser::file_key::set_flowlib_root(VIRTUAL_ROOT);
+    });
+}
+
+/// Build the builtins, or return the shared ones.
+pub(crate) fn prepare() -> Result<BuiltinsTiming, CheckError> {
+    let started = Instant::now();
+    let mut cold = false;
+    let cached = BUILTINS.get_or_init(|| {
+        cold = true;
+        build()
+    });
+    let elapsed = started.elapsed();
+
+    match cached {
+        Ok(builtins) => Ok(BuiltinsTiming {
+            elapsed,
+            cold_elapsed: builtins.cold_elapsed,
+            cold,
+        }),
+        Err(detail) => Err(CheckError::Builtins {
+            detail: detail.clone(),
+        }),
+    }
+}
+
+/// The shared master context, building it on first use.
+pub(super) fn master_context() -> Result<Arc<MasterContext>, CheckError> {
+    match BUILTINS.get_or_init(build) {
+        Ok(builtins) => Ok(builtins.master_cx.dupe()),
+        Err(detail) => Err(CheckError::Builtins {
+            detail: detail.clone(),
+        }),
+    }
+}
+
+/// Parse and merge every library definition baked into the port.
+fn build() -> Result<Builtins, CompactString> {
+    ensure_roots();
+    let started = Instant::now();
+    // Library definitions are merged in reverse declaration order: later
+    // definitions shadow earlier ones, and `merge_lib_files` folds from the
+    // front. This mirrors `flow_dot_js_wasm`.
+    let contents = flow_flowlib::contents_list(false);
+    let options = options(&CheckLimits::default());
+    let mut asts = Vec::with_capacity(contents.len());
+    for (name, content) in contents.into_iter().rev() {
+        let file_key = FileKey::new(FileKeyInner::LibFile(name.to_string()));
+        let parsed = parse_file(file_key, content, &options, true);
+        if let Some((loc, error)) = parsed.parse_errors.first() {
+            return Err(format!(
+                "{name}:{}:{}: {error}",
+                loc.start.line,
+                loc.start.column + 1
+            )
+            .to_compact_string());
+        }
+        asts.push((TypeStrictnessKind::from_is_typescript(false), parsed.ast));
+    }
+
+    // The merge's own error set describes problems inside Flow's library
+    // definitions, which are vendored and fixed. `flow_dot_js_wasm` discards it
+    // for the same reason: there is nothing a user of this crate could do.
+    let (_lib_errors, master_cx) =
+        merge::merge_lib_files(&builtin_sig_options(), Arc::default(), &asts);
+
+    Ok(Builtins {
+        master_cx: Arc::new(master_cx),
+        cold_elapsed: started.elapsed(),
+    })
+}

--- a/crates/uf_check/src/upstream/convert.rs
+++ b/crates/uf_check/src/upstream/convert.rs
@@ -1,0 +1,324 @@
+//! Turning Flow's printable errors into [`TypeDiagnostic`]s.
+//!
+//! Flow keeps an error as a tree of message fragments with the locations they
+//! reference held out of line, and `error_utils`'s own accessors expose the
+//! code, kind, and primary location of one directly. The message tree itself is
+//! private to `flow_common_errors`, and `json_output`'s v2 rendering is the
+//! only public way to reach it — so that is what this module walks, mapping
+//! each fragment back onto a typed segment instead of concatenating it into a
+//! sentence.
+
+use compact_str::CompactString;
+use flow_common_errors::error_codes::ErrorCode;
+use flow_common_errors::error_utils::{
+    ConcreteLocPrintableErrorSet, ErrorKind, PrintableError, code_of_printable_error, json_output,
+    kind_of_printable_error,
+};
+use flow_parser::loc::Loc;
+use flow_parser::offset_utils::OffsetKind;
+use serde_json::Value;
+use smallvec::SmallVec;
+
+use crate::diagnostic::{
+    DiagnosticKind, MessageFeatures, MessageSegment, Position, RelatedLocation, RelatedLocations,
+    Severity, Span, TypeDiagnostic,
+};
+
+/// Strip [`super::VIRTUAL_ROOT`] back off, so a diagnostic reports the
+/// project-relative path `uf` handed in rather than the synthetic absolute one
+/// the port insists on resolving it to.
+const STRIP_ROOT: Option<&str> = Some(super::VIRTUAL_ROOT);
+
+/// How deep a message tree is walked before the rest is dropped.
+///
+/// Speculation errors nest one group per branch, and branch counts come from
+/// user-written unions. A bound here is what keeps a hostile union from turning
+/// message rendering into unbounded recursion on the check thread.
+const MAX_MARKUP_DEPTH: u8 = 16;
+
+/// Convert both error sets into diagnostics, errors first.
+///
+/// `fallback_path` names the file being checked; it is used only for a
+/// diagnostic Flow gave no location at all, which is rare enough that pointing
+/// at the head of the file is better than dropping the diagnostic.
+pub(super) fn diagnostics(
+    errors: &ConcreteLocPrintableErrorSet,
+    warnings: &ConcreteLocPrintableErrorSet,
+    fallback_path: &str,
+) -> Vec<TypeDiagnostic> {
+    // `json_of_errors_with_context` walks `errors` then `warnings`, both of
+    // which are ordered sets, so the rendered array lines up one-to-one with
+    // the same traversal here. Passing no stdin file keeps Flow's byte columns
+    // (the code-frame renderer wants bytes) and skips building an offset table
+    // per error.
+    let rendered = json_output::json_of_errors_with_context(
+        STRIP_ROOT,
+        &None,
+        &[],
+        json_output::JsonVersion::JsonV2,
+        OffsetKind::Utf8,
+        errors,
+        warnings,
+    );
+    let rendered = rendered.as_array().map(Vec::as_slice).unwrap_or_default();
+
+    let printable = errors
+        .iter()
+        .map(|error| (Severity::Error, error))
+        .chain(warnings.iter().map(|error| (Severity::Warning, error)));
+
+    printable
+        .zip(rendered)
+        .map(|((severity, error), value)| diagnostic(severity, error, value, fallback_path))
+        .collect()
+}
+
+fn diagnostic(
+    severity: Severity,
+    error: &PrintableError<Loc>,
+    value: &Value,
+    fallback_path: &str,
+) -> TypeDiagnostic {
+    let primary = span(value.get("primaryLoc"))
+        .or_else(|| {
+            span_of_loc(&flow_common_errors::error_utils::loc_of_printable_error(
+                error,
+            ))
+        })
+        .unwrap_or_else(|| Span {
+            path: CompactString::new(fallback_path),
+            start: Position::START,
+            end: Position::START,
+        });
+
+    let error_kind = kind_of_printable_error(error);
+    let code = code_of_printable_error(error).map(ErrorCode::as_str);
+    let mut message = segments(value.get("messageMarkup"));
+    strip_code_suffix(&mut message, code, error_kind);
+
+    TypeDiagnostic {
+        severity,
+        kind: kind(error_kind),
+        code,
+        primary,
+        root: span(value.get("rootLoc")),
+        message,
+        related: related(value.get("referenceLocs")),
+    }
+}
+
+/// Drop the ` [error-code]` Flow appends to every rendered message.
+///
+/// `json_output` renders for a CLI that prints nothing else, so it folds the
+/// code into the prose. Here the code is a typed field and the renderer already
+/// prints it in the frame header, so leaving it in the message would show it
+/// twice — and would be exactly the string-flattening this module exists to
+/// avoid. A message that does not end with the suffix is left untouched.
+fn strip_code_suffix(segments: &mut MessageFeatures, code: Option<&'static str>, kind: ErrorKind) {
+    let mut suffix = String::with_capacity(24);
+    suffix.push_str(" [");
+    match code {
+        Some(code) => suffix.push_str(code),
+        // Uncoded errors are labelled with their kind instead; `ErrorKind`'s
+        // `Display` is what upstream uses for exactly this.
+        None => suffix.push_str(&kind.to_string()),
+    }
+    suffix.push(']');
+
+    let trailing = segments
+        .iter()
+        .rev()
+        .take_while(|segment| matches!(segment, MessageSegment::Text { .. }))
+        .count();
+    if trailing == 0 {
+        return;
+    }
+    let tail: String = segments[segments.len() - trailing..]
+        .iter()
+        .map(MessageSegment::text)
+        .collect();
+    let Some(kept) = tail.strip_suffix(suffix.as_str()) else {
+        return;
+    };
+
+    segments.truncate(segments.len() - trailing);
+    if !kept.is_empty() {
+        segments.push(MessageSegment::Text {
+            text: CompactString::new(kept),
+        });
+    }
+}
+
+/// Map Flow's error kinds onto `uf`'s.
+///
+/// `InferWarning` is an infer error whose name upstream calls outdated; which
+/// set an error landed in decides its severity, not its kind.
+fn kind(kind: ErrorKind) -> DiagnosticKind {
+    match kind {
+        ErrorKind::ParseError | ErrorKind::PseudoParseError => DiagnosticKind::Parse,
+        ErrorKind::InferError | ErrorKind::InferWarning(_) => DiagnosticKind::Infer,
+        ErrorKind::InternalError => DiagnosticKind::Internal,
+        ErrorKind::DuplicateProviderError => DiagnosticKind::DuplicateProvider,
+        ErrorKind::RecursionLimitError => DiagnosticKind::RecursionLimit,
+        ErrorKind::LintError(_) => DiagnosticKind::Lint,
+    }
+}
+
+/// Read one rendered location.
+///
+/// `json_of_loc` reports a one-based start column and an exclusive zero-based
+/// end column, which are the same number written two different ways. Adding one
+/// to the end makes both one-based, so `end.column - start.column` is the byte
+/// length of the span.
+fn span(value: Option<&Value>) -> Option<Span> {
+    let value = value?;
+    let path = value.get("source")?.as_str()?;
+    let start = value.get("start")?;
+    let end = value.get("end")?;
+    Some(Span {
+        path: CompactString::new(path),
+        start: Position {
+            line: number(start.get("line")?)?,
+            column: number(start.get("column")?)?,
+        },
+        end: Position {
+            line: number(end.get("line")?)?,
+            column: number(end.get("column")?)?.saturating_add(1),
+        },
+    })
+}
+
+/// The same conversion from a `Loc`, for the rare error `json_output` renders
+/// without a primary location.
+fn span_of_loc(loc: &Loc) -> Option<Span> {
+    let source = loc.source.as_ref()?;
+    Some(Span {
+        path: CompactString::new(source.as_str()),
+        start: Position {
+            line: u32::try_from(loc.start.line).ok()?,
+            column: u32::try_from(loc.start.column).ok()?.saturating_add(1),
+        },
+        end: Position {
+            line: u32::try_from(loc.end.line).ok()?,
+            column: u32::try_from(loc.end.column).ok()?.saturating_add(1),
+        },
+    })
+}
+
+fn number(value: &Value) -> Option<u32> {
+    u32::try_from(value.as_i64()?.max(0)).ok()
+}
+
+fn related(value: Option<&Value>) -> RelatedLocations {
+    let Some(Value::Object(references)) = value else {
+        return RelatedLocations::new();
+    };
+    let mut locations: RelatedLocations = references
+        .iter()
+        .filter_map(|(id, loc)| {
+            Some(RelatedLocation {
+                id: id.parse().ok()?,
+                span: span(Some(loc))?,
+            })
+        })
+        .collect();
+    // Reference ids are the numbers printed in the message, so they must come
+    // out in that order however the renderer keyed them.
+    locations.sort_unstable_by_key(|location| location.id);
+    locations
+}
+
+fn segments(value: Option<&Value>) -> MessageFeatures {
+    let mut out = MessageFeatures::new();
+    if let Some(value) = value {
+        push_markup(&mut out, value, 0);
+    }
+    out
+}
+
+/// Walk one `messageMarkup` node.
+///
+/// A node is either a flat array of fragments or an `UnorderedList` group whose
+/// items are themselves nodes. Groups are joined with a single space so that a
+/// one-line rendering reads as a sentence, while the fragments stay separate.
+fn push_markup(out: &mut MessageFeatures, value: &Value, depth: u8) {
+    if depth >= MAX_MARKUP_DEPTH {
+        return;
+    }
+    match value {
+        Value::Array(features) => {
+            for feature in features {
+                push_feature(out, feature);
+            }
+        }
+        Value::Object(group) => {
+            if let Some(message) = group.get("message") {
+                push_markup(out, message, depth + 1);
+            }
+            if let Some(Value::Array(items)) = group.get("items") {
+                for item in items {
+                    push_separator(out);
+                    push_markup(out, item, depth + 1);
+                }
+            }
+            if let Some(post) = group.get("post_message") {
+                push_separator(out);
+                push_markup(out, post, depth + 1);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_separator(out: &mut MessageFeatures) {
+    out.push(MessageSegment::Text {
+        text: CompactString::const_new(" "),
+    });
+}
+
+fn push_feature(out: &mut MessageFeatures, value: &Value) {
+    let Some(kind) = value.get("kind").and_then(Value::as_str) else {
+        return;
+    };
+    match kind {
+        "Text" => out.push(MessageSegment::Text {
+            text: text_of(value),
+        }),
+        "Code" => out.push(MessageSegment::Code {
+            text: text_of(value),
+        }),
+        "Reference" => {
+            let id = value
+                .get("referenceId")
+                .and_then(Value::as_str)
+                .and_then(|id| id.parse().ok())
+                .unwrap_or_default();
+            let inline: SmallVec<[&str; 4]> = value
+                .get("message")
+                .and_then(Value::as_array)
+                .map(|inlines| {
+                    inlines
+                        .iter()
+                        .filter_map(|inline| inline.get("text").and_then(Value::as_str))
+                        .collect()
+                })
+                .unwrap_or_default();
+            out.push(MessageSegment::Reference {
+                text: CompactString::new(inline.concat()),
+                id,
+            });
+        }
+        _ => {}
+    }
+}
+
+fn text_of(value: &Value) -> CompactString {
+    value
+        .get("text")
+        .and_then(Value::as_str)
+        .map(CompactString::new)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_check/src/upstream/convert/tests.rs
+++ b/crates/uf_check/src/upstream/convert/tests.rs
@@ -1,0 +1,213 @@
+use serde_json::json;
+
+use super::*;
+
+#[test]
+fn a_rendered_location_becomes_a_one_based_byte_span() {
+    let value = json!({
+        "source": "app.js",
+        "type": "SourceFile",
+        "start": { "line": 2, "column": 19 },
+        "end": { "line": 2, "column": 32 },
+    });
+
+    let span = span(Some(&value)).expect("a located span");
+
+    assert_eq!(span.path, "app.js");
+    assert_eq!(
+        span.start,
+        Position {
+            line: 2,
+            column: 19
+        }
+    );
+    // Flow reports the end column exclusive and zero-based; making it one-based
+    // is what lets `end - start` be the byte length.
+    assert_eq!(
+        span.end,
+        Position {
+            line: 2,
+            column: 33
+        }
+    );
+    assert_eq!(span.single_line_len(), Some(14));
+}
+
+#[test]
+fn a_location_without_a_source_is_dropped() {
+    let value = json!({
+        "source": null,
+        "type": null,
+        "start": { "line": 0, "column": 1 },
+        "end": { "line": 0, "column": 0 },
+    });
+
+    assert_eq!(span(Some(&value)), None);
+}
+
+#[test]
+fn a_missing_location_is_dropped() {
+    assert_eq!(span(None), None);
+    assert_eq!(span(Some(&json!(null))), None);
+    assert_eq!(span(Some(&json!({ "source": "app.js" }))), None);
+}
+
+#[test]
+fn negative_positions_clamp_instead_of_wrapping() {
+    let value = json!({
+        "source": "app.js",
+        "start": { "line": -1, "column": -1 },
+        "end": { "line": -1, "column": -1 },
+    });
+
+    let span = span(Some(&value)).expect("a located span");
+
+    assert_eq!(span.start, Position { line: 0, column: 0 });
+}
+
+#[test]
+fn flat_markup_becomes_typed_segments() {
+    let markup = json!([
+        { "kind": "Text", "text": "Cannot assign " },
+        { "kind": "Code", "text": "\"x\"" },
+        { "kind": "Reference", "referenceId": "1", "message": [
+            { "kind": "Code", "text": "number" },
+        ]},
+    ]);
+
+    let segments = segments(Some(&markup));
+
+    assert_eq!(segments.len(), 3);
+    assert!(matches!(&segments[0], MessageSegment::Text { text } if text == "Cannot assign "));
+    assert!(matches!(&segments[1], MessageSegment::Code { text } if text == "\"x\""));
+    assert!(
+        matches!(&segments[2], MessageSegment::Reference { text, id } if text == "number" && *id == 1)
+    );
+}
+
+#[test]
+fn a_reference_joins_every_inline_fragment_it_carries() {
+    let markup = json!([
+        { "kind": "Reference", "referenceId": "2", "message": [
+            { "kind": "Text", "text": "the " },
+            { "kind": "Code", "text": "Props" },
+        ]},
+    ]);
+
+    let segments = segments(Some(&markup));
+
+    assert!(
+        matches!(&segments[0], MessageSegment::Reference { text, id } if text == "the Props" && *id == 2)
+    );
+}
+
+#[test]
+fn grouped_markup_is_flattened_with_separators() {
+    let markup = json!({
+        "kind": "UnorderedList",
+        "message": [{ "kind": "Text", "text": "head" }],
+        "items": [
+            [{ "kind": "Text", "text": "one" }],
+            [{ "kind": "Text", "text": "two" }],
+        ],
+        "post_message": [{ "kind": "Text", "text": "tail" }],
+    });
+
+    let text: String = segments(Some(&markup))
+        .iter()
+        .map(MessageSegment::text)
+        .collect();
+
+    assert_eq!(text, "head one two tail");
+}
+
+#[test]
+fn markup_recursion_is_bounded() {
+    let mut markup = json!([{ "kind": "Text", "text": "deep" }]);
+    for _ in 0..(MAX_MARKUP_DEPTH as usize * 4) {
+        markup = json!({ "kind": "UnorderedList", "message": markup, "items": [] });
+    }
+
+    // The point is that this terminates at all; the bound also keeps the
+    // result small rather than letting a nested union render forever.
+    assert!(segments(Some(&markup)).len() <= MAX_MARKUP_DEPTH as usize);
+}
+
+#[test]
+fn unknown_markup_kinds_are_ignored_rather_than_guessed_at() {
+    let markup = json!([
+        { "kind": "SomethingNew", "text": "?" },
+        { "text": "no kind at all" },
+        { "kind": "Text", "text": "kept" },
+    ]);
+
+    let segments = segments(Some(&markup));
+
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].text(), "kept");
+}
+
+#[test]
+fn reference_locations_come_out_in_reference_order() {
+    let references = json!({
+        "10": { "source": "b.js", "start": { "line": 1, "column": 1 }, "end": { "line": 1, "column": 2 } },
+        "2": { "source": "a.js", "start": { "line": 3, "column": 1 }, "end": { "line": 3, "column": 2 } },
+    });
+
+    let related = related(Some(&references));
+
+    assert_eq!(related.len(), 2);
+    assert_eq!(related[0].id, 2);
+    assert_eq!(related[0].span.path, "a.js");
+    assert_eq!(related[1].id, 10);
+}
+
+#[test]
+fn unlocatable_references_are_dropped_rather_than_faked() {
+    let references = json!({
+        "1": { "source": null, "start": { "line": 0, "column": 1 }, "end": { "line": 0, "column": 0 } },
+        "not-a-number": { "source": "a.js", "start": { "line": 1, "column": 1 }, "end": { "line": 1, "column": 2 } },
+    });
+
+    assert!(related(Some(&references)).is_empty());
+}
+
+#[test]
+fn missing_references_are_an_empty_list() {
+    assert!(related(None).is_empty());
+    assert!(related(Some(&json!([]))).is_empty());
+}
+
+#[test]
+fn every_flow_error_kind_maps_onto_a_uf_kind() {
+    use flow_common_errors::error_utils::InferWarningKind;
+    use flow_lint_settings::lints::LintKind;
+
+    assert_eq!(kind(ErrorKind::ParseError), DiagnosticKind::Parse);
+    assert_eq!(kind(ErrorKind::PseudoParseError), DiagnosticKind::Parse);
+    assert_eq!(kind(ErrorKind::InferError), DiagnosticKind::Infer);
+    assert_eq!(
+        kind(ErrorKind::InferWarning(InferWarningKind::OtherKind)),
+        DiagnosticKind::Infer
+    );
+    assert_eq!(kind(ErrorKind::InternalError), DiagnosticKind::Internal);
+    assert_eq!(
+        kind(ErrorKind::DuplicateProviderError),
+        DiagnosticKind::DuplicateProvider
+    );
+    assert_eq!(
+        kind(ErrorKind::RecursionLimitError),
+        DiagnosticKind::RecursionLimit
+    );
+    assert_eq!(
+        kind(ErrorKind::LintError(LintKind::UnclearType)),
+        DiagnosticKind::Lint
+    );
+}
+
+#[test]
+fn no_errors_means_no_diagnostics() {
+    let empty = ConcreteLocPrintableErrorSet::empty();
+
+    assert!(diagnostics(&empty, &empty, "app.js").is_empty());
+}

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -1,0 +1,350 @@
+//! The checker itself, driven from Meta's official Flow Rust port.
+//!
+//! This is `flow_dot_js_wasm`'s check path with three things changed: the
+//! builtin environment is merged once and shared, the work runs on a thread
+//! with enough stack for user-controlled recursion, and the result comes back
+//! as [`TypeDiagnostic`]s instead of JSON.
+//!
+//! Nothing below this module is allowed to leak upstream's types: everything
+//! the crate exposes is `uf`'s own, so the shape of the port stays an
+//! implementation detail of this one directory.
+
+// The port's API is `Rc` and `Arc` all the way down — `Context` is built from
+// `Rc` closures and `MasterContext` is shared through an `Arc` — so the
+// workspace's "prefer references or arena allocation" policy has nothing to
+// bite on here. The reference counting is upstream's, not ours; it stops at the
+// module boundary, and no `Rc` or `Arc` appears in this crate's public API.
+#![allow(
+    clippy::disallowed_types,
+    reason = "the upstream Flow port's own API is Rc- and Arc-based"
+)]
+
+mod builtins;
+mod convert;
+mod options;
+mod parse;
+
+use std::cell::{LazyCell, RefCell};
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Instant;
+
+use compact_str::{CompactString, ToCompactString};
+use dupe::Dupe;
+use flow_aloc::{ALoc, ALocTable};
+use flow_common::flow_import_specifier::{FlowImportSpecifier, Userland};
+use flow_common::options::Options;
+use flow_common_errors::error_utils::ConcreteLocPrintableErrorSet;
+use flow_parser::ast;
+use flow_parser::file_key::{FileKey, FileKeyInner};
+use flow_parser::loc::{LOC_NONE, Loc};
+use flow_typing::{merge, type_inference};
+use flow_typing_context::{Context, MasterContext, ResolvedRequire};
+use flow_typing_errors::error_message::ErrorMessage;
+use flow_typing_errors::error_suppressions::ErrorSuppressions;
+use flow_typing_errors::flow_error::ErrorSet;
+use flow_typing_errors::{flow_error, intermediate_error};
+use flow_typing_type::type_::{ModuleType, Type};
+use flow_utils_concurrency::check_budget::CheckBudget;
+use flow_utils_concurrency::job_error::JobError;
+
+use crate::diagnostic::TypeDiagnostic;
+use crate::limits::CHECK_STACK_BYTES;
+use crate::{BuiltinsTiming, CheckError, CheckLimits, CheckReport, Source};
+
+/// The absolute root every Flow path is resolved against.
+///
+/// Flow resolves a file key to an absolute path before rendering it, and its
+/// renderer *panics* on a relative one, so an embedder has to supply a root
+/// even when it has no filesystem in play — `uf` hands the checker
+/// project-relative paths and gets them back stripped.
+///
+/// It is deliberately a path that cannot exist: the renderer reads a location's
+/// file from disk when it can, to build a codepoint offset table. `uf` does not
+/// want that. It wants Flow's raw byte columns, which is what `uf_term`'s code
+/// frames and `uf_lint`'s diagnostics both measure in, and it already holds
+/// every source in memory. A root under a dot-directory at `/` cannot be
+/// created without root privileges, so the read always misses and the columns
+/// stay in bytes.
+pub(super) const VIRTUAL_ROOT: &str = "/.uf-check-virtual-root";
+
+/// Merge the builtins, on the check thread so the merge gets its stack too.
+pub(crate) fn prepare_builtins() -> Result<BuiltinsTiming, CheckError> {
+    on_check_thread("<builtins>", builtins::prepare)?
+}
+
+/// Check every source in one batch, sharing one builtin environment.
+pub(crate) fn check_sources(
+    sources: &[Source<'_>],
+    limits: &CheckLimits,
+) -> Result<CheckReport, CheckError> {
+    let path = sources.first().map_or("<empty>", |source| source.path);
+    on_check_thread(path, || check_batch(sources, limits))?
+}
+
+/// Run `work` on a thread with a stack large enough for recursive descent over
+/// user-controlled nesting.
+///
+/// Both the parser and inference recurse once per level of nesting, so a file
+/// full of nested generics is a stack-depth attack against a default 2 MiB
+/// worker. A large stack turns that into Flow's own recursion limit firing,
+/// which is a diagnostic rather than an abort.
+fn on_check_thread<T, F>(path: &str, work: F) -> Result<T, CheckError>
+where
+    F: FnOnce() -> T + Send,
+    T: Send,
+{
+    std::thread::scope(|scope| {
+        let worker = std::thread::Builder::new()
+            .name("uf-typecheck".to_owned())
+            .stack_size(CHECK_STACK_BYTES)
+            .spawn_scoped(scope, work)
+            .map_err(|error| CheckError::Worker {
+                path: path.to_compact_string(),
+                detail: error.to_compact_string(),
+            })?;
+        worker.join().map_err(|_| CheckError::Worker {
+            path: path.to_compact_string(),
+            detail: CompactString::const_new("the checker panicked"),
+        })
+    })
+}
+
+fn check_batch(sources: &[Source<'_>], limits: &CheckLimits) -> Result<CheckReport, CheckError> {
+    let builtins = builtins::prepare()?;
+    let master_cx = builtins::master_context()?;
+    let options = options::options(limits);
+    let untyped: UntypedModules = Rc::new(RefCell::new(BTreeSet::new()));
+
+    let started = Instant::now();
+    let mut diagnostics = Vec::new();
+    for source in sources {
+        diagnostics.extend(check_one(&master_cx, &options, limits, source, &untyped)?);
+    }
+
+    Ok(CheckReport {
+        diagnostics,
+        files_checked: sources.len(),
+        untyped_modules: untyped.borrow().iter().cloned().collect(),
+        builtins,
+        elapsed: started.elapsed(),
+    })
+}
+
+/// Module specifiers that resolved to nothing typed, shared across a batch.
+///
+/// A `BTreeSet` rather than a counter: the same import in twenty files is one
+/// hole, not twenty, and the sorted order keeps the report deterministic.
+type UntypedModules = Rc<RefCell<BTreeSet<CompactString>>>;
+
+fn check_one(
+    master_cx: &Arc<MasterContext>,
+    options: &Options,
+    limits: &CheckLimits,
+    source: &Source<'_>,
+    untyped: &UntypedModules,
+) -> Result<Vec<TypeDiagnostic>, CheckError> {
+    // Checked before the parser sees the text: the AST alone is several times
+    // the size of the source, so an unbounded file is an unbounded allocation.
+    if source.source.len() > limits.max_source_bytes {
+        return Err(CheckError::SourceTooLarge {
+            path: source.path.to_compact_string(),
+            size: source.source.len(),
+            limit: limits.max_source_bytes,
+        });
+    }
+
+    let file_key = FileKey::new(FileKeyInner::SourceFile(source.path.to_owned()));
+    let parsed = parse::parse_file(file_key.dupe(), source.source, options, false);
+    if !parsed.is_parseable() {
+        let errors = printable(&parsed, parse_error_set(&parsed));
+        return Ok(convert::diagnostics(
+            &errors,
+            &ConcreteLocPrintableErrorSet::empty(),
+            source.path,
+        ));
+    }
+
+    let metadata = parsed.metadata.clone();
+    let lint_severities = merge::get_lint_severities(
+        &metadata,
+        &options.strict_mode,
+        options.lint_severities.clone(),
+    );
+    let aloc_table = Rc::new(LazyCell::new(Box::new({
+        let file_key = file_key.dupe();
+        move || Rc::new(ALocTable::empty(file_key))
+    }) as Box<dyn FnOnce() -> Rc<ALocTable>>));
+    let cx = Context::make(
+        Rc::new(flow_typing_context::make_ccx()),
+        metadata.clone(),
+        file_key.dupe(),
+        Arc::default(),
+        aloc_table,
+        resolve_require(file_key, untyped),
+        merge::mk_builtins(&metadata, master_cx),
+        CheckBudget::new(limits.file_timeout),
+    );
+    cx.set_merge_dst_cx(&cx);
+
+    let ast::Program { all_comments, .. } = parsed.ast.as_ref();
+    let aloc_ast = flow_aloc::loc_to_aloc_ast(parsed.ast.as_ref());
+    type_inference::infer_ast(
+        &lint_severities,
+        &cx,
+        &parsed.file_key,
+        parsed.file_sig.dupe(),
+        &metadata,
+        all_comments,
+        aloc_ast,
+    )
+    .map_err(|error| job_error(source.path, error))?;
+
+    let (errors, warnings) = suppressed(&cx, &parsed, cx.errors());
+    Ok(convert::diagnostics(&errors, &warnings, source.path))
+}
+
+fn job_error(path: &str, error: JobError) -> CheckError {
+    match error {
+        JobError::TimedOut(timeout) => CheckError::Budget {
+            path: path.to_compact_string(),
+            limit_ms: u64::try_from(timeout.elapsed.as_millis()).unwrap_or(u64::MAX),
+        },
+        JobError::Canceled(_) => CheckError::Cancelled {
+            path: path.to_compact_string(),
+        },
+        JobError::DebugThrow { .. } => CheckError::Worker {
+            path: path.to_compact_string(),
+            detail: CompactString::const_new("$Flow$DebugThrow"),
+        },
+    }
+}
+
+/// The resolver a file's context looks imports up through.
+type Resolver = Rc<dyn Fn(&Context<'static>, &FlowImportSpecifier) -> ResolvedRequire<'static>>;
+
+/// Resolve an `import` against the builtin `declare module` blocks.
+///
+/// What this gives the checker is Flow's standard library — `react`,
+/// `react-dom`, and everything else the library definitions declare. Anything
+/// else resolves to an *unchecked* module rather than a missing one, exactly as
+/// `flow_services_inference`'s own `unchecked_module_t` does for a dependency
+/// Flow cannot type: the import becomes `any` and the file still checks.
+///
+/// Reporting those as missing instead would be a lie — the modules exist, `uf`
+/// simply does not merge signatures across files yet — and would bury every
+/// real type error under one `cannot-resolve-module` per import. The names are
+/// recorded in [`CheckReport::untyped_modules`] so the gap is stated rather
+/// than hidden.
+fn resolve_require(file_key: FileKey, untyped: &UntypedModules) -> Resolver {
+    let untyped = Rc::clone(untyped);
+    Rc::new(
+        move |cx: &Context<'static>, specifier: &FlowImportSpecifier| match specifier {
+            FlowImportSpecifier::Userland(userland) => match typed_builtin_module(cx, userland) {
+                Some(module) => ResolvedRequire::TypedModule(module),
+                None => {
+                    untyped
+                        .borrow_mut()
+                        .insert(userland.as_str().to_compact_string());
+                    ResolvedRequire::UncheckedModule(ALoc::of_loc(Loc {
+                        source: Some(file_key.dupe()),
+                        ..LOC_NONE
+                    }))
+                }
+            },
+        },
+    )
+}
+
+type TypedModule<'cx> = Rc<dyn Fn(&Context<'cx>, &Context<'cx>) -> Result<ModuleType, Type> + 'cx>;
+
+fn typed_builtin_module<'cx>(cx: &Context<'cx>, name: &Userland) -> Option<TypedModule<'cx>> {
+    cx.builtin_module_opt(name).map(|(reason, lazy_module)| {
+        let forcing_state =
+            flow_typing_type::type_::constraint::forcing_state::ModuleTypeForcingState::of_lazy_module(
+                reason,
+                lazy_module,
+            );
+        flow_typing_utils::annotation_inference::force_module_type_thunk(cx.dupe(), forcing_state)
+    })
+}
+
+fn parse_error_set(parsed: &parse::Parsed) -> ErrorSet {
+    let mut errors = ErrorSet::empty();
+    for (loc, error) in parsed.parse_errors.iter().cloned() {
+        errors.add(flow_error::error_of_msg(
+            parsed.file_key.dupe(),
+            ErrorMessage::EParseError(Box::new((ALoc::of_loc(loc), error))),
+        ));
+    }
+    errors
+}
+
+fn printable(parsed: &parse::Parsed, errors: ErrorSet) -> ConcreteLocPrintableErrorSet {
+    let ast = parsed.ast.dupe();
+    let file_key = parsed.file_key.dupe();
+    intermediate_error::make_errors_printable(
+        |aloc: &ALoc| aloc.to_loc_exn().dupe(),
+        move |requested: &FileKey| (requested == &file_key).then(|| ast.dupe()),
+        Some(Path::new(VIRTUAL_ROOT)),
+        errors,
+        FileKey::is_lib_file,
+    )
+}
+
+/// Split lints by severity and drop anything a suppression comment covers.
+///
+/// Mirrors `flow_dot_js_wasm`, which mirrors OCaml `check_content`: without
+/// this, `$FlowFixMe` and `$FlowExpectedError` comments in a real project would
+/// be ignored.
+fn suppressed(
+    cx: &Context<'_>,
+    parsed: &parse::Parsed,
+    errors: ErrorSet,
+) -> (ConcreteLocPrintableErrorSet, ConcreteLocPrintableErrorSet) {
+    let mut suppressions = cx.take_error_suppressions();
+    let severity_cover = cx.severity_cover();
+    let include_suppressions = cx.include_suppressions();
+    let aloc_tables = cx.aloc_tables();
+    let (errors, warnings) =
+        suppressions.filter_lints(errors, &aloc_tables, include_suppressions, &severity_cover);
+    drop(aloc_tables);
+    drop(severity_cover);
+
+    let loc_of_aloc = |aloc: &ALoc| aloc.to_loc_exn().dupe();
+    let file_key = parsed.file_key.dupe();
+    let ast = parsed.ast.dupe();
+    let get_ast = move |requested: &FileKey| (requested == &file_key).then(|| ast.dupe());
+    let root = Path::new(VIRTUAL_ROOT);
+    let unsuppressable = BTreeSet::new();
+
+    let mut unused = ErrorSuppressions::empty();
+    let (errors, _) = suppressions.filter_suppressed_errors(
+        root,
+        None,
+        false,
+        &unsuppressable,
+        loc_of_aloc,
+        &get_ast,
+        FileKey::is_lib_file,
+        &errors,
+        &mut unused,
+    );
+
+    let mut unused = ErrorSuppressions::empty();
+    let (warnings, _) = suppressions.filter_suppressed_errors(
+        root,
+        None,
+        false,
+        &unsuppressable,
+        loc_of_aloc,
+        &get_ast,
+        FileKey::is_lib_file,
+        &warnings,
+        &mut unused,
+    );
+
+    (errors, warnings)
+}

--- a/crates/uf_check/src/upstream/options.rs
+++ b/crates/uf_check/src/upstream/options.rs
@@ -1,0 +1,171 @@
+//! How `uf` configures Flow.
+//!
+//! `uf` has no `.flowconfig`: the toolchain decides, and every project gets the
+//! same modern dialect. That is the whole point of a unified toolchain, so
+//! these are constants rather than configuration. They match what
+//! `flow_dot_js_wasm` runs with, which is the configuration Flow's own
+//! try-it-online uses, plus `uf`'s limits.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use dupe::Dupe;
+use flow_common::options::{Options, ReactRule, ReactRuntime};
+use flow_lint_settings::lint_settings::LintSettings;
+use flow_lint_settings::severity::Severity;
+use flow_parser_utils::file_sig::FileSigOptions;
+use flow_type_sig::type_sig_options::TypeSigOptions;
+
+use crate::CheckLimits;
+
+/// The React rules Flow enforces during inference.
+///
+/// These are the rules React itself requires to hold for the compiler to be
+/// sound, not style preferences, so they are on for every `uf` project.
+const REACT_RULES: [ReactRule; 4] = [
+    ReactRule::ValidateRefAccessDuringRender,
+    ReactRule::DeepReadOnlyProps,
+    ReactRule::DeepReadOnlyHookReturns,
+    ReactRule::RulesOfHooks,
+];
+
+/// How many tokens of a file's header are scanned for a docblock.
+const MAX_HEADER_TOKENS: i32 = 10;
+
+/// Build the checker options for one run.
+///
+/// Flow lints are left entirely off: `uf_lint` owns lint rules and reports them
+/// with its own ids, so turning Flow's on here would double-report and give the
+/// same finding two different names.
+pub(super) fn options(limits: &CheckLimits) -> Options {
+    Options {
+        all: true,
+        component_syntax: true,
+        enable_pattern_matching: true,
+        enable_records: true,
+        enums: true,
+        hook_compatibility: true,
+        lint_severities: LintSettings::<Severity>::empty_severities(),
+        max_header_tokens: MAX_HEADER_TOKENS,
+        react_rules: Arc::from(REACT_RULES),
+        react_runtime: ReactRuntime::Automatic,
+        recursion_limit: recursion_limit(limits.recursion_limit),
+        root: Arc::new(PathBuf::new()),
+        strip_root: true,
+        ts_syntax: true,
+        tslib_syntax: true,
+        ts_utility_syntax: true,
+        type_expansion_recursion_limit: recursion_limit(limits.type_expansion_recursion_limit),
+        ..Default::default()
+    }
+}
+
+/// Flow's recursion limits are `i32`; [`CheckLimits`] keeps them unsigned
+/// because a negative limit is not a thing. Saturate rather than wrap, so a
+/// caller who asks for a limit past `i32::MAX` gets the largest limit Flow can
+/// express instead of a negative one that disables the guard entirely.
+fn recursion_limit(limit: u32) -> i32 {
+    i32::try_from(limit).unwrap_or(i32::MAX)
+}
+
+/// Signature options for the builtin library definitions.
+///
+/// `for_builtins` and `is_lib_file` are what separate this from a source file:
+/// library definitions may declare globals and are never munged.
+pub(super) fn builtin_sig_options() -> TypeSigOptions {
+    TypeSigOptions {
+        munge: false,
+        facebook_key_mirror: false,
+        facebook_fbt: None,
+        enable_custom_error: false,
+        enable_enums: true,
+        enable_component_syntax: true,
+        component_syntax_enabled_in_config: true,
+        enable_ts_syntax: true,
+        enable_ts_utility_syntax: true,
+        hook_compatibility: true,
+        enable_records: true,
+        enable_relay_integration: false,
+        relay_integration_module_prefix: None,
+        for_builtins: true,
+        locs_to_dirtify: Vec::new(),
+        is_ts_file: false,
+        is_dts_file: false,
+        tslib_syntax: true,
+        is_lib_file: true,
+    }
+}
+
+/// File signature options for one parsed file.
+pub(super) fn file_sig_options(options: &Options, is_lib_file: bool) -> FileSigOptions {
+    FileSigOptions {
+        enable_enums: options.enums,
+        enable_jest_integration: options.enable_jest_integration,
+        enable_relay_integration: options.enable_relay_integration,
+        explicit_available_platforms: None,
+        file_options: options.file_options.dupe(),
+        haste_module_ref_prefix: options.haste_module_ref_prefix.dupe(),
+        project_options: options.projects_options.dupe(),
+        relay_integration_module_prefix: options.relay_integration_module_prefix.dupe(),
+        is_lib_file,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modern_flow_syntax_is_on() {
+        let options = options(&CheckLimits::default());
+
+        assert!(options.component_syntax);
+        assert!(options.enums);
+        assert!(options.enable_pattern_matching);
+        assert!(options.hook_compatibility);
+    }
+
+    #[test]
+    fn flow_lints_are_left_to_uf_lint() {
+        use flow_lint_settings::lints::LintKind;
+
+        let options = options(&CheckLimits::default());
+
+        assert_eq!(*options.lint_severities.get_default(), Severity::Off);
+        assert!(!options.lint_severities.is_enabled(LintKind::UnclearType));
+        assert!(!options.lint_severities.is_enabled(LintKind::UntypedImport));
+    }
+
+    #[test]
+    fn the_recursion_limit_follows_the_configured_limits() {
+        let limits = CheckLimits {
+            recursion_limit: 42,
+            ..CheckLimits::default()
+        };
+
+        assert_eq!(options(&limits).recursion_limit, 42);
+    }
+
+    #[test]
+    fn an_out_of_range_recursion_limit_saturates_instead_of_going_negative() {
+        assert_eq!(recursion_limit(u32::MAX), i32::MAX);
+        assert_eq!(recursion_limit(0), 0);
+    }
+
+    #[test]
+    fn builtin_signature_options_declare_a_library_file() {
+        let sig_options = builtin_sig_options();
+
+        assert!(sig_options.for_builtins);
+        assert!(sig_options.is_lib_file);
+        assert!(!sig_options.munge);
+    }
+
+    #[test]
+    fn source_file_signature_options_are_not_library_options() {
+        let options = options(&CheckLimits::default());
+
+        assert!(!file_sig_options(&options, false).is_lib_file);
+        assert!(file_sig_options(&options, true).is_lib_file);
+    }
+}

--- a/crates/uf_check/src/upstream/parse.rs
+++ b/crates/uf_check/src/upstream/parse.rs
@@ -1,0 +1,85 @@
+//! Parsing one file into everything the checker needs from it.
+//!
+//! The docblock is deliberately consumed here rather than stored. Upstream's
+//! `Docblock` type is private to `flow_parsing`, so the only thing an embedder
+//! can do with one is fold it into a [`Metadata`] immediately — which is also
+//! the only thing anyone wants it for.
+
+use std::sync::Arc;
+
+use dupe::Dupe;
+use flow_common::options::Options;
+use flow_parser::PERMISSIVE_PARSE_OPTIONS;
+use flow_parser::ast;
+use flow_parser::file_key::FileKey;
+use flow_parser::loc::Loc;
+use flow_parser::parse_error::ParseError;
+use flow_parser_utils::file_sig::FileSig;
+use flow_parsing::docblock_parser;
+use flow_typing_context::Metadata;
+
+use super::options::file_sig_options;
+
+/// One parsed file.
+pub(super) struct Parsed {
+    /// The key Flow identifies the file by.
+    pub(super) file_key: FileKey,
+    /// Checker metadata, with this file's docblock already applied.
+    pub(super) metadata: Metadata,
+    /// The untyped AST.
+    pub(super) ast: Arc<ast::Program<Loc, Loc>>,
+    /// The module's imports and exports.
+    pub(super) file_sig: Arc<FileSig>,
+    /// Syntax errors, in source order. Non-empty means inference must not run.
+    pub(super) parse_errors: Vec<(Loc, ParseError)>,
+}
+
+impl Parsed {
+    /// Whether the file parsed cleanly enough to type check.
+    pub(super) fn is_parseable(&self) -> bool {
+        self.parse_errors.is_empty()
+    }
+}
+
+/// Parse `content` as `file_key`.
+///
+/// `is_lib_file` changes how the module signature is built, not how the source
+/// is parsed: library definitions may declare globals.
+pub(super) fn parse_file(
+    file_key: FileKey,
+    content: &str,
+    options: &Options,
+    is_lib_file: bool,
+) -> Parsed {
+    let (_docblock_errors, docblock) = docblock_parser::parse_docblock(
+        options.max_header_tokens as usize,
+        &options.file_options,
+        &file_key,
+        content,
+    );
+    let metadata = flow_typing_context::docblock_overrides(
+        &docblock,
+        &file_key,
+        flow_typing_context::mk_context_metadata(options, Arc::default()),
+    );
+    let (ast, parse_errors) = flow_parser::parse_program_file::<()>(
+        false,
+        None,
+        Some(PERMISSIVE_PARSE_OPTIONS),
+        file_key.dupe(),
+        Ok(content),
+    );
+    let file_sig = Arc::new(FileSig::from_program(
+        &file_key,
+        &ast,
+        &file_sig_options(options, is_lib_file),
+    ));
+
+    Parsed {
+        file_key,
+        metadata,
+        ast: Arc::new(ast),
+        file_sig,
+        parse_errors,
+    }
+}

--- a/crates/uf_check/tests/fixtures/bad_renders.js
+++ b/crates/uf_check/tests/fixtures/bad_renders.js
@@ -1,0 +1,8 @@
+// @flow
+import * as React from "react";
+
+type NotAComponent = { label: string };
+
+export component Broken() renders NotAComponent {
+  return { label: "nope" };
+}

--- a/crates/uf_check/tests/fixtures/clean_component.js
+++ b/crates/uf_check/tests/fixtures/clean_component.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from "react";
+
+opaque type UserId = string;
+
+export type Status = "idle" | "loading" | "ready";
+
+type Profile = {| id: UserId, name: string, status: Status |};
+
+export function makeUserId(raw: string): UserId {
+  return raw;
+}
+
+function first<T>(items: $ReadOnlyArray<T>): T | void {
+  return items[0];
+}
+
+hook useStatus(initial: Status): Status {
+  const [status] = React.useState<Status>(initial);
+  return status;
+}
+
+component Badge(profile: Profile) {
+  const status = useStatus(profile.status);
+  return status;
+}
+
+export component ProfileList(profiles: $ReadOnlyArray<Profile>) renders* Badge {
+  return profiles.map((profile) => <Badge key={profile.id} profile={profile} />);
+}
+
+export component Featured(profiles: $ReadOnlyArray<Profile>) renders? Badge {
+  const head = first(profiles);
+  if (head == null) {
+    return null;
+  }
+  return <Badge profile={head} />;
+}

--- a/crates/uf_check/tests/fixtures/missing_prop.js
+++ b/crates/uf_check/tests/fixtures/missing_prop.js
@@ -1,0 +1,10 @@
+// @flow
+import * as React from "react";
+
+component Greeting(name: string, times: number) {
+  return name.repeat(times);
+}
+
+export component Page() renders Greeting {
+  return <Greeting name="world" />;
+}

--- a/crates/uf_check/tests/fixtures/string_to_number.js
+++ b/crates/uf_check/tests/fixtures/string_to_number.js
@@ -1,0 +1,4 @@
+// @flow
+const total: number = "twelve";
+
+export default total;

--- a/crates/uf_check/tests/fixtures/unhandled_null.js
+++ b/crates/uf_check/tests/fixtures/unhandled_null.js
@@ -1,0 +1,4 @@
+// @flow
+export function width(label: ?string): number {
+  return label.length;
+}

--- a/crates/uf_check/tests/typecheck.rs
+++ b/crates/uf_check/tests/typecheck.rs
@@ -1,0 +1,366 @@
+//! End-to-end checks that `uf` really runs Flow's own inference.
+//!
+//! Assertions are on error **codes** and **locations**, never on message text:
+//! the codes are Flow's public contract and the messages are not, so asserting
+//! on prose would turn every upstream wording change into a red build.
+
+#![cfg(feature = "upstream-typecheck")]
+
+use std::time::Duration;
+
+use uf_check::{
+    CheckError, CheckLimits, DiagnosticKind, Severity, Source, TypeDiagnostic, check_source,
+    check_sources, prepare_builtins,
+};
+
+const CLEAN_COMPONENT: &str = include_str!("fixtures/clean_component.js");
+const STRING_TO_NUMBER: &str = include_str!("fixtures/string_to_number.js");
+const MISSING_PROP: &str = include_str!("fixtures/missing_prop.js");
+const BAD_RENDERS: &str = include_str!("fixtures/bad_renders.js");
+const UNHANDLED_NULL: &str = include_str!("fixtures/unhandled_null.js");
+
+/// Tests must not race the wall clock; a loaded CI box is not a type error.
+fn limits() -> CheckLimits {
+    CheckLimits::default().without_timeout()
+}
+
+fn check(path: &str, source: &str) -> Vec<TypeDiagnostic> {
+    check_source(Source::new(path, source), &limits()).expect("the checker runs")
+}
+
+fn codes(diagnostics: &[TypeDiagnostic]) -> Vec<&str> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.unwrap_or("<none>"))
+        .collect()
+}
+
+fn find<'a>(diagnostics: &'a [TypeDiagnostic], code: &str) -> &'a TypeDiagnostic {
+    diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == Some(code))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a `{code}` diagnostic, got {:?}",
+                codes(diagnostics)
+            )
+        })
+}
+
+#[test]
+fn a_modern_flow_react_file_checks_clean() {
+    let diagnostics = check("clean_component.js", CLEAN_COMPONENT);
+
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics, got {:#?}",
+        diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.code, diagnostic.primary.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn assigning_a_string_to_a_number_is_an_incompatible_type_at_the_literal() {
+    let diagnostics = check("string_to_number.js", STRING_TO_NUMBER);
+
+    let diagnostic = find(&diagnostics, "incompatible-type");
+    assert_eq!(diagnostic.severity, Severity::Error);
+    assert_eq!(diagnostic.kind, DiagnosticKind::Infer);
+    assert_eq!(diagnostic.primary.path, "string_to_number.js");
+    // `const total: number = "twelve";` — the caret belongs on the literal.
+    assert_eq!(diagnostic.primary.start.line, 2);
+    assert_eq!(diagnostic.primary.start.column, 23);
+    assert_eq!(diagnostic.primary.single_line_len(), Some(8));
+}
+
+#[test]
+fn an_incompatible_type_keeps_the_locations_its_message_refers_to() {
+    let diagnostics = check("string_to_number.js", STRING_TO_NUMBER);
+
+    let diagnostic = find(&diagnostics, "incompatible-type");
+    assert!(
+        !diagnostic.related.is_empty(),
+        "expected the annotation's location to be kept as a reference"
+    );
+    // Every reference the message points at must have a location, and every
+    // location must be one the message points at.
+    let referenced: Vec<u32> = diagnostic
+        .message
+        .iter()
+        .filter_map(|segment| match segment {
+            uf_check::MessageSegment::Reference { id, .. } => Some(*id),
+            _ => None,
+        })
+        .collect();
+    for related in &diagnostic.related {
+        assert!(
+            referenced.contains(&related.id),
+            "reference {} has a location but no mention in the message",
+            related.id
+        );
+    }
+    assert!(
+        diagnostic
+            .related
+            .iter()
+            .any(|related| related.span.start.line == 2)
+    );
+}
+
+#[test]
+fn omitting_a_required_prop_is_an_error_on_the_element_that_points_at_the_component() {
+    let diagnostics = check("missing_prop.js", MISSING_PROP);
+
+    assert_eq!(diagnostics.len(), 1, "{:?}", codes(&diagnostics));
+    let diagnostic = find(&diagnostics, "incompatible-type");
+    assert_eq!(diagnostic.severity, Severity::Error);
+    assert_eq!(diagnostic.primary.path, "missing_prop.js");
+    // `  return <Greeting name="world" />;` — the caret belongs on the element.
+    assert_eq!(diagnostic.primary.start.line, 9);
+    assert_eq!(diagnostic.primary.start.column, 11);
+    // ...and one of the references must be the component that declares `times`.
+    assert!(
+        diagnostic
+            .related
+            .iter()
+            .any(|related| related.span.start.line == 4),
+        "expected a reference to the component declaration, got {:?}",
+        diagnostic.related
+    );
+}
+
+#[test]
+fn an_invalid_renders_type_is_reported_as_an_invalid_render() {
+    let diagnostics = check("bad_renders.js", BAD_RENDERS);
+
+    assert_eq!(diagnostics.len(), 1, "{:?}", codes(&diagnostics));
+    let diagnostic = find(&diagnostics, "invalid-render");
+    assert_eq!(diagnostic.severity, Severity::Error);
+    // `export component Broken() renders NotAComponent {` — on the type.
+    assert_eq!(diagnostic.primary.start.line, 6);
+    assert_eq!(diagnostic.primary.start.column, 35);
+    assert_eq!(diagnostic.primary.single_line_len(), Some(13));
+}
+
+#[test]
+fn dereferencing_a_maybe_string_is_an_incompatible_use() {
+    let diagnostics = check("unhandled_null.js", UNHANDLED_NULL);
+
+    assert_eq!(diagnostics.len(), 1, "{:?}", codes(&diagnostics));
+    let diagnostic = find(&diagnostics, "incompatible-use");
+    // `  return label.length;` — the caret belongs on the property.
+    assert_eq!(diagnostic.primary.start.line, 3);
+    assert_eq!(diagnostic.primary.start.column, 16);
+    assert_eq!(diagnostic.primary.single_line_len(), Some(6));
+    // The reference points back at the `?string` annotation.
+    assert_eq!(diagnostic.related[0].span.start.line, 2);
+}
+
+#[test]
+fn a_message_does_not_repeat_the_error_code_the_diagnostic_already_carries() {
+    let diagnostics = check("string_to_number.js", STRING_TO_NUMBER);
+
+    let diagnostic = find(&diagnostics, "incompatible-type");
+    let text = diagnostic.message_text();
+
+    assert!(!text.contains("[incompatible-type]"), "{text}");
+    assert!(text.ends_with('.'), "{text}");
+}
+
+#[test]
+fn every_diagnostic_carries_a_code_and_a_located_primary_span() {
+    for (path, source) in [
+        ("string_to_number.js", STRING_TO_NUMBER),
+        ("missing_prop.js", MISSING_PROP),
+        ("bad_renders.js", BAD_RENDERS),
+        ("unhandled_null.js", UNHANDLED_NULL),
+    ] {
+        for diagnostic in check(path, source) {
+            assert!(
+                diagnostic.code.is_some(),
+                "{path} produced an uncoded error"
+            );
+            assert_eq!(diagnostic.primary.path, path);
+            assert!(diagnostic.primary.start.line >= 1);
+            assert!(diagnostic.primary.start.column >= 1);
+            assert!(!diagnostic.message.is_empty());
+        }
+    }
+}
+
+#[test]
+fn checking_the_same_input_twice_is_byte_identical() {
+    let first = check("missing_prop.js", MISSING_PROP);
+    let second = check("missing_prop.js", MISSING_PROP);
+
+    assert_eq!(
+        serde_json::to_string(&first).expect("serializes"),
+        serde_json::to_string(&second).expect("serializes"),
+    );
+}
+
+#[test]
+fn a_batch_reports_diagnostics_in_the_order_it_was_given() {
+    let sources = [
+        Source::new("a.js", STRING_TO_NUMBER),
+        Source::new("b.js", UNHANDLED_NULL),
+    ];
+
+    let report = check_sources(&sources, &limits()).expect("the checker runs");
+
+    assert_eq!(report.files_checked, 2);
+    assert!(report.has_errors());
+    let paths: Vec<&str> = report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.primary.path.as_str())
+        .collect();
+    let first_b = paths.iter().position(|path| *path == "b.js");
+    let last_a = paths.iter().rposition(|path| *path == "a.js");
+    assert!(matches!((first_b, last_a), (Some(b), Some(a)) if a < b));
+}
+
+#[test]
+fn a_clean_file_costs_nothing_to_report() {
+    let report = check_sources(&[Source::new("clean.js", CLEAN_COMPONENT)], &limits())
+        .expect("the checker runs");
+
+    assert_eq!(report.count(Severity::Error), 0);
+    assert!(!report.has_errors());
+}
+
+#[test]
+fn a_syntax_error_comes_back_as_a_parse_diagnostic_rather_than_a_failure() {
+    let diagnostics = check("broken.js", "// @flow\ntype = ;\n");
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.kind == DiagnosticKind::Parse),
+        "{:?}",
+        codes(&diagnostics)
+    );
+    assert!(!diagnostics.is_empty());
+    assert_eq!(diagnostics[0].primary.start.line, 2);
+}
+
+#[test]
+fn an_empty_file_is_clean() {
+    assert!(check("empty.js", "").is_empty());
+}
+
+#[test]
+fn a_file_with_a_bom_and_crlf_line_endings_still_reports_real_lines() {
+    let source = "\u{feff}// @flow\r\nconst total: number = \"twelve\";\r\n";
+
+    let diagnostics = check("crlf.js", source);
+
+    let diagnostic = find(&diagnostics, "incompatible-type");
+    assert_eq!(diagnostic.primary.start.line, 2);
+}
+
+#[test]
+fn non_ascii_identifiers_report_byte_columns() {
+    let source = "// @flow\nconst \u{e9}l\u{e9}ment: number = \"x\";\n";
+
+    let diagnostics = check("non_ascii.js", source);
+
+    let diagnostic = find(&diagnostics, "incompatible-type");
+    assert_eq!(diagnostic.primary.start.line, 2);
+    // "const élément: number = " is 24 characters but 26 bytes.
+    assert_eq!(diagnostic.primary.start.column, 27);
+}
+
+#[test]
+fn a_source_over_the_limit_is_rejected_before_it_is_parsed() {
+    let limits = limits().with_max_source_bytes(64);
+    let source = format!("// @flow\n{}\n", "const x: number = 1;".repeat(64));
+
+    let error = check_source(Source::new("big.js", &source), &limits)
+        .expect_err("the limit must be enforced");
+
+    assert!(matches!(
+        error,
+        CheckError::SourceTooLarge { limit: 64, .. }
+    ));
+}
+
+#[test]
+fn a_five_megabyte_file_is_rejected_by_the_default_limits() {
+    let source = "// @flow\n".to_owned() + &"const x: number = 1;\n".repeat(250_000);
+    assert!(source.len() > 5_000_000);
+
+    let error = check_source(Source::new("huge.js", &source), &CheckLimits::default())
+        .expect_err("the default limit must be enforced");
+
+    assert!(matches!(error, CheckError::SourceTooLarge { .. }));
+}
+
+#[test]
+fn ten_thousand_nested_generics_terminate_instead_of_overflowing() {
+    let depth = 10_000;
+    let mut source = String::with_capacity(depth * 8 + 64);
+    source.push_str("// @flow\ntype Box<T> = { value: T };\ntype Deep = ");
+    for _ in 0..depth {
+        source.push_str("Box<");
+    }
+    source.push_str("number");
+    for _ in 0..depth {
+        source.push('>');
+    }
+    source.push_str(";\nexport type Out = Deep;\n");
+
+    // The bar is that this returns at all. Whether Flow reports a recursion
+    // limit, a type error, or nothing is upstream's call; hanging or aborting
+    // the process is not an option.
+    let outcome = check_source(
+        Source::new("nested.js", &source),
+        &limits().with_file_timeout(Duration::from_secs(60)),
+    );
+
+    match outcome {
+        Ok(diagnostics) => assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.primary.path == "nested.js")
+        ),
+        Err(error) => assert!(
+            matches!(
+                error,
+                CheckError::Budget { .. } | CheckError::SourceTooLarge { .. }
+            ),
+            "unexpected failure: {error}"
+        ),
+    }
+}
+
+#[test]
+fn builtins_are_merged_once_and_then_free() {
+    let first = prepare_builtins().expect("builtins merge");
+    let second = prepare_builtins().expect("builtins are cached");
+
+    assert!(!second.cold, "the second call must not rebuild");
+    assert_eq!(first.cold_elapsed, second.cold_elapsed);
+    assert!(
+        first.cold_elapsed > Duration::ZERO,
+        "the merge must be measured"
+    );
+    assert!(
+        second.elapsed < first.cold_elapsed,
+        "a warm call ({:?}) must be cheaper than the merge ({:?})",
+        second.elapsed,
+        first.cold_elapsed
+    );
+}
+
+#[test]
+fn a_report_separates_the_builtin_cost_from_the_check_cost() {
+    let report = check_sources(&[Source::new("clean.js", CLEAN_COMPONENT)], &limits())
+        .expect("the checker runs");
+
+    assert_eq!(report.files_checked, 1);
+    assert!(report.builtins.cold_elapsed > Duration::ZERO);
+    assert!(report.files_per_second().is_some());
+}

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -20,12 +20,18 @@ path = "src/bin/ufr.rs"
 name = "ufx"
 path = "src/bin/ufx.rs"
 
+[features]
+default = []
+# Run Flow's own type inference in `uf check`; see `crates/uf_check`.
+upstream-typecheck = ["uf_check/upstream-typecheck"]
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true
 uf_bundle = { path = "../uf_bundle" }
 uf_bundler = { path = "../uf_bundler" }
+uf_check = { path = "../uf_check" }
 uf_config = { path = "../uf_config" }
 uf_devserver = { path = "../uf_devserver" }
 uf_effect = { path = "../uf_effect" }

--- a/crates/uf_cli/src/commands.rs
+++ b/crates/uf_cli/src/commands.rs
@@ -4,6 +4,7 @@
 //! shape of `uf build` on screen lives next to what `uf build` actually does.
 
 pub(crate) mod build;
+pub(crate) mod check;
 pub(crate) mod create;
 pub(crate) mod dev;
 pub(crate) mod env;

--- a/crates/uf_cli/src/commands/check.rs
+++ b/crates/uf_cli/src/commands/check.rs
@@ -1,0 +1,359 @@
+//! `uf check`: the linter, and then Flow's own type inference.
+//!
+//! `uf lint` answers whether the source is well-formed and idiomatic. `uf
+//! check` answers that *and* whether the types hold, by running the checker
+//! from `uf_check`. Both halves render through the same `uf_term` code frames,
+//! so a type error and a lint error look alike on screen — the difference a
+//! reader cares about is the rule or error code in the header, not the shape of
+//! the block.
+//!
+//! When the checker is not compiled in, the type-checking half reports itself
+//! unavailable and `uf check` is exactly `uf lint` under another name.
+
+use anyhow::{Result, bail};
+use camino::Utf8Path;
+use serde_json::{Value, json};
+use uf_check::{
+    CheckError, CheckLimits, CheckReport, Source, TypeDiagnostic, active_backend, backend_name,
+    check_sources,
+};
+use uf_lint::{LintReport, Severity, SourceFile};
+use uf_term::{CodeFrame, DiagnosticLevel, KeyValue, Status, Tone, push_spaces};
+
+use crate::commands::lint::{
+    LintCommand, group_by_path, lint_payload, render_file_summary, render_group, render_verdict,
+    run_lint, severity_count,
+};
+use crate::support::{plural, problem_summary};
+use crate::ui::Ui;
+
+/// How many untyped imports are named before the list is summarised.
+const UNTYPED_MODULES_SHOWN: usize = 5;
+
+/// What the type-checking half of `uf check` produced.
+///
+/// The three cases are genuinely different and a reader must be able to tell
+/// them apart: no checker in this build, a clean or failing check, and a
+/// checker that could not run at all.
+enum TypeCheck {
+    /// No checker was compiled in.
+    Unavailable,
+    /// Inference ran over the project.
+    Checked(CheckReport),
+    /// Inference could not run.
+    Failed(CheckError),
+}
+
+impl TypeCheck {
+    fn report(&self) -> Option<&CheckReport> {
+        match self {
+            Self::Checked(report) => Some(report),
+            Self::Unavailable | Self::Failed(_) => None,
+        }
+    }
+
+    fn diagnostics(&self) -> &[TypeDiagnostic] {
+        self.report()
+            .map_or(&[][..], |report| report.diagnostics.as_slice())
+    }
+
+    fn count(&self, severity: uf_check::Severity) -> usize {
+        self.report().map_or(0, |report| report.count(severity))
+    }
+
+    fn status(&self) -> &'static str {
+        match self {
+            Self::Unavailable => "unavailable",
+            Self::Checked(_) => "checked",
+            Self::Failed(_) => "failed",
+        }
+    }
+}
+
+pub(crate) fn check(cwd: &Utf8Path, ui: &mut Ui, json: bool) -> Result<()> {
+    let mut progress = ui.progress();
+    progress.draw("scanning sources");
+    let (lint, sources) = run_lint(cwd)?;
+    progress.draw("type checking");
+    let types = type_check(&sources);
+    progress.finish();
+    drop(progress);
+
+    if json {
+        ui.json(&payload(&lint, &types))?;
+    } else {
+        render(ui, &lint, &sources, &types);
+    }
+
+    let errors = severity_count(&lint, Severity::Error) + types.count(uf_check::Severity::Error);
+    if errors > 0 {
+        bail!(
+            "{} failed with {}",
+            LintCommand::Check.title(),
+            plural(errors, "error")
+        );
+    }
+    if let TypeCheck::Failed(error) = types {
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+/// Run inference over every source the linter collected.
+///
+/// Syntax errors are dropped here rather than in `uf_check`: the checker
+/// reports them because a library caller needs to know why inference did not
+/// run, but `uf lint` has already reported the same syntax error with its own
+/// rule id, and printing it twice helps nobody.
+fn type_check(sources: &[SourceFile]) -> TypeCheck {
+    let inputs: Vec<Source<'_>> = sources
+        .iter()
+        .map(|source| Source::new(&source.path, &source.source))
+        .collect();
+
+    match check_sources(&inputs, &CheckLimits::default()) {
+        Ok(mut report) => {
+            report
+                .diagnostics
+                .retain(|diagnostic| diagnostic.kind != uf_check::DiagnosticKind::Parse);
+            TypeCheck::Checked(report)
+        }
+        Err(error) if error.is_unavailable() => TypeCheck::Unavailable,
+        Err(error) => TypeCheck::Failed(error),
+    }
+}
+
+fn payload(lint: &LintReport, types: &TypeCheck) -> Value {
+    let mut value = lint_payload(LintCommand::Check, lint);
+    let errors = severity_count(lint, Severity::Error) + types.count(uf_check::Severity::Error);
+    let warnings = severity_count(lint, Severity::Warn) + types.count(uf_check::Severity::Warning);
+
+    let mut type_check = json!({
+        "backend": backend_name(active_backend()),
+        "status": types.status(),
+        "diagnostics": types.diagnostics(),
+    });
+    if let Some(report) = types.report() {
+        type_check["filesChecked"] = json!(report.files_checked);
+        type_check["elapsedMs"] = json!(report.elapsed.as_secs_f64() * 1000.0);
+        type_check["builtinsMs"] = json!(report.builtins.cold_elapsed.as_secs_f64() * 1000.0);
+        type_check["builtinsCold"] = json!(report.builtins.cold);
+        type_check["untypedModules"] = json!(report.untyped_modules);
+    }
+    if let TypeCheck::Failed(error) = types {
+        type_check["error"] = json!(error.to_string());
+    }
+
+    value["errors"] = json!(errors);
+    value["warnings"] = json!(warnings);
+    value["typeCheck"] = type_check;
+    value
+}
+
+fn render(ui: &mut Ui, lint: &LintReport, sources: &[SourceFile], types: &TypeCheck) {
+    let lint_errors = severity_count(lint, Severity::Error);
+    let lint_warnings = severity_count(lint, Severity::Warn);
+    let groups = group_by_path(&lint.diagnostics);
+
+    ui.render(|renderer, out| {
+        renderer.banner(out, LintCommand::Check.title(), None);
+        renderer.blank(out);
+    });
+
+    for group in &groups {
+        render_group(ui, group, sources);
+    }
+    if groups.len() > 1 {
+        render_file_summary(ui, &groups);
+    }
+
+    render_type_diagnostics(ui, sources, types);
+
+    render_verdict(
+        ui,
+        lint,
+        lint_errors + types.count(uf_check::Severity::Error),
+        lint_warnings + types.count(uf_check::Severity::Warning),
+    );
+    render_type_footer(ui, types);
+}
+
+/// Type diagnostics, grouped by file, as code frames.
+fn render_type_diagnostics(ui: &mut Ui, sources: &[SourceFile], types: &TypeCheck) {
+    let diagnostics = types.diagnostics();
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    let mut start = 0;
+    while start < diagnostics.len() {
+        let path = diagnostics[start].primary.path.as_str();
+        let mut end = start;
+        while end < diagnostics.len() && diagnostics[end].primary.path == path {
+            end += 1;
+        }
+        render_type_group(ui, sources, &diagnostics[start..end]);
+        start = end;
+    }
+}
+
+fn render_type_group(ui: &mut Ui, sources: &[SourceFile], group: &[TypeDiagnostic]) {
+    let path = group[0].primary.path.as_str();
+    let lines: Option<Vec<&str>> = sources
+        .iter()
+        .find(|source| source.path == path)
+        .map(|source| source.source.lines().collect());
+    let errors = group
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .count();
+    let header = problem_summary(errors, group.len() - errors);
+    let messages: Vec<String> = group.iter().map(TypeDiagnostic::message_text).collect();
+    // `[1]` in the message and `[1]` on the note have to be the same marker, or
+    // a reader has no way to tell two references apart.
+    let notes: Vec<Vec<String>> = group
+        .iter()
+        .map(|diagnostic| {
+            diagnostic
+                .related
+                .iter()
+                .map(|related| format!("[{}] is here", related.id))
+                .collect()
+        })
+        .collect();
+
+    ui.render(|renderer, out| {
+        renderer.theme().path.paint(renderer.color(), path, out);
+        out.push_str("  ");
+        renderer.theme().muted.paint(renderer.color(), &header, out);
+        out.push('\n');
+        renderer.blank(out);
+
+        for ((diagnostic, message), notes) in group.iter().zip(&messages).zip(&notes) {
+            let level = if diagnostic.is_error() {
+                DiagnosticLevel::Error
+            } else {
+                DiagnosticLevel::Warning
+            };
+            let line = diagnostic.primary.start.line as usize;
+            let column = diagnostic.primary.start.column as usize;
+            let mut frame = CodeFrame::new(level, message, path, line, column);
+            if let Some(code) = diagnostic.code {
+                frame = frame.with_rule(code);
+            }
+            if let Some(span) = diagnostic.primary.single_line_len() {
+                frame = frame.with_span(span);
+            }
+            if let Some(source_line) = lines
+                .as_ref()
+                .and_then(|lines| lines.get(line.saturating_sub(1)).copied())
+            {
+                frame = frame.with_source_line(source_line);
+            }
+            renderer.code_frame_at(out, &frame, 2);
+
+            // Flow's messages point at other locations by number; without the
+            // locations themselves a reader cannot follow `[1]` anywhere.
+            for (related, note_label) in diagnostic.related.iter().zip(notes) {
+                let related_line = related.span.start.line as usize;
+                let mut note = CodeFrame::new(
+                    DiagnosticLevel::Note,
+                    note_label,
+                    related.span.path.as_str(),
+                    related_line,
+                    related.span.start.column as usize,
+                );
+                if let Some(span) = related.span.single_line_len() {
+                    note = note.with_span(span);
+                }
+                let related_source = lines
+                    .as_ref()
+                    .filter(|_| related.span.path == path)
+                    .and_then(|lines| lines.get(related_line.saturating_sub(1)).copied());
+                if let Some(source_line) = related_source {
+                    note = note.with_source_line(source_line);
+                }
+                renderer.code_frame_at(out, &note, 4);
+            }
+            renderer.blank(out);
+        }
+    });
+}
+
+/// One line saying what the type checker did, under the verdict.
+fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
+    match types {
+        TypeCheck::Unavailable => ui.render(|renderer, out| {
+            renderer.blank(out);
+            renderer.status(
+                out,
+                Status::Info,
+                "type inference is not compiled into this build",
+            );
+        }),
+        TypeCheck::Failed(error) => {
+            let detail = error.to_string();
+            ui.render(|renderer, out| {
+                renderer.blank(out);
+                renderer.status(out, Status::Warn, &detail);
+            });
+        }
+        TypeCheck::Checked(report) => {
+            let files = report.files_checked.to_string();
+            let inference = format!("{:.1?}", report.elapsed);
+            let builtins = format!(
+                "{:.1?} ({})",
+                report.builtins.cold_elapsed,
+                if report.builtins.cold { "cold" } else { "warm" }
+            );
+            let untyped = untyped_module_list(report);
+            ui.render(|renderer, out| {
+                renderer.blank(out);
+                renderer.key_values(
+                    out,
+                    2,
+                    &[
+                        KeyValue::toned("types checked", &files, Tone::Number),
+                        KeyValue::toned("inference", &inference, Tone::Muted),
+                        KeyValue::toned("builtins", &builtins, Tone::Muted),
+                    ],
+                );
+                if !untyped.is_empty() {
+                    renderer.blank(out);
+                    push_spaces(out, 2);
+                    renderer.status(
+                        out,
+                        Status::Info,
+                        "these imports are typed as any; uf does not check across modules yet",
+                    );
+                    let items: Vec<&str> = untyped.iter().map(String::as_str).collect();
+                    renderer.bullet_list(out, 4, &items);
+                }
+            });
+        }
+    }
+}
+
+/// The untyped imports to name on screen, with the tail summarised.
+///
+/// A project pulls in more packages than a terminal should list, and the full
+/// set is always in `--json`.
+fn untyped_module_list(report: &CheckReport) -> Vec<String> {
+    let mut named: Vec<String> = report
+        .untyped_modules
+        .iter()
+        .take(UNTYPED_MODULES_SHOWN)
+        .map(ToString::to_string)
+        .collect();
+    let overflow = report
+        .untyped_modules
+        .len()
+        .saturating_sub(UNTYPED_MODULES_SHOWN);
+    if overflow > 0 {
+        named.push(format!("and {overflow} more"));
+    }
+    named
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_cli/src/commands/check/tests.rs
+++ b/crates/uf_cli/src/commands/check/tests.rs
@@ -1,0 +1,114 @@
+//! The `uf check` payload, and how the two halves of it are combined.
+
+use uf_lint::Diagnostic;
+
+use super::*;
+
+fn lint_report(errors: usize, warnings: usize) -> LintReport {
+    let mut diagnostics = Vec::new();
+    for index in 0..errors {
+        diagnostics.push(diagnostic(index, Severity::Error));
+    }
+    for index in 0..warnings {
+        diagnostics.push(diagnostic(index, Severity::Warn));
+    }
+    LintReport {
+        diagnostics,
+        files_checked: 2,
+        unavailable: Vec::new(),
+    }
+}
+
+fn diagnostic(index: usize, severity: Severity) -> Diagnostic {
+    Diagnostic {
+        rule: "flow/unclear-type",
+        severity,
+        path: Some("a.js".to_string()),
+        line: index + 1,
+        column: 1,
+        message: "unclear type".to_string(),
+    }
+}
+
+#[test]
+fn the_payload_keeps_the_shape_uf_lint_emits() {
+    let value = payload(&lint_report(1, 1), &TypeCheck::Unavailable);
+
+    assert_eq!(value["command"], json!("uf check"));
+    assert_eq!(value["filesChecked"], json!(2));
+    assert_eq!(value["errors"], json!(1));
+    assert_eq!(value["warnings"], json!(1));
+    assert!(value["diagnostics"].is_array());
+    assert!(value["unavailableRules"].is_array());
+}
+
+#[test]
+fn the_payload_names_the_checker_backend_and_its_status() {
+    let value = payload(&lint_report(0, 0), &TypeCheck::Unavailable);
+
+    assert_eq!(value["typeCheck"]["status"], json!("unavailable"));
+    assert_eq!(
+        value["typeCheck"]["backend"],
+        json!(backend_name(active_backend()))
+    );
+    assert_eq!(value["typeCheck"]["diagnostics"], json!([]));
+}
+
+#[test]
+fn a_checker_failure_is_reported_without_losing_the_lint_counts() {
+    let types = TypeCheck::Failed(CheckError::SourceTooLarge {
+        path: "big.js".into(),
+        size: 8,
+        limit: 4,
+    });
+
+    let value = payload(&lint_report(2, 0), &types);
+
+    assert_eq!(value["errors"], json!(2));
+    assert_eq!(value["typeCheck"]["status"], json!("failed"));
+    assert!(
+        value["typeCheck"]["error"]
+            .as_str()
+            .expect("an error string")
+            .contains("big.js")
+    );
+}
+
+#[test]
+fn an_unavailable_checker_contributes_no_counts() {
+    let types = TypeCheck::Unavailable;
+
+    assert_eq!(types.count(uf_check::Severity::Error), 0);
+    assert_eq!(types.count(uf_check::Severity::Warning), 0);
+    assert!(types.diagnostics().is_empty());
+    assert!(types.report().is_none());
+}
+
+#[test]
+fn statuses_are_stable() {
+    assert_eq!(TypeCheck::Unavailable.status(), "unavailable");
+    assert_eq!(
+        TypeCheck::Failed(CheckError::Unavailable).status(),
+        "failed"
+    );
+}
+
+#[test]
+fn a_build_with_a_checker_reports_it_and_one_without_says_so() {
+    let types = type_check(&[]);
+
+    if uf_check::is_available() {
+        assert_eq!(types.status(), "checked");
+        assert_eq!(
+            value_of(&types)["filesChecked"],
+            json!(0),
+            "an empty project checks zero files"
+        );
+    } else {
+        assert_eq!(types.status(), "unavailable");
+    }
+}
+
+fn value_of(types: &TypeCheck) -> Value {
+    payload(&lint_report(0, 0), types)["typeCheck"].clone()
+}

--- a/crates/uf_cli/src/commands/lint.rs
+++ b/crates/uf_cli/src/commands/lint.rs
@@ -66,7 +66,7 @@ pub(crate) fn lint_command(
     Ok(())
 }
 
-fn run_lint(cwd: &Utf8Path) -> Result<(LintReport, Vec<SourceFile>)> {
+pub(crate) fn run_lint(cwd: &Utf8Path) -> Result<(LintReport, Vec<SourceFile>)> {
     let resolved = load_config(cwd)?;
     let files = collect_source_files(&resolved.root, &resolved.config)?;
     let sources = files
@@ -174,7 +174,7 @@ fn render_lint_report(
 }
 
 /// One file's diagnostics: a header naming the file, then the code frames.
-fn render_group(ui: &mut Ui, group: &[Diagnostic], sources: &[SourceFile]) {
+pub(crate) fn render_group(ui: &mut Ui, group: &[Diagnostic], sources: &[SourceFile]) {
     let path = diagnostic_path(&group[0]);
     let lines: Option<Vec<&str>> = sources
         .iter()
@@ -221,7 +221,7 @@ fn render_group(ui: &mut Ui, group: &[Diagnostic], sources: &[SourceFile]) {
 }
 
 /// A per-file count table, printed once diagnostics span more than one file.
-fn render_file_summary(ui: &mut Ui, groups: &[&[Diagnostic]]) {
+pub(crate) fn render_file_summary(ui: &mut Ui, groups: &[&[Diagnostic]]) {
     let rows: Vec<(String, String, String)> = groups
         .iter()
         .map(|group| {
@@ -255,7 +255,7 @@ fn render_file_summary(ui: &mut Ui, groups: &[&[Diagnostic]]) {
     });
 }
 
-fn render_verdict(ui: &mut Ui, report: &LintReport, errors: usize, warnings: usize) {
+pub(crate) fn render_verdict(ui: &mut Ui, report: &LintReport, errors: usize, warnings: usize) {
     let files_checked = report.files_checked.to_string();
     let error_count = errors.to_string();
     let warning_count = warnings.to_string();

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -77,9 +77,7 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
 
     match cli.command {
         Commands::Build { size_report } => commands::build::build(&cwd, ui, size_report),
-        Commands::Check { json } => {
-            commands::lint::lint_command(&cwd, ui, commands::lint::LintCommand::Check, json)
-        }
+        Commands::Check { json } => commands::check::check(&cwd, ui, json),
         Commands::Create { command } => commands::create::create(&cwd, ui, command),
         Commands::Dev { host, once } => commands::dev::dev(&cwd, ui, host.as_deref(), once),
         Commands::Env { command } => commands::env::env(&cwd, ui, command),

--- a/crates/uf_cli/tests/typecheck.rs
+++ b/crates/uf_cli/tests/typecheck.rs
@@ -1,0 +1,166 @@
+//! `uf check` with Flow's own type inference compiled in.
+//!
+//! Only built with the `upstream-typecheck` feature; without it `uf check` is
+//! the linter alone and `tests/output.rs` already covers that shape.
+
+#![cfg(feature = "upstream-typecheck")]
+
+mod support;
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+use support::{assert_plain, uf};
+
+/// A project whose one file has a type error and nothing for the linter to say.
+fn typed_project(dir: &Path) {
+    let src = dir.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("total.js"),
+        "// @flow\nexport const total: number = \"twelve\";\n",
+    )
+    .unwrap();
+}
+
+/// A project that both halves of `uf check` are happy with.
+fn clean_project(dir: &Path) {
+    let src = dir.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("total.js"),
+        "// @flow\nexport function add(a: number, b: number): number {\n  return a + b;\n}\n",
+    )
+    .unwrap();
+}
+
+fn check_json(dir: &Path) -> Value {
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir)
+        .args(["check", "--json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_plain(&stdout);
+    serde_json::from_str(&stdout).expect("--json must parse")
+}
+
+#[test]
+fn check_reports_the_upstream_checker_as_its_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    clean_project(dir.path());
+
+    let value = check_json(dir.path());
+
+    assert_eq!(value["command"], serde_json::json!("uf check"));
+    assert_eq!(
+        value["typeCheck"]["backend"],
+        serde_json::json!("upstream-flow-rust-port")
+    );
+    assert_eq!(value["typeCheck"]["status"], serde_json::json!("checked"));
+    assert!(value["typeCheck"]["filesChecked"].as_u64().unwrap() >= 1);
+    assert!(value["typeCheck"]["builtinsMs"].as_f64().unwrap() > 0.0);
+}
+
+#[test]
+fn a_clean_project_passes_both_halves_of_the_check() {
+    let dir = tempfile::tempdir().unwrap();
+    clean_project(dir.path());
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["check", "--color", "never"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("types checked"), "{stdout}");
+}
+
+#[test]
+fn a_type_error_fails_the_run_and_carries_a_flow_error_code() {
+    let dir = tempfile::tempdir().unwrap();
+    typed_project(dir.path());
+
+    let value = check_json(dir.path());
+
+    assert_eq!(value["errors"], serde_json::json!(1));
+    let diagnostics = value["typeCheck"]["diagnostics"].as_array().unwrap();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0]["code"],
+        serde_json::json!("incompatible-type")
+    );
+    assert_eq!(diagnostics[0]["severity"], serde_json::json!("error"));
+    assert_eq!(diagnostics[0]["kind"], serde_json::json!("infer"));
+    assert_eq!(
+        diagnostics[0]["primary"]["start"]["line"],
+        serde_json::json!(2)
+    );
+    assert_eq!(
+        diagnostics[0]["primary"]["path"],
+        serde_json::json!("src/total.js")
+    );
+}
+
+#[test]
+fn a_type_error_is_rendered_as_a_code_frame() {
+    let dir = tempfile::tempdir().unwrap();
+    typed_project(dir.path());
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["check", "--color", "never"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!output.status.success());
+    assert!(stdout.contains("error[incompatible-type]"), "{stdout}");
+    assert!(stdout.contains("src/total.js:2:"), "{stdout}");
+    // The offending line, and a caret under it.
+    assert!(stdout.contains("\"twelve\""), "{stdout}");
+    assert!(stdout.contains('^'), "{stdout}");
+}
+
+#[test]
+fn two_runs_of_the_same_project_report_identical_diagnostics() {
+    let dir = tempfile::tempdir().unwrap();
+    typed_project(dir.path());
+
+    let first = check_json(dir.path());
+    let second = check_json(dir.path());
+
+    assert_eq!(
+        first["typeCheck"]["diagnostics"],
+        second["typeCheck"]["diagnostics"]
+    );
+    assert_eq!(first["diagnostics"], second["diagnostics"]);
+    assert_eq!(first["errors"], second["errors"]);
+}
+
+#[test]
+fn imports_that_uf_cannot_type_yet_are_named_rather_than_hidden() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("app.js"),
+        "// @flow\nimport { thing } from \"./other.js\";\nexport const used: mixed = thing;\n",
+    )
+    .unwrap();
+    fs::write(src.join("other.js"), "// @flow\nexport const thing = 1;\n").unwrap();
+
+    let value = check_json(dir.path());
+
+    let untyped = value["typeCheck"]["untypedModules"].as_array().unwrap();
+    assert!(
+        untyped.iter().any(|name| name == "./other.js"),
+        "{untyped:?}"
+    );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ manager performance, and integrated feature coverage.
 - `uf_config`: zero-config defaults and `uf.config.js` loading
 - `uf_browser`: Playwright-compatible browser and VRT contracts
 - `uf_bundle`: bundle size measurement and `build.budgets` enforcement
+- `uf_check`: Flow type inference, driven from `upstream/flow`
 - `uf_fetch`: explicit ofetch-style client contracts
 - `uf_flow`: Flow parser/typechecker adapter boundary over `upstream/flow`
 - `uf_fmt`: native formatter runner
@@ -103,6 +104,45 @@ a copy of each crate at a different depth, where `uf_flow`'s relative path to
 `upstream/flow` no longer resolves. `uf_flow` is excluded from that check
 rather than the check being switched off, and it is the crate whose public API
 moves least — the backends sit behind one `validate_source`.
+
+## Type Checking
+
+`uf_check` is the embedding of Flow's own inference, behind the
+`upstream-typecheck` feature. It is a separate crate rather than a feature on
+`uf_flow` for one reason: `uf_lint` depends on `uf_flow`, Cargo resolves path
+dependencies whether or not the feature that uses them is on, and inference
+needs sixteen path dependencies on the submodule plus a pinned nightly. Keeping
+them here means exactly one crate — and, through it, `uf_cli` — carries that
+weight.
+
+| Concern | Where it lands |
+| --- | --- |
+| Toolchain | `nightly-2026-08-01`, pinned by the `Upstream Flow Typecheck` CI job |
+| Default build | feature off; `uf check` is the linter alone and `uf` still builds on 1.98.0 |
+| Diagnostics | typed: severity, Flow's error code, primary and root spans, message fragments, and every location the message references |
+| Bounds | `Options::recursion_limit`, `CheckBudget`, a 4 MiB source cap, and a 1 GiB check stack |
+
+Measured on that toolchain, optimized: builtins merge in **19 ms** cold and cost
+nothing warm; a dense Flow React component file checks in **4.3 ms**
+(230 files/s, one thread). Unoptimized those are 60 ms and 15 ms.
+
+What it does not do yet is resolve modules. Every file is checked against Flow's
+standard library — `react` and everything else the library definitions declare —
+but `uf` does not run Flow's merge service, so an import of another project file
+has no signature to check against. Those resolve to Flow's own *unchecked
+module*, which types the import as `any` and lets the rest of the file check, and
+the specifiers are reported in `CheckReport::untyped_modules` so the hole is
+stated rather than silent. Cross-module inference is the next step.
+
+Errors are never flattened into strings. `flow_common_errors`'s accessors give
+the code, kind, and primary location directly; the message tree itself is private
+to that crate, so `json_output`'s v2 rendering is walked once to recover the
+message fragments and the locations they point at, and each fragment is mapped
+back onto a typed segment. Two embedding details worth knowing: Flow's renderer
+panics on a relative path and reads a location's file from disk to build a
+codepoint offset table, so `uf_check` resolves every path against a synthetic
+absolute root that cannot exist — the read always misses, and the columns stay in
+the **bytes** that `uf_term`'s code frames and `uf_lint` both measure in.
 
 ## Flow And React
 


### PR DESCRIPTION
## Summary

`uf check` ran the linter and stopped there — the toolchain claimed Flow and
never checked a type. This adds **`uf_check`**, an embedding of Meta's Flow Rust
port from the `upstream/flow` submodule, and wires it into `uf check` behind an
off-by-default `upstream-typecheck` feature.

**Why a new crate, not a feature on `uf_flow`.** `uf_lint` depends on `uf_flow`,
Cargo resolves path dependencies whether or not the feature that uses them is on,
and inference needs sixteen path dependencies plus a nightly old enough to still
accept `#![feature(box_patterns)]`. Hanging that off `uf_flow` puts the whole
lint graph behind those constraints. One crate carries the weight instead, and
`uf_cli` is the only thing that depends on it.

**Typed diagnostics, not strings.** `TypeDiagnostic` carries severity, Flow's own
error code (borrowed from upstream's table, so it never drifts), primary and root
spans, the message as `Text` / `Code` / `Reference` fragments, and every location
those references point at. `flow_common_errors`'s accessors give the code, kind,
and primary location directly; the message tree is private to that crate, so
`json_output`'s v2 rendering is walked once and each fragment mapped back onto a
typed segment. Flow appends `[error-code]` to its own rendered messages — that
suffix is stripped, because the code is a field and the frame header already
prints it.

**Rendering.** Through `uf_term`'s existing code frames, with a `note` frame per
reference so `[1]` in the message has somewhere to point:

```
  error[incompatible-type]: Cannot create Greeting element because property times
    is missing in props [1] but exists in props of component Greeting [2].
   --> src/missing_prop.js:9:11
    │
  9 │   return <Greeting name="world" />;
    │           ^^^^^^^^
    note: [1] is here
     --> src/missing_prop.js:9:10
    note: [2] is here
     --> src/missing_prop.js:4:1
```

**Numbers** (optimized, `ci-opt`, one thread, 903-byte Flow React component):

| | cold | warm |
| --- | --- | --- |
| builtin merge | 18.8 ms | 0 ns (`OnceLock`) |
| per file | — | 4.35 ms (**230 files/s**, ~208 KB/s) |

Unoptimized the same numbers are 60.0 ms and 15.2 ms (66 files/s). `uf check` on
a scaffolded app: 12 files, 142 ms inference, 79 ms builtins.

**Bounded.** `Options::recursion_limit`, `CheckBudget` (a 30 s per-file
wall-clock budget), a 4 MiB source cap checked before the parser sees the text,
and a 1 GiB check stack — the parser and inference are both recursive descent
over user-controlled nesting, so a default 2 MiB worker is a stack-depth attack
surface. 10 000 nested generics terminate in 2.5 s optimized / 14.6 s
unoptimized; a 5 MB file is rejected with `CheckError::SourceTooLarge`.

**What is deliberately not here: module resolution.** Every file is checked
against Flow's standard library — `react` and everything else the library
definitions declare, through `typed_builtin_module_opt`. An import of another
project file has no signature to check against, because `uf` does not run Flow's
merge service yet. Those resolve to Flow's own *unchecked module*, exactly as
`flow_services_inference::unchecked_module_t` does: the import types as `any`,
the rest of the file still checks, and the specifiers are reported in
`CheckReport::untyped_modules` and named on screen, so the hole is stated rather
than hidden. Reporting them as `cannot-resolve-module` would be a lie and would
bury every real type error. Cross-module inference is the next step.

### Also worth knowing

- **The `Upstream Flow` CI job is now two jobs.** The existing one keeps tracking
  the *moving* `nightly` (it is what tells us when `never_type` stabilizes and
  `upstream-parser` can become the default), so it narrows from `--all-features`
  to `--features uf_flow/upstream-parser`. A new `Upstream Flow Typecheck` job
  pins `nightly-2026-08-01` and runs the full `--all-features` clippy + test.
- **Two embedding traps, both documented in code.** Flow's renderer panics on a
  relative path *and* reads a location's file from disk to build a codepoint
  offset table; `uf_check` resolves every path against a synthetic absolute root
  that cannot exist, so the read always misses and columns stay in the **bytes**
  `uf_term` and `uf_lint` measure in. And `file_key::{set_project_root,
  set_flowlib_root}` are process-global and panic if unset, so they go behind a
  `std::sync::Once`.
- `crates/uf_check/src/upstream/` carries one `#![allow(clippy::disallowed_types)]`:
  the port's API is `Rc`/`Arc` all the way down. No `Rc` or `Arc` appears in this
  crate's public API.
- **Follow-up, not done here:** `uf_check` will need adding to `semver.yml`'s
  `exclude` list for the same reason `uf_flow` is there (relative path to
  `upstream/flow` from the baseline copy). It has no baseline yet, so it cannot
  fail today; adding it blind risked breaking the action's input format on a job
  I cannot run locally.
- `README.md` still shows `cargo +nightly test --workspace --all-features`, which
  now needs the pinned nightly. Left alone per the "don't touch README" rule;
  `CONTRIBUTING.md` and `docs/architecture.md` are updated.

### Tests

74 new tests. `crates/uf_check`: 49 unit (diagnostic model, limits, markup
conversion, option construction, error paths) + 20 integration; `uf_cli`: 5 unit
+ 6 integration behind the feature. Fixtures assert on **error code and
location**, never message text:

- clean: a Flow React file with `component`/`hook`, `renders`/`renders*`/`renders?`,
  generics, `opaque type`, unions, exact object types → 0 diagnostics
- `incompatible-type` at `2:23` len 8 (string assigned to `number`)
- `incompatible-type` at `9:11` with a reference to the declaration at `4:1`
  (missing required prop)
- `invalid-render` at `6:35` len 13 (bad `renders` type)
- `incompatible-use` at `3:16` len 6 (unhandled `null`)

Plus determinism (same input twice → byte-identical JSON), CRLF/BOM, non-ASCII
byte columns, empty file, syntax error, size limits, and the nesting bomb.

## Verification

From a clean checkout, materialize the upstream Flow submodule first —
Cargo resolves the `flow_parser` path dependency during metadata loading:

```sh
tools/upstream/sync.sh
```

Pinned release toolchain (1.98.0):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo bench --workspace --no-run`

Current nightly, for `uf_flow`'s `upstream-parser` (the `Upstream Flow` job):

- [x] `cargo +nightly clippy --workspace --all-targets --features uf_flow/upstream-parser -- -D warnings`
- [x] `cargo +nightly test --workspace --features uf_flow/upstream-parser`

Pinned nightly, for the type checker (the `Upstream Flow Typecheck` job):

- [x] `cargo +nightly-2026-08-01 test --workspace --all-features`
- [ ] `cargo +nightly-2026-08-01 clippy --workspace --all-targets --all-features -- -D warnings`
      — clippy is not installed for that toolchain on this machine and there is no
      `rustup` to add it; CI installs it via `components: clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790928009&installation_model_id=422833&pr_number=37&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F37&signature=3804ea8dc7f9361ddf0d1b86453103e356d2d1dac7b2c15f774eeaf7698c6adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `uf check` command, combining linting with Flow type checking.
  * Added human-readable code-frame and JSON diagnostic output.
  * Added structured type diagnostics, severity reporting, resource limits, and check performance details.
  * Added support for identifying unavailable checkers and modules that cannot yet be type checked.

* **Documentation**
  * Documented type-checking behavior, diagnostics, limits, performance, and supported module resolution.

* **Tests**
  * Added comprehensive coverage for type checking, diagnostics, reporting, limits, and CLI output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->