### PR TITLE
fix: publish prereleases with npm dist tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,13 @@ jobs:
               echo "::notice::${name}@${version} is already published"
               return 0
             fi
-            ( cd "$1" && npm publish --access public )
+            tag_args=()
+            case "$version" in
+              *-alpha*) tag_args=(--tag alpha) ;;
+              *-beta*) tag_args=(--tag beta) ;;
+              *-rc*) tag_args=(--tag rc) ;;
+            esac
+            ( cd "$1" && npm publish --access public "${tag_args[@]}" )
           }
 
           publish packages/core


### PR DESCRIPTION
## Summary
- pass npm dist-tags when publishing prerelease package versions
- map alpha, beta, and rc versions to matching npm tags while keeping stable versions on the default tag

## Verification
- bash -n on the publish shell body
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790962763&installation_model_id=422833&pr_number=62&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F62&signature=4026dcf4eb629dc81374245909abb781fc8c3cb5892a72c56484e477aba75e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->