### PR TITLE
fix: mark alpha releases as prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,10 @@ jobs:
           set -eu
           version="${INPUT_VERSION:-${REF_NAME#uf@}}"
           tag="uf@${version}"
+          release_kind_args=()
+          case "$version" in
+            *-alpha*|*-beta*|*-rc*) release_kind_args=(--prerelease) ;;
+          esac
           assets="artifacts/VERSION"
           for file in artifacts/uf-*.tar.gz artifacts/uf-*.tar.gz.sha256 \
                       artifacts/manifest.json artifacts/manifest-*.json; do
@@ -150,10 +154,11 @@ jobs:
           done
           # shellcheck disable=SC2086
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$tag" --repo "$GITHUB_REPOSITORY" "${release_kind_args[@]}"
             gh release upload "$tag" --repo "$GITHUB_REPOSITORY" --clobber $assets
           else
             gh release create "$tag" --repo "$GITHUB_REPOSITORY" \
-              --title "uf ${version}" --generate-notes $assets
+              --title "uf ${version}" --generate-notes "${release_kind_args[@]}" $assets
           fi
 
       - name: Mirror to R2


### PR DESCRIPTION
## Summary
- mark alpha, beta, and rc GitHub Releases as prereleases
- update existing releases before clobbering uploaded assets
- keep stable release metadata unchanged

## Verification
- sed -n '141,164p' .github/workflows/release.yml | sed 's/^          //' | bash -n
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790971994&installation_model_id=422833&pr_number=66&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F66&signature=f1f73585af04a5d2d18becda380c35070d4261987e1df036e3113f51453496f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Pre-release versions are now automatically marked as pre-releases on GitHub.
  * Existing releases updated through the publishing workflow now receive the appropriate release title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->