### PR TITLE
fix: stop the formatter mangling bounded type parameters

### DIFF
--- a/crates/uf_cli/tests/bundle.rs
+++ b/crates/uf_cli/tests/bundle.rs
@@ -229,6 +229,98 @@ fn a_scaffolded_app_has_no_reserved_router_file_errors() {
     assert!(reserved.is_empty(), "{reserved:?}");
 }
 
+/// The generated router must survive uf's own tooling for a route that *has*
+/// parameters, and for one with a catch-all segment.
+///
+/// The default scaffold has a single parameterless route, so nothing exercised
+/// the nested params object. `uf_router`'s own tests assert the generated
+/// *text*, which cannot notice that the formatter rewrites it or that the
+/// parser rejects it — `route<P extends X>` was being reformatted to
+/// `route < P extends X > (` with the mangling baked back into the codegen.
+#[test]
+fn a_generated_router_with_params_survives_fmt_and_check() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let created = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["create", "app", "react"])
+        .output()
+        .unwrap();
+    assert!(
+        created.status.success(),
+        "{}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+
+    for route in ["app/users/[id]", "app/files/[...path]"] {
+        let page = dir.path().join(route);
+        fs::create_dir_all(&page).unwrap();
+        fs::write(
+            page.join("_uf.page.js"),
+            "// @flow\nexport function Page(): null {\n  return null;\n}\n",
+        )
+        .unwrap();
+    }
+
+    let built = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("build")
+        .output()
+        .unwrap();
+    assert!(
+        built.status.success(),
+        "{}",
+        String::from_utf8_lossy(&built.stderr)
+    );
+
+    let router = fs::read_to_string(dir.path().join("router.js")).unwrap();
+    assert!(
+        router.contains("\"/users/:id\"") && router.contains("\"/files/:path*\""),
+        "the router did not pick up the added routes:\n{router}"
+    );
+
+    // Generated code has to be what the formatter would have written, or every
+    // `uf fmt --check` in CI fails on a file the user never wrote.
+    let formatted = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["fmt", "--check"])
+        .output()
+        .unwrap();
+    let fmt_stdout = String::from_utf8(formatted.stdout).unwrap();
+    assert!(
+        !fmt_stdout.contains("router.js"),
+        "the generated router is not formatted the way `uf fmt` writes it:\n{fmt_stdout}"
+    );
+
+    let checked = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("check")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(checked.stdout).unwrap();
+    let stderr = String::from_utf8(checked.stderr).unwrap();
+    let errors = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("error["))
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "a generated router with params fails `uf check`:\n{}",
+        errors.join("\n")
+    );
+    // A backend that cannot parse the generated syntax fails before it reports
+    // any per-file error, so the error list above would be empty either way.
+    assert!(
+        checked.status.success(),
+        "`uf check` exited non-zero on a generated router:\n{stdout}{stderr}"
+    );
+}
+
 /// A freshly scaffolded project must pass `uf check` with no errors.
 ///
 /// Not "no errors in files the user wrote" — no errors at all. Everything in a
@@ -273,6 +365,7 @@ fn a_scaffolded_app_passes_its_own_check() {
         .unwrap();
 
     let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
     let errors = stdout
         .lines()
         .filter(|line| line.trim_start().starts_with("error["))
@@ -282,8 +375,11 @@ fn a_scaffolded_app_passes_its_own_check() {
         "a freshly created project fails its own `uf check`:\n{}",
         errors.join("\n")
     );
+    // `uf check` reports a backend that failed before it reached a file on
+    // stderr, leaving stdout empty — so a bare stdout dump says nothing about
+    // why this failed.
     assert!(
         output.status.success(),
-        "`uf check` exited non-zero on a fresh project:\n{stdout}"
+        "`uf check` exited non-zero on a fresh project:\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }

--- a/crates/uf_cli/tests/support/mod.rs
+++ b/crates/uf_cli/tests/support/mod.rs
@@ -14,8 +14,20 @@ pub fn uf() -> Command {
 }
 
 /// One of the alias binaries, `ufr` or `ufx`.
+///
+/// The path comes from `CARGO_BIN_EXE_*`, which Cargo sets to the artifact it
+/// guarantees is built before this test runs. `Command::cargo_bin` instead
+/// guesses the path by convention, so it can hand back a binary that is still
+/// being linked — which surfaces as an empty stdout and a non-zero exit that
+/// looks like the tool failing rather than a race.
 pub fn binary(name: &str) -> Command {
-    let mut command = Command::cargo_bin(name).unwrap();
+    let path = match name {
+        "uf" => env!("CARGO_BIN_EXE_uf"),
+        "ufr" => env!("CARGO_BIN_EXE_ufr"),
+        "ufx" => env!("CARGO_BIN_EXE_ufx"),
+        other => panic!("unknown uf binary: {other}"),
+    };
+    let mut command = Command::new(path);
     command
         .env_remove("NO_COLOR")
         .env_remove("FORCE_COLOR")

--- a/crates/uf_fmt/src/printer/angle.rs
+++ b/crates/uf_fmt/src/printer/angle.rs
@@ -95,6 +95,13 @@ fn scan_type_arguments(tokens: &[Token], start: usize) -> Option<usize> {
 
         match kind {
             TokenKind::Identifier | TokenKind::Number | TokenKind::String => saw_content = true,
+            // `extends` bounds a type parameter and `in` marks a contravariant
+            // one — both sit inside the brackets in modern Flow, and both
+            // replace syntax that is now deprecated (`<T: Bound>` and `<-T>`).
+            // Rejecting them made the scan give up and print the brackets as
+            // comparisons, so the formatter mangled exactly the spellings uf
+            // tells users to write. (`out`, the covariant sigil, lexes as an
+            // identifier and was already accepted.)
             TokenKind::Keyword(
                 Keyword::Typeof
                 | Keyword::Void
@@ -103,7 +110,9 @@ fn scan_type_arguments(tokens: &[Token], start: usize) -> Option<usize> {
                 | Keyword::False
                 | Keyword::This
                 | Keyword::Static
-                | Keyword::Interface,
+                | Keyword::Interface
+                | Keyword::Extends
+                | Keyword::In,
             ) => saw_content = true,
             TokenKind::Punctuator(punctuator) => match punctuator {
                 Punctuator::Less => {

--- a/crates/uf_fmt/src/tests/flow.rs
+++ b/crates/uf_fmt/src/tests/flow.rs
@@ -24,6 +24,53 @@ fn comparisons_are_not_mistaken_for_type_arguments() {
     similar_asserts::assert_eq!(format("if (a<b) f();\n"), "if (a < b) f();\n");
 }
 
+/// A bounded or variance-annotated type parameter list is still a type
+/// parameter list.
+///
+/// The speculative scan accepted only a handful of keywords between the angle
+/// brackets, and `extends` was not among them, so it gave up and printed the
+/// brackets as comparisons: `route<P extends string>(` came out as
+/// `route < P extends string > (`. These are the spellings Flow now requires —
+/// `<T: Bound>` and `<+T>` are deprecated — so the formatter mangled exactly
+/// the syntax uf tells users to write, and the router codegen had the mangling
+/// baked into it to survive `uf fmt --check`.
+#[test]
+fn bounded_and_variance_annotated_type_parameters_are_not_comparisons() {
+    for source in [
+        "declare export function route<P extends string>(p: P): string;\n",
+        "export function f<P extends string>(p: P): P {\n  return p;\n}\n",
+        "type A<P extends string> = P;\n",
+        "type B<A, P extends string> = [A, P];\n",
+        "type N<P extends Array<string>> = P;\n",
+        "class C<P extends string> {}\n",
+        // `out` lexes as an identifier, `in` as a keyword; both are the modern
+        // replacements for the deprecated `+`/`-` sigils.
+        "type Cov<out P> = (P) => void;\n",
+        "type Con<in P> = (P) => void;\n",
+    ] {
+        similar_asserts::assert_eq!(format(source), source);
+    }
+
+    // And the spacing is actively removed, not merely preserved.
+    similar_asserts::assert_eq!(
+        format("type A < P extends string > = P;\n"),
+        "type A<P extends string> = P;\n"
+    );
+}
+
+/// `in` inside angle brackets must not make an ordinary `in` lose its spacing.
+#[test]
+fn the_in_operator_is_still_an_operator() {
+    similar_asserts::assert_eq!(
+        format("const has = \"k\" in obj;\n"),
+        "const has = \"k\" in obj;\n"
+    );
+    similar_asserts::assert_eq!(
+        format("for (const k in obj) {\n  f(k);\n}\n"),
+        "for (const k in obj) {\n  f(k);\n}\n"
+    );
+}
+
 #[test]
 fn nullable_and_optional_flow_markers_hug_their_type() {
     similar_asserts::assert_eq!(format("type A = ? string;\n"), "type A = ?string;\n");

--- a/crates/uf_router/src/lib.rs
+++ b/crates/uf_router/src/lib.rs
@@ -151,7 +151,10 @@ pub fn generate_router_flow(routes: &[Route]) -> String {
     // which is the mistake the generated types exist to prevent. It also keeps a
     // freshly scaffolded project passing `flow/ambiguous-object-type`, which uf
     // turns on by default — generated code has to satisfy the rules uf ships.
-    output.push_str("export type RouteParams = {|\n");
+    // `Readonly<>` wraps the map rather than each key carrying a modifier: the
+    // keys are route paths, so they are quoted, and Flow rejects `readonly` on a
+    // string-literal key.
+    output.push_str("export type RouteParams = Readonly<{|\n");
     for route in routes {
         output.push_str(&format!(
             "  \"{}\": {},\n",
@@ -159,9 +162,9 @@ pub fn generate_router_flow(routes: &[Route]) -> String {
             route_params_type(&route.params)
         ));
     }
-    output.push_str("|};\n\n");
+    output.push_str("|}>;\n\n");
     output.push_str(
-        "declare export function route < Path extends RoutePath > (\n  path: Path,\n  params: RouteParams[Path]\n): string;\n",
+        "declare export function route<Path extends RoutePath>(\n  path: Path,\n  params: RouteParams[Path]\n): string;\n",
     );
     output
 }
@@ -330,7 +333,7 @@ mod tests {
                 );
             }
         }
-        assert!(source.contains("export type RouteParams = {|"));
+        assert!(source.contains("export type RouteParams = Readonly<{|"));
         assert!(source.ends_with("string;\n"));
     }
 
@@ -339,7 +342,7 @@ mod tests {
         let source = generate_router_flow(&[]);
 
         assert!(source.contains("export type RoutePath = empty;"));
-        assert!(source.contains("export type RouteParams = {|"));
+        assert!(source.contains("export type RouteParams = Readonly<{|"));
         assert!(!source.contains("= {\n"));
     }
 


### PR DESCRIPTION
`uf fmt` rewrites `route<Path extends RoutePath>(` as `route < Path extends RoutePath > (`.

The speculative scan in `angle.rs` that tells `A<B>` from `a < b` accepts only a short list of keywords between the brackets. `extends` was not on it, so the scan gave up and the brackets were printed as comparison operators.

This hits **exactly the syntax uf tells users to write**. `<T: Bound>` and `<+T>` are deprecated in the pinned Flow version, so `extends` and `in`/`out` are the only spellings available — and the formatter mangled all of them, across functions, type aliases, classes and components alike.

The router codegen had the mangling **baked into its source literal** so the generated file could pass `uf fmt --check`. With the formatter fixed it emits ordinary syntax again.

## Read-only guarantee

`RouteParams` lost its read-only-ness when the `+` sigil was removed — dropped rather than converted. Restored via `Readonly<>` around the map, because:

- the keys are route paths, so they are quoted, and Flow rejects `readonly` on a string-literal key
- the `readonly` **property modifier crashes the parser shipped binaries use** — its AST deserializer predates the spelling (`unknown variant 'readonly', expected 'plus' or 'minus'`)

So `Readonly<>` on the map is the only form that both parses everywhere and keeps the guarantee.

## Why the existing tests missed it

`uf_router`'s tests assert the generated **text**. They cannot notice that the formatter rewrites that text, or that a parser rejects it. The default scaffold also has one parameterless route, so nothing exercised the nested params object at all — I confirmed a mutation reverting that path **survived** the whole suite.

Added a CLI test that generates a router with a parameterised route *and* a catch-all, then runs `uf fmt --check` and `uf check` over the result. Verified by mutation — each of these fails it:

| mutation | caught |
|---|---|
| drop `Extends` from the scan | ✅ |
| drop `In` from the scan | ✅ |
| re-mangle the codegen literal | ✅ |
| revert nested param variance | ✅ |
| drop the `Readonly<>` wrapper | ✅ (router tests) |

## Test binary path

`Command::cargo_bin` guesses the path by convention and can hand back a binary that is still being linked — which surfaces as an empty stdout and a non-zero exit that reads as the tool failing. Switched to `CARGO_BIN_EXE_*`, which Cargo guarantees points at a built artifact. I hit this twice as an intermittent failure before tracking it down.

## Verification

- `cargo test --workspace` — 2770 passing, 3 consecutive clean runs
- `cargo test --workspace --all-features` (nightly-2026-08-01) — 2816 passing
- `cargo clippy --workspace --all-targets --features uf_flow/upstream-parser -- -D warnings` — clean
- `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790935356&installation_model_id=422833&pr_number=48&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F48&signature=253663529f90d93a79fae87a0a49e3a029fc0a1a0857bb5e2ccd11389d162aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->