### PR TITLE
fix: retry transient release mirror uploads

### DIFF
--- a/tools/release/publish-r2.sh
+++ b/tools/release/publish-r2.sh
@@ -13,6 +13,8 @@ if [ "${2:-}" = "--latest" ]; then
 fi
 
 bucket="${UF_RELEASE_BUCKET:-uf-releases}"
+retry_count="${UF_R2_RETRIES:-4}"
+retry_delay="${UF_R2_RETRY_DELAY:-5}"
 
 if [ ! -d "$release_dir" ]; then
   echo "publish-r2: release directory does not exist: $release_dir" >&2
@@ -39,6 +41,21 @@ need() {
 
 need npx
 
+with_retry() {
+  attempt=1
+  while :; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$retry_count" ]; then
+      return 1
+    fi
+    echo "publish-r2: upload failed; retrying in ${retry_delay}s ($attempt/$retry_count)" >&2
+    sleep "$retry_delay"
+    attempt=$((attempt + 1))
+  done
+}
+
 put_object() {
   src="$1"
   key="$2"
@@ -46,7 +63,7 @@ put_object() {
   if [ "${UF_R2_DRY_RUN:-0}" = "1" ]; then
     return 0
   fi
-  npx --yes wrangler@latest r2 object put "$bucket/$key" --file "$src" --remote
+  with_retry npx --yes wrangler@latest r2 object put "$bucket/$key" --file "$src" --remote
 }
 
 for file in "$release_dir"/*; do


### PR DESCRIPTION
## Summary
- retry Cloudflare R2 object uploads during release mirroring
- keep retry count and delay configurable for release operations
- preserve dry-run behavior for local release verification

## Verification
- bash -n tools/release/publish-r2.sh
- UF_R2_DRY_RUN=1 UF_RELEASE_BUCKET=uf-test tools/release/publish-r2.sh <tmpdir> --latest
- PATH=<fake-npx> UF_R2_RETRIES=2 UF_R2_RETRY_DELAY=0 UF_RELEASE_BUCKET=uf-test tools/release/publish-r2.sh <tmpdir>
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790969673&installation_model_id=422833&pr_number=65&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F65&signature=6c31ade1f3e80da09a3e1a9f5dddc5805f4ccfcc4e7996d4275ec7c9328683c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->