### PR TITLE
fix: expose version flags for release aliases

### DIFF
--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -126,6 +126,12 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
 }
 
 /// Parse the process arguments, expanding the `ufr` and `ufx` aliases.
+///
+/// Alias binaries behave like their longhand commands for real work, but keep
+/// the root command's version surface. Release smoke tests exercise the binary
+/// after installation, before any project or script exists, so `ufr --version`
+/// and `ufx --version` must never be interpreted as `uf run --version` or
+/// `uf exec --version`.
 fn parse_cli() -> Result<Cli> {
     let mut args = std::env::args_os().collect::<Vec<_>>();
     let bin_name = args
@@ -135,16 +141,31 @@ fn parse_cli() -> Result<Cli> {
         .unwrap_or("uf");
 
     match bin_name {
-        "ufr" => {
+        "ufr" if !args_request_root_version(&args) => {
             args.insert(1, "run".into());
             Cli::try_parse_from(args).map_err(Into::into)
         }
-        "ufx" => {
+        "ufx" if !args_request_root_version(&args) => {
             args.insert(1, "exec".into());
             Cli::try_parse_from(args).map_err(Into::into)
         }
         _ => Cli::try_parse_from(args).map_err(Into::into),
     }
+}
+
+fn args_request_root_version(args: &[std::ffi::OsString]) -> bool {
+    let mut args = args.iter().skip(1);
+    while let Some(arg) = args.next().and_then(|arg| arg.to_str()) {
+        match arg {
+            "--version" | "-V" => return true,
+            "--cwd" | "--color" => {
+                let _ = args.next();
+            }
+            arg if arg.starts_with("--cwd=") || arg.starts_with("--color=") => {}
+            _ => return false,
+        }
+    }
+    false
 }
 
 fn resolve_cwd(cwd: Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -18,6 +18,64 @@ fn uf_prints_help() {
 }
 
 #[test]
+fn alias_binaries_print_the_root_version() {
+    for name in ["ufr", "ufx"] {
+        let output = binary(name).arg("--version").output().unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            stdout.contains(env!("CARGO_PKG_VERSION")),
+            "{name} should expose the installed uf version, got {stdout:?}"
+        );
+    }
+}
+
+#[test]
+fn ufr_keeps_version_flags_after_the_task_name_as_task_args() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: {
+                show: { command: "printf %s \"$1\"" },
+              },
+            });
+        "#,
+    )
+    .unwrap();
+    let runner = dir.path().join("vp");
+    fs::write(
+        &runner,
+        "#!/bin/sh\n[ \"$1\" = run ] && [ \"$2\" = show ] && [ \"$3\" = -- ] && [ \"$4\" = --version ] && printf payload-version\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&runner).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&runner, permissions).unwrap();
+
+    let output = binary("ufr")
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["show", "--", "--version"])
+        .env("UF_VITE_TASK_BIN", &runner)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "payload-version");
+}
+
+#[test]
 fn ufr_alias_runs_config_task() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(


### PR DESCRIPTION
## Summary
- keep ufr and ufx --version on the root CLI surface
- preserve task payload version flags after the task argument separator
- cover both release-smoke and task-payload paths in CLI integration tests

## Verification
- cargo fmt --all --check
- cargo test --profile ci -p uf_cli --test cli
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967934&installation_model_id=422833&pr_number=64&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F64&signature=99ff30c094877503f25779604c8a6dcb73f40186fcc939619a40d52911981ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `ufr` and `ufx` version handling so root-level `--version` and `-V` flags work correctly, including when preceded by global options.
  * Preserved version-like arguments passed after a task name, allowing tasks to receive them as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->