### PR TITLE
ci: exclude every crate that reaches the upstream submodule

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -25,11 +25,16 @@ jobs:
         with:
           baseline-rev: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           rust-toolchain: "1.98.0"
-          # `uf_flow` and `uf_check` optionally path-depend on `upstream/flow`,
-          # and cargo-semver-checks builds its baseline from a copy of the crate
-          # at a different depth, where `../../upstream/...` no longer resolves.
-          # The relative path is not something either crate can fix, so they are
-          # excluded rather than the whole gate being turned off. Both are also
-          # the crates whose public API moves least: one `validate_source`, and
-          # one `check_sources`.
-          exclude: uf_flow,uf_check
+          # cargo-semver-checks builds its baseline from a copy of each crate,
+          # outside the workspace, where the relative path to the `upstream/flow`
+          # submodule no longer resolves. A path dependency is relative by
+          # definition, so this is not something a crate can fix.
+          #
+          # `uf_flow` and `uf_check` name the submodule; the other three reach it
+          # transitively, and cargo resolves a path dependency whether or not the
+          # feature using it is enabled. Excluding them keeps 37 of 42 crates
+          # gated, which is worth more than switching the gate off.
+          #
+          # The list grows as more crates use the parser. See
+          # docs/architecture.md for what to do when it covers too little.
+          exclude: uf_bundler,uf_check,uf_cli,uf_flow,uf_lint

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,12 +99,25 @@ Measured against `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`:
 reach outside `rust_port` into `lib/`, `prelude/`, and `tslib/`, so
 `tools/upstream/sync.sh` checks those out too and asserts they arrived.
 
-The submodule costs one gate: `cargo-semver-checks` builds its baseline from
-a copy of each crate at a different depth, where the relative path to
-`upstream/flow` no longer resolves. `uf_flow` and `uf_check` are excluded from
-that check rather than the check being switched off, and they are the crates
-whose public API moves least — the parser backends sit behind one
-`validate_source`, and the checker behind one `check_sources`.
+The submodule costs one gate. `cargo-semver-checks` builds its baseline from a
+copy of each crate, outside the workspace, where the relative path to
+`upstream/flow` no longer resolves — and a path dependency is relative by
+definition, so no crate can fix it from its own manifest.
+
+Five crates are excluded from that check: `uf_flow` and `uf_check` name the
+submodule, and `uf_bundler`, `uf_cli` and `uf_lint` reach it transitively,
+because cargo resolves a path dependency whether or not the feature using it is
+enabled. That leaves 37 of 42 crates gated, which is worth more than switching
+the gate off — but the list grows as more crates use the parser, and it already
+includes three of the more interesting public APIs.
+
+If it grows to where the gate covers little, the fix is to make the upstream
+dependency a rev-pinned git dependency, which cargo resolves from any directory,
+and keep the submodule for reading. That would also undo the other three costs
+the submodule has charged: `cargo fmt --all` visiting vendored code, every CI job
+needing `tools/upstream/sync.sh` before cargo will parse the workspace at all,
+and the `include_str!` paths reaching outside `rust_port`. The trade is that the
+built code and the readable checkout stop being the same bytes by construction.
 
 ## Type Checking
 


### PR DESCRIPTION
## Summary

`Cargo Semver Checks` is red on `main`:

```
error: running 'cargo update' on crate 'uf_cli' failed with output:
error: failed to get `flow_aloc` as a dependency of package `uf_check`
  No such file or directory (os error 2)
```

Excluding `uf_flow` (#26) and `uf_check` (#39) was not enough, and would not have
been: cargo resolves a path dependency **whether or not the feature using it is
enabled**, so every crate that reaches the submodule transitively fails the same
way.

Computed from `cargo metadata` rather than guessed:

```
direct submodule deps:   uf_check, uf_flow
transitively affected:   uf_bundler, uf_check, uf_cli, uf_flow, uf_lint
total workspace crates:  42
```

Excluding all five keeps **37 of 42** crates gated, which is worth more than
switching the gate off.

## What this costs, said out loud

The list grows with every crate that picks up the parser, and it already holds
three of the more interesting public APIs (`uf_lint`, `uf_cli`, `uf_bundler`).

`docs/architecture.md` now records the exit rather than leaving the next person
to rediscover it: making the upstream dependency a **rev-pinned git dependency**
— which cargo resolves from any directory — would undo this *and* the submodule's
three other charges:

- `cargo fmt --all` visiting vendored code (worked around with `upstream/rustfmt.toml`)
- every CI job needing `tools/upstream/sync.sh` before cargo will parse the workspace at all
- `flow_flowlib`'s `include_str!` paths reaching outside `rust_port` (#20)

The trade is that the built code and the readable checkout stop being the same
bytes by construction, which is a real loss and why this change does not make it
unilaterally.

## Verification

- [x] The affected set is computed, not guessed — `cargo metadata` walk over
      workspace dependencies, seeded from manifests naming `upstream/flow`
- [ ] `Cargo Semver Checks` passes on this PR — that is the test

Workflow and documentation only; no Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790930921&installation_model_id=422833&pr_number=45&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F45&signature=1c312816b90f91b13d0fdf066be46fd80ede42eae701283b9530744901622069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->