### PR TITLE
fix: use dist profile for release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           UF_TARGET: ${{ matrix.target }}
           UF_VERSION: ${{ steps.version.outputs.version }}
+          UF_CARGO_PROFILE: dist
         run: tools/release/package-binaries.sh
 
       # The point of the whole workflow is that `curl … | sh` works. Prove it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,18 @@ strip = "symbols"
 codegen-units = 1
 opt-level = 3
 
+[profile.dist]
+inherits = "release"
+# Release jobs build on every supported architecture. Thin LTO keeps the
+# installable binaries optimized while avoiding the peak memory of one huge
+# fat-LTO codegen unit on hosted arm64 runners.
+codegen-units = 16
+lto = "thin"
+
+[profile.dist.build-override]
+codegen-units = 16
+opt-level = 3
+
 [profile.bench]
 codegen-units = 1
 lto = "fat"

--- a/tools/release/package-binaries.sh
+++ b/tools/release/package-binaries.sh
@@ -6,6 +6,7 @@ cd "$repo_root"
 
 target="${UF_TARGET:-}"
 version="${UF_VERSION:-}"
+profile="${UF_CARGO_PROFILE:-dist}"
 if [ -z "$version" ]; then
   version="$(cargo metadata --no-deps --format-version 1 | node -e '
 const fs = require("node:fs");
@@ -25,12 +26,21 @@ if [ -z "$target" ]; then
   exit 1
 fi
 
-bin_root="target/release"
+profile_dir="$profile"
+cargo_profile_flag="--profile $profile"
+if [ "$profile" = "release" ]; then
+  profile_dir="release"
+  cargo_profile_flag="--release"
+fi
+
+bin_root="target/$profile_dir"
 if [ "${UF_CARGO_TARGET:-1}" != "0" ]; then
-  bin_root="target/$target/release"
-  cargo build --release --locked --package uf_cli --bins --target "$target"
+  bin_root="target/$target/$profile_dir"
+  # shellcheck disable=SC2086
+  cargo build $cargo_profile_flag --locked --package uf_cli --bins --target "$target"
 else
-  cargo build --release --locked --package uf_cli --bins
+  # shellcheck disable=SC2086
+  cargo build $cargo_profile_flag --locked --package uf_cli --bins
 fi
 
 stage_dir="dist/stage/uf-${version}-${target}"


### PR DESCRIPTION
## Summary
- add a dedicated dist Cargo profile for release archives
- keep installable binaries optimized with thin LTO while lowering peak arm64 runner memory
- teach package-binaries.sh to package binaries from the selected Cargo profile

## Verification
- bash -n tools/release/package-binaries.sh
- git diff --check
- UF_CARGO_PROFILE=ci UF_CARGO_TARGET=0 tools/release/package-binaries.sh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790964319&installation_model_id=422833&pr_number=63&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F63&signature=d5569672b92c7b79424bafc3e86f0bcacb20ac402915a55b7fe2ba3c9afd5739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->