### PR TITLE
ci: exclude uf_check from cargo-semver-checks

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -25,9 +25,11 @@ jobs:
         with:
           baseline-rev: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           rust-toolchain: "1.98.0"
-          # `uf_flow` optionally path-depends on `upstream/flow`, and
-          # cargo-semver-checks builds its baseline from a copy of the crate at
-          # a different depth, where `../../upstream/...` no longer resolves.
-          # The relative path is not something the crate can fix, so the crate
-          # is excluded rather than the whole gate being turned off.
-          exclude: uf_flow
+          # `uf_flow` and `uf_check` optionally path-depend on `upstream/flow`,
+          # and cargo-semver-checks builds its baseline from a copy of the crate
+          # at a different depth, where `../../upstream/...` no longer resolves.
+          # The relative path is not something either crate can fix, so they are
+          # excluded rather than the whole gate being turned off. Both are also
+          # the crates whose public API moves least: one `validate_source`, and
+          # one `check_sources`.
+          exclude: uf_flow,uf_check

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,10 +100,11 @@ reach outside `rust_port` into `lib/`, `prelude/`, and `tslib/`, so
 `tools/upstream/sync.sh` checks those out too and asserts they arrived.
 
 The submodule costs one gate: `cargo-semver-checks` builds its baseline from
-a copy of each crate at a different depth, where `uf_flow`'s relative path to
-`upstream/flow` no longer resolves. `uf_flow` is excluded from that check
-rather than the check being switched off, and it is the crate whose public API
-moves least — the backends sit behind one `validate_source`.
+a copy of each crate at a different depth, where the relative path to
+`upstream/flow` no longer resolves. `uf_flow` and `uf_check` are excluded from
+that check rather than the check being switched off, and they are the crates
+whose public API moves least — the parser backends sit behind one
+`validate_source`, and the checker behind one `check_sources`.
 
 ## Type Checking
 


### PR DESCRIPTION
## Summary

Follow-up to #37. `Cargo Semver Checks` failed there and, not being a required
check, the PR merged anyway:

```
error: failed to retrieve local crate data from git revision
  2: package `uf_check` not found in .../semver-checks/git-<base-sha>/...
```

Two reasons, one fix. `uf_check` did not exist in that PR's baseline, so there
was nothing to compare against — and once it does exist in a baseline, it hits
the problem `uf_flow` is already excluded for: cargo-semver-checks builds the
baseline from a copy of the crate at a different depth, where the relative path
to `upstream/flow` no longer resolves.

So `uf_check` joins `uf_flow` in the `exclude` list, with the same reasoning and
the same justification for excluding a crate rather than switching the gate off:
both have a public API that is a single entry point — `validate_source` and
`check_sources`.

`exclude` is documented by the action as a comma-separated list, hence
`uf_flow,uf_check`.

## Verification

Workflow-only change; the local Rust gate is unaffected and unchanged by this
commit. #37's own run is the evidence for everything else:

- [x] `Format`, `Clippy`, `Test`, `Bench Compile`, `Metadata` — pass
- [x] `Upstream Flow` — pass on the current nightly
- [x] `Upstream Flow Typecheck` — pass on `nightly-2026-08-01`, both
      `cargo clippy --workspace --all-targets --all-features -- -D warnings`
      and `cargo test --workspace --all-features`
- [ ] `Cargo Semver Checks` — what this PR fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790928206&installation_model_id=422833&pr_number=39&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F39&signature=e6053345d4fccaff2a5900cf4e1021defcef6a2e047acaec9c4e54cc87781374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture guidance to clarify semver-check exclusions for the `uf_flow` and `uf_check` crates.
  * Added context about path resolution and the stability of their public APIs. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->