### PR TITLE
docs: say plainly that uf is not usable yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,26 @@
 
 Unified Toolchain for Flow (React)
 
+**🚧 Under active construction — not usable yet. 🚧**
+
 </div>
+
+> [!WARNING]
+> **This is a work in progress, not a released tool.** It is being built in the
+> open and large parts of it are unfinished or actively being replaced.
+>
+> - **Nothing is published.** There is no release on GitHub, nothing on
+>   crates.io, and nothing on npm. `curl … | sh` will not install anything until
+>   the first tag exists.
+> - **The build is being moved onto Vite.** The dev server and bundler in this
+>   repository are being deleted as Vite takes over, so `uf dev` and `uf build`
+>   are mid-migration.
+> - **The formatter is being rewritten** for Prettier compatibility. The current
+>   one works from a token stream and misformats some valid Flow.
+> - Commands, config keys and package names may change without notice.
+>
+> Everything below describes where `uf` is going. Treat it as the plan, not as
+> documentation of something you can rely on today.
 
 
 
@@ -25,9 +44,18 @@ Roadmap tracking lives in [Issue #1](https://github.com/ubugeeei-prod/uf/issues/
 
 ## Usage
 
+Once a release exists, this is how `uf` will be installed. **Neither command
+works yet** — no tag has been cut, so there is nothing behind either URL.
+
 ```sh
 curl -fsSL https://setup.uniflowed.dev | sh
 nix run github:ubugeeei-prod/uf#uf -- --version
+```
+
+Until then, build from a checkout:
+
+```sh
+tools/upstream/sync.sh && cargo build --release --bin uf
 ```
 
 - `uf create`: Create your new flow project (zero-config)


### PR DESCRIPTION
The README described a released tool.

**Nothing is published.** No tag, no GitHub release, nothing on crates.io, nothing on npm — so the `curl -fsSL https://setup.uniflowed.dev | sh` sitting at the top of the Usage section installs nothing. That is exactly the 404 that started today.

Adds a warning at the top of the README stating:

- nothing is published, and `curl … | sh` will not work until a tag exists
- the dev server and bundler are being deleted as Vite takes over, so `uf dev` and `uf build` are mid-migration
- the formatter is being rewritten for Prettier compatibility; the current one works from a token stream and misformats some valid Flow
- commands, config keys and package names may change without notice

and marks the Usage section as aspirational, with the one command that does work today:

```sh
tools/upstream/sync.sh && cargo build --release --bin uf
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790943524&installation_model_id=422833&pr_number=58&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F58&signature=d3dd46a95cbbe1cc60a68b9b276101b711d1b45ac0b0ef22e6820063de0a04b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->