### PR TITLE
feat(transform): Flow to JavaScript without Babel

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -34,7 +34,7 @@ jobs:
           # submodule no longer resolves. A path dependency is relative by
           # definition, so this is not something a crate can fix.
           #
-          # `uf_flow` and `uf_check` name the submodule; the other four reach it
+          # `uf_flow`, `uf_check` and `uf_transform` name the submodule; the other four reach it
           # transitively, and cargo resolves a path dependency whether or not the
           # feature using it is enabled. Excluding them keeps 37 of 43 crates
           # gated, which is worth more than switching the gate off.
@@ -46,4 +46,4 @@ jobs:
           #
           # The list grows as more crates use the parser. See
           # docs/architecture.md for what to do when it covers too little.
-          exclude: uf_bundler,uf_check,uf_cli,uf_flow,uf_jsx,uf_lint
+          exclude: uf_bundler,uf_check,uf_cli,uf_flow,uf_jsx,uf_lint,uf_transform

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,6 +4691,7 @@ dependencies = [
  "uf_runtime",
  "uf_term",
  "uf_test",
+ "uf_transform",
  "uf_tui",
 ]
 
@@ -4973,6 +4974,30 @@ dependencies = [
  "thiserror",
  "uf_infra",
  "uf_rsc",
+]
+
+[[package]]
+name = "uf_transform"
+version = "0.0.0-alpha.0"
+dependencies = [
+ "criterion",
+ "flow_parser",
+ "indexmap",
+ "oxc_allocator",
+ "oxc_codegen",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_sourcemap",
+ "oxc_span",
+ "oxc_transformer",
+ "react_compiler",
+ "react_compiler_ast",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "similar-asserts",
+ "thiserror",
+ "uf_infra",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "crates/uf_stylex",
   "crates/uf_term",
   "crates/uf_test",
+  "crates/uf_transform",
   "crates/uf_tui",
 ]
 exclude = ["upstream"]
@@ -54,6 +55,13 @@ flow_common_errors = { path = "upstream/flow/rust_port/crates/flow_common_errors
 flow_flowlib = { path = "upstream/flow/rust_port/crates/flow_flowlib" }
 flow_lint_settings = { path = "upstream/flow/rust_port/crates/flow_lint_settings" }
 flow_parser = { path = "upstream/flow/rust_port/crates/flow_parser" }
+oxc_allocator = "0.147.0"
+oxc_codegen = "0.147.0"
+oxc_parser = "0.147.0"
+oxc_semantic = "0.147.0"
+oxc_sourcemap = "8.1.2"
+oxc_span = "0.147.0"
+oxc_transformer = "0.147.0"
 rolldown = "1.2.6"
 rolldown_common = "1.2.6"
 rolldown_plugin = "1.2.6"
@@ -69,6 +77,7 @@ flow_typing_utils = { path = "upstream/flow/rust_port/crates/flow_typing_utils" 
 flow_utils_concurrency = { path = "upstream/flow/rust_port/crates/flow_utils_concurrency" }
 flate2 = { version = "1.1.10", default-features = false, features = ["rust_backend"] }
 ignore = "0.4.25"
+indexmap = "2"
 json5 = "1.3.1"
 memchr = "2.7.6"
 mimalloc = "0.1.52"

--- a/README.md
+++ b/README.md
@@ -180,7 +180,10 @@ enables:
   to Biome formatting
 
 No Babel, Jest, Yarn, npm scripts, or `.flowconfig` is required for generated
-projects. Project automation belongs in `uf.config.js` tasks and runs through
+projects. Flow becomes JavaScript through `uf transform`: the official Flow
+Rust parser, Flow's own lowering rules for `component`/`hook`/`match`/enums,
+the official React Compiler (Rust, `syntax` mode) and oxc for JSX and code
+generation — no Babel anywhere. Project automation belongs in `uf.config.js` tasks and runs through
 Vite Task.
 
 When config is needed, use the Vite-like entrypoint through Flow syntax. The

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -49,6 +49,7 @@ uf_rsc = { path = "../uf_rsc" }
 uf_runtime = { path = "../uf_runtime" }
 uf_term = { path = "../uf_term" }
 uf_test = { path = "../uf_test" }
+uf_transform = { path = "../uf_transform" }
 uf_tui = { path = "../uf_tui" }
 compact_str.workspace = true
 mimalloc.workspace = true

--- a/crates/uf_cli/src/commands/transform.rs
+++ b/crates/uf_cli/src/commands/transform.rs
@@ -1,65 +1,156 @@
-//! `uf transform` — uf's module transform, as a service Vite can pipe through.
+//! `uf transform` — the Flow → JavaScript transform, as a service.
 //!
-//! Vite runs its plugins in JavaScript, and uf's transform is native Rust. A
-//! plugin that spawned `uf` per module would pay process startup thousands of
-//! times in one build, so this is a service instead: one process for the whole
-//! run, newline-delimited JSON in, newline-delimited JSON out.
+//! Vite runs its plugins in JavaScript and uf's transform is native. A plugin
+//! that spawned `uf` per module would pay process start-up thousands of times
+//! in one build, so this is a long-lived process instead: one per run,
+//! newline-delimited JSON in, newline-delimited JSON out, replies in request
+//! order. `@uniflowed/vite`, the Node loader hook and the Bun preload all
+//! speak this protocol, which is what makes every host produce the same
+//! module from the same source.
 //!
-//! Request: `{"id": "/abs/path.js", "code": "…"}`
-//! Reply:   `{"id": "…", "code": "…"}` — the transformed module
-//!          `{"id": "…"}`              — nothing to do, use the source as-is
-//!          `{"id": "…", "error": "…"}` — the module could not be transformed
+//! Request, one per line:
 //!
-//! One object per line, in the order they arrived. A request is a line so the
-//! reader never has to guess where one ends; the code is JSON-escaped, so a
-//! newline in the source cannot be mistaken for the end of a request.
+//! ```json
+//! {"id": "/abs/path.js", "code": "…", "options": {"development": true, "refresh": true}}
+//! ```
+//!
+//! Reply, one per line, in order:
+//!
+//! ```json
+//! {"id": "…", "code": "…", "map": "…", "diagnostics": []}   // transformed
+//! {"id": "…"}                                               // not uf's to transform
+//! {"id": "…", "error": "…", "line": 3, "column": 8}         // could not be transformed
+//! ```
+//!
+//! A request is a line so the reader never has to guess where one ends; the
+//! code is JSON-escaped, so a newline in the source cannot end a request.
 
-use std::io::{BufRead, BufReader, StdinLock, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
-use uf_bundler::{is_project_module, transform_module};
 use uf_config::load_config;
-use uf_jsx::JsxOptions;
+use uf_transform::{
+    CompilerDiagnostic, ReactCompilerMode, TransformError, TransformOptions, is_flow_module,
+    transform,
+};
+
+/// Stack for the service thread.
+///
+/// Every stage walks a tree recursively — the parser, the lowering passes,
+/// the compiler — and a deeply nested module must fail with a clear error,
+/// not by overflowing the main thread's stack. 512 MiB is reserved, not
+/// committed; an ordinary module touches a few hundred kilobytes of it.
+const SERVICE_STACK_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 struct Request {
     id: String,
     code: String,
+    #[serde(default)]
+    options: RequestOptions,
 }
 
-#[derive(Debug, Serialize)]
+/// The per-request knobs; everything else comes from `uf.config.js`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct RequestOptions {
+    development: bool,
+    refresh: bool,
+    source_map: bool,
+}
+
+impl Default for RequestOptions {
+    /// Production output with a source map — what a build wants when it
+    /// says nothing.
+    fn default() -> Self {
+        Self {
+            development: false,
+            refresh: false,
+            source_map: true,
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
 struct Reply {
     id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    map: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    diagnostics: Vec<CompilerDiagnostic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    column: Option<u32>,
+}
+
+/// What the project's config says about every transform.
+#[derive(Debug, Clone)]
+struct ProjectTransform {
+    react_compiler: ReactCompilerMode,
+    jsx_import_source: String,
+}
+
+impl ProjectTransform {
+    fn from_config(config: &uf_config::UniflowedConfig) -> Self {
+        let compiler = &config.app.builtins.react_compiler;
+        Self {
+            react_compiler: if compiler.enabled {
+                ReactCompilerMode::Syntax
+            } else {
+                ReactCompilerMode::Off
+            },
+            jsx_import_source: String::from("react"),
+        }
+    }
+
+    fn options(&self, id: &str, request: &RequestOptions) -> TransformOptions {
+        TransformOptions {
+            filename: id.to_owned(),
+            development: request.development,
+            refresh: request.development && request.refresh,
+            react_compiler: self.react_compiler,
+            jsx_import_source: self.jsx_import_source.clone(),
+            source_map: request.source_map,
+        }
+    }
 }
 
 /// Serve transform requests until stdin closes.
-pub(crate) fn transform(cwd: &Utf8Path) -> Result<()> {
+pub(crate) fn transform_service(cwd: &Utf8Path) -> Result<()> {
     let resolved = load_config(cwd)?;
-    let jsx = JsxOptions::from_config(&resolved.config);
+    let project = ProjectTransform::from_config(&resolved.config);
 
-    let stdin = std::io::stdin().lock();
-    let mut stdout = std::io::stdout().lock();
-    serve(stdin, &mut stdout, &jsx)
+    std::thread::Builder::new()
+        .name(String::from("uf-transform"))
+        .stack_size(SERVICE_STACK_BYTES)
+        .spawn(move || {
+            let stdin = std::io::stdin().lock();
+            let mut stdout = std::io::stdout().lock();
+            serve(stdin, &mut stdout, &project)
+        })
+        .context("failed to start the transform service thread")?
+        .join()
+        .map_err(|_| anyhow::anyhow!("the transform service panicked"))?
 }
 
-fn serve(stdin: StdinLock<'_>, out: &mut impl Write, jsx: &JsxOptions) -> Result<()> {
-    for line in BufReader::new(stdin).lines() {
+fn serve(input: impl Read, out: &mut impl Write, project: &ProjectTransform) -> Result<()> {
+    for line in BufReader::new(input).lines() {
         let line = line.context("reading a transform request")?;
         if line.trim().is_empty() {
             continue;
         }
         let reply = match serde_json::from_str::<Request>(&line) {
-            Ok(request) => handle(request, jsx),
+            Ok(request) => handle(&request, project),
             Err(error) => Reply {
-                id: String::new(),
-                code: None,
                 error: Some(format!("malformed request: {error}")),
+                ..Reply::default()
             },
         };
         serde_json::to_writer(&mut *out, &reply).context("writing a transform reply")?;
@@ -70,24 +161,107 @@ fn serve(stdin: StdinLock<'_>, out: &mut impl Write, jsx: &JsxOptions) -> Result
     Ok(())
 }
 
-fn handle(request: Request, jsx: &JsxOptions) -> Reply {
-    if !is_project_module(&request.id) {
+fn handle(request: &Request, project: &ProjectTransform) -> Reply {
+    if !is_flow_module(&request.id) {
         return Reply {
-            id: request.id,
-            code: None,
-            error: None,
+            id: request.id.clone(),
+            ..Reply::default()
         };
     }
-    match transform_module(&request.id, &request.code, jsx) {
-        Ok(code) => Reply {
-            id: request.id,
-            code,
-            error: None,
+    let options = project.options(&request.id, &request.options);
+    match transform(&request.code, &options) {
+        Ok(transformed) => Reply {
+            id: request.id.clone(),
+            code: Some(transformed.code),
+            map: transformed.map,
+            diagnostics: transformed.compiler_diagnostics,
+            ..Reply::default()
         },
-        Err(error) => Reply {
-            id: request.id,
-            code: None,
-            error: Some(error.to_string()),
-        },
+        Err(error) => {
+            let (line, column) = match &error {
+                TransformError::Syntax { line, column, .. } => (Some(*line), Some(*column)),
+                TransformError::Lowering { line, column, .. } => (*line, *column),
+                _ => (None, None),
+            };
+            Reply {
+                id: request.id.clone(),
+                error: Some(error.to_string()),
+                line,
+                column,
+                ..Reply::default()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project() -> ProjectTransform {
+        ProjectTransform::from_config(&uf_config::UniflowedConfig::default())
+    }
+
+    fn replies(input: &str) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        serve(input.as_bytes(), &mut out, &project()).unwrap();
+        String::from_utf8(out)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn replies_come_back_in_request_order() {
+        let mut input = String::new();
+        for index in 0..8 {
+            input.push_str(&format!(
+                "{{\"id\": \"/app/m{index}.js\", \"code\": \"export const v{index}: number = {index};\"}}\n"
+            ));
+        }
+        let replies = replies(&input);
+        assert_eq!(replies.len(), 8);
+        for (index, reply) in replies.iter().enumerate() {
+            assert_eq!(reply["id"], format!("/app/m{index}.js"));
+            assert!(
+                reply["code"]
+                    .as_str()
+                    .unwrap()
+                    .contains(&format!("v{index} = {index}"))
+            );
+        }
+    }
+
+    #[test]
+    fn a_third_party_module_is_left_alone() {
+        let replies = replies("{\"id\": \"/app/node_modules/react/index.js\", \"code\": \"x\"}\n");
+        assert!(replies[0]["code"].is_null());
+        assert!(replies[0]["error"].is_null());
+    }
+
+    #[test]
+    fn a_syntax_error_is_reported_with_its_position() {
+        let replies = replies("{\"id\": \"/app/bad.js\", \"code\": \"const a = ;\"}\n");
+        assert!(replies[0]["error"].as_str().is_some());
+        assert_eq!(replies[0]["line"], 1);
+    }
+
+    #[test]
+    fn a_blank_line_is_skipped_and_garbage_is_named() {
+        let replies = replies("\nnot json\n");
+        assert_eq!(replies.len(), 1);
+        assert!(replies[0]["error"].as_str().unwrap().contains("malformed"));
+    }
+
+    #[test]
+    fn development_requests_get_refresh_registrations() {
+        let replies = replies(
+            "{\"id\": \"/app/A.js\", \"code\": \"export component A() { return <p />; }\", \"options\": {\"development\": true, \"refresh\": true}}\n",
+        );
+        let code = replies[0]["code"].as_str().unwrap();
+        assert!(code.contains("$RefreshReg$"), "{code}");
+        assert!(code.contains("jsxDEV"), "{code}");
+        assert!(replies[0]["map"].as_str().is_some());
     }
 }

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -86,7 +86,7 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
         Commands::Fmt { check } => commands::fmt::fmt(&cwd, ui, check),
         Commands::Info => commands::info::info(&cwd, ui),
         Commands::Inspect { json } => commands::inspect::inspect(&cwd, ui, json),
-        Commands::Transform => commands::transform::transform(&cwd),
+        Commands::Transform => commands::transform::transform_service(&cwd),
         Commands::Install => commands::pm::install(&cwd, ui),
         Commands::Lint { json } => {
             commands::lint::lint_command(&cwd, ui, commands::lint::LintCommand::Lint, json)

--- a/crates/uf_cli/tests/transform.rs
+++ b/crates/uf_cli/tests/transform.rs
@@ -1,4 +1,5 @@
-//! `uf transform`, the service `@uniflowed/vite` pipes modules through.
+//! `uf transform`, the service `@uniflowed/vite` and the host loaders pipe
+//! modules through.
 //!
 //! The protocol is what a Vite build depends on, so these exercise it as a
 //! caller does: write requests, read replies, in order.
@@ -49,7 +50,7 @@ fn project() -> tempfile::TempDir {
 }
 
 #[test]
-fn a_flow_module_comes_back_as_javascript() {
+fn a_flow_module_comes_back_as_javascript_with_a_map() {
     let dir = project();
     let replies = exchange(
         dir.path(),
@@ -59,48 +60,76 @@ fn a_flow_module_comes_back_as_javascript() {
         })],
     );
 
-    assert_eq!(replies.len(), 1);
     let code = replies[0]["code"].as_str().expect("transformed");
-    assert!(!code.contains(": string"), "annotation survived:\n{code}");
-    assert!(code.contains("function greet(who"), "body lost:\n{code}");
+    assert!(code.contains("function greet(who)"), "{code}");
+    assert!(!code.contains(": string"), "{code}");
+    let map: serde_json::Value =
+        serde_json::from_str(replies[0]["map"].as_str().expect("a map")).unwrap();
+    assert_eq!(map["sources"][0], "/app/main.js");
 }
 
-/// Replies are paired with requests by order, which is what the plugin relies
-/// on — it keeps a queue of resolvers, not a map of ids.
+/// Flow's own syntax — components, `match`, enums, JSX — comes out as the
+/// JavaScript Flow specifies, memoised by the official React Compiler.
 #[test]
-fn replies_come_back_in_the_order_the_requests_were_sent() {
+fn modern_flow_syntax_is_lowered_and_compiled() {
     let dir = project();
-    let requests: Vec<_> = (0..8)
+    let replies = exchange(
+        dir.path(),
+        &[serde_json::json!({
+            "id": "/app/Toggle.js",
+            "code": "// @flow\nimport {useState} from 'react';\nenum Mode { On, Off }\nexport component Toggle(label: string) {\n  const [mode, setMode] = useState<Mode>(Mode.On);\n  const text = match (mode) { Mode.On => 'on', Mode.Off => 'off' };\n  return <button onClick={() => setMode(Mode.Off)}>{label}: {text}</button>;\n}\n",
+        })],
+    );
+
+    let code = replies[0]["code"].as_str().expect("transformed");
+    assert!(code.contains("function Toggle"), "{code}");
+    assert!(code.contains("$$ufEnumMirrored"), "{code}");
+    assert!(code.contains("react/compiler-runtime"), "{code}");
+    assert!(code.contains("react/jsx-runtime"), "{code}");
+    assert!(!code.contains("match ("), "{code}");
+    assert!(!code.contains("component "), "{code}");
+}
+
+/// The order *is* the protocol: a caller pairs replies with requests by
+/// position.
+#[test]
+fn replies_arrive_in_request_order() {
+    let dir = project();
+    let requests: Vec<serde_json::Value> = (0..8)
         .map(|index| {
             serde_json::json!({
                 "id": format!("/app/m{index}.js"),
-                "code": format!("// @flow\nexport const value: number = {index};\n"),
+                "code": format!("export const v{index}: number = {index};\n"),
             })
         })
         .collect();
 
     let replies = exchange(dir.path(), &requests);
 
-    assert_eq!(replies.len(), requests.len());
+    assert_eq!(replies.len(), 8);
     for (index, reply) in replies.iter().enumerate() {
         assert_eq!(reply["id"], format!("/app/m{index}.js"));
         let code = reply["code"].as_str().expect("transformed");
-        assert!(code.contains(&format!("= {index};")), "{index}: {code}");
+        assert!(code.contains(&format!("v{index} = {index}")), "{code}");
     }
 }
 
-/// A module needing no stage reports no code, so the caller keeps the original
-/// source and its source map rather than taking a copy.
+/// Development requests get readable output and Fast Refresh registrations.
 #[test]
-fn a_module_with_nothing_to_do_reports_no_code() {
+fn development_output_registers_for_fast_refresh() {
     let dir = project();
     let replies = exchange(
         dir.path(),
-        &[serde_json::json!({"id": "/app/plain.js", "code": "export const a = 1;\n"})],
+        &[serde_json::json!({
+            "id": "/app/App.js",
+            "code": "// @flow\nexport component App() { return <p>hi</p>; }\n",
+            "options": { "development": true, "refresh": true },
+        })],
     );
 
-    assert!(replies[0]["code"].is_null(), "{:?}", replies[0]);
-    assert!(replies[0]["error"].is_null(), "{:?}", replies[0]);
+    let code = replies[0]["code"].as_str().expect("transformed");
+    assert!(code.contains("$RefreshReg$"), "{code}");
+    assert!(code.contains("jsxDEV"), "{code}");
 }
 
 /// uf's own packages ship Flow, so they are transformed even under
@@ -129,8 +158,20 @@ fn only_uf_packages_are_transformed_under_node_modules() {
     );
 }
 
-/// A module that cannot be transformed reports the failure instead of silently
-/// handing back something the bundler will misread.
+/// A syntax error names its position, so a build can point at the line.
+#[test]
+fn a_syntax_error_is_reported_with_its_position() {
+    let dir = project();
+    let replies = exchange(
+        dir.path(),
+        &[serde_json::json!({"id": "/app/bad.js", "code": "// @flow\nconst a = ;\n"})],
+    );
+
+    assert!(replies[0]["error"].as_str().is_some(), "{:?}", replies[0]);
+    assert_eq!(replies[0]["line"], 2);
+}
+
+/// A request that cannot be read is reported instead of silently dropped.
 #[test]
 fn a_malformed_request_is_reported_rather_than_ignored() {
     let dir = project();

--- a/crates/uf_transform/Cargo.toml
+++ b/crates/uf_transform/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "uf_transform"
+description = "Flow to JavaScript for uf: the official Flow parser, Flow's own lowering rules, the official React Compiler, and oxc for JSX and code generation."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+flow_parser.workspace = true
+indexmap.workspace = true
+oxc_allocator.workspace = true
+oxc_codegen.workspace = true
+oxc_parser.workspace = true
+oxc_semantic.workspace = true
+oxc_sourcemap.workspace = true
+oxc_span.workspace = true
+oxc_transformer.workspace = true
+react_compiler.workspace = true
+react_compiler_ast.workspace = true
+rustc-hash.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+uf_infra = { path = "../uf_infra" }
+
+[dev-dependencies]
+criterion.workspace = true
+similar-asserts.workspace = true
+
+[[bench]]
+name = "transform"
+harness = false

--- a/crates/uf_transform/benches/transform.rs
+++ b/crates/uf_transform/benches/transform.rs
@@ -1,0 +1,69 @@
+//! Throughput of the whole Flow → JavaScript pipeline on a realistic module.
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use uf_transform::{ReactCompilerMode, TransformOptions, transform};
+
+const COMPONENT: &str = r#"// @flow
+import * as React from "react";
+import { useState } from "react";
+import type { Node } from "react";
+
+type Item = {| +id: string, +label: string, +done: boolean |};
+
+enum Filter { All, Active, Done }
+
+export component TodoList(items: $ReadOnlyArray<Item>, onToggle: (id: string) => void) {
+  const [filter, setFilter] = useState<Filter>(Filter.All);
+  const visible = items.filter((item) =>
+    match (filter) {
+      Filter.All => true,
+      Filter.Active => !item.done,
+      Filter.Done => item.done,
+    },
+  );
+  return (
+    <section className="todos">
+      <header>
+        <button onClick={() => setFilter(Filter.All)}>All</button>
+        <button onClick={() => setFilter(Filter.Active)}>Active</button>
+        <button onClick={() => setFilter(Filter.Done)}>Done</button>
+      </header>
+      <ul>
+        {visible.map((item) => (
+          <li key={item.id} className={item.done ? "done" : ""}>
+            <label>
+              <input type="checkbox" checked={item.done} onChange={() => onToggle(item.id)} />
+              {item.label}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export hook useCounter(initial: number = 0): [number, () => void] {
+  const [value, setValue] = useState(initial);
+  return [value, () => setValue((v) => v + 1)];
+}
+"#;
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transform");
+    group.throughput(Throughput::Bytes(COMPONENT.len() as u64));
+    group.bench_function("component (compiler on)", |b| {
+        let options = TransformOptions::new("todo.js");
+        b.iter(|| transform(COMPONENT, &options).unwrap());
+    });
+    group.bench_function("component (compiler off)", |b| {
+        let options = TransformOptions {
+            react_compiler: ReactCompilerMode::Off,
+            ..TransformOptions::new("todo.js")
+        };
+        b.iter(|| transform(COMPONENT, &options).unwrap());
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/uf_transform/src/babel.rs
+++ b/crates/uf_transform/src/babel.rs
@@ -1,0 +1,663 @@
+//! ESTree → Babel's AST shape.
+//!
+//! The official React Compiler consumes Babel's AST, whose node vocabulary
+//! differs from ESTree's in a handful of well-known places: literals are
+//! typed (`StringLiteral`, not `Literal`), object members are `ObjectProperty`
+//! and `ObjectMethod`, class members are `ClassMethod` and `ClassProperty`,
+//! optional chains are `OptionalMemberExpression` and `OptionalCallExpression`
+//! rather than a `ChainExpression` wrapper, `import()` is a call to an
+//! `Import` callee, and directives are lifted out of statement lists. This is
+//! a port of `hermes-parser`'s `TransformESTreeToBabel.js` covering exactly
+//! those differences.
+//!
+//! Every node also gets a `_nodeId`, unique within the file, which is how the
+//! compiler's scope information refers to nodes; and `start`/`end` offsets,
+//! which it uses for positional queries.
+
+use serde_json::{Map, Value, json};
+
+use crate::TransformError;
+use crate::lower::{Edit, bool_field, node_type, str_field, take, transform_post};
+
+/// Convert a lowered ESTree `Program` into a Babel `File`.
+///
+/// # Errors
+///
+/// [`TransformError::Internal`] when a node is not the shape the parser
+/// produces — a `Property` whose method value is not a function, say.
+pub fn to_babel(mut program: Value, source: &str) -> Result<Value, TransformError> {
+    transform_post(&mut program, &mut |node| convert(node))?;
+    let mut file = wrap_file(program);
+    let lines = LineTable::new(source);
+    let mut next_id = 0u32;
+    finalize(&mut file, &mut next_id, &lines);
+    Ok(file)
+}
+
+/// Where each line starts, in UTF-16 code units.
+///
+/// The parser's `loc` columns count code points; source maps and editors
+/// count UTF-16 code units, and so do the `range` offsets. This table turns
+/// an offset back into the (line, column) pair everything downstream uses.
+struct LineTable {
+    starts: Vec<u32>,
+}
+
+impl LineTable {
+    fn new(source: &str) -> Self {
+        let mut starts = vec![0u32];
+        let mut offset = 0u32;
+        for ch in source.chars() {
+            offset += u32::try_from(ch.len_utf16()).unwrap_or(1);
+            if ch == '\n' {
+                starts.push(offset);
+            }
+        }
+        Self { starts }
+    }
+
+    /// 1-based line and 0-based column of an offset.
+    fn position(&self, offset: u32) -> (u32, u32) {
+        let line = self.starts.partition_point(|start| *start <= offset).max(1);
+        let column = offset - self.starts[line - 1];
+        (u32::try_from(line).unwrap_or(u32::MAX), column)
+    }
+}
+
+fn convert(node: &mut Value) -> Result<Edit, TransformError> {
+    let Some(kind) = node_type(node).map(str::to_owned) else {
+        return Ok(Edit::Keep);
+    };
+    // The parser attaches comments to nodes in its own shape; the compiler
+    // reads them from the file's list, so the attached copies only get in
+    // the way of deserialization.
+    for key in ["leadingComments", "trailingComments", "innerComments"] {
+        remove_key(node, key);
+    }
+    Ok(match kind.as_str() {
+        "Literal" => Edit::Replace(literal(node)),
+        "Property" => Edit::Replace(property(node)?),
+        "MethodDefinition" => Edit::Replace(method_definition(node)),
+        "PropertyDefinition" => Edit::Replace(property_definition(node)),
+        "PrivateIdentifier" => Edit::Replace(private_name(node)),
+        "ImportExpression" => Edit::Replace(import_expression(node)),
+        "ExportAllDeclaration" if !node["exported"].is_null() => {
+            Edit::Replace(export_namespace(node))
+        }
+        "ChainExpression" => Edit::Replace(chain(take(node, "expression"))),
+        "Program" | "BlockStatement" => {
+            lift_directives(node);
+            Edit::Keep
+        }
+        "JSXText" => {
+            let value = node["value"].clone();
+            let raw = take(node, "raw");
+            node["extra"] = json!({ "rawValue": value, "raw": raw });
+            Edit::Keep
+        }
+        "ArrayExpression" => {
+            remove_key(node, "trailingComma");
+            Edit::Keep
+        }
+        "VariableDeclaration" => {
+            remove_key(node, "__ufEnum");
+            Edit::Keep
+        }
+        "ClassDeclaration" | "ClassExpression" => {
+            if node
+                .get("decorators")
+                .and_then(Value::as_array)
+                .is_some_and(Vec::is_empty)
+            {
+                remove_key(node, "decorators");
+            }
+            Edit::Keep
+        }
+        "ImportDeclaration" => {
+            for key in ["attributes", "assertions"] {
+                if node
+                    .get(key)
+                    .and_then(Value::as_array)
+                    .is_some_and(Vec::is_empty)
+                {
+                    remove_key(node, key);
+                }
+            }
+            Edit::Keep
+        }
+        "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration" => {
+            remove_key(node, "expression");
+            Edit::Keep
+        }
+        _ => Edit::Keep,
+    })
+}
+
+fn remove_key(node: &mut Value, key: &str) {
+    if let Some(object) = node.as_object_mut() {
+        object.remove(key);
+    }
+}
+
+fn base(node: &Value, kind: &str) -> Map<String, Value> {
+    let mut map = Map::new();
+    map.insert("type".to_owned(), Value::String(kind.to_owned()));
+    for key in ["loc", "range"] {
+        if let Some(value) = node.get(key) {
+            map.insert(key.to_owned(), value.clone());
+        }
+    }
+    map
+}
+
+fn literal(node: &mut Value) -> Value {
+    let raw = node.get("raw").cloned().unwrap_or(Value::Null);
+    let value = take(node, "value");
+    if let Some(regex) = node.get("regex") {
+        let mut out = base(node, "RegExpLiteral");
+        out.insert("pattern".to_owned(), regex["pattern"].clone());
+        out.insert("flags".to_owned(), regex["flags"].clone());
+        out.insert("extra".to_owned(), json!({ "raw": raw }));
+        return Value::Object(out);
+    }
+    if let Some(bigint) = node.get("bigint") {
+        let mut out = base(node, "BigIntLiteral");
+        out.insert("value".to_owned(), bigint.clone());
+        out.insert(
+            "extra".to_owned(),
+            json!({ "rawValue": bigint, "raw": raw }),
+        );
+        return Value::Object(out);
+    }
+    match value {
+        Value::String(text) => {
+            let mut out = base(node, "StringLiteral");
+            out.insert("value".to_owned(), Value::String(text.clone()));
+            out.insert("extra".to_owned(), json!({ "rawValue": text, "raw": raw }));
+            Value::Object(out)
+        }
+        Value::Number(number) => {
+            let mut out = base(node, "NumericLiteral");
+            out.insert("value".to_owned(), Value::Number(number.clone()));
+            out.insert(
+                "extra".to_owned(),
+                json!({ "rawValue": number, "raw": raw }),
+            );
+            Value::Object(out)
+        }
+        Value::Bool(flag) => {
+            let mut out = base(node, "BooleanLiteral");
+            out.insert("value".to_owned(), Value::Bool(flag));
+            Value::Object(out)
+        }
+        _ => Value::Object(base(node, "NullLiteral")),
+    }
+}
+
+fn property(node: &mut Value) -> Result<Value, TransformError> {
+    let kind = str_field(node, "kind").unwrap_or("init").to_owned();
+    let is_method = bool_field(node, "method");
+    let computed = bool_field(node, "computed");
+    let key = take(node, "key");
+    let mut value = take(node, "value");
+
+    if is_method || kind != "init" {
+        if node_type(&value) != Some("FunctionExpression") {
+            return Err(TransformError::Internal(format!(
+                "a method property must hold a FunctionExpression, found {}",
+                node_type(&value).unwrap_or("nothing")
+            )));
+        }
+        let mut out = base(node, "ObjectMethod");
+        out.insert(
+            "kind".to_owned(),
+            Value::String(if kind == "init" {
+                "method".to_owned()
+            } else {
+                kind.clone()
+            }),
+        );
+        out.insert("method".to_owned(), Value::Bool(kind == "init"));
+        out.insert("computed".to_owned(), Value::Bool(computed));
+        out.insert("key".to_owned(), key);
+        out.insert("id".to_owned(), Value::Null);
+        out.insert("params".to_owned(), take(&mut value, "params"));
+        out.insert("body".to_owned(), take(&mut value, "body"));
+        out.insert("async".to_owned(), Value::Bool(bool_field(&value, "async")));
+        out.insert(
+            "generator".to_owned(),
+            Value::Bool(bool_field(&value, "generator")),
+        );
+        return Ok(Value::Object(out));
+    }
+
+    let mut out = base(node, "ObjectProperty");
+    out.insert("computed".to_owned(), Value::Bool(computed));
+    out.insert("key".to_owned(), key);
+    out.insert("value".to_owned(), value);
+    out.insert("method".to_owned(), Value::Bool(false));
+    out.insert(
+        "shorthand".to_owned(),
+        Value::Bool(bool_field(node, "shorthand")),
+    );
+    Ok(Value::Object(out))
+}
+
+fn method_definition(node: &mut Value) -> Value {
+    let key = take(node, "key");
+    let mut value = take(node, "value");
+    let private = node_type(&key) == Some("PrivateName");
+    let mut out = base(
+        node,
+        if private {
+            "ClassPrivateMethod"
+        } else {
+            "ClassMethod"
+        },
+    );
+    out.insert(
+        "kind".to_owned(),
+        node.get("kind")
+            .cloned()
+            .unwrap_or_else(|| Value::String("method".to_owned())),
+    );
+    out.insert(
+        "computed".to_owned(),
+        Value::Bool(bool_field(node, "computed")),
+    );
+    out.insert("static".to_owned(), Value::Bool(bool_field(node, "static")));
+    out.insert("key".to_owned(), key);
+    out.insert("id".to_owned(), Value::Null);
+    out.insert("params".to_owned(), take(&mut value, "params"));
+    out.insert("body".to_owned(), take(&mut value, "body"));
+    out.insert("async".to_owned(), Value::Bool(bool_field(&value, "async")));
+    out.insert(
+        "generator".to_owned(),
+        Value::Bool(bool_field(&value, "generator")),
+    );
+    Value::Object(out)
+}
+
+fn property_definition(node: &mut Value) -> Value {
+    let key = take(node, "key");
+    let private = node_type(&key) == Some("PrivateName");
+    let mut out = base(
+        node,
+        if private {
+            "ClassPrivateProperty"
+        } else {
+            "ClassProperty"
+        },
+    );
+    out.insert("key".to_owned(), key);
+    out.insert("value".to_owned(), take(node, "value"));
+    out.insert("static".to_owned(), Value::Bool(bool_field(node, "static")));
+    if !private {
+        out.insert(
+            "computed".to_owned(),
+            Value::Bool(bool_field(node, "computed")),
+        );
+    }
+    Value::Object(out)
+}
+
+fn private_name(node: &mut Value) -> Value {
+    let name = take(node, "name");
+    let mut id = base(node, "Identifier");
+    id.insert("name".to_owned(), name);
+    let mut out = base(node, "PrivateName");
+    out.insert("id".to_owned(), Value::Object(id));
+    Value::Object(out)
+}
+
+fn import_expression(node: &mut Value) -> Value {
+    let source = take(node, "source");
+    let options = take(node, "options");
+    let mut arguments = vec![source];
+    if !options.is_null() {
+        arguments.push(options);
+    }
+    let mut out = base(node, "CallExpression");
+    out.insert("callee".to_owned(), json!({ "type": "Import" }));
+    out.insert("arguments".to_owned(), Value::Array(arguments));
+    Value::Object(out)
+}
+
+fn export_namespace(node: &mut Value) -> Value {
+    let exported = take(node, "exported");
+    let mut specifier = base(&exported, "ExportNamespaceSpecifier");
+    specifier.insert("exported".to_owned(), exported);
+    let mut out = base(node, "ExportNamedDeclaration");
+    out.insert("declaration".to_owned(), Value::Null);
+    out.insert(
+        "specifiers".to_owned(),
+        Value::Array(vec![Value::Object(specifier)]),
+    );
+    out.insert("source".to_owned(), take(node, "source"));
+    out.insert("exportKind".to_owned(), Value::String("value".to_owned()));
+    Value::Object(out)
+}
+
+/// Rewrite the members of an optional chain into Babel's `Optional*` nodes.
+///
+/// A member or call inside the chain that is itself not optional but sits on
+/// an optional one still becomes `Optional*` with `optional: false`, which is
+/// how Babel marks "part of the chain" — short-circuiting has to cover it.
+fn chain(node: Value) -> Value {
+    match node_type(&node) {
+        Some("MemberExpression") => {
+            let mut node = node;
+            let object = chain(take(&mut node, "object"));
+            let optional = bool_field(&node, "optional");
+            let inner_optional = matches!(
+                node_type(&object),
+                Some("OptionalMemberExpression" | "OptionalCallExpression")
+            );
+            if !optional && !inner_optional {
+                node["object"] = object;
+                return node;
+            }
+            let mut out = base(&node, "OptionalMemberExpression");
+            out.insert("object".to_owned(), object);
+            out.insert("property".to_owned(), take(&mut node, "property"));
+            out.insert(
+                "computed".to_owned(),
+                Value::Bool(bool_field(&node, "computed")),
+            );
+            out.insert("optional".to_owned(), Value::Bool(optional));
+            Value::Object(out)
+        }
+        Some("CallExpression") => {
+            let mut node = node;
+            let callee = chain(take(&mut node, "callee"));
+            let optional = bool_field(&node, "optional");
+            let inner_optional = matches!(
+                node_type(&callee),
+                Some("OptionalMemberExpression" | "OptionalCallExpression")
+            );
+            if !optional && !inner_optional {
+                node["callee"] = callee;
+                return node;
+            }
+            let mut out = base(&node, "OptionalCallExpression");
+            out.insert("callee".to_owned(), callee);
+            out.insert("optional".to_owned(), Value::Bool(optional));
+            out.insert("arguments".to_owned(), take(&mut node, "arguments"));
+            Value::Object(out)
+        }
+        _ => node,
+    }
+}
+
+/// Move a statement list's leading directive prologue into `directives`.
+fn lift_directives(node: &mut Value) {
+    if node.get("directives").is_some() {
+        return;
+    }
+    let mut directives = Vec::new();
+    let mut leading = 0usize;
+    if let Some(body) = node.get("body").and_then(Value::as_array) {
+        for statement in body {
+            let Some(text) = str_field(statement, "directive") else {
+                break;
+            };
+            let raw = statement["expression"]
+                .get("extra")
+                .and_then(|extra| extra.get("raw"))
+                .cloned()
+                .or_else(|| statement["expression"].get("raw").cloned())
+                .unwrap_or_else(|| Value::String(format!("\"{text}\"")));
+            let mut literal = base(&statement["expression"], "DirectiveLiteral");
+            literal.insert("value".to_owned(), Value::String(text.to_owned()));
+            literal.insert("extra".to_owned(), json!({ "rawValue": text, "raw": raw }));
+            let mut directive = base(statement, "Directive");
+            directive.insert("value".to_owned(), Value::Object(literal));
+            directives.push(Value::Object(directive));
+            leading += 1;
+        }
+    }
+    if let Some(body) = node.get_mut("body").and_then(Value::as_array_mut) {
+        body.drain(..leading);
+    }
+    node["directives"] = Value::Array(directives);
+}
+
+fn wrap_file(mut program: Value) -> Value {
+    let comments: Vec<Value> = take(&mut program, "comments")
+        .as_array()
+        .map(|list| list.iter().map(comment).collect())
+        .unwrap_or_default();
+    if program.get("sourceType").is_none() {
+        program["sourceType"] = Value::String("module".to_owned());
+    }
+    let loc = program.get("loc").cloned().unwrap_or(Value::Null);
+    let range = program.get("range").cloned().unwrap_or(Value::Null);
+    json!({
+        "type": "File",
+        "program": program,
+        "comments": comments,
+        "loc": loc,
+        "range": range,
+    })
+}
+
+fn comment(node: &Value) -> Value {
+    let kind = if node_type(node) == Some("Line") {
+        "CommentLine"
+    } else {
+        "CommentBlock"
+    };
+    let mut out = base(node, kind);
+    out.insert(
+        "value".to_owned(),
+        node.get("value").cloned().unwrap_or(Value::Null),
+    );
+    Value::Object(out)
+}
+
+/// The keys `finalize` never descends into.
+const SKIPPED: [&str; 4] = ["type", "loc", "range", "extra"];
+
+/// Assign node ids and Babel's `start`/`end`, and tidy the fields Babel
+/// omits, throughout the file.
+fn finalize(node: &mut Value, next_id: &mut u32, lines: &LineTable) {
+    let Some(object) = node.as_object_mut() else {
+        return;
+    };
+    let Some(kind) = object
+        .get("type")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+    else {
+        return;
+    };
+
+    object.insert("_nodeId".to_owned(), Value::from(*next_id));
+    *next_id += 1;
+
+    let mut offsets = None;
+    if let Some(range) = object.remove("range")
+        && let Some(pair) = range.as_array()
+        && pair.len() == 2
+    {
+        object.insert("start".to_owned(), pair[0].clone());
+        object.insert("end".to_owned(), pair[1].clone());
+        offsets = pair[0].as_u64().zip(pair[1].as_u64());
+    }
+    if let Some((start, end)) = offsets {
+        let (start_line, start_column) = lines.position(u32::try_from(start).unwrap_or(u32::MAX));
+        let (end_line, end_column) = lines.position(u32::try_from(end).unwrap_or(u32::MAX));
+        object.insert(
+            "loc".to_owned(),
+            json!({
+                "start": { "line": start_line, "column": start_column },
+                "end": { "line": end_line, "column": end_column },
+            }),
+        );
+    } else if let Some(loc) = object.get_mut("loc").and_then(Value::as_object_mut) {
+        loc.remove("source");
+    }
+
+    match kind.as_str() {
+        "ExpressionStatement" => {
+            object.remove("directive");
+        }
+        "MemberExpression" => {
+            object.remove("optional");
+        }
+        "CallExpression" | "NewExpression" => {
+            if object.get("optional") == Some(&Value::Bool(false)) {
+                object.remove("optional");
+            }
+        }
+        "Identifier" => {
+            let name = object.get("name").cloned();
+            if let (Some(loc), Some(name)) =
+                (object.get_mut("loc").and_then(Value::as_object_mut), name)
+            {
+                loc.insert("identifierName".to_owned(), name);
+            }
+        }
+        _ => {}
+    }
+
+    let keys: Vec<String> = object
+        .keys()
+        .filter(|key| !SKIPPED.contains(&key.as_str()))
+        .cloned()
+        .collect();
+    for key in keys {
+        match object.get_mut(&key) {
+            Some(Value::Array(items)) => {
+                for item in items {
+                    finalize(item, next_id, lines);
+                }
+            }
+            Some(child @ Value::Object(_)) => finalize(child, next_id, lines),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+    use crate::lower;
+
+    fn babel(source: &str) -> Value {
+        let mut program = parse(source).unwrap();
+        lower::lower(&mut program, source).unwrap();
+        to_babel(program, source).unwrap()
+    }
+
+    #[test]
+    fn literals_are_typed_and_carry_their_raw_text() {
+        let file = babel("const a = 'x', b = 0x10, c = true, d = null, e = /r/g, f = 10n;\n");
+        let declarations = file["program"]["body"][0]["declarations"]
+            .as_array()
+            .unwrap();
+        assert_eq!(declarations[0]["init"]["type"], "StringLiteral");
+        assert_eq!(declarations[0]["init"]["extra"]["raw"], "'x'");
+        assert_eq!(declarations[1]["init"]["type"], "NumericLiteral");
+        assert_eq!(declarations[1]["init"]["value"], 16);
+        assert_eq!(declarations[2]["init"]["type"], "BooleanLiteral");
+        assert_eq!(declarations[3]["init"]["type"], "NullLiteral");
+        assert_eq!(declarations[4]["init"]["type"], "RegExpLiteral");
+        assert_eq!(declarations[4]["init"]["flags"], "g");
+        assert_eq!(declarations[5]["init"]["type"], "BigIntLiteral");
+    }
+
+    #[test]
+    fn object_and_class_members_take_babel_s_names() {
+        let file = babel(
+            "const o = { a: 1, b() {}, get c() { return 1; } };\nclass K { m() {} #p = 1; static q = 2; #r() {} }\n",
+        );
+        let props = file["program"]["body"][0]["declarations"][0]["init"]["properties"]
+            .as_array()
+            .unwrap();
+        assert_eq!(props[0]["type"], "ObjectProperty");
+        assert_eq!(props[1]["type"], "ObjectMethod");
+        assert_eq!(props[1]["kind"], "method");
+        assert_eq!(props[2]["kind"], "get");
+        let members = file["program"]["body"][1]["body"]["body"]
+            .as_array()
+            .unwrap();
+        assert_eq!(members[0]["type"], "ClassMethod");
+        assert_eq!(members[1]["type"], "ClassPrivateProperty");
+        assert_eq!(members[1]["key"]["type"], "PrivateName");
+        assert_eq!(members[2]["type"], "ClassProperty");
+        assert_eq!(members[3]["type"], "ClassPrivateMethod");
+    }
+
+    #[test]
+    fn optional_chains_become_optional_nodes() {
+        let file = babel("a?.b.c?.();\n");
+        let expression = &file["program"]["body"][0]["expression"];
+        assert_eq!(expression["type"], "OptionalCallExpression");
+        assert_eq!(expression["callee"]["type"], "OptionalMemberExpression");
+        assert_eq!(expression["callee"]["optional"], false);
+        assert_eq!(expression["callee"]["object"]["optional"], true);
+    }
+
+    #[test]
+    fn directives_are_lifted_and_dynamic_import_is_a_call() {
+        let file =
+            babel("'use client';\nfunction f() { 'use strict'; return import('./x.js'); }\n");
+        assert_eq!(
+            file["program"]["directives"][0]["value"]["value"],
+            "use client"
+        );
+        assert_eq!(file["program"]["body"].as_array().unwrap().len(), 1);
+        let function = &file["program"]["body"][0];
+        assert_eq!(
+            function["body"]["directives"][0]["value"]["value"],
+            "use strict"
+        );
+        assert_eq!(
+            function["body"]["body"][0]["argument"]["callee"]["type"],
+            "Import"
+        );
+    }
+
+    #[test]
+    fn every_node_has_a_unique_id_and_offsets() {
+        let file = babel("const a = 1;\n");
+        assert_eq!(file["_nodeId"], 0);
+        assert_eq!(file["program"]["_nodeId"], 1);
+        assert_eq!(file["program"]["body"][0]["start"], 0);
+        assert_eq!(file["program"]["body"][0]["end"], 12);
+        assert_eq!(
+            file["program"]["body"][0]["declarations"][0]["id"]["loc"]["identifierName"],
+            "a"
+        );
+    }
+
+    #[test]
+    fn columns_count_utf16_code_units() {
+        let file = babel("const s = \"😀\";\nconst t = \"日本\"; const u = 1;\n");
+        let u = &file["program"]["body"][2]["declarations"][0];
+        assert_eq!(u["loc"]["start"]["line"], 2);
+        // `const t = "日本"; ` is 16 code units; the declarator starts after `const `.
+        assert_eq!(u["loc"]["start"]["column"], 22);
+        // The first line, `const s = "😀";` plus its newline, is 16 code units too.
+        assert_eq!(u["start"], 16 + 22);
+    }
+
+    #[test]
+    fn export_star_as_becomes_a_namespace_specifier() {
+        let file = babel("export * as ns from './x.js';\n");
+        let export = &file["program"]["body"][0];
+        assert_eq!(export["type"], "ExportNamedDeclaration");
+        assert_eq!(export["specifiers"][0]["type"], "ExportNamespaceSpecifier");
+    }
+
+    #[test]
+    fn the_result_deserializes_into_the_compiler_s_ast() {
+        let file = babel(
+            "// @flow\nimport {useState} from 'react';\nexport component App(title: string) { const [n, setN] = useState(0); return <h1 onClick={() => setN(n + 1)}>{title}{n}</h1>; }\n",
+        );
+        let parsed: Result<react_compiler_ast::File, _> = serde_json::from_value(file);
+        assert!(parsed.is_ok(), "{parsed:?}");
+    }
+}

--- a/crates/uf_transform/src/compiler.rs
+++ b/crates/uf_transform/src/compiler.rs
@@ -1,0 +1,239 @@
+//! The official React Compiler, in process.
+//!
+//! `react_compiler` is Meta's Rust implementation of the compiler that ships
+//! as `babel-plugin-react-compiler`. It takes Babel's AST and the scope
+//! information a front end computed, and returns the same AST with memoised
+//! functions substituted. uf drives it in `syntax` mode by default: only
+//! functions declared with Flow's `component` and `hook` syntax are compiled,
+//! which is precisely the set an author has opted into by writing them that
+//! way.
+//!
+//! The panic threshold is `none`: a function the compiler cannot handle is
+//! left as written and reported as a diagnostic, never a failed build.
+
+use react_compiler::entrypoint::{CompileResult, PluginOptions, compile_program};
+use react_compiler_ast::File;
+use react_compiler_ast::scope::ScopeInfo;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::{TransformError, TransformOptions};
+
+/// Which functions the React Compiler memoises.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReactCompilerMode {
+    /// Do not run the compiler.
+    Off,
+    /// Only `component` and `hook` declarations. The default.
+    #[default]
+    Syntax,
+    /// Also functions the compiler infers to be components or hooks from
+    /// their name and shape, as it does for plain JavaScript projects.
+    Infer,
+    /// Only functions carrying a `"use memo"` directive.
+    Annotation,
+    /// Every function.
+    All,
+}
+
+impl ReactCompilerMode {
+    /// The compiler's own name for the mode.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Syntax => "syntax",
+            Self::Infer => "infer",
+            Self::Annotation => "annotation",
+            Self::All => "all",
+        }
+    }
+}
+
+/// Something the compiler reported about one function.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompilerDiagnostic {
+    /// The event kind, e.g. `CompileError` or `CompileSkip`.
+    pub kind: String,
+    /// What the compiler said.
+    pub message: String,
+    /// The function's name, when known.
+    pub function: Option<String>,
+    /// 1-based line of the finding, when known.
+    pub line: Option<u32>,
+    /// 0-based column of the finding, when known.
+    pub column: Option<u32>,
+}
+
+/// Compile `file`, returning the (possibly rewritten) file, the compiler's
+/// diagnostics, and how many functions were memoised.
+///
+/// # Errors
+///
+/// [`TransformError::Internal`] when the tree does not deserialize into the
+/// compiler's AST, and [`TransformError::Compiler`] when the compiler reports
+/// a fatal error.
+pub fn compile(
+    file: Value,
+    scope: ScopeInfo,
+    source: &str,
+    options: &TransformOptions,
+) -> Result<(Value, Vec<CompilerDiagnostic>, usize), TransformError> {
+    let ast: File = serde_json::from_value(file.clone()).map_err(|error| {
+        TransformError::Internal(format!("Babel AST rejected by the React Compiler: {error}"))
+    })?;
+    let plugin_options = plugin_options(source, options)?;
+
+    match compile_program(ast, scope, plugin_options) {
+        CompileResult::Success { ast, events, .. } => {
+            let events: Vec<Value> = events
+                .iter()
+                .map(|event| serde_json::to_value(event).unwrap_or(Value::Null))
+                .collect();
+            let compiled = events
+                .iter()
+                .filter(|event| event["kind"] == "CompileSuccess")
+                .count();
+            let diagnostics = events.iter().filter_map(diagnostic).collect();
+            let rewritten = match ast {
+                Some(ast) => serde_json::to_value(ast).map_err(|error| {
+                    TransformError::Internal(format!(
+                        "compiled AST could not be serialized: {error}"
+                    ))
+                })?,
+                None => file,
+            };
+            Ok((rewritten, diagnostics, compiled))
+        }
+        CompileResult::Error { error, .. } => {
+            let mut message = error.reason.clone();
+            if let Some(description) = &error.description {
+                message.push_str(": ");
+                message.push_str(description);
+            }
+            Err(TransformError::Compiler(message))
+        }
+    }
+}
+
+fn plugin_options(
+    source: &str,
+    options: &TransformOptions,
+) -> Result<PluginOptions, TransformError> {
+    serde_json::from_value(json!({
+        "shouldCompile": true,
+        "enableReanimated": false,
+        "isDev": options.development,
+        "filename": options.filename,
+        "compilationMode": options.react_compiler.as_str(),
+        "panicThreshold": "none",
+        "target": "19",
+        "noEmit": false,
+        "flowSuppressions": true,
+        "ignoreUseNoForget": false,
+        "environment": {},
+        "__sourceCode": source,
+    }))
+    .map_err(|error| TransformError::Internal(format!("React Compiler options rejected: {error}")))
+}
+
+/// A diagnostic from a logger event that is not a success.
+fn diagnostic(event: &Value) -> Option<CompilerDiagnostic> {
+    let kind = event.get("kind")?.as_str()?;
+    if kind == "CompileSuccess" || kind == "PipelineError" && false {
+        return None;
+    }
+    let message = event
+        .get("detail")
+        .and_then(|detail| detail.get("reason").or_else(|| detail.get("description")))
+        .and_then(Value::as_str)
+        .or_else(|| event.get("reason").and_then(Value::as_str))
+        .map(str::to_owned)
+        .unwrap_or_else(|| kind.to_owned());
+    let function = event
+        .get("fnName")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let position = event
+        .get("fnLoc")
+        .or_else(|| event.get("detail").and_then(|detail| detail.get("loc")))
+        .and_then(|loc| loc.get("start"));
+    let number = |key: &str| {
+        position
+            .and_then(|p| p.get(key))
+            .and_then(Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+    };
+    Some(CompilerDiagnostic {
+        kind: kind.to_owned(),
+        message,
+        function,
+        line: number("line"),
+        column: number("column"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+    use crate::{lower, scope};
+
+    fn compiled(source: &str, mode: ReactCompilerMode) -> (Value, Vec<CompilerDiagnostic>, usize) {
+        let mut program = parse(source).unwrap();
+        lower::lower(&mut program, source).unwrap();
+        let file = crate::babel::to_babel(program, source).unwrap();
+        let info = scope::analyze(&file);
+        let options = TransformOptions {
+            react_compiler: mode,
+            ..TransformOptions::new("app.js")
+        };
+        compile(file, info, source, &options).unwrap()
+    }
+
+    #[test]
+    fn syntax_mode_compiles_a_component_and_leaves_a_plain_function() {
+        let source = "import {useState} from 'react';\nexport component App(title: string) { const [n, setN] = useState(0); return <h1 onClick={() => setN(n + 1)}>{title}{n}</h1>; }\nexport function Plain(props) { return <p>{props.x}</p>; }\n";
+        let (file, diagnostics, count) = compiled(source, ReactCompilerMode::Syntax);
+        assert_eq!(count, 1, "{diagnostics:?}");
+        let text = file.to_string();
+        assert!(
+            text.contains("react/compiler-runtime"),
+            "compiler runtime import missing"
+        );
+        let declaration = |name: &str| {
+            file["program"]["body"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|statement| &statement["declaration"])
+                .find(|declaration| declaration["id"]["name"] == name)
+                .cloned()
+                .unwrap_or_else(|| panic!("no declaration named {name}"))
+        };
+        let app = declaration("App");
+        let first = &app["body"]["body"][0];
+        assert_eq!(first["type"], "VariableDeclaration");
+        assert_eq!(first["declarations"][0]["id"]["name"], "$");
+        let plain = declaration("Plain");
+        assert_eq!(plain["body"]["body"][0]["type"], "ReturnStatement");
+    }
+
+    #[test]
+    fn a_module_without_components_comes_back_unchanged() {
+        let source = "export const a = 1;\n";
+        let (file, diagnostics, count) = compiled(source, ReactCompilerMode::Syntax);
+        assert_eq!(count, 0);
+        assert!(diagnostics.is_empty());
+        assert_eq!(file["program"]["body"][0]["type"], "ExportNamedDeclaration");
+    }
+
+    #[test]
+    fn a_hook_rules_violation_is_a_diagnostic_not_a_failure() {
+        let source = "import {useState} from 'react';\ncomponent Bad(flag: boolean) { if (flag) { useState(0); } return null; }\n";
+        let (_, diagnostics, count) = compiled(source, ReactCompilerMode::Syntax);
+        assert_eq!(count, 0);
+        assert!(!diagnostics.is_empty());
+    }
+}

--- a/crates/uf_transform/src/emit.rs
+++ b/crates/uf_transform/src/emit.rs
@@ -1,0 +1,229 @@
+//! The last mile: JSX, Fast Refresh and code generation through oxc.
+//!
+//! oxc is the compiler inside Vite and Rolldown, so what it does to JSX here
+//! is what Vite would have done to a `.jsx` file: the automatic runtime
+//! (`jsx`/`jsxs`, or `jsxDEV` in development) imported from the configured
+//! source, and `react-refresh` registrations in development. Running it in
+//! process means `uf test` and the Vite plugin produce byte-identical modules.
+//!
+//! The source map oxc produces points at the printed JavaScript; it is
+//! composed with the printer's mappings so the final map points at the Flow
+//! source.
+
+use std::path::{Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_sourcemap::SourceMapBuilder;
+use oxc_span::SourceType;
+use oxc_transformer::{
+    EnvOptions, JsxOptions, JsxRuntime, ReactRefreshOptions, TransformOptions, Transformer,
+};
+
+use crate::print::{Mapping, Printed};
+use crate::{TransformError, TransformOptions as UfOptions};
+
+/// The final module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Emitted {
+    /// JavaScript with JSX lowered.
+    pub code: String,
+    /// Source map JSON, when asked for.
+    pub map: Option<String>,
+}
+
+/// Lower JSX, register components for Fast Refresh, and generate code.
+///
+/// # Errors
+///
+/// [`TransformError::Internal`] when the printed code does not parse, which
+/// would be a printer bug, and [`TransformError::Lowering`] when the JSX
+/// transform refuses something (a namespaced tag, say).
+pub fn emit(
+    printed: &Printed,
+    source: &str,
+    options: &UfOptions,
+) -> Result<Emitted, TransformError> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::mjs().with_jsx(true);
+    let parsed = Parser::new(&allocator, &printed.code, source_type).parse();
+    if let Some(error) = parsed.diagnostics.iter().next() {
+        return Err(TransformError::Internal(format!(
+            "printed module does not parse: {error}\n{}",
+            printed.code
+        )));
+    }
+    let mut program = parsed.program;
+
+    let scoping = SemanticBuilder::new()
+        .build(&program)
+        .semantic
+        .into_scoping();
+
+    let mut jsx = JsxOptions {
+        runtime: JsxRuntime::Automatic,
+        development: options.development,
+        import_source: Some(options.jsx_import_source.clone()),
+        pure: !options.development,
+        refresh: (options.development && options.refresh).then(ReactRefreshOptions::default),
+        ..JsxOptions::enable()
+    };
+    jsx.conform();
+    let transform_options = TransformOptions {
+        // No down-levelling: the host runs modern JavaScript, and Vite applies
+        // its own targets to the bundle.
+        env: EnvOptions::from_target("esnext").map_err(|error| {
+            TransformError::Internal(format!("oxc rejected the esnext target: {error}"))
+        })?,
+        jsx,
+        ..TransformOptions::default()
+    };
+
+    let result = Transformer::new(&allocator, Path::new(&options.filename), &transform_options)
+        .build_with_scoping(scoping, &mut program);
+    if let Some(error) = result.diagnostics.iter().next() {
+        return Err(TransformError::Lowering {
+            message: error.to_string(),
+            line: None,
+            column: None,
+        });
+    }
+
+    let codegen_options = CodegenOptions {
+        source_map_path: options.source_map.then(|| PathBuf::from(&options.filename)),
+        ..CodegenOptions::default()
+    };
+    let generated = Codegen::new().with_options(codegen_options).build(&program);
+
+    let map = if options.source_map {
+        generated
+            .map
+            .as_ref()
+            .map(|map| compose(map, &printed.mappings, &options.filename, source))
+    } else {
+        None
+    };
+
+    Ok(Emitted {
+        code: generated.code,
+        map,
+    })
+}
+
+/// Compose oxc's map (printed → final) with the printer's mappings
+/// (source → printed) into one map (source → final).
+fn compose(
+    oxc_map: &oxc_sourcemap::SourceMap,
+    printer_mappings: &[Mapping],
+    filename: &str,
+    source: &str,
+) -> String {
+    let mut builder = SourceMapBuilder::default();
+    let source_id = builder.add_source_and_content(filename, source);
+    for token in oxc_map.get_tokens() {
+        let Some(original) = lookup(printer_mappings, token.get_src_line(), token.get_src_col())
+        else {
+            continue;
+        };
+        builder.add_token(
+            token.get_dst_line(),
+            token.get_dst_col(),
+            original.original_line,
+            original.original_column,
+            Some(source_id),
+            None,
+        );
+    }
+    builder.into_sourcemap().to_json_string()
+}
+
+/// The printer mapping in effect at a printed position: the last one on the
+/// same line at or before the column.
+fn lookup(mappings: &[Mapping], line: u32, column: u32) -> Option<Mapping> {
+    let index =
+        mappings.partition_point(|m| (m.generated_line, m.generated_column) <= (line, column));
+    let candidate = mappings.get(index.checked_sub(1)?)?;
+    (candidate.generated_line == line).then_some(*candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::print::print;
+    use crate::{estree, lower};
+
+    fn emitted(source: &str, options: &UfOptions) -> Emitted {
+        let mut program = estree::parse(source).unwrap();
+        lower::lower(&mut program, source).unwrap();
+        let file = crate::babel::to_babel(program, source).unwrap();
+        let printed = print(&file).unwrap();
+        emit(&printed, source, options).unwrap()
+    }
+
+    #[test]
+    fn jsx_becomes_the_automatic_runtime() {
+        let out = emitted(
+            "export const el = <p className=\"a\">hi</p>;\n",
+            &UfOptions::new("a.js"),
+        );
+        assert!(
+            out.code.contains("from \"react/jsx-runtime\""),
+            "{}",
+            out.code
+        );
+        assert!(out.code.contains("jsx(\"p\""), "{}", out.code);
+        assert!(!out.code.contains("<p"), "{}", out.code);
+    }
+
+    #[test]
+    fn development_uses_jsxdev_and_registers_refresh() {
+        let options = UfOptions {
+            development: true,
+            refresh: true,
+            ..UfOptions::new("App.js")
+        };
+        let out = emitted("export component App() { return <p>hi</p>; }\n", &options);
+        assert!(out.code.contains("react/jsx-dev-runtime"), "{}", out.code);
+        assert!(out.code.contains("$RefreshReg$"), "{}", out.code);
+    }
+
+    #[test]
+    fn the_map_points_at_the_flow_source() {
+        let source = "// @flow\nconst a: number = 1;\nexport function f(): number {\n  return <p>{a}</p>;\n}\n";
+        let out = emitted(source, &UfOptions::new("f.js"));
+        let map: serde_json::Value = serde_json::from_str(out.map.as_deref().unwrap()).unwrap();
+        assert_eq!(map["sources"][0], "f.js");
+        assert_eq!(map["sourcesContent"][0], source);
+        assert!(!map["mappings"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn lookup_takes_the_last_mapping_on_the_line() {
+        let mappings = [
+            Mapping {
+                generated_line: 0,
+                generated_column: 0,
+                original_line: 5,
+                original_column: 0,
+            },
+            Mapping {
+                generated_line: 0,
+                generated_column: 8,
+                original_line: 5,
+                original_column: 10,
+            },
+            Mapping {
+                generated_line: 2,
+                generated_column: 0,
+                original_line: 9,
+                original_column: 0,
+            },
+        ];
+        assert_eq!(lookup(&mappings, 0, 9).unwrap().original_column, 10);
+        assert_eq!(lookup(&mappings, 0, 3).unwrap().original_column, 0);
+        assert!(lookup(&mappings, 1, 0).is_none());
+        assert_eq!(lookup(&mappings, 2, 4).unwrap().original_line, 9);
+    }
+}

--- a/crates/uf_transform/src/estree.rs
+++ b/crates/uf_transform/src/estree.rs
@@ -1,0 +1,130 @@
+//! Parsing with the official Flow parser, rendered as ESTree.
+//!
+//! `flow_parser` is Meta's Rust port of Flow's parser and it ships its own
+//! ESTree translator — the same rendering `flow-parser` on npm produces. uf
+//! takes that rendering as a `serde_json::Value` tree and works on it
+//! directly: every later stage in this crate is a rewrite of that tree, and
+//! the lowering rules it applies were written against exactly this shape.
+//!
+//! Offsets (`range`) are JavaScript string indices, in UTF-16 code units,
+//! which is what source maps and editors expect. The translator's `loc`
+//! columns count code points instead; [`crate::babel`] recomputes them from
+//! the offsets so every position downstream agrees.
+
+use flow_parser::ParseOptions;
+use flow_parser::estree_translator::{self, Config, OffsetStyle};
+use flow_parser::loc::Loc;
+use flow_parser::offset_utils::{OffsetKind, OffsetTable};
+use flow_parser::parse_error::ParseError;
+use serde_json::Value;
+
+use crate::TransformError;
+
+/// Longest source the transform will read, in bytes.
+///
+/// A dependency can put a generated or hostile file in `node_modules`; every
+/// scan in uf has an explicit ceiling rather than trusting its input.
+pub const MAX_SOURCE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Parse options aligned with the `uf` project defaults.
+///
+/// Every syntax uf documents is on: components, hooks, enums, pattern
+/// matching, records. Decorators stay off because generated projects never
+/// emit them.
+pub const PARSE_OPTIONS: ParseOptions = ParseOptions {
+    components: true,
+    enums: true,
+    pattern_matching: true,
+    records: true,
+    esproposal_decorators: false,
+    types: true,
+    ambiguous_types: true,
+    enable_types_in_comments: true,
+    use_strict: false,
+    assert_operator: false,
+    module_ref_prefix: None,
+    ambient: false,
+    allow_return_outside_function: false,
+};
+
+/// Parse `source` and render it as an ESTree `Program`.
+///
+/// Comments come back twice: on the program (`comments`) and attached to the
+/// nodes they sit beside. The React Compiler reads the program's list; the
+/// attached copies are dropped when the tree is converted for it.
+///
+/// # Errors
+///
+/// [`TransformError::SourceTooLarge`] over the ceiling, and
+/// [`TransformError::Syntax`] with the first error the parser reported.
+pub fn parse(source: &str) -> Result<Value, TransformError> {
+    if source.len() > MAX_SOURCE_BYTES {
+        return Err(TransformError::SourceTooLarge {
+            bytes: source.len(),
+            limit: MAX_SOURCE_BYTES,
+        });
+    }
+
+    // JavaScript columns: UTF-16 code units, which is what source maps count.
+    let offsets = OffsetTable::make_with_kind(OffsetKind::JavaScript, source);
+    let (ast, errors): (_, Vec<(Loc, ParseError)>) =
+        flow_parser::parse_program_without_file(false, None, Some(PARSE_OPTIONS), Ok(source));
+
+    if let Some((loc, error)) = errors.first() {
+        let position = offsets
+            .convert_flow_position_to_js_position(loc.start)
+            .unwrap_or(loc.start);
+        return Err(TransformError::Syntax {
+            message: error.to_string(),
+            line: u32::try_from(position.line).unwrap_or(u32::MAX),
+            column: u32::try_from(position.column).unwrap_or(u32::MAX),
+        });
+    }
+
+    let config = Config {
+        include_locs: true,
+        include_filename: false,
+        offset_style: OffsetStyle::JsIndices,
+    };
+    Ok(estree_translator::program(&offsets, &config, &ast))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_component_syntax_as_estree() {
+        let program = parse("// @flow\ncomponent A(x: string) { return null; }\n").unwrap();
+        let body = program["body"].as_array().unwrap();
+        assert_eq!(body[0]["type"], "ComponentDeclaration");
+        assert_eq!(body[0]["params"][0]["type"], "ComponentParameter");
+        assert_eq!(program["comments"][0]["type"], "Line");
+    }
+
+    #[test]
+    fn reports_the_first_syntax_error_with_a_position() {
+        let error = parse("const a = ;\n").unwrap_err();
+        match error {
+            TransformError::Syntax { line, .. } => assert_eq!(line, 1),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn offsets_count_utf16_code_units() {
+        let program = parse("const s = \"😀\"; const t = 1;\n").unwrap();
+        let second = &program["body"][1];
+        // `const s = "😀"; ` is 16 code units (the emoji is two) and 19 bytes.
+        assert_eq!(second["range"][0], 16);
+    }
+
+    #[test]
+    fn refuses_oversized_input() {
+        let big = "a;".repeat(MAX_SOURCE_BYTES / 2 + 1);
+        assert!(matches!(
+            parse(&big),
+            Err(TransformError::SourceTooLarge { .. })
+        ));
+    }
+}

--- a/crates/uf_transform/src/lib.rs
+++ b/crates/uf_transform/src/lib.rs
@@ -1,0 +1,259 @@
+#![deny(missing_docs)]
+//! Flow → JavaScript, with nothing but upstream code deciding what the language means.
+//!
+//! `uf` projects are written in Flow — `component` and `hook` declarations,
+//! `match`, enums, and type annotations — and every host runs JavaScript. This
+//! crate is the one place that turns one into the other, and it is deliberately
+//! assembled from the implementations that *own* each step:
+//!
+//! 1. **Parse** with Meta's official Flow parser (`flow_parser`, vendored from
+//!    `upstream/flow`), and take its ESTree rendering ([`estree`]).
+//! 2. **Lower** Flow-only syntax exactly the way Flow's own toolchain does
+//!    ([`lower`]): the rules are ported from `hermes-parser`'s
+//!    `TransformComponentSyntax`, `TransformMatchSyntax`, `TransformEnumSyntax`
+//!    and `StripFlowTypes`, so a `match` compiles to the same conditions Flow
+//!    documents and a `component` to the same destructured function.
+//! 3. **Convert** the ESTree to Babel's AST shape ([`babel`]) and analyse its
+//!    scopes ([`scope`]), which is the contract the official React Compiler
+//!    consumes.
+//! 4. **Compile** with the official React Compiler's Rust implementation
+//!    ([`compiler`]) in `syntax` mode: only `component`/`hook` declarations are
+//!    memoised, which is the mode Flow's syntax exists for.
+//! 5. **Print** the compiled program back to JavaScript with a source map
+//!    ([`print`]), then hand it to oxc — the engine inside Vite and Rolldown —
+//!    for the JSX automatic runtime, React Fast Refresh registration and code
+//!    generation ([`emit`]).
+//!
+//! There is no Babel anywhere in this pipeline, and no grammar uf invented.
+//!
+//! ```
+//! use uf_transform::{TransformOptions, transform};
+//!
+//! let source = "// @flow\nexport component Hello(name: string) { return <p>{name}</p>; }\n";
+//! let out = transform(source, &TransformOptions::new("hello.js")).expect("transforms");
+//! assert!(out.code.contains("function Hello"));
+//! assert!(!out.code.contains(": string"));
+//! assert!(out.code.contains("jsx"));
+//! ```
+
+pub mod babel;
+pub mod compiler;
+pub mod emit;
+pub mod estree;
+pub mod lower;
+pub mod print;
+pub mod scope;
+
+use thiserror::Error;
+
+pub use crate::compiler::{CompilerDiagnostic, ReactCompilerMode};
+pub use crate::estree::MAX_SOURCE_BYTES;
+
+/// How one module is transformed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransformOptions {
+    /// The module's path, used in source maps and in diagnostics.
+    pub filename: String,
+    /// Development output: `jsxDEV`, readable code, and Fast Refresh when
+    /// [`TransformOptions::refresh`] is set.
+    pub development: bool,
+    /// Add React Fast Refresh registrations (`$RefreshReg$`/`$RefreshSig$`).
+    /// Only meaningful in development.
+    pub refresh: bool,
+    /// Which functions the React Compiler memoises.
+    pub react_compiler: ReactCompilerMode,
+    /// Where the automatic JSX runtime is imported from.
+    pub jsx_import_source: String,
+    /// Produce a source map.
+    pub source_map: bool,
+}
+
+impl TransformOptions {
+    /// Production options for a module at `filename`.
+    #[must_use]
+    pub fn new(filename: impl Into<String>) -> Self {
+        Self {
+            filename: filename.into(),
+            development: false,
+            refresh: false,
+            react_compiler: ReactCompilerMode::Syntax,
+            jsx_import_source: String::from("react"),
+            source_map: true,
+        }
+    }
+}
+
+/// A transformed module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Transformed {
+    /// The JavaScript.
+    pub code: String,
+    /// A source map (JSON) back to the Flow source, when one was asked for.
+    pub map: Option<String>,
+    /// What the React Compiler reported: functions it declined, and why.
+    pub compiler_diagnostics: Vec<CompilerDiagnostic>,
+    /// How many functions the React Compiler memoised.
+    pub compiled_functions: usize,
+}
+
+/// Why a module could not be transformed.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TransformError {
+    /// The source is larger than [`MAX_SOURCE_BYTES`].
+    #[error("source is {bytes} bytes, over the {limit} byte ceiling")]
+    SourceTooLarge {
+        /// Size of the rejected source.
+        bytes: usize,
+        /// The ceiling.
+        limit: usize,
+    },
+    /// The official parser rejected the source.
+    #[error("{message}")]
+    Syntax {
+        /// What the parser said.
+        message: String,
+        /// 1-based line.
+        line: u32,
+        /// 0-based column, in UTF-16 code units, as editors count.
+        column: u32,
+    },
+    /// A construct the lowering rules refuse, such as a `var` binding in a
+    /// `match` pattern.
+    #[error("{message}")]
+    Lowering {
+        /// What was refused.
+        message: String,
+        /// 1-based line, when known.
+        line: Option<u32>,
+        /// 0-based column, when known.
+        column: Option<u32>,
+    },
+    /// The React Compiler failed in a way it asked to be fatal.
+    #[error("React Compiler: {0}")]
+    Compiler(String),
+    /// The AST produced along the way did not match the shape the next stage
+    /// expects. This is a bug in uf, never in the user's source.
+    #[error("internal transform error: {0}")]
+    Internal(String),
+}
+
+/// Whether uf is responsible for transforming the module at `id`.
+///
+/// Two things are excluded and one deliberately is not. A build driver
+/// synthesises modules of its own — Vite's client, a bundler's shims, ids
+/// starting with a NUL byte — and a third-party dependency ships JavaScript
+/// that is already JavaScript; handing either to a Flow transform turns a
+/// file nobody wrote into a syntax error. `@uniflowed/*` under `node_modules`
+/// is *not* excluded: those packages ship Flow source, because that is what
+/// uf tells everyone to write.
+///
+/// `@uniflowed/vite` applies the same policy in JavaScript before it asks,
+/// and must keep doing so: a `uf dev` session and a `uf test` run that
+/// disagree about which files are Flow disagree about what the code is.
+#[must_use]
+pub fn is_flow_module(id: &str) -> bool {
+    if id.starts_with('\0') {
+        return false;
+    }
+    let path = id.split_once('?').map_or(id, |(path, _)| path);
+    if !FLOW_EXTENSIONS
+        .iter()
+        .any(|extension| path.ends_with(extension))
+    {
+        return false;
+    }
+    match path.rfind("/node_modules/") {
+        Some(at) => path[at..].starts_with("/node_modules/@uniflowed/"),
+        None => true,
+    }
+}
+
+/// File extensions uf treats as Flow source.
+pub const FLOW_EXTENSIONS: [&str; 4] = [".js", ".jsx", ".mjs", ".cjs"];
+
+/// Transform one Flow module to JavaScript.
+///
+/// # Errors
+///
+/// See [`TransformError`].
+pub fn transform(source: &str, options: &TransformOptions) -> Result<Transformed, TransformError> {
+    let mut program = estree::parse(source)?;
+    let lowered = lower::lower(&mut program, source)?;
+    let file = babel::to_babel(program, source)?;
+
+    let (file, compiler_diagnostics, compiled_functions) =
+        if options.react_compiler == ReactCompilerMode::Off || !lowered.may_compile {
+            (file, Vec::new(), 0)
+        } else {
+            let scope = scope::analyze(&file);
+            compiler::compile(file, scope, source, options)?
+        };
+
+    let printed = print::print(&file)?;
+    let emitted = emit::emit(&printed, source, options)?;
+
+    Ok(Transformed {
+        code: emitted.code,
+        map: emitted.map,
+        compiler_diagnostics,
+        compiled_functions,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_driver_s_own_modules_are_not_flow_modules() {
+        assert!(is_flow_module("/app/main.js"));
+        assert!(is_flow_module("/app/main.js?v=1"));
+        assert!(!is_flow_module("\0vite/client"));
+        assert!(!is_flow_module("/app/node_modules/react/index.js"));
+        assert!(is_flow_module(
+            "/app/node_modules/@uniflowed/react/index.js"
+        ));
+        assert!(!is_flow_module("/app/styles.css"));
+        assert!(!is_flow_module("/app/page.mdx"));
+    }
+
+    #[test]
+    fn the_whole_pipeline_produces_a_module_with_a_map() {
+        let source = "// @flow\nimport {useState} from 'react';\nenum Mode { On, Off }\nexport component Toggle(label: string) {\n  const [mode, setMode] = useState<Mode>(Mode.On);\n  const text = match (mode) { Mode.On => 'on', Mode.Off => 'off' };\n  return <button onClick={() => setMode(Mode.Off)}>{label}: {text}</button>;\n}\n";
+        let options = TransformOptions {
+            development: true,
+            refresh: true,
+            ..TransformOptions::new("Toggle.js")
+        };
+        let out = transform(source, &options).expect("transforms");
+        assert!(out.code.contains("function Toggle"), "{}", out.code);
+        assert!(out.code.contains("$$ufEnumMirrored"), "{}", out.code);
+        assert!(out.code.contains("jsxDEV"), "{}", out.code);
+        assert!(out.code.contains("$RefreshReg$"), "{}", out.code);
+        assert!(out.code.contains("react/compiler-runtime"), "{}", out.code);
+        assert!(!out.code.contains("match ("), "{}", out.code);
+        assert_eq!(out.compiled_functions, 1, "{:?}", out.compiler_diagnostics);
+        assert!(out.map.is_some());
+    }
+
+    #[test]
+    fn a_syntax_error_names_its_position() {
+        let error = transform("const a = ;\n", &TransformOptions::new("x.js")).unwrap_err();
+        assert!(
+            matches!(error, TransformError::Syntax { line: 1, .. }),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn the_compiler_can_be_turned_off() {
+        let source = "export component A() { return <p />; }\n";
+        let options = TransformOptions {
+            react_compiler: ReactCompilerMode::Off,
+            ..TransformOptions::new("a.js")
+        };
+        let out = transform(source, &options).unwrap();
+        assert!(!out.code.contains("compiler-runtime"));
+        assert_eq!(out.compiled_functions, 0);
+    }
+}

--- a/crates/uf_transform/src/lower/builders.rs
+++ b/crates/uf_transform/src/lower/builders.rs
@@ -1,0 +1,197 @@
+//! Constructors for the ESTree nodes the lowering passes synthesise.
+//!
+//! A port of `hermes-parser`'s `utils/Builders.js`. Nodes built here carry no
+//! position: the printer falls back to the nearest positioned ancestor for the
+//! source map, which is the right answer for code the author never wrote.
+
+use serde_json::{Value, json};
+
+/// `name`
+#[must_use]
+pub fn ident(name: &str) -> Value {
+    json!({ "type": "Identifier", "name": name })
+}
+
+/// A string literal.
+#[must_use]
+pub fn string_literal(value: &str) -> Value {
+    json!({ "type": "Literal", "value": value, "raw": serde_json::to_string(value).unwrap_or_default() })
+}
+
+/// A number literal.
+#[must_use]
+pub fn number_literal(value: usize) -> Value {
+    json!({ "type": "Literal", "value": value, "raw": value.to_string() })
+}
+
+/// `null`
+#[must_use]
+pub fn null_literal() -> Value {
+    json!({ "type": "Literal", "value": null, "raw": "null" })
+}
+
+/// `object.property` or `object[property]`.
+#[must_use]
+pub fn member(object: Value, property: Value, computed: bool) -> Value {
+    json!({
+        "type": "MemberExpression",
+        "object": object,
+        "property": property,
+        "computed": computed,
+        "optional": false,
+    })
+}
+
+/// `callee(arguments)`
+#[must_use]
+pub fn call(callee: Value, arguments: Vec<Value>) -> Value {
+    json!({
+        "type": "CallExpression",
+        "callee": callee,
+        "arguments": arguments,
+        "optional": false,
+    })
+}
+
+/// `left <operator> right`
+#[must_use]
+pub fn binary(operator: &str, left: Value, right: Value) -> Value {
+    json!({ "type": "BinaryExpression", "operator": operator, "left": left, "right": right })
+}
+
+/// `left <operator> right` for `&&`, `||`, `??`.
+#[must_use]
+pub fn logical(operator: &str, left: Value, right: Value) -> Value {
+    json!({ "type": "LogicalExpression", "operator": operator, "left": left, "right": right })
+}
+
+/// `<operator> argument`
+#[must_use]
+pub fn unary(operator: &str, argument: Value) -> Value {
+    json!({ "type": "UnaryExpression", "operator": operator, "prefix": true, "argument": argument })
+}
+
+/// `typeof argument === "kind"`
+#[must_use]
+pub fn typeof_is(argument: Value, kind: &str) -> Value {
+    binary("===", unary("typeof", argument), string_literal(kind))
+}
+
+/// `a && b && c`, or `a` alone, or `true` for nothing.
+#[must_use]
+pub fn conjunction(mut tests: Vec<Value>) -> Value {
+    if tests.is_empty() {
+        return json!({ "type": "Literal", "value": true, "raw": "true" });
+    }
+    let mut result = tests.remove(0);
+    for test in tests {
+        result = logical("&&", result, test);
+    }
+    result
+}
+
+/// `a || b || c`, or `a` alone.
+#[must_use]
+pub fn disjunction(mut tests: Vec<Value>) -> Value {
+    if tests.is_empty() {
+        return json!({ "type": "Literal", "value": false, "raw": "false" });
+    }
+    let mut result = tests.remove(0);
+    for test in tests {
+        result = logical("||", result, test);
+    }
+    result
+}
+
+/// `<kind> id = init;`
+#[must_use]
+pub fn variable_declaration(kind: &str, id: Value, init: Value) -> Value {
+    json!({
+        "type": "VariableDeclaration",
+        "kind": kind,
+        "declarations": [{ "type": "VariableDeclarator", "id": id, "init": init }],
+    })
+}
+
+/// `{ body }`
+#[must_use]
+pub fn block(body: Vec<Value>) -> Value {
+    json!({ "type": "BlockStatement", "body": body })
+}
+
+/// `return argument;`
+#[must_use]
+pub fn return_statement(argument: Value) -> Value {
+    json!({ "type": "ReturnStatement", "argument": argument })
+}
+
+/// `throw argument;`
+#[must_use]
+pub fn throw_statement(argument: Value) -> Value {
+    json!({ "type": "ThrowStatement", "argument": argument })
+}
+
+/// `if (test) consequent [else alternate]`
+#[must_use]
+pub fn if_statement(test: Value, consequent: Value, alternate: Option<Value>) -> Value {
+    json!({
+        "type": "IfStatement",
+        "test": test,
+        "consequent": consequent,
+        "alternate": alternate.unwrap_or(Value::Null),
+    })
+}
+
+/// `expression;`
+#[must_use]
+pub fn expression_statement(expression: Value) -> Value {
+    json!({ "type": "ExpressionStatement", "expression": expression })
+}
+
+/// `((params) => { statements })(arguments)`
+#[must_use]
+pub fn iife(statements: Vec<Value>, params: Vec<Value>, arguments: Vec<Value>) -> Value {
+    call(
+        json!({
+            "type": "ArrowFunctionExpression",
+            "id": null,
+            "params": params,
+            "body": block(statements),
+            "async": false,
+            "expression": false,
+            "generator": false,
+        }),
+        arguments,
+    )
+}
+
+/// `test ? consequent : alternate`
+#[must_use]
+pub fn conditional(test: Value, consequent: Value, alternate: Value) -> Value {
+    json!({
+        "type": "ConditionalExpression",
+        "test": test,
+        "consequent": consequent,
+        "alternate": alternate,
+    })
+}
+
+/// A `Property` in an object pattern or expression.
+#[must_use]
+pub fn property(key: Value, value: Value, computed: bool, shorthand: bool) -> Value {
+    json!({
+        "type": "Property",
+        "key": key,
+        "value": value,
+        "kind": "init",
+        "method": false,
+        "shorthand": shorthand,
+        "computed": computed,
+    })
+}
+
+/// `...argument`
+#[must_use]
+pub fn rest_element(argument: Value) -> Value {
+    json!({ "type": "RestElement", "argument": argument })
+}

--- a/crates/uf_transform/src/lower/components.rs
+++ b/crates/uf_transform/src/lower/components.rs
@@ -1,0 +1,253 @@
+//! `component` and `hook` declarations become functions.
+//!
+//! A port of `hermes-parser`'s `TransformComponentSyntax.js`, for React 19:
+//! `ref` is an ordinary prop there, so no `forwardRef` wrapper is ever built.
+//! The lowered function carries `__componentDeclaration` or
+//! `__hookDeclaration`, which is how the official React Compiler's `syntax`
+//! mode knows which functions to compile.
+//!
+//! ```text
+//! component Foo(a: string, b?: number = 1, ...rest: Rest) { … }
+//! function Foo({ a, b = 1, ...rest }) { … }
+//!
+//! component Bar(...props: Props) { … }
+//! function Bar(props) { … }
+//!
+//! hook useX(v: T): number { … }
+//! function useX(v) { … }
+//! ```
+
+use serde_json::{Value, json};
+
+use super::builders::{property, rest_element};
+use super::{Edit, bool_field, list_field, node_type, refuse, str_field, take, transform_post};
+use crate::TransformError;
+
+/// Lower every component and hook declaration in `program`.
+///
+/// Returns whether any was found.
+pub fn lower(program: &mut Value) -> Result<bool, TransformError> {
+    let mut found = false;
+    transform_post(program, &mut |node| {
+        Ok(match node_type(node) {
+            Some("ComponentDeclaration") => {
+                found = true;
+                Edit::Replace(component_to_function(node)?)
+            }
+            Some("HookDeclaration") => {
+                found = true;
+                Edit::Replace(hook_to_function(node))
+            }
+            _ => Edit::Keep,
+        })
+    })?;
+    Ok(found)
+}
+
+fn component_to_function(node: &mut Value) -> Result<Value, TransformError> {
+    let params = component_parameters(node)?;
+    let mut function = json!({
+        "type": "FunctionDeclaration",
+        "id": take(node, "id"),
+        "params": params,
+        "body": take(node, "body"),
+        "async": bool_field(node, "async"),
+        "generator": false,
+        "__componentDeclaration": true,
+    });
+    copy_position(&mut function, node);
+    Ok(function)
+}
+
+fn hook_to_function(node: &mut Value) -> Value {
+    let mut function = json!({
+        "type": "FunctionDeclaration",
+        "id": take(node, "id"),
+        "params": take(node, "params"),
+        "body": take(node, "body"),
+        "async": bool_field(node, "async"),
+        "generator": false,
+        "__hookDeclaration": true,
+    });
+    copy_position(&mut function, node);
+    function
+}
+
+fn copy_position(target: &mut Value, source: &Value) {
+    if let (Some(target), Some(source)) = (target.as_object_mut(), source.as_object()) {
+        for key in ["loc", "range"] {
+            if let Some(value) = source.get(key) {
+                target.insert(key.to_owned(), value.clone());
+            }
+        }
+    }
+}
+
+/// The parameter list of the lowered function.
+///
+/// Mirrors `mapComponentParameters` with `reactRuntimeTarget: "19"`: no
+/// parameters stay no parameters; a lone `...props: Props` becomes the single
+/// parameter `props`; anything else becomes one destructuring pattern.
+fn component_parameters(node: &mut Value) -> Result<Vec<Value>, TransformError> {
+    let params = take(node, "params");
+    let params = params.as_array().cloned().unwrap_or_default();
+    if params.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if params.len() == 1
+        && node_type(&params[0]) == Some("RestElement")
+        && node_type(&params[0]["argument"]) == Some("Identifier")
+    {
+        return Ok(vec![strip_pattern(params[0]["argument"].clone())]);
+    }
+
+    let mut properties = Vec::with_capacity(params.len());
+    for param in &params {
+        match node_type(param) {
+            Some("RestElement") => match node_type(&param["argument"]) {
+                Some("Identifier") => {
+                    properties.push(rest_element(strip_pattern(param["argument"].clone())));
+                }
+                Some("ObjectPattern") => {
+                    for property in list_field(&param["argument"], "properties") {
+                        properties.push(strip_pattern(property.clone()));
+                    }
+                }
+                other => {
+                    return Err(refuse(
+                        param,
+                        format!(
+                            "unhandled {} encountered in component rest parameter",
+                            other.unwrap_or("node")
+                        ),
+                    ));
+                }
+            },
+            Some("ComponentParameter") => {
+                let name = param["name"].clone();
+                let value = strip_pattern(param["local"].clone());
+                let shorthand = node_type(&name) == Some("Identifier")
+                    && bool_field(param, "shorthand")
+                    && matches!(node_type(&value), Some("Identifier" | "AssignmentPattern"));
+                let mut entry = property(name, value, false, shorthand);
+                copy_position(&mut entry, param);
+                properties.push(entry);
+            }
+            other => {
+                return Err(refuse(
+                    param,
+                    format!(
+                        "unknown component parameter type {:?}",
+                        other.unwrap_or("node")
+                    ),
+                ));
+            }
+        }
+    }
+
+    let first = properties.first().cloned().unwrap_or(Value::Null);
+    let last = properties.last().cloned().unwrap_or(Value::Null);
+    let mut pattern = json!({ "type": "ObjectPattern", "properties": properties });
+    if let (Some(start), Some(end)) = (first.get("range"), last.get("range")) {
+        pattern["range"] = json!([start[0], end[1]]);
+    }
+    if let (Some(start), Some(end)) = (first.get("loc"), last.get("loc")) {
+        pattern["loc"] = json!({ "start": start["start"], "end": end["end"] });
+    }
+    Ok(vec![pattern])
+}
+
+/// A binding pattern with its annotation and optional marker removed.
+///
+/// An `AssignmentPattern` keeps its default; only its left side is stripped.
+fn strip_pattern(mut pattern: Value) -> Value {
+    if let Some(object) = pattern.as_object_mut() {
+        object.remove("typeAnnotation");
+        object.remove("optional");
+        if object.get("type").and_then(Value::as_str) == Some("AssignmentPattern")
+            && let Some(left) = object.get_mut("left")
+        {
+            let stripped = strip_pattern(left.take());
+            *left = stripped;
+        }
+        if str_field(&pattern, "type") == Some("RestElement")
+            && let Some(argument) = pattern.get_mut("argument")
+        {
+            let stripped = strip_pattern(argument.take());
+            *argument = stripped;
+        }
+    }
+    pattern
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+
+    fn lowered(source: &str) -> Value {
+        let mut program = parse(source).unwrap();
+        lower(&mut program).unwrap();
+        program
+    }
+
+    #[test]
+    fn a_component_becomes_a_flagged_function_with_destructured_props() {
+        let program =
+            lowered("component Foo(a: string, b?: number = 1, ...rest: R) { return a; }\n");
+        let function = &program["body"][0];
+        assert_eq!(function["type"], "FunctionDeclaration");
+        assert_eq!(function["__componentDeclaration"], true);
+        let pattern = &function["params"][0];
+        assert_eq!(pattern["type"], "ObjectPattern");
+        let properties = pattern["properties"].as_array().unwrap();
+        assert_eq!(properties.len(), 3);
+        assert_eq!(properties[0]["shorthand"], true);
+        assert_eq!(properties[1]["value"]["type"], "AssignmentPattern");
+        assert!(
+            properties[1]["value"]["left"]
+                .get("typeAnnotation")
+                .is_none()
+        );
+        assert_eq!(properties[2]["type"], "RestElement");
+        assert_eq!(properties[2]["argument"]["name"], "rest");
+    }
+
+    #[test]
+    fn a_lone_rest_parameter_is_the_props_object() {
+        let program = lowered("export component Foo(...props: Props) { return null; }\n");
+        let function = &program["body"][0]["declaration"];
+        assert_eq!(function["params"][0]["type"], "Identifier");
+        assert_eq!(function["params"][0]["name"], "props");
+    }
+
+    #[test]
+    fn a_renamed_and_string_keyed_parameter_keeps_its_key() {
+        let program =
+            lowered("component Foo('data-x' as dataX: string, y as z: number) { return z; }\n");
+        let properties = program["body"][0]["params"][0]["properties"]
+            .as_array()
+            .unwrap();
+        assert_eq!(properties[0]["key"]["type"], "Literal");
+        assert_eq!(properties[0]["value"]["name"], "dataX");
+        assert_eq!(properties[0]["shorthand"], false);
+        assert_eq!(properties[1]["key"]["name"], "y");
+        assert_eq!(properties[1]["value"]["name"], "z");
+    }
+
+    #[test]
+    fn a_hook_becomes_a_flagged_function() {
+        let program = lowered("hook useX(v: T): number { return v; }\n");
+        let function = &program["body"][0];
+        assert_eq!(function["type"], "FunctionDeclaration");
+        assert_eq!(function["__hookDeclaration"], true);
+        assert_eq!(function["params"][0]["name"], "v");
+    }
+
+    #[test]
+    fn a_component_with_no_parameters_has_none() {
+        let program = lowered("component Empty() { return null; }\n");
+        assert_eq!(program["body"][0]["params"].as_array().unwrap().len(), 0);
+    }
+}

--- a/crates/uf_transform/src/lower/enums.rs
+++ b/crates/uf_transform/src/lower/enums.rs
@@ -1,0 +1,175 @@
+//! Flow enums become runtime objects.
+//!
+//! A port of `hermes-parser`'s `TransformEnumSyntax.js`, with one difference:
+//! upstream emits `require("flow-enums-runtime")`, which is a CommonJS call
+//! that a browser or an ES module cannot make. uf prepends the equivalent of
+//! that runtime to the module instead, once, only when the module declares an
+//! enum. The helper reproduces `flow-enums-runtime`'s contract — `cast`,
+//! `isValid`, `members`, `getName` as non-enumerable methods, members frozen
+//! and enumerable — so an enum behaves exactly as Flow documents.
+//!
+//! ```text
+//! enum Status { Active, Off }            → const Status = $$ufEnumMirrored(["Active", "Off"]);
+//! enum Code of number { A = 1, B = 2 }   → const Code = $$ufEnum({ A: 1, B: 2 });
+//! enum Sym of symbol { X, Y }            → const Sym = $$ufEnum({ X: Symbol("X"), Y: Symbol("Y") });
+//! ```
+
+use serde_json::{Value, json};
+
+use super::builders::{call, ident, string_literal, variable_declaration};
+use super::{Edit, bool_field, list_field, node_type, str_field, take, transform_post};
+use crate::TransformError;
+
+/// The runtime prepended to a module that declares an enum.
+///
+/// Kept as source rather than hand-built nodes so it reads as the JavaScript
+/// it is; it is parsed with the same parser as everything else.
+pub const RUNTIME_SOURCE: &str = r#"
+function $$ufEnum(members) {
+  const byValue = new Map();
+  for (const name of Object.keys(members)) byValue.set(members[name], name);
+  const value = Object.assign(Object.create(null), members);
+  Object.defineProperties(value, {
+    isValid: { value: (candidate) => byValue.has(candidate) },
+    cast: { value: (candidate) => (byValue.has(candidate) ? candidate : undefined) },
+    members: { value: () => Object.values(members)[Symbol.iterator]() },
+    getName: { value: (candidate) => byValue.get(candidate) },
+  });
+  return Object.freeze(value);
+}
+function $$ufEnumMirrored(names) {
+  const members = {};
+  for (const name of names) members[name] = name;
+  return $$ufEnum(members);
+}
+"#;
+
+/// Lower every enum declaration in `program`, prepending the runtime when
+/// at least one was found.
+pub fn lower(program: &mut Value, _source: &str) -> Result<(), TransformError> {
+    let mut found = false;
+    transform_post(program, &mut |node| {
+        Ok(match node_type(node) {
+            Some("EnumDeclaration") => {
+                found = true;
+                Edit::Replace(enum_to_declaration(node))
+            }
+            // Children are lowered first, so by the time the export is
+            // visited its enum is already a `const` — one that carries a
+            // marker saying so.
+            Some("ExportDefaultDeclaration") if bool_field(&node["declaration"], "__ufEnum") => {
+                let mut lowered = take(node, "declaration");
+                if let Some(object) = lowered.as_object_mut() {
+                    object.remove("__ufEnum");
+                }
+                let name = str_field(&lowered["declarations"][0]["id"], "name")
+                    .unwrap_or("")
+                    .to_owned();
+                let mut export = node.clone();
+                export["declaration"] = ident(&name);
+                Edit::Splice(vec![lowered, export])
+            }
+            _ => Edit::Keep,
+        })
+    })?;
+
+    if found {
+        let runtime = crate::estree::parse(RUNTIME_SOURCE)?;
+        let helpers = runtime["body"].as_array().cloned().unwrap_or_default();
+        if let Some(body) = program.get_mut("body").and_then(Value::as_array_mut) {
+            let rest = std::mem::take(body);
+            body.extend(helpers);
+            body.extend(rest);
+        }
+    }
+    Ok(())
+}
+
+fn enum_to_declaration(node: &mut Value) -> Value {
+    let id = take(node, "id");
+    let body = take(node, "body");
+    let members = list_field(&body, "members");
+    let explicit = str_field(&body, "explicitType");
+    let mirrored = matches!(explicit, None | Some("string"))
+        && members
+            .first()
+            .is_none_or(|member| node_type(member) == Some("EnumDefaultedMember"));
+
+    let init = if mirrored {
+        let names: Vec<Value> = members
+            .iter()
+            .map(|member| string_literal(str_field(&member["id"], "name").unwrap_or("")))
+            .collect();
+        call(
+            ident("$$ufEnumMirrored"),
+            vec![json!({ "type": "ArrayExpression", "elements": names })],
+        )
+    } else {
+        let properties: Vec<Value> = members
+            .iter()
+            .map(|member| {
+                let name = str_field(&member["id"], "name").unwrap_or("");
+                let value = if node_type(member) == Some("EnumDefaultedMember") {
+                    // Only a symbol enum defaults a member without mirroring.
+                    call(ident("Symbol"), vec![string_literal(name)])
+                } else {
+                    member["init"].clone()
+                };
+                super::builders::property(ident(name), value, false, false)
+            })
+            .collect();
+        call(
+            ident("$$ufEnum"),
+            vec![json!({ "type": "ObjectExpression", "properties": properties })],
+        )
+    };
+    let mut declaration = super::with_position_of(variable_declaration("const", id, init), node);
+    declaration["__ufEnum"] = Value::Bool(true);
+    declaration
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+
+    fn lowered(source: &str) -> Value {
+        let mut program = parse(source).unwrap();
+        lower(&mut program, source).unwrap();
+        program
+    }
+
+    #[test]
+    fn a_string_enum_without_initialisers_mirrors_its_names() {
+        let program = lowered("enum Status { Active, Off }\n");
+        let body = program["body"].as_array().unwrap();
+        // Two helper functions, then the declaration.
+        assert_eq!(body.len(), 3);
+        let init = &body[2]["declarations"][0]["init"];
+        assert_eq!(init["callee"]["name"], "$$ufEnumMirrored");
+        assert_eq!(init["arguments"][0]["elements"][1]["value"], "Off");
+    }
+
+    #[test]
+    fn an_initialised_enum_keeps_its_values() {
+        let program = lowered("export enum Code of number { A = 1, B = 2 }\n");
+        let init = &program["body"][2]["declaration"]["declarations"][0]["init"];
+        assert_eq!(init["callee"]["name"], "$$ufEnum");
+        assert_eq!(init["arguments"][0]["properties"][1]["value"]["value"], 2);
+    }
+
+    #[test]
+    fn a_default_export_is_split_into_a_declaration_and_an_export() {
+        let program = lowered("export default enum E { A }\n");
+        let body = program["body"].as_array().unwrap();
+        assert_eq!(body[2]["type"], "VariableDeclaration");
+        assert_eq!(body[3]["type"], "ExportDefaultDeclaration");
+        assert_eq!(body[3]["declaration"]["name"], "E");
+    }
+
+    #[test]
+    fn a_module_without_enums_gets_no_runtime() {
+        let program = lowered("const a = 1;\n");
+        assert_eq!(program["body"].as_array().unwrap().len(), 1);
+    }
+}

--- a/crates/uf_transform/src/lower/matches.rs
+++ b/crates/uf_transform/src/lower/matches.rs
@@ -1,0 +1,831 @@
+//! `match` expressions and statements become conditions and bindings.
+//!
+//! A port of `hermes-parser`'s `TransformMatchSyntax.js`. A pattern is
+//! analysed into *conditions* (what must be true of the value) and *bindings*
+//! (what names it introduces), and each case becomes a test over those
+//! conditions with its bindings declared inside. The generated tests are the
+//! ones Flow documents — `typeof x === "object" && x !== null`, `"k" in x`,
+//! `Array.isArray(x) && x.length === n` — so an author can read the output.
+//!
+//! An expression with no bindings over a side-effect-free argument becomes a
+//! nested conditional; everything else becomes an immediately invoked arrow
+//! function, and a statement becomes a labelled block that each case
+//! `break`s out of. Falling off the end throws, unless a wildcard catches
+//! everything.
+
+use serde_json::{Value, json};
+use uf_infra::FxHashSet;
+
+use super::builders::{
+    binary, block, call, conditional, conjunction, disjunction, ident, if_statement, iife, member,
+    null_literal, number_literal, property, rest_element, return_statement, string_literal,
+    throw_statement, typeof_is, unary, variable_declaration,
+};
+use super::{Edit, list_field, node_type, refuse, str_field, take, transform_post, walk};
+use crate::TransformError;
+
+/// Lower every `match` in `program`.
+pub fn lower(program: &mut Value) -> Result<(), TransformError> {
+    let mut names = GenId::new(program);
+    transform_post(program, &mut |node| {
+        Ok(match node_type(node) {
+            Some("MatchExpression") => Edit::Replace(super::with_position_of(
+                map_match_expression(node, &mut names)?,
+                node,
+            )),
+            Some("MatchStatement") => Edit::Replace(super::with_position_of(
+                map_match_statement(node, &mut names)?,
+                node,
+            )),
+            _ => Edit::Keep,
+        })
+    })?;
+    Ok(())
+}
+
+/// Generated identifiers that cannot collide with a name the module uses.
+///
+/// `hermes-parser` records every identifier in the program before it
+/// generates any; so does this.
+struct GenId {
+    used: FxHashSet<String>,
+    next: usize,
+}
+
+impl GenId {
+    fn new(program: &Value) -> Self {
+        let mut used = FxHashSet::default();
+        walk(program, &mut |node| {
+            if node_type(node) == Some("Identifier")
+                && let Some(name) = str_field(node, "name")
+            {
+                used.insert(name.to_owned());
+            }
+        });
+        Self { used, next: 0 }
+    }
+
+    fn id(&mut self) -> Value {
+        loop {
+            let candidate = format!("$$gen$m{}", self.next);
+            self.next += 1;
+            if !self.used.contains(&candidate) {
+                self.used.insert(candidate.clone());
+                return ident(&candidate);
+            }
+        }
+    }
+}
+
+/// A path from the matched value to a position inside it.
+type Key = Vec<Value>;
+
+/// What must hold at one position for a pattern to match.
+enum Condition {
+    Eq {
+        key: Key,
+        arg: Value,
+    },
+    IsNan {
+        key: Key,
+    },
+    Array {
+        key: Key,
+        length: usize,
+        at_least: bool,
+    },
+    Object {
+        key: Key,
+    },
+    InstanceOf {
+        key: Key,
+        constructor: Value,
+    },
+    PropExists {
+        key: Key,
+        name: String,
+    },
+    Or {
+        alternatives: Vec<Vec<Condition>>,
+    },
+}
+
+/// A name a pattern introduces.
+enum Binding {
+    Id {
+        key: Key,
+        kind: String,
+        id: Value,
+    },
+    ArrayRest {
+        key: Key,
+        kind: String,
+        id: Value,
+        exclude: usize,
+    },
+    ObjectRest {
+        key: Key,
+        kind: String,
+        id: Value,
+        exclude: Vec<Value>,
+    },
+}
+
+struct Analysis {
+    conditions: Vec<Condition>,
+    bindings: Vec<Binding>,
+}
+
+fn object_key_name(node: &Value) -> String {
+    match node_type(node) {
+        Some("Identifier") => str_field(node, "name").unwrap_or("").to_owned(),
+        _ => match &node["value"] {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            _ => str_field(node, "raw").unwrap_or("").to_owned(),
+        },
+    }
+}
+
+fn convert_member_pattern(pattern: &Value) -> Value {
+    let base = &pattern["base"];
+    let object = if node_type(base) == Some("MatchIdentifierPattern") {
+        base["id"].clone()
+    } else {
+        convert_member_pattern(base)
+    };
+    let property = pattern["property"].clone();
+    let computed = node_type(&property) != Some("Identifier");
+    super::with_position_of(member(object, property, computed), pattern)
+}
+
+fn check_duplicate(
+    seen: &mut FxHashSet<String>,
+    node: &Value,
+    name: &str,
+) -> Result<(), TransformError> {
+    if !seen.insert(name.to_owned()) {
+        return Err(refuse(
+            node,
+            format!("Duplicate variable name '{name}' in match case pattern."),
+        ));
+    }
+    Ok(())
+}
+
+fn check_kind(node: &Value, kind: &str) -> Result<(), TransformError> {
+    if kind == "var" {
+        return Err(refuse(
+            node,
+            "'var' bindings are not allowed. Use 'const' or 'let'.",
+        ));
+    }
+    Ok(())
+}
+
+/// Whether a property pattern needs an explicit `"k" in x` test.
+///
+/// A literal test implies the property exists; a test that could be an
+/// equality with `undefined` does not.
+fn needs_prop_exists(pattern: &Value) -> bool {
+    match node_type(pattern) {
+        Some(
+            "MatchWildcardPattern"
+            | "MatchBindingPattern"
+            | "MatchIdentifierPattern"
+            | "MatchMemberPattern",
+        ) => true,
+        Some("MatchAsPattern") => needs_prop_exists(&pattern["pattern"]),
+        Some("MatchOrPattern") => list_field(pattern, "patterns")
+            .iter()
+            .any(needs_prop_exists),
+        _ => false,
+    }
+}
+
+fn analyze_properties(
+    key: &Key,
+    pattern: &Value,
+    seen: &mut FxHashSet<String>,
+    properties: &[Value],
+    rest: &Value,
+) -> Result<Analysis, TransformError> {
+    let mut conditions = Vec::new();
+    let mut bindings = Vec::new();
+    let mut object_keys = Vec::new();
+    let mut names = FxHashSet::default();
+
+    for prop in properties {
+        let object_key = prop["key"].clone();
+        let name = object_key_name(&object_key);
+        if !names.insert(name.clone()) {
+            return Err(refuse(
+                &prop["pattern"],
+                format!("Duplicate property name '{name}' in match object pattern."),
+            ));
+        }
+        object_keys.push(object_key.clone());
+        let mut property_key = key.clone();
+        property_key.push(object_key);
+        if needs_prop_exists(&prop["pattern"]) {
+            conditions.push(Condition::PropExists {
+                key: key.clone(),
+                name,
+            });
+        }
+        let child = analyze_pattern(&prop["pattern"], property_key, seen)?;
+        conditions.extend(child.conditions);
+        bindings.extend(child.bindings);
+    }
+
+    if node_type(rest) == Some("MatchRestPattern")
+        && node_type(&rest["argument"]) == Some("MatchBindingPattern")
+    {
+        let argument = &rest["argument"];
+        let id = argument["id"].clone();
+        let kind = str_field(argument, "kind").unwrap_or("const").to_owned();
+        check_duplicate(seen, argument, str_field(&id, "name").unwrap_or(""))?;
+        check_kind(pattern, &kind)?;
+        bindings.push(Binding::ObjectRest {
+            key: key.clone(),
+            kind,
+            id,
+            exclude: object_keys,
+        });
+    }
+
+    Ok(Analysis {
+        conditions,
+        bindings,
+    })
+}
+
+fn constructor_expression(constructor: &Value) -> Value {
+    match node_type(constructor) {
+        Some("MatchIdentifierPattern") => constructor["id"].clone(),
+        _ => convert_member_pattern(constructor),
+    }
+}
+
+fn analyze_pattern(
+    pattern: &Value,
+    key: Key,
+    seen: &mut FxHashSet<String>,
+) -> Result<Analysis, TransformError> {
+    let none = Analysis {
+        conditions: Vec::new(),
+        bindings: Vec::new(),
+    };
+    match node_type(pattern) {
+        Some("MatchWildcardPattern") => Ok(none),
+        Some("MatchLiteralPattern") => Ok(Analysis {
+            conditions: vec![Condition::Eq {
+                key,
+                arg: pattern["literal"].clone(),
+            }],
+            bindings: Vec::new(),
+        }),
+        Some("MatchUnaryPattern") => {
+            let argument = &pattern["argument"];
+            if argument["value"].as_f64() == Some(0.0) {
+                return Err(refuse(
+                    pattern,
+                    "'+0' and '-0' are not yet supported in match unary patterns.",
+                ));
+            }
+            let operator = str_field(pattern, "operator").unwrap_or("-");
+            let arg = super::with_position_of(unary(operator, argument.clone()), pattern);
+            Ok(Analysis {
+                conditions: vec![Condition::Eq { key, arg }],
+                bindings: Vec::new(),
+            })
+        }
+        Some("MatchIdentifierPattern") => {
+            let id = pattern["id"].clone();
+            let condition = if str_field(&id, "name") == Some("NaN") {
+                Condition::IsNan { key }
+            } else {
+                Condition::Eq { key, arg: id }
+            };
+            Ok(Analysis {
+                conditions: vec![condition],
+                bindings: Vec::new(),
+            })
+        }
+        Some("MatchMemberPattern") => Ok(Analysis {
+            conditions: vec![Condition::Eq {
+                key,
+                arg: convert_member_pattern(pattern),
+            }],
+            bindings: Vec::new(),
+        }),
+        Some("MatchBindingPattern") => {
+            let id = pattern["id"].clone();
+            let kind = str_field(pattern, "kind").unwrap_or("const").to_owned();
+            check_duplicate(seen, pattern, str_field(&id, "name").unwrap_or(""))?;
+            check_kind(pattern, &kind)?;
+            Ok(Analysis {
+                conditions: Vec::new(),
+                bindings: vec![Binding::Id { key, kind, id }],
+            })
+        }
+        Some("MatchAsPattern") => {
+            let inner = &pattern["pattern"];
+            if node_type(inner) == Some("MatchBindingPattern") {
+                return Err(refuse(
+                    pattern,
+                    "Match 'as' patterns are not allowed directly on binding patterns.",
+                ));
+            }
+            let mut analysis = analyze_pattern(inner, key.clone(), seen)?;
+            let target = &pattern["target"];
+            let (id, kind) = if node_type(target) == Some("MatchBindingPattern") {
+                (
+                    target["id"].clone(),
+                    str_field(target, "kind").unwrap_or("const").to_owned(),
+                )
+            } else {
+                (target.clone(), String::from("const"))
+            };
+            check_duplicate(seen, pattern, str_field(&id, "name").unwrap_or(""))?;
+            check_kind(pattern, &kind)?;
+            analysis.bindings.push(Binding::Id { key, kind, id });
+            Ok(analysis)
+        }
+        Some("MatchArrayPattern") => {
+            let elements = list_field(pattern, "elements");
+            let rest = &pattern["rest"];
+            let has_rest = node_type(rest) == Some("MatchRestPattern");
+            let mut conditions = vec![Condition::Array {
+                key: key.clone(),
+                length: elements.len(),
+                at_least: has_rest,
+            }];
+            let mut bindings = Vec::new();
+            for (index, element) in elements.iter().enumerate() {
+                let mut element_key = key.clone();
+                element_key.push(number_literal(index));
+                let child = analyze_pattern(element, element_key, seen)?;
+                conditions.extend(child.conditions);
+                bindings.extend(child.bindings);
+            }
+            if has_rest && node_type(&rest["argument"]) == Some("MatchBindingPattern") {
+                let argument = &rest["argument"];
+                let id = argument["id"].clone();
+                let kind = str_field(argument, "kind").unwrap_or("const").to_owned();
+                check_duplicate(seen, argument, str_field(&id, "name").unwrap_or(""))?;
+                check_kind(pattern, &kind)?;
+                bindings.push(Binding::ArrayRest {
+                    key,
+                    kind,
+                    id,
+                    exclude: elements.len(),
+                });
+            }
+            Ok(Analysis {
+                conditions,
+                bindings,
+            })
+        }
+        Some("MatchObjectPattern") => {
+            let inner = analyze_properties(
+                &key,
+                pattern,
+                seen,
+                list_field(pattern, "properties"),
+                &pattern["rest"],
+            )?;
+            let mut conditions = vec![Condition::Object { key }];
+            conditions.extend(inner.conditions);
+            Ok(Analysis {
+                conditions,
+                bindings: inner.bindings,
+            })
+        }
+        Some("MatchInstancePattern") => {
+            let properties = &pattern["properties"];
+            let inner = analyze_properties(
+                &key,
+                pattern,
+                seen,
+                list_field(properties, "properties"),
+                &properties["rest"],
+            )?;
+            let mut conditions = vec![Condition::InstanceOf {
+                key,
+                constructor: constructor_expression(&pattern["targetConstructor"]),
+            }];
+            conditions.extend(inner.conditions);
+            Ok(Analysis {
+                conditions,
+                bindings: inner.bindings,
+            })
+        }
+        Some("MatchOrPattern") => {
+            let mut has_wildcard = false;
+            let mut alternatives = Vec::new();
+            for subpattern in list_field(pattern, "patterns") {
+                let child = analyze_pattern(subpattern, key.clone(), seen)?;
+                if !child.bindings.is_empty() {
+                    return Err(refuse(
+                        pattern,
+                        "Bindings in match 'or' patterns are not yet supported.",
+                    ));
+                }
+                if child.conditions.is_empty() {
+                    has_wildcard = true;
+                }
+                alternatives.push(child.conditions);
+            }
+            if has_wildcard {
+                return Ok(none);
+            }
+            Ok(Analysis {
+                conditions: vec![Condition::Or { alternatives }],
+                bindings: Vec::new(),
+            })
+        }
+        other => Err(refuse(
+            pattern,
+            format!("unknown match pattern {:?}", other.unwrap_or("node")),
+        )),
+    }
+}
+
+fn expression_of_key(root: &Value, key: &Key) -> Value {
+    key.iter().fold(root.clone(), |acc, prop| {
+        let computed = node_type(prop) != Some("Identifier");
+        member(acc, prop.clone(), computed)
+    })
+}
+
+fn tests_of_condition(root: &Value, condition: &Condition) -> Vec<Value> {
+    match condition {
+        Condition::Eq { key, arg } => {
+            vec![binary("===", expression_of_key(root, key), arg.clone())]
+        }
+        Condition::IsNan { key } => {
+            vec![call(
+                member(ident("Number"), ident("isNaN"), false),
+                vec![expression_of_key(root, key)],
+            )]
+        }
+        Condition::Array {
+            key,
+            length,
+            at_least,
+        } => {
+            let is_array = call(
+                member(ident("Array"), ident("isArray"), false),
+                vec![expression_of_key(root, key)],
+            );
+            let operator = if *at_least { ">=" } else { "===" };
+            let length_check = binary(
+                operator,
+                member(expression_of_key(root, key), ident("length"), false),
+                number_literal(*length),
+            );
+            vec![is_array, length_check]
+        }
+        Condition::Object { key } => {
+            let is_object = typeof_is(expression_of_key(root, key), "object");
+            let not_null = binary("!==", expression_of_key(root, key), null_literal());
+            let is_function = typeof_is(expression_of_key(root, key), "function");
+            vec![disjunction(vec![
+                conjunction(vec![is_object, not_null]),
+                is_function,
+            ])]
+        }
+        Condition::InstanceOf { key, constructor } => {
+            vec![binary(
+                "instanceof",
+                expression_of_key(root, key),
+                constructor.clone(),
+            )]
+        }
+        Condition::PropExists { key, name } => {
+            vec![binary(
+                "in",
+                string_literal(name),
+                expression_of_key(root, key),
+            )]
+        }
+        Condition::Or { alternatives } => {
+            let tests = alternatives
+                .iter()
+                .map(|conditions| conjunction(tests_of_conditions(root, conditions)))
+                .collect();
+            vec![disjunction(tests)]
+        }
+    }
+}
+
+fn tests_of_conditions(root: &Value, conditions: &[Condition]) -> Vec<Value> {
+    conditions
+        .iter()
+        .flat_map(|condition| tests_of_condition(root, condition))
+        .collect()
+}
+
+fn statements_of_bindings(root: &Value, bindings: &[Binding], names: &mut GenId) -> Vec<Value> {
+    bindings
+        .iter()
+        .map(|binding| match binding {
+            Binding::Id { key, kind, id } => {
+                variable_declaration(kind, id.clone(), expression_of_key(root, key))
+            }
+            Binding::ArrayRest {
+                key,
+                kind,
+                id,
+                exclude,
+            } => {
+                let init = call(
+                    member(expression_of_key(root, key), ident("slice"), false),
+                    vec![number_literal(*exclude)],
+                );
+                variable_declaration(kind, id.clone(), init)
+            }
+            Binding::ObjectRest {
+                key,
+                kind,
+                id,
+                exclude,
+            } => {
+                let mut properties: Vec<Value> = exclude
+                    .iter()
+                    .map(|prop| {
+                        let computed = node_type(prop) != Some("Identifier");
+                        property(prop.clone(), names.id(), computed, false)
+                    })
+                    .collect();
+                properties.push(rest_element(id.clone()));
+                let destructuring = json!({ "type": "ObjectPattern", "properties": properties });
+                variable_declaration(kind, destructuring, expression_of_key(root, key))
+            }
+        })
+        .collect()
+}
+
+const FALLTHROUGH_MESSAGE: &str = "Match: No case succesfully matched. Make exhaustive or add a wildcard case using '_'. Argument: ";
+
+fn fallthrough_error(value: Value) -> Value {
+    throw_statement(binary("+", string_literal(FALLTHROUGH_MESSAGE), value))
+}
+
+/// Whether evaluating `node` twice is harmless: an identifier, or a member
+/// chain over one whose computed keys are literals.
+fn is_simple_argument(node: &Value) -> bool {
+    match node_type(node) {
+        Some("Identifier" | "Super") => true,
+        Some("MemberExpression") => {
+            let computed = super::bool_field(node, "computed");
+            if computed && node_type(&node["property"]) != Some("Literal") {
+                return false;
+            }
+            is_simple_argument(&node["object"])
+        }
+        _ => false,
+    }
+}
+
+struct CaseAnalysis {
+    conditions: Vec<Condition>,
+    bindings: Vec<Binding>,
+    guard: Value,
+    body: Value,
+}
+
+struct Cases {
+    has_bindings: bool,
+    has_wildcard: bool,
+    analyses: Vec<CaseAnalysis>,
+}
+
+fn analyze_cases(cases: &[Value]) -> Result<Cases, TransformError> {
+    let mut has_bindings = false;
+    let mut has_wildcard = false;
+    let mut analyses = Vec::new();
+    for case in cases {
+        let analysis = analyze_pattern(&case["pattern"], Vec::new(), &mut FxHashSet::default())?;
+        has_bindings = has_bindings || !analysis.bindings.is_empty();
+        let guard = case["guard"].clone();
+        let catches_all = analysis.conditions.is_empty() && guard.is_null();
+        analyses.push(CaseAnalysis {
+            conditions: analysis.conditions,
+            bindings: analysis.bindings,
+            guard,
+            body: case["body"].clone(),
+        });
+        if catches_all {
+            has_wildcard = true;
+            break;
+        }
+    }
+    Ok(Cases {
+        has_bindings,
+        has_wildcard,
+        analyses,
+    })
+}
+
+fn map_match_expression(node: &mut Value, names: &mut GenId) -> Result<Value, TransformError> {
+    let argument = take(node, "argument");
+    let cases = take(node, "cases");
+    let Cases {
+        has_bindings,
+        has_wildcard,
+        mut analyses,
+    } = analyze_cases(cases.as_array().map_or(&[], Vec::as_slice))?;
+
+    let simple = !has_bindings && is_simple_argument(&argument);
+    let generated_root = if simple { None } else { Some(names.id()) };
+    let root = generated_root.clone().unwrap_or_else(|| argument.clone());
+
+    if simple {
+        let wildcard = if has_wildcard { analyses.pop() } else { None };
+        let last = match wildcard {
+            Some(analysis) => analysis.body,
+            None => iife(
+                vec![fallthrough_error(root.clone())],
+                Vec::new(),
+                Vec::new(),
+            ),
+        };
+        return Ok(analyses.into_iter().rev().fold(last, |acc, analysis| {
+            let mut tests = tests_of_conditions(&root, &analysis.conditions);
+            if !analysis.guard.is_null() {
+                tests.push(analysis.guard);
+            }
+            conditional(conjunction(tests), analysis.body, acc)
+        }));
+    }
+
+    let mut statements: Vec<Value> = Vec::with_capacity(analyses.len() + 1);
+    for analysis in analyses {
+        let return_node = return_statement(analysis.body);
+        let body_node = if analysis.guard.is_null() {
+            return_node
+        } else {
+            if_statement(analysis.guard, return_node, None)
+        };
+        let binding_nodes = statements_of_bindings(&root, &analysis.bindings, names);
+        let has_binding_nodes = !binding_nodes.is_empty();
+        let mut case_body = binding_nodes;
+        case_body.push(body_node);
+        if !analysis.conditions.is_empty() {
+            let tests = tests_of_conditions(&root, &analysis.conditions);
+            statements.push(if_statement(conjunction(tests), block(case_body), None));
+        } else if has_binding_nodes {
+            statements.push(block(case_body));
+        } else {
+            statements.extend(case_body);
+        }
+    }
+    if !has_wildcard {
+        statements.push(fallthrough_error(root.clone()));
+    }
+
+    let (params, arguments) = match generated_root {
+        Some(root) => (vec![root], vec![argument]),
+        None => (Vec::new(), Vec::new()),
+    };
+    Ok(iife(statements, params, arguments))
+}
+
+fn map_match_statement(node: &mut Value, names: &mut GenId) -> Result<Value, TransformError> {
+    let argument = take(node, "argument");
+    let cases = take(node, "cases");
+    let Cases {
+        has_bindings,
+        has_wildcard,
+        analyses,
+    } = analyze_cases(cases.as_array().map_or(&[], Vec::as_slice))?;
+
+    let label = names.id();
+    let simple = !has_bindings && is_simple_argument(&argument);
+    let generated_root = if simple { None } else { Some(names.id()) };
+    let root = generated_root.clone().unwrap_or_else(|| argument.clone());
+
+    let mut statements = Vec::new();
+    if let Some(generated) = generated_root {
+        statements.push(variable_declaration("const", generated, argument));
+    }
+    for analysis in analyses {
+        let break_node = json!({ "type": "BreakStatement", "label": label.clone() });
+        let mut body_statements = list_field(&analysis.body, "body").to_vec();
+        body_statements.push(break_node);
+        let guarded = if analysis.guard.is_null() {
+            body_statements
+        } else {
+            vec![if_statement(analysis.guard, block(body_statements), None)]
+        };
+        let mut case_body = statements_of_bindings(&root, &analysis.bindings, names);
+        case_body.extend(guarded);
+        if !analysis.conditions.is_empty() {
+            let tests = tests_of_conditions(&root, &analysis.conditions);
+            statements.push(if_statement(conjunction(tests), block(case_body), None));
+        } else {
+            statements.push(block(case_body));
+        }
+    }
+    if !has_wildcard {
+        statements.push(fallthrough_error(root));
+    }
+
+    Ok(json!({ "type": "LabeledStatement", "label": label, "body": block(statements) }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+
+    fn lowered(source: &str) -> Value {
+        let mut program = parse(source).unwrap();
+        lower(&mut program).unwrap();
+        program
+    }
+
+    #[test]
+    fn a_simple_argument_without_bindings_becomes_conditionals() {
+        let program = lowered("const y = match (x) { \"a\" => 1, _ => 2 };\n");
+        let init = &program["body"][0]["declarations"][0]["init"];
+        assert_eq!(init["type"], "ConditionalExpression");
+        assert_eq!(init["test"]["operator"], "===");
+        assert_eq!(init["consequent"]["value"], 1);
+        assert_eq!(init["alternate"]["value"], 2);
+    }
+
+    #[test]
+    fn bindings_force_an_immediately_invoked_function() {
+        let program = lowered("const y = match (x) { {kind: \"a\", v: const v} => v, _ => 0 };\n");
+        let init = &program["body"][0]["declarations"][0]["init"];
+        assert_eq!(init["type"], "CallExpression");
+        assert_eq!(init["callee"]["type"], "ArrowFunctionExpression");
+        assert_eq!(init["callee"]["params"][0]["name"], "$$gen$m0");
+        let first = &init["callee"]["body"]["body"][0];
+        assert_eq!(first["type"], "IfStatement");
+        assert_eq!(
+            first["consequent"]["body"][0]["type"],
+            "VariableDeclaration"
+        );
+        assert_eq!(
+            first["consequent"]["body"][0]["declarations"][0]["id"]["name"],
+            "v"
+        );
+    }
+
+    #[test]
+    fn a_missing_wildcard_throws_at_the_end() {
+        let program = lowered("const y = match (x) { 1 => \"one\" };\n");
+        let init = &program["body"][0]["declarations"][0]["init"];
+        assert_eq!(init["alternate"]["type"], "CallExpression");
+        assert_eq!(
+            init["alternate"]["callee"]["body"]["body"][0]["type"],
+            "ThrowStatement"
+        );
+    }
+
+    #[test]
+    fn array_patterns_test_shape_and_slice_the_rest() {
+        let program =
+            lowered("const y = match (x) { [1, const b, ...const rest] => b, _ => 0 };\n");
+        let body = &program["body"][0]["declarations"][0]["init"]["callee"]["body"]["body"][0];
+        let test = &body["test"];
+        assert_eq!(test["type"], "LogicalExpression");
+        let bindings = body["consequent"]["body"].as_array().unwrap();
+        assert_eq!(
+            bindings[1]["declarations"][0]["init"]["callee"]["property"]["name"],
+            "slice"
+        );
+    }
+
+    #[test]
+    fn a_match_statement_becomes_a_labelled_block() {
+        let program = lowered("match (x) { 1 => { f(); } _ => { g(); } }\n");
+        let labelled = &program["body"][0];
+        assert_eq!(labelled["type"], "LabeledStatement");
+        let body = labelled["body"]["body"].as_array().unwrap();
+        assert_eq!(body[0]["type"], "IfStatement");
+        let inner = body[0]["consequent"]["body"].as_array().unwrap();
+        assert_eq!(inner.last().unwrap()["type"], "BreakStatement");
+    }
+
+    #[test]
+    fn var_bindings_are_refused() {
+        let mut program = parse("const y = match (x) { var v => v };\n").unwrap();
+        let error = lower(&mut program).unwrap_err();
+        assert!(
+            matches!(error, TransformError::Lowering { .. }),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn generated_names_avoid_the_module_s_own() {
+        let program = lowered("const $$gen$m0 = 1; const y = match (f()) { const v => v };\n");
+        let init = &program["body"][1]["declarations"][0]["init"];
+        assert_eq!(init["callee"]["params"][0]["name"], "$$gen$m1");
+    }
+}

--- a/crates/uf_transform/src/lower/mod.rs
+++ b/crates/uf_transform/src/lower/mod.rs
@@ -1,0 +1,341 @@
+//! Lowering Flow-only syntax to JavaScript, by Flow's own rules.
+//!
+//! Each pass here is a port of the corresponding transform in Meta's
+//! `hermes-parser` package — the code Flow's toolchain runs when it emits
+//! Babel-compatible output — kept structurally close to the original so the
+//! two can be compared line by line:
+//!
+//! | pass           | upstream source                     |
+//! | -------------- | ----------------------------------- |
+//! | [`components`] | `estree/TransformComponentSyntax.js` |
+//! | [`matches`]    | `estree/TransformMatchSyntax.js`     |
+//! | [`enums`]      | `estree/TransformEnumSyntax.js`      |
+//! | [`strip`]      | `estree/StripFlowTypes.js`           |
+//!
+//! All four work on the ESTree `serde_json::Value` tree from [`crate::estree`]
+//! and run in that order: components and hooks become functions, `match`
+//! becomes conditions, enums become runtime objects, and finally every type is
+//! erased. Running the strip last is what lets the earlier passes read the
+//! annotations they need (a component's prop types, say) before they are gone.
+
+pub mod builders;
+pub mod components;
+pub mod enums;
+pub mod matches;
+pub mod strip;
+
+use serde_json::Value;
+
+use crate::TransformError;
+
+/// Deepest tree the walker follows before refusing the module.
+///
+/// The parser has already bounded the input; this is the belt to that
+/// suspenders, so an adversarially nested program cannot overflow the stack
+/// in a rewrite pass.
+pub const MAX_DEPTH: usize = 1024;
+
+/// What a pass found out about the module, for the stages after it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Lowered {
+    /// The module declares at least one `component` or `hook`, so the React
+    /// Compiler has something to do in `syntax` mode.
+    pub may_compile: bool,
+}
+
+/// Run every lowering pass over `program`, in order.
+///
+/// # Errors
+///
+/// [`TransformError::Lowering`] when a construct is refused (the same cases
+/// `hermes-parser` raises a syntax error for), and
+/// [`TransformError::Internal`] when the tree is not the shape the parser
+/// promised.
+pub fn lower(program: &mut Value, source: &str) -> Result<Lowered, TransformError> {
+    let may_compile = components::lower(program)?;
+    matches::lower(program)?;
+    enums::lower(program, source)?;
+    strip::lower(program)?;
+    Ok(Lowered { may_compile })
+}
+
+/// What a visitor asks to happen to the node it was handed.
+#[derive(Debug)]
+pub enum Edit {
+    /// Leave the node in place.
+    Keep,
+    /// Put this node in its place.
+    Replace(Value),
+    /// Drop the node. In a list it disappears; in a single slot it becomes `null`.
+    Remove,
+    /// Put these nodes in its place. Only valid for a node in a list.
+    Splice(Vec<Value>),
+}
+
+/// The keys the walker never descends into.
+///
+/// `loc`/`range` are positions, `comments` on a program is the comment list
+/// and the `*Comments` fields are the comments the parser attached to a node,
+/// and `type` is the discriminator. Nothing else on a node is anything but a
+/// child node, a list of them, or a scalar.
+const SKIPPED_KEYS: [&str; 7] = [
+    "type",
+    "loc",
+    "range",
+    "comments",
+    "leadingComments",
+    "trailingComments",
+    "innerComments",
+];
+
+/// The node type of `value`, when it is an AST node.
+#[must_use]
+pub fn node_type(value: &Value) -> Option<&str> {
+    value.as_object()?.get("type")?.as_str()
+}
+
+/// Whether `value` is an AST node: an object with a string `type`.
+#[must_use]
+pub fn is_node(value: &Value) -> bool {
+    node_type(value).is_some()
+}
+
+/// Walk `node` post-order, offering every descendant and then the node itself
+/// to `visit`, and applying what it asks.
+///
+/// Children are rewritten before their parent, so a visitor that replaces a
+/// node sees already-lowered children in it and never has to recurse. Lists
+/// honour [`Edit::Remove`] and [`Edit::Splice`]; a single child slot turns a
+/// removal into `null`.
+///
+/// # Errors
+///
+/// [`TransformError::Internal`] past [`MAX_DEPTH`] or when a splice is asked
+/// of a single slot.
+pub fn transform_post(
+    node: &mut Value,
+    visit: &mut dyn FnMut(&mut Value) -> Result<Edit, TransformError>,
+) -> Result<Edit, TransformError> {
+    transform_post_at(node, visit, 0)
+}
+
+fn transform_post_at(
+    node: &mut Value,
+    visit: &mut dyn FnMut(&mut Value) -> Result<Edit, TransformError>,
+    depth: usize,
+) -> Result<Edit, TransformError> {
+    if depth > MAX_DEPTH {
+        return Err(TransformError::Internal(format!(
+            "syntax tree deeper than {MAX_DEPTH} levels"
+        )));
+    }
+    let Some(object) = node.as_object_mut() else {
+        return Ok(Edit::Keep);
+    };
+    if !object.get("type").is_some_and(Value::is_string) {
+        return Ok(Edit::Keep);
+    }
+
+    let keys: Vec<String> = object
+        .keys()
+        .filter(|key| !SKIPPED_KEYS.contains(&key.as_str()))
+        .cloned()
+        .collect();
+    for key in keys {
+        let Some(child) = object.get_mut(&key) else {
+            continue;
+        };
+        match child {
+            Value::Array(items) => {
+                let mut rebuilt = Vec::with_capacity(items.len());
+                for mut item in std::mem::take(items) {
+                    if !is_node(&item) {
+                        rebuilt.push(item);
+                        continue;
+                    }
+                    match transform_post_at(&mut item, visit, depth + 1)? {
+                        Edit::Keep => rebuilt.push(item),
+                        Edit::Replace(next) => rebuilt.push(next),
+                        Edit::Remove => {}
+                        Edit::Splice(nodes) => rebuilt.extend(nodes),
+                    }
+                }
+                *items = rebuilt;
+            }
+            child if is_node(child) => match transform_post_at(child, visit, depth + 1)? {
+                Edit::Keep => {}
+                Edit::Replace(next) => *child = next,
+                Edit::Remove => *child = Value::Null,
+                Edit::Splice(_) => {
+                    return Err(TransformError::Internal(format!(
+                        "cannot splice several nodes into the single slot `{key}`"
+                    )));
+                }
+            },
+            _ => {}
+        }
+    }
+
+    visit(node)
+}
+
+/// Visit every node pre-order, read-only.
+pub fn walk(node: &Value, visit: &mut dyn FnMut(&Value)) {
+    walk_at(node, visit, 0);
+}
+
+fn walk_at(node: &Value, visit: &mut dyn FnMut(&Value), depth: usize) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Some(object) = node.as_object() else {
+        return;
+    };
+    if !object.get("type").is_some_and(Value::is_string) {
+        return;
+    }
+    visit(node);
+    for (key, child) in object {
+        if SKIPPED_KEYS.contains(&key.as_str()) {
+            continue;
+        }
+        match child {
+            Value::Array(items) => {
+                for item in items {
+                    walk_at(item, visit, depth + 1);
+                }
+            }
+            child => walk_at(child, visit, depth + 1),
+        }
+    }
+}
+
+/// A lowering error at a node's position.
+pub(crate) fn refuse(node: &Value, message: impl Into<String>) -> TransformError {
+    let start = node.get("loc").and_then(|loc| loc.get("start"));
+    let number = |key: &str| {
+        start
+            .and_then(|position| position.get(key))
+            .and_then(Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+    };
+    TransformError::Lowering {
+        message: message.into(),
+        line: number("line"),
+        column: number("column"),
+    }
+}
+
+/// Copy the `loc` and `range` of `from` onto a freshly built node.
+pub(crate) fn with_position_of(mut node: Value, from: &Value) -> Value {
+    if let (Some(object), Some(source)) = (node.as_object_mut(), from.as_object()) {
+        for key in ["loc", "range"] {
+            if let Some(value) = source.get(key) {
+                object.insert(key.to_owned(), value.clone());
+            }
+        }
+    }
+    node
+}
+
+/// Take a field out of a node, leaving `null` behind.
+pub(crate) fn take(node: &mut Value, key: &str) -> Value {
+    node.as_object_mut()
+        .and_then(|object| object.get_mut(key))
+        .map(Value::take)
+        .unwrap_or(Value::Null)
+}
+
+/// A node's field as a string.
+pub(crate) fn str_field<'a>(node: &'a Value, key: &str) -> Option<&'a str> {
+    node.get(key).and_then(Value::as_str)
+}
+
+/// A node's field as a bool, `false` when absent.
+pub(crate) fn bool_field(node: &Value, key: &str) -> bool {
+    node.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+/// A node's field as a list, empty when absent.
+pub(crate) fn list_field<'a>(node: &'a Value, key: &str) -> &'a [Value] {
+    node.get(key)
+        .and_then(Value::as_array)
+        .map_or(&[], Vec::as_slice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn post_order_visits_children_before_parents() {
+        let mut tree = json!({
+            "type": "Program",
+            "body": [{ "type": "A", "child": { "type": "B" } }, { "type": "C" }],
+        });
+        let mut order = Vec::new();
+        transform_post(&mut tree, &mut |node| {
+            order.push(node_type(node).unwrap().to_owned());
+            Ok(Edit::Keep)
+        })
+        .unwrap();
+        assert_eq!(order, ["B", "A", "C", "Program"]);
+    }
+
+    #[test]
+    fn lists_honour_removal_and_splicing() {
+        let mut tree = json!({
+            "type": "Program",
+            "body": [{ "type": "Drop" }, { "type": "Twice" }, { "type": "Keep" }],
+        });
+        transform_post(&mut tree, &mut |node| {
+            Ok(match node_type(node) {
+                Some("Drop") => Edit::Remove,
+                Some("Twice") => Edit::Splice(vec![json!({"type": "X"}), json!({"type": "Y"})]),
+                _ => Edit::Keep,
+            })
+        })
+        .unwrap();
+        let types: Vec<&str> = tree["body"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|node| node_type(node).unwrap())
+            .collect();
+        assert_eq!(types, ["X", "Y", "Keep"]);
+    }
+
+    #[test]
+    fn a_single_slot_cannot_take_a_splice() {
+        let mut tree = json!({ "type": "A", "child": { "type": "B" } });
+        let error = transform_post(&mut tree, &mut |node| {
+            Ok(if node_type(node) == Some("B") {
+                Edit::Splice(vec![])
+            } else {
+                Edit::Keep
+            })
+        })
+        .unwrap_err();
+        assert!(matches!(error, TransformError::Internal(_)));
+    }
+
+    #[test]
+    fn refuses_a_tree_deeper_than_the_ceiling() {
+        // Building and dropping a tree this deep is itself recursive, so the
+        // test runs on a thread with room for it.
+        std::thread::Builder::new()
+            .stack_size(256 * 1024 * 1024)
+            .spawn(|| {
+                let mut tree = json!({ "type": "Leaf" });
+                for _ in 0..=MAX_DEPTH {
+                    tree = json!({ "type": "Wrap", "inner": tree });
+                }
+                let error = transform_post(&mut tree, &mut |_| Ok(Edit::Keep)).unwrap_err();
+                assert!(matches!(error, TransformError::Internal(_)));
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+}

--- a/crates/uf_transform/src/lower/strip.rs
+++ b/crates/uf_transform/src/lower/strip.rs
@@ -1,0 +1,234 @@
+//! Every type is erased.
+//!
+//! A port of `hermes-parser`'s `StripFlowTypes.js`, extended to cover the
+//! declaration forms that transform only strips for Babel (`declare enum`,
+//! `declare namespace`, `declare component`, `declare hook`): after this pass
+//! there is no type left in the tree for anything downstream to know about.
+//!
+//! One deliberate departure: upstream drops an `import "x";` with no
+//! specifiers as if it had been all type imports. A bare import is a side
+//! effect the author asked for, so it stays.
+
+use serde_json::Value;
+
+use super::{Edit, list_field, node_type, str_field, take, transform_post};
+use crate::TransformError;
+
+/// Statement forms that exist only for the type checker.
+const TYPE_ONLY_STATEMENTS: [&str; 19] = [
+    "TypeAlias",
+    "OpaqueType",
+    "InterfaceDeclaration",
+    "DeclareClass",
+    "DeclareComponent",
+    "DeclareEnum",
+    "DeclareExportAllDeclaration",
+    "DeclareExportDeclaration",
+    "DeclareFunction",
+    "DeclareHook",
+    "DeclareInterface",
+    "DeclareModule",
+    "DeclareModuleExports",
+    "DeclareNamespace",
+    "DeclareOpaqueType",
+    "DeclareTypeAlias",
+    "DeclareVariable",
+    "TypeParameterDeclaration",
+    "TypeParameterInstantiation",
+];
+
+/// Fields that hold type syntax on any node that has them.
+const TYPE_FIELDS: [&str; 9] = [
+    "typeAnnotation",
+    "typeArguments",
+    "typeParameters",
+    "returnType",
+    "predicate",
+    "variance",
+    "rendersType",
+    "superTypeArguments",
+    "implements",
+];
+
+/// Erase every type in `program`.
+pub fn lower(program: &mut Value) -> Result<(), TransformError> {
+    transform_post(program, &mut |node| Ok(strip_node(node)))?;
+    Ok(())
+}
+
+fn strip_node(node: &mut Value) -> Edit {
+    let Some(kind) = node_type(node).map(str::to_owned) else {
+        return Edit::Keep;
+    };
+    if TYPE_ONLY_STATEMENTS.contains(&kind.as_str()) {
+        return Edit::Remove;
+    }
+
+    match kind.as_str() {
+        "AsExpression" | "AsConstExpression" | "TypeCastExpression" | "SatisfiesExpression" => {
+            return Edit::Replace(take(node, "expression"));
+        }
+        "ImportDeclaration" => {
+            if matches!(str_field(node, "importKind"), Some("type" | "typeof")) {
+                return Edit::Remove;
+            }
+            let had_specifiers = !list_field(node, "specifiers").is_empty();
+            if let Some(specifiers) = node.get_mut("specifiers").and_then(Value::as_array_mut) {
+                specifiers.retain(|specifier| {
+                    !matches!(str_field(specifier, "importKind"), Some("type" | "typeof"))
+                });
+                for specifier in specifiers.iter_mut() {
+                    remove_key(specifier, "importKind");
+                }
+                if had_specifiers && specifiers.is_empty() {
+                    return Edit::Remove;
+                }
+            }
+            remove_key(node, "importKind");
+        }
+        "ExportAllDeclaration" => {
+            if str_field(node, "exportKind") == Some("type") {
+                return Edit::Remove;
+            }
+            remove_key(node, "exportKind");
+        }
+        "ExportNamedDeclaration" => {
+            if str_field(node, "exportKind") == Some("type") {
+                return Edit::Remove;
+            }
+            let had_specifiers = !list_field(node, "specifiers").is_empty();
+            if let Some(specifiers) = node.get_mut("specifiers").and_then(Value::as_array_mut) {
+                specifiers.retain(|specifier| str_field(specifier, "exportKind") != Some("type"));
+                for specifier in specifiers.iter_mut() {
+                    remove_key(specifier, "exportKind");
+                }
+            }
+            let declaration_gone = node.get("declaration").is_none_or(Value::is_null);
+            let no_specifiers = list_field(node, "specifiers").is_empty();
+            let no_source = node.get("source").is_none_or(Value::is_null);
+            if declaration_gone && no_specifiers && (had_specifiers || no_source) {
+                return Edit::Remove;
+            }
+            remove_key(node, "exportKind");
+        }
+        "FunctionDeclaration" | "FunctionExpression" | "ArrowFunctionExpression" => {
+            strip_function(node);
+        }
+        "ClassDeclaration" | "ClassExpression" => {
+            for key in [
+                "typeParameters",
+                "superTypeArguments",
+                "superTypeParameters",
+                "implements",
+            ] {
+                remove_key(node, key);
+            }
+        }
+        "PropertyDefinition" => {
+            if node.get("declare").and_then(Value::as_bool) == Some(true) {
+                return Edit::Remove;
+            }
+            for key in ["typeAnnotation", "variance", "optional", "declare"] {
+                remove_key(node, key);
+            }
+        }
+        "Identifier" | "ObjectPattern" | "ArrayPattern" | "RestElement" | "AssignmentPattern" => {
+            remove_key(node, "typeAnnotation");
+            remove_key(node, "optional");
+        }
+        _ => {}
+    }
+
+    for key in TYPE_FIELDS {
+        remove_key(node, key);
+    }
+    Edit::Keep
+}
+
+fn strip_function(node: &mut Value) {
+    if let Some(params) = node.get_mut("params").and_then(Value::as_array_mut)
+        && params.first().is_some_and(|first| {
+            node_type(first) == Some("Identifier") && str_field(first, "name") == Some("this")
+        })
+    {
+        params.remove(0);
+    }
+    for key in ["returnType", "typeParameters", "predicate"] {
+        remove_key(node, key);
+    }
+}
+
+fn remove_key(node: &mut Value, key: &str) {
+    if let Some(object) = node.as_object_mut() {
+        object.remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+
+    fn stripped(source: &str) -> Value {
+        let mut program = parse(source).unwrap();
+        lower(&mut program).unwrap();
+        program
+    }
+
+    fn types(program: &Value) -> Vec<&str> {
+        program["body"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|node| node_type(node).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn type_declarations_disappear() {
+        let program = stripped(
+            "type A = string;\nopaque type B = number;\ninterface C {}\ndeclare var d: number;\ndeclare function f(): void;\nexport type {A};\nconst x = 1;\n",
+        );
+        assert_eq!(types(&program), ["VariableDeclaration"]);
+    }
+
+    #[test]
+    fn type_imports_disappear_and_value_imports_stay() {
+        let program = stripped(
+            "import type {A} from './a';\nimport typeof B from './b';\nimport {type C, d} from './c';\nimport {type E} from './e';\nimport './side-effect';\n",
+        );
+        let body = program["body"].as_array().unwrap();
+        assert_eq!(body.len(), 2);
+        assert_eq!(body[0]["specifiers"].as_array().unwrap().len(), 1);
+        assert_eq!(body[0]["specifiers"][0]["local"]["name"], "d");
+        assert_eq!(body[1]["specifiers"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn annotations_and_casts_are_erased() {
+        let program = stripped(
+            "function f(this: T, a: string, b?: number = 1): void {}\nconst y = (x: any);\nconst z = x as number;\nclass K<T> extends B<T> implements I { p: string = ''; declare q: number; }\ncall<T>(a);\n",
+        );
+        let function = &program["body"][0];
+        assert_eq!(function["params"].as_array().unwrap().len(), 2);
+        assert!(function.get("returnType").is_none());
+        assert!(function["params"][0].get("typeAnnotation").is_none());
+        assert_eq!(
+            program["body"][1]["declarations"][0]["init"]["type"],
+            "Identifier"
+        );
+        assert_eq!(
+            program["body"][2]["declarations"][0]["init"]["type"],
+            "Identifier"
+        );
+        let class = &program["body"][3];
+        assert!(class.get("implements").is_none());
+        assert!(class.get("typeParameters").is_none());
+        assert_eq!(class["body"]["body"].as_array().unwrap().len(), 1);
+        assert!(
+            program["body"][4]["expression"]
+                .get("typeArguments")
+                .is_none()
+        );
+    }
+}

--- a/crates/uf_transform/src/print.rs
+++ b/crates/uf_transform/src/print.rs
@@ -1,0 +1,1605 @@
+//! Babel AST → JavaScript text, with a source map.
+//!
+//! This printer exists for one reason: the React Compiler hands back an AST,
+//! and something has to turn it into text again before oxc can lower the JSX
+//! and generate the final module. It prints Babel's node vocabulary — the
+//! subset that survives type erasure — readably but without pretence at
+//! Prettier's layout; `uf fmt` is the formatter, this is the code generator.
+//!
+//! Two things it is careful about:
+//!
+//! * **Parentheses come from precedence, never from the input.** The compiler
+//!   synthesises nodes with no notion of how the author bracketed them, so
+//!   every operand is bracketed by comparing its precedence to its position.
+//! * **Every node with a position becomes a mapping.** The map points at the
+//!   Flow source the author wrote; nodes the compiler or the lowering passes
+//!   invented carry no position and map to nothing, so a debugger lands on
+//!   the author's line or nowhere, never on the wrong line.
+
+use serde_json::Value;
+
+use crate::TransformError;
+use crate::lower::{bool_field, list_field, node_type, str_field};
+
+/// One point in the generated text that came from one point in the source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Mapping {
+    /// 0-based line in the generated text.
+    pub generated_line: u32,
+    /// 0-based column in the generated text, in UTF-16 code units.
+    pub generated_column: u32,
+    /// 0-based line in the source.
+    pub original_line: u32,
+    /// 0-based column in the source, in UTF-16 code units.
+    pub original_column: u32,
+}
+
+/// Printed JavaScript and its mappings, in generated order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Printed {
+    /// The JavaScript, JSX included.
+    pub code: String,
+    /// Mappings sorted by generated position.
+    pub mappings: Vec<Mapping>,
+}
+
+/// Print a Babel `File`.
+///
+/// # Errors
+///
+/// [`TransformError::Internal`] for a node kind the printer does not know,
+/// which means a stage before it produced something outside the contract.
+pub fn print(file: &Value) -> Result<Printed, TransformError> {
+    let mut printer = Printer::default();
+    printer.program(&file["program"])?;
+    Ok(Printed {
+        code: printer.out,
+        mappings: printer.mappings,
+    })
+}
+
+/// Operator precedence, higher binds tighter. Mirrors the ECMAScript grammar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Prec {
+    Sequence = 0,
+    Yield = 1,
+    Assignment = 2,
+    Conditional = 3,
+    Coalesce = 4,
+    LogicalOr = 5,
+    LogicalAnd = 6,
+    BitOr = 7,
+    BitXor = 8,
+    BitAnd = 9,
+    Equality = 10,
+    Relational = 11,
+    Shift = 12,
+    Additive = 13,
+    Multiplicative = 14,
+    Exponent = 15,
+    Unary = 16,
+    Update = 17,
+    LeftHandSide = 18,
+    Member = 19,
+    Primary = 20,
+}
+
+fn binary_prec(operator: &str) -> Prec {
+    match operator {
+        "??" => Prec::Coalesce,
+        "||" => Prec::LogicalOr,
+        "&&" => Prec::LogicalAnd,
+        "|" => Prec::BitOr,
+        "^" => Prec::BitXor,
+        "&" => Prec::BitAnd,
+        "==" | "!=" | "===" | "!==" => Prec::Equality,
+        "<" | ">" | "<=" | ">=" | "instanceof" | "in" => Prec::Relational,
+        "<<" | ">>" | ">>>" => Prec::Shift,
+        "+" | "-" => Prec::Additive,
+        "*" | "/" | "%" => Prec::Multiplicative,
+        "**" => Prec::Exponent,
+        _ => Prec::Primary,
+    }
+}
+
+fn prec_of(node: &Value) -> Prec {
+    match node_type(node) {
+        Some("SequenceExpression") => Prec::Sequence,
+        Some("YieldExpression") => Prec::Yield,
+        Some("AssignmentExpression" | "ArrowFunctionExpression" | "AssignmentPattern") => {
+            Prec::Assignment
+        }
+        Some("ConditionalExpression") => Prec::Conditional,
+        Some("BinaryExpression" | "LogicalExpression") => {
+            binary_prec(str_field(node, "operator").unwrap_or(""))
+        }
+        Some("UnaryExpression" | "AwaitExpression") => Prec::Unary,
+        Some("UpdateExpression") => Prec::Update,
+        Some("CallExpression" | "OptionalCallExpression" | "NewExpression") => Prec::LeftHandSide,
+        Some("MemberExpression" | "OptionalMemberExpression" | "TaggedTemplateExpression") => {
+            Prec::Member
+        }
+        _ => Prec::Primary,
+    }
+}
+
+#[derive(Default)]
+struct Printer {
+    out: String,
+    line: u32,
+    column: u32,
+    indent: usize,
+    mappings: Vec<Mapping>,
+}
+
+impl Printer {
+    // ------------------------------------------------------------------
+    // Output primitives
+    // ------------------------------------------------------------------
+
+    fn push(&mut self, text: &str) {
+        for ch in text.chars() {
+            if ch == '\n' {
+                self.line += 1;
+                self.column = 0;
+            } else {
+                self.column += u32::try_from(ch.len_utf16()).unwrap_or(1);
+            }
+        }
+        self.out.push_str(text);
+    }
+
+    fn newline(&mut self) {
+        self.push("\n");
+        for _ in 0..self.indent {
+            self.push("  ");
+        }
+    }
+
+    fn space(&mut self) {
+        self.push(" ");
+    }
+
+    /// A word that must not fuse with what came before it.
+    fn word(&mut self, text: &str) {
+        if let Some(last) = self.out.chars().last()
+            && (last.is_alphanumeric() || last == '_' || last == '$')
+            && text
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '$')
+        {
+            self.push(" ");
+        }
+        self.push(text);
+    }
+
+    fn mark(&mut self, node: &Value) {
+        let Some(start) = node.get("loc").and_then(|loc| loc.get("start")) else {
+            return;
+        };
+        let (Some(line), Some(column)) = (
+            start.get("line").and_then(Value::as_u64),
+            start.get("column").and_then(Value::as_u64),
+        ) else {
+            return;
+        };
+        if line == 0 {
+            return;
+        }
+        self.mappings.push(Mapping {
+            generated_line: self.line,
+            generated_column: self.column,
+            original_line: u32::try_from(line - 1).unwrap_or(u32::MAX),
+            original_column: u32::try_from(column).unwrap_or(u32::MAX),
+        });
+    }
+
+    fn unknown(node: &Value, context: &str) -> TransformError {
+        TransformError::Internal(format!(
+            "printer does not know {} in {context}",
+            node_type(node).unwrap_or("a non-node")
+        ))
+    }
+
+    // ------------------------------------------------------------------
+    // Program and statements
+    // ------------------------------------------------------------------
+
+    fn program(&mut self, program: &Value) -> Result<(), TransformError> {
+        self.directives(program)?;
+        for statement in list_field(program, "body") {
+            self.statement(statement)?;
+            self.newline();
+        }
+        Ok(())
+    }
+
+    fn directives(&mut self, owner: &Value) -> Result<(), TransformError> {
+        for directive in list_field(owner, "directives") {
+            self.mark(directive);
+            let literal = &directive["value"];
+            match literal
+                .get("extra")
+                .and_then(|extra| extra.get("raw"))
+                .and_then(Value::as_str)
+            {
+                Some(raw) => self.push(raw),
+                None => self.string(str_field(literal, "value").unwrap_or("")),
+            }
+            self.push(";");
+            self.newline();
+        }
+        Ok(())
+    }
+
+    fn block(&mut self, block: &Value) -> Result<(), TransformError> {
+        self.push("{");
+        let statements = list_field(block, "body");
+        let directives = list_field(block, "directives");
+        if statements.is_empty() && directives.is_empty() {
+            self.push("}");
+            return Ok(());
+        }
+        self.indent += 1;
+        self.newline();
+        self.directives(block)?;
+        for (index, statement) in statements.iter().enumerate() {
+            self.statement(statement)?;
+            if index + 1 < statements.len() {
+                self.newline();
+            }
+        }
+        self.indent -= 1;
+        self.newline();
+        self.push("}");
+        Ok(())
+    }
+
+    /// A statement in a position that takes one statement: braces if it is a
+    /// block, otherwise indented on its own line.
+    fn body(&mut self, statement: &Value) -> Result<(), TransformError> {
+        if node_type(statement) == Some("BlockStatement") {
+            self.space();
+            return self.block(statement);
+        }
+        self.indent += 1;
+        self.newline();
+        self.statement(statement)?;
+        self.indent -= 1;
+        Ok(())
+    }
+
+    fn statement(&mut self, statement: &Value) -> Result<(), TransformError> {
+        self.mark(statement);
+        match node_type(statement) {
+            Some("ExpressionStatement") => {
+                let expression = &statement["expression"];
+                let bracket = starts_statement_ambiguously(expression);
+                if bracket {
+                    self.push("(");
+                }
+                self.expression(expression, Prec::Sequence)?;
+                if bracket {
+                    self.push(")");
+                }
+                self.push(";");
+            }
+            Some("BlockStatement") => self.block(statement)?,
+            Some("EmptyStatement") => self.push(";"),
+            Some("DebuggerStatement") => self.push("debugger;"),
+            Some("VariableDeclaration") => {
+                self.variable_declaration(statement)?;
+                self.push(";");
+            }
+            Some("FunctionDeclaration") => self.function(statement, true)?,
+            Some("ClassDeclaration") => self.class(statement)?,
+            Some("ReturnStatement") => {
+                self.push("return");
+                if !statement["argument"].is_null() {
+                    self.space();
+                    self.expression(&statement["argument"], Prec::Sequence)?;
+                }
+                self.push(";");
+            }
+            Some("ThrowStatement") => {
+                self.push("throw ");
+                self.expression(&statement["argument"], Prec::Sequence)?;
+                self.push(";");
+            }
+            Some("IfStatement") => {
+                self.push("if (");
+                self.expression(&statement["test"], Prec::Sequence)?;
+                self.push(")");
+                self.body(&statement["consequent"])?;
+                if !statement["alternate"].is_null() {
+                    if node_type(&statement["consequent"]) == Some("BlockStatement") {
+                        self.space();
+                    } else {
+                        self.newline();
+                    }
+                    self.push("else");
+                    if node_type(&statement["alternate"]) == Some("IfStatement") {
+                        self.space();
+                        self.statement(&statement["alternate"])?;
+                    } else {
+                        self.body(&statement["alternate"])?;
+                    }
+                }
+            }
+            Some("ForStatement") => {
+                self.push("for (");
+                let init = &statement["init"];
+                if node_type(init) == Some("VariableDeclaration") {
+                    self.variable_declaration(init)?;
+                } else if !init.is_null() {
+                    self.expression(init, Prec::Sequence)?;
+                }
+                self.push(";");
+                if !statement["test"].is_null() {
+                    self.space();
+                    self.expression(&statement["test"], Prec::Sequence)?;
+                }
+                self.push(";");
+                if !statement["update"].is_null() {
+                    self.space();
+                    self.expression(&statement["update"], Prec::Sequence)?;
+                }
+                self.push(")");
+                self.body(&statement["body"])?;
+            }
+            Some("ForInStatement" | "ForOfStatement") => {
+                self.push("for");
+                if bool_field(statement, "await") {
+                    self.push(" await");
+                }
+                self.push(" (");
+                let left = &statement["left"];
+                if node_type(left) == Some("VariableDeclaration") {
+                    self.variable_declaration(left)?;
+                } else {
+                    self.pattern(left)?;
+                }
+                self.push(if node_type(statement) == Some("ForInStatement") {
+                    " in "
+                } else {
+                    " of "
+                });
+                self.expression(&statement["right"], Prec::Assignment)?;
+                self.push(")");
+                self.body(&statement["body"])?;
+            }
+            Some("WhileStatement") => {
+                self.push("while (");
+                self.expression(&statement["test"], Prec::Sequence)?;
+                self.push(")");
+                self.body(&statement["body"])?;
+            }
+            Some("DoWhileStatement") => {
+                self.push("do");
+                self.body(&statement["body"])?;
+                if node_type(&statement["body"]) == Some("BlockStatement") {
+                    self.space();
+                } else {
+                    self.newline();
+                }
+                self.push("while (");
+                self.expression(&statement["test"], Prec::Sequence)?;
+                self.push(");");
+            }
+            Some("BreakStatement" | "ContinueStatement") => {
+                self.push(if node_type(statement) == Some("BreakStatement") {
+                    "break"
+                } else {
+                    "continue"
+                });
+                if !statement["label"].is_null() {
+                    self.space();
+                    self.identifier(&statement["label"]);
+                }
+                self.push(";");
+            }
+            Some("LabeledStatement") => {
+                self.identifier(&statement["label"]);
+                self.push(": ");
+                self.statement(&statement["body"])?;
+            }
+            Some("WithStatement") => {
+                self.push("with (");
+                self.expression(&statement["object"], Prec::Sequence)?;
+                self.push(")");
+                self.body(&statement["body"])?;
+            }
+            Some("SwitchStatement") => {
+                self.push("switch (");
+                self.expression(&statement["discriminant"], Prec::Sequence)?;
+                self.push(") {");
+                self.indent += 1;
+                for case in list_field(statement, "cases") {
+                    self.newline();
+                    self.mark(case);
+                    if case["test"].is_null() {
+                        self.push("default:");
+                    } else {
+                        self.push("case ");
+                        self.expression(&case["test"], Prec::Sequence)?;
+                        self.push(":");
+                    }
+                    self.indent += 1;
+                    for consequent in list_field(case, "consequent") {
+                        self.newline();
+                        self.statement(consequent)?;
+                    }
+                    self.indent -= 1;
+                }
+                self.indent -= 1;
+                self.newline();
+                self.push("}");
+            }
+            Some("TryStatement") => {
+                self.push("try ");
+                self.block(&statement["block"])?;
+                let handler = &statement["handler"];
+                if !handler.is_null() {
+                    self.push(" catch");
+                    if !handler["param"].is_null() {
+                        self.push(" (");
+                        self.pattern(&handler["param"])?;
+                        self.push(")");
+                    }
+                    self.space();
+                    self.block(&handler["body"])?;
+                }
+                if !statement["finalizer"].is_null() {
+                    self.push(" finally ");
+                    self.block(&statement["finalizer"])?;
+                }
+            }
+            Some("ImportDeclaration") => self.import_declaration(statement)?,
+            Some("ExportNamedDeclaration") => self.export_named(statement)?,
+            Some("ExportDefaultDeclaration") => {
+                self.push("export default ");
+                let declaration = &statement["declaration"];
+                match node_type(declaration) {
+                    Some("FunctionDeclaration") => self.function(declaration, true)?,
+                    Some("ClassDeclaration") => self.class(declaration)?,
+                    _ => {
+                        let bracket = matches!(node_type(declaration), Some("SequenceExpression"))
+                            || starts_statement_ambiguously(declaration);
+                        if bracket {
+                            self.push("(");
+                        }
+                        self.expression(declaration, Prec::Assignment)?;
+                        if bracket {
+                            self.push(")");
+                        }
+                        self.push(";");
+                    }
+                }
+            }
+            Some("ExportAllDeclaration") => {
+                self.push("export * from ");
+                self.expression(&statement["source"], Prec::Primary)?;
+                self.import_attributes(statement)?;
+                self.push(";");
+            }
+            Some("StaticBlock") => {
+                self.push("static ");
+                self.block(statement)?;
+            }
+            _ => return Err(Self::unknown(statement, "statement position")),
+        }
+        Ok(())
+    }
+
+    fn variable_declaration(&mut self, declaration: &Value) -> Result<(), TransformError> {
+        self.mark(declaration);
+        self.push(str_field(declaration, "kind").unwrap_or("let"));
+        self.space();
+        for (index, declarator) in list_field(declaration, "declarations").iter().enumerate() {
+            if index > 0 {
+                self.push(", ");
+            }
+            self.mark(declarator);
+            self.pattern(&declarator["id"])?;
+            if !declarator["init"].is_null() {
+                self.push(" = ");
+                self.expression(&declarator["init"], Prec::Assignment)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn import_declaration(&mut self, declaration: &Value) -> Result<(), TransformError> {
+        self.push("import");
+        let specifiers = list_field(declaration, "specifiers");
+        if specifiers.is_empty() {
+            self.space();
+            self.expression(&declaration["source"], Prec::Primary)?;
+            self.import_attributes(declaration)?;
+            self.push(";");
+            return Ok(());
+        }
+        self.space();
+        let mut named_open = false;
+        let mut first = true;
+        for specifier in specifiers {
+            match node_type(specifier) {
+                Some("ImportDefaultSpecifier") => {
+                    if !first {
+                        self.push(", ");
+                    }
+                    self.identifier(&specifier["local"]);
+                }
+                Some("ImportNamespaceSpecifier") => {
+                    if !first {
+                        self.push(", ");
+                    }
+                    self.push("* as ");
+                    self.identifier(&specifier["local"]);
+                }
+                _ => {
+                    if !named_open {
+                        if !first {
+                            self.push(", ");
+                        }
+                        self.push("{ ");
+                        named_open = true;
+                    } else {
+                        self.push(", ");
+                    }
+                    let imported = &specifier["imported"];
+                    let local = &specifier["local"];
+                    self.module_export_name(imported)?;
+                    if str_field(imported, "name").or_else(|| str_field(imported, "value"))
+                        != str_field(local, "name")
+                    {
+                        self.push(" as ");
+                        self.identifier(local);
+                    }
+                }
+            }
+            first = false;
+        }
+        if named_open {
+            self.push(" }");
+        }
+        self.push(" from ");
+        self.expression(&declaration["source"], Prec::Primary)?;
+        self.import_attributes(declaration)?;
+        self.push(";");
+        Ok(())
+    }
+
+    fn import_attributes(&mut self, declaration: &Value) -> Result<(), TransformError> {
+        let attributes = if !list_field(declaration, "attributes").is_empty() {
+            list_field(declaration, "attributes")
+        } else {
+            list_field(declaration, "assertions")
+        };
+        if attributes.is_empty() {
+            return Ok(());
+        }
+        self.push(" with { ");
+        for (index, attribute) in attributes.iter().enumerate() {
+            if index > 0 {
+                self.push(", ");
+            }
+            self.property_key(&attribute["key"], false)?;
+            self.push(": ");
+            self.expression(&attribute["value"], Prec::Primary)?;
+        }
+        self.push(" }");
+        Ok(())
+    }
+
+    fn export_named(&mut self, declaration: &Value) -> Result<(), TransformError> {
+        self.push("export ");
+        let inner = &declaration["declaration"];
+        if !inner.is_null() {
+            match node_type(inner) {
+                Some("VariableDeclaration") => {
+                    self.variable_declaration(inner)?;
+                    self.push(";");
+                }
+                Some("FunctionDeclaration") => self.function(inner, true)?,
+                Some("ClassDeclaration") => self.class(inner)?,
+                _ => return Err(Self::unknown(inner, "export declaration")),
+            }
+            return Ok(());
+        }
+        let specifiers = list_field(declaration, "specifiers");
+        let namespace = specifiers
+            .iter()
+            .find(|s| node_type(s) == Some("ExportNamespaceSpecifier"));
+        if let Some(namespace) = namespace {
+            self.push("* as ");
+            self.module_export_name(&namespace["exported"])?;
+        } else {
+            self.push("{ ");
+            for (index, specifier) in specifiers.iter().enumerate() {
+                if index > 0 {
+                    self.push(", ");
+                }
+                let local = &specifier["local"];
+                let exported = &specifier["exported"];
+                self.module_export_name(local)?;
+                if str_field(local, "name").or_else(|| str_field(local, "value"))
+                    != str_field(exported, "name").or_else(|| str_field(exported, "value"))
+                {
+                    self.push(" as ");
+                    self.module_export_name(exported)?;
+                }
+            }
+            self.push(" }");
+        }
+        if !declaration["source"].is_null() {
+            self.push(" from ");
+            self.expression(&declaration["source"], Prec::Primary)?;
+            self.import_attributes(declaration)?;
+        }
+        self.push(";");
+        Ok(())
+    }
+
+    fn module_export_name(&mut self, name: &Value) -> Result<(), TransformError> {
+        match node_type(name) {
+            Some("Identifier") => {
+                self.identifier(name);
+                Ok(())
+            }
+            Some("StringLiteral") => self.expression(name, Prec::Primary),
+            _ => Err(Self::unknown(name, "module export name")),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Functions and classes
+    // ------------------------------------------------------------------
+
+    fn function(&mut self, function: &Value, declaration: bool) -> Result<(), TransformError> {
+        self.mark(function);
+        if bool_field(function, "async") {
+            self.word("async");
+            self.space();
+        }
+        self.word("function");
+        if bool_field(function, "generator") {
+            self.push("*");
+        }
+        if !function["id"].is_null() {
+            self.space();
+            self.identifier(&function["id"]);
+        } else if !declaration {
+            // `function () {}`, the way Prettier spells an anonymous one.
+            self.space();
+        }
+        self.params(function)?;
+        self.space();
+        self.block(&function["body"])?;
+        Ok(())
+    }
+
+    fn params(&mut self, function: &Value) -> Result<(), TransformError> {
+        self.push("(");
+        for (index, param) in list_field(function, "params").iter().enumerate() {
+            if index > 0 {
+                self.push(", ");
+            }
+            self.pattern(param)?;
+        }
+        self.push(")");
+        Ok(())
+    }
+
+    fn arrow(&mut self, arrow: &Value) -> Result<(), TransformError> {
+        self.mark(arrow);
+        if bool_field(arrow, "async") {
+            self.word("async");
+            self.space();
+        }
+        self.params(arrow)?;
+        self.push(" => ");
+        let body = &arrow["body"];
+        if node_type(body) == Some("BlockStatement") {
+            return self.block(body);
+        }
+        let bracket = matches!(
+            node_type(body),
+            Some("ObjectExpression" | "SequenceExpression")
+        ) || starts_with_object(body);
+        if bracket {
+            self.push("(");
+        }
+        self.expression(body, Prec::Assignment)?;
+        if bracket {
+            self.push(")");
+        }
+        Ok(())
+    }
+
+    fn class(&mut self, class: &Value) -> Result<(), TransformError> {
+        self.mark(class);
+        self.word("class");
+        if !class["id"].is_null() {
+            self.space();
+            self.identifier(&class["id"]);
+        }
+        if !class["superClass"].is_null() {
+            self.push(" extends ");
+            self.expression(&class["superClass"], Prec::LeftHandSide)?;
+        }
+        self.push(" {");
+        let members = list_field(&class["body"], "body");
+        if members.is_empty() {
+            self.push("}");
+            return Ok(());
+        }
+        self.indent += 1;
+        for member in members {
+            self.newline();
+            self.class_member(member)?;
+        }
+        self.indent -= 1;
+        self.newline();
+        self.push("}");
+        Ok(())
+    }
+
+    fn class_member(&mut self, member: &Value) -> Result<(), TransformError> {
+        self.mark(member);
+        match node_type(member) {
+            Some("ClassMethod" | "ClassPrivateMethod") => {
+                if bool_field(member, "static") {
+                    self.push("static ");
+                }
+                self.method_head(member)?;
+                self.params(member)?;
+                self.space();
+                self.block(&member["body"])
+            }
+            Some("ClassProperty" | "ClassPrivateProperty") => {
+                if bool_field(member, "static") {
+                    self.push("static ");
+                }
+                self.property_key(&member["key"], bool_field(member, "computed"))?;
+                if !member["value"].is_null() {
+                    self.push(" = ");
+                    self.expression(&member["value"], Prec::Assignment)?;
+                }
+                self.push(";");
+                Ok(())
+            }
+            Some("StaticBlock") => {
+                self.push("static ");
+                self.block(member)
+            }
+            _ => Err(Self::unknown(member, "class body")),
+        }
+    }
+
+    /// `async *get [key]` — everything before a method's parameter list.
+    fn method_head(&mut self, method: &Value) -> Result<(), TransformError> {
+        if bool_field(method, "async") {
+            self.push("async ");
+        }
+        match str_field(method, "kind") {
+            Some("get") => self.push("get "),
+            Some("set") => self.push("set "),
+            _ => {}
+        }
+        if bool_field(method, "generator") {
+            self.push("*");
+        }
+        self.property_key(&method["key"], bool_field(method, "computed"))
+    }
+
+    fn property_key(&mut self, key: &Value, computed: bool) -> Result<(), TransformError> {
+        if computed {
+            self.push("[");
+            self.expression(key, Prec::Assignment)?;
+            self.push("]");
+            return Ok(());
+        }
+        match node_type(key) {
+            Some("Identifier") => {
+                self.identifier(key);
+                Ok(())
+            }
+            Some("PrivateName") => {
+                self.mark(key);
+                self.push("#");
+                self.push(str_field(&key["id"], "name").unwrap_or(""));
+                Ok(())
+            }
+            Some("StringLiteral" | "NumericLiteral" | "BigIntLiteral") => {
+                self.expression(key, Prec::Primary)
+            }
+            _ => Err(Self::unknown(key, "property key")),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Patterns
+    // ------------------------------------------------------------------
+
+    fn pattern(&mut self, pattern: &Value) -> Result<(), TransformError> {
+        self.mark(pattern);
+        match node_type(pattern) {
+            Some("Identifier") => {
+                self.identifier(pattern);
+                Ok(())
+            }
+            Some("ObjectPattern") => {
+                self.push("{");
+                let properties = list_field(pattern, "properties");
+                for (index, property) in properties.iter().enumerate() {
+                    self.push(if index == 0 { " " } else { ", " });
+                    match node_type(property) {
+                        Some("RestElement") => {
+                            self.push("...");
+                            self.pattern(&property["argument"])?;
+                        }
+                        _ => {
+                            let computed = bool_field(property, "computed");
+                            if bool_field(property, "shorthand") && !computed {
+                                self.pattern(&property["value"])?;
+                            } else {
+                                self.property_key(&property["key"], computed)?;
+                                self.push(": ");
+                                self.pattern(&property["value"])?;
+                            }
+                        }
+                    }
+                }
+                if !properties.is_empty() {
+                    self.space();
+                }
+                self.push("}");
+                Ok(())
+            }
+            Some("ArrayPattern") => {
+                self.push("[");
+                let elements = list_field(pattern, "elements");
+                for (index, element) in elements.iter().enumerate() {
+                    if index > 0 {
+                        self.push(", ");
+                    }
+                    if !element.is_null() {
+                        self.pattern(element)?;
+                    }
+                }
+                if elements.last().is_some_and(Value::is_null) {
+                    self.push(",");
+                }
+                self.push("]");
+                Ok(())
+            }
+            Some("AssignmentPattern") => {
+                self.pattern(&pattern["left"])?;
+                self.push(" = ");
+                self.expression(&pattern["right"], Prec::Assignment)
+            }
+            Some("RestElement") => {
+                self.push("...");
+                self.pattern(&pattern["argument"])
+            }
+            Some("MemberExpression" | "OptionalMemberExpression") => {
+                self.expression(pattern, Prec::Member)
+            }
+            _ => Err(Self::unknown(pattern, "pattern position")),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Expressions
+    // ------------------------------------------------------------------
+
+    fn identifier(&mut self, identifier: &Value) {
+        self.mark(identifier);
+        self.word(str_field(identifier, "name").unwrap_or(""));
+    }
+
+    fn string(&mut self, value: &str) {
+        self.push(&serde_json::to_string(value).unwrap_or_else(|_| String::from("\"\"")));
+    }
+
+    /// Print `node` inside brackets this caller decided on, so the node's own
+    /// precedence does not add a second pair.
+    fn bracketed(&mut self, node: &Value) -> Result<(), TransformError> {
+        self.push("(");
+        self.expression(node, Prec::Sequence)?;
+        self.push(")");
+        Ok(())
+    }
+
+    /// Print `node` as an expression in a position that requires at least
+    /// `required` precedence, bracketing it when it binds looser.
+    fn expression(&mut self, node: &Value, required: Prec) -> Result<(), TransformError> {
+        let own = prec_of(node);
+        let bracket = own < required || needs_brackets_in_chain(node, required);
+        if bracket {
+            self.push("(");
+        }
+        self.expression_inner(node)?;
+        if bracket {
+            self.push(")");
+        }
+        Ok(())
+    }
+
+    fn expression_inner(&mut self, node: &Value) -> Result<(), TransformError> {
+        self.mark(node);
+        match node_type(node) {
+            Some("Identifier") => {
+                self.word(str_field(node, "name").unwrap_or(""));
+            }
+            Some("StringLiteral") => match node
+                .get("extra")
+                .and_then(|e| e.get("raw"))
+                .and_then(Value::as_str)
+            {
+                Some(raw) => self.push(raw),
+                None => self.string(str_field(node, "value").unwrap_or("")),
+            },
+            Some("NumericLiteral") => match node
+                .get("extra")
+                .and_then(|e| e.get("raw"))
+                .and_then(Value::as_str)
+            {
+                Some(raw) => self.word(raw),
+                None => {
+                    let value = node["value"].as_f64().unwrap_or(0.0);
+                    self.word(&format_number(value));
+                }
+            },
+            Some("BigIntLiteral") => {
+                let text = str_field(node, "value").unwrap_or("0");
+                self.word(&format!("{}n", text.trim_end_matches('n')));
+            }
+            Some("BooleanLiteral") => self.word(if bool_field(node, "value") {
+                "true"
+            } else {
+                "false"
+            }),
+            Some("NullLiteral") => self.word("null"),
+            Some("RegExpLiteral") => {
+                self.push("/");
+                self.push(str_field(node, "pattern").unwrap_or(""));
+                self.push("/");
+                self.push(str_field(node, "flags").unwrap_or(""));
+            }
+            Some("ThisExpression") => self.word("this"),
+            Some("Super") => self.word("super"),
+            Some("Import") => self.word("import"),
+            Some("MetaProperty") => {
+                self.identifier(&node["meta"]);
+                self.push(".");
+                self.identifier(&node["property"]);
+            }
+            Some("TemplateLiteral") => self.template(node)?,
+            Some("TaggedTemplateExpression") => {
+                self.expression(&node["tag"], Prec::Member)?;
+                self.template(&node["quasi"])?;
+            }
+            Some("ArrayExpression") => {
+                self.push("[");
+                let elements = list_field(node, "elements");
+                for (index, element) in elements.iter().enumerate() {
+                    if index > 0 {
+                        self.push(", ");
+                    }
+                    if !element.is_null() {
+                        self.expression(element, Prec::Assignment)?;
+                    }
+                }
+                if elements.last().is_some_and(Value::is_null) {
+                    self.push(",");
+                }
+                self.push("]");
+            }
+            Some("ObjectExpression") => self.object(node)?,
+            Some("FunctionExpression") => self.function(node, false)?,
+            Some("ArrowFunctionExpression") => self.arrow(node)?,
+            Some("ClassExpression") => self.class(node)?,
+            Some("SpreadElement") => {
+                self.push("...");
+                self.expression(&node["argument"], Prec::Assignment)?;
+            }
+            Some("UnaryExpression") => {
+                let operator = str_field(node, "operator").unwrap_or("");
+                self.word(operator);
+                let argument = &node["argument"];
+                let same_sign = matches!(operator, "+" | "-")
+                    && matches!(
+                        node_type(argument),
+                        Some("UnaryExpression" | "UpdateExpression")
+                    )
+                    && str_field(argument, "operator")
+                        .is_some_and(|inner| inner.starts_with(operator));
+                if operator.chars().all(char::is_alphabetic) || same_sign {
+                    self.space();
+                }
+                self.expression(argument, Prec::Unary)?;
+            }
+            Some("UpdateExpression") => {
+                let operator = str_field(node, "operator").unwrap_or("++");
+                if bool_field(node, "prefix") {
+                    self.push(operator);
+                    self.expression(&node["argument"], Prec::Unary)?;
+                } else {
+                    self.expression(&node["argument"], Prec::LeftHandSide)?;
+                    self.push(operator);
+                }
+            }
+            Some("AwaitExpression") => {
+                self.word("await");
+                self.space();
+                self.expression(&node["argument"], Prec::Unary)?;
+            }
+            Some("YieldExpression") => {
+                self.word("yield");
+                if bool_field(node, "delegate") {
+                    self.push("*");
+                }
+                if !node["argument"].is_null() {
+                    self.space();
+                    self.expression(&node["argument"], Prec::Assignment)?;
+                }
+            }
+            Some("BinaryExpression" | "LogicalExpression") => self.binary(node)?,
+            Some("AssignmentExpression") => {
+                let left = &node["left"];
+                if matches!(node_type(left), Some("ObjectPattern" | "ArrayPattern")) {
+                    self.pattern(left)?;
+                } else {
+                    self.expression(left, Prec::LeftHandSide)?;
+                }
+                self.space();
+                self.push(str_field(node, "operator").unwrap_or("="));
+                self.space();
+                self.expression(&node["right"], Prec::Assignment)?;
+            }
+            Some("AssignmentPattern") => self.pattern(node)?,
+            Some("ConditionalExpression") => {
+                self.expression(&node["test"], Prec::Coalesce)?;
+                self.push(" ? ");
+                self.expression(&node["consequent"], Prec::Assignment)?;
+                self.push(" : ");
+                self.expression(&node["alternate"], Prec::Assignment)?;
+            }
+            Some("SequenceExpression") => {
+                for (index, expression) in list_field(node, "expressions").iter().enumerate() {
+                    if index > 0 {
+                        self.push(", ");
+                    }
+                    self.expression(expression, Prec::Assignment)?;
+                }
+            }
+            Some("CallExpression" | "OptionalCallExpression") => {
+                let callee = &node["callee"];
+                let bracket = matches!(
+                    node_type(callee),
+                    Some("FunctionExpression" | "ClassExpression")
+                ) || (node_type(node) == Some("CallExpression")
+                    && matches!(
+                        node_type(callee),
+                        Some("OptionalMemberExpression" | "OptionalCallExpression")
+                    ));
+                if bracket {
+                    self.bracketed(callee)?;
+                } else {
+                    self.expression(callee, Prec::LeftHandSide)?;
+                }
+                if bool_field(node, "optional") {
+                    self.push("?.");
+                }
+                self.arguments(node)?;
+            }
+            Some("NewExpression") => {
+                self.word("new");
+                self.space();
+                let callee = &node["callee"];
+                if contains_call(callee) {
+                    self.bracketed(callee)?;
+                } else {
+                    self.expression(callee, Prec::Member)?;
+                }
+                self.arguments(node)?;
+            }
+            Some("MemberExpression" | "OptionalMemberExpression") => {
+                let object = &node["object"];
+                let bracket = matches!(node_type(object), Some("NumericLiteral"))
+                    || (node_type(node) == Some("MemberExpression")
+                        && matches!(
+                            node_type(object),
+                            Some("OptionalMemberExpression" | "OptionalCallExpression")
+                        ));
+                if bracket {
+                    self.bracketed(object)?;
+                } else {
+                    self.expression(object, Prec::Member)?;
+                }
+                let optional = bool_field(node, "optional");
+                if bool_field(node, "computed") {
+                    self.push(if optional { "?.[" } else { "[" });
+                    self.expression(&node["property"], Prec::Sequence)?;
+                    self.push("]");
+                } else {
+                    self.push(if optional { "?." } else { "." });
+                    let property = &node["property"];
+                    if node_type(property) == Some("PrivateName") {
+                        self.property_key(property, false)?;
+                    } else {
+                        self.mark(property);
+                        self.push(str_field(property, "name").unwrap_or(""));
+                    }
+                }
+            }
+            Some("ParenthesizedExpression") => {
+                self.push("(");
+                self.expression(&node["expression"], Prec::Sequence)?;
+                self.push(")");
+            }
+            Some("JSXElement") => self.jsx_element(node)?,
+            Some("JSXFragment") => self.jsx_fragment(node)?,
+            Some("ObjectPattern" | "ArrayPattern" | "RestElement") => self.pattern(node)?,
+            _ => return Err(Self::unknown(node, "expression position")),
+        }
+        Ok(())
+    }
+
+    fn binary(&mut self, node: &Value) -> Result<(), TransformError> {
+        let operator = str_field(node, "operator").unwrap_or("+");
+        let own = binary_prec(operator);
+        let left = &node["left"];
+        let right = &node["right"];
+        // `**` is right-associative and refuses a unary operand on its left;
+        // everything else is left-associative.
+        let (left_required, right_required) = if operator == "**" {
+            (Prec::Update, own)
+        } else {
+            (own, higher(own))
+        };
+        let mix = |operand: &Value| {
+            // `a ?? b || c` is a syntax error without brackets.
+            matches!(node_type(operand), Some("LogicalExpression"))
+                && ((operator == "??") != (str_field(operand, "operator") == Some("??")))
+        };
+        if mix(left) {
+            self.bracketed(left)?;
+        } else {
+            self.expression(left, left_required)?;
+        }
+        self.space();
+        self.word(operator);
+        self.space();
+        if mix(right) {
+            self.bracketed(right)?;
+        } else {
+            self.expression(right, right_required)?;
+        }
+        Ok(())
+    }
+
+    fn arguments(&mut self, node: &Value) -> Result<(), TransformError> {
+        self.push("(");
+        for (index, argument) in list_field(node, "arguments").iter().enumerate() {
+            if index > 0 {
+                self.push(", ");
+            }
+            self.expression(argument, Prec::Assignment)?;
+        }
+        self.push(")");
+        Ok(())
+    }
+
+    fn object(&mut self, object: &Value) -> Result<(), TransformError> {
+        let properties = list_field(object, "properties");
+        if properties.is_empty() {
+            self.push("{}");
+            return Ok(());
+        }
+        self.push("{");
+        self.indent += 1;
+        for (index, property) in properties.iter().enumerate() {
+            self.newline();
+            self.mark(property);
+            match node_type(property) {
+                Some("SpreadElement") => {
+                    self.push("...");
+                    self.expression(&property["argument"], Prec::Assignment)?;
+                }
+                Some("ObjectMethod") => {
+                    self.method_head(property)?;
+                    self.params(property)?;
+                    self.space();
+                    self.block(&property["body"])?;
+                }
+                Some("ObjectProperty") => {
+                    let computed = bool_field(property, "computed");
+                    let value = &property["value"];
+                    if bool_field(property, "shorthand")
+                        && !computed
+                        && node_type(value) == Some("Identifier")
+                        && str_field(value, "name") == str_field(&property["key"], "name")
+                    {
+                        self.identifier(value);
+                    } else {
+                        self.property_key(&property["key"], computed)?;
+                        self.push(": ");
+                        self.expression(value, Prec::Assignment)?;
+                    }
+                }
+                _ => return Err(Self::unknown(property, "object literal")),
+            }
+            if index + 1 < properties.len() {
+                self.push(",");
+            }
+        }
+        self.indent -= 1;
+        self.newline();
+        self.push("}");
+        Ok(())
+    }
+
+    fn template(&mut self, template: &Value) -> Result<(), TransformError> {
+        self.push("`");
+        let quasis = list_field(template, "quasis");
+        let expressions = list_field(template, "expressions");
+        for (index, quasi) in quasis.iter().enumerate() {
+            let raw = quasi
+                .get("value")
+                .and_then(|value| value.get("raw"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            self.push(raw);
+            if let Some(expression) = expressions.get(index) {
+                self.push("${");
+                self.expression(expression, Prec::Sequence)?;
+                self.push("}");
+            }
+        }
+        self.push("`");
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // JSX
+    // ------------------------------------------------------------------
+
+    fn jsx_name(&mut self, name: &Value) -> Result<(), TransformError> {
+        match node_type(name) {
+            Some("JSXIdentifier") => {
+                self.mark(name);
+                self.push(str_field(name, "name").unwrap_or(""));
+                Ok(())
+            }
+            Some("JSXMemberExpression") => {
+                self.jsx_name(&name["object"])?;
+                self.push(".");
+                self.jsx_name(&name["property"])
+            }
+            Some("JSXNamespacedName") => {
+                self.jsx_name(&name["namespace"])?;
+                self.push(":");
+                self.jsx_name(&name["name"])
+            }
+            _ => Err(Self::unknown(name, "JSX name")),
+        }
+    }
+
+    fn jsx_element(&mut self, element: &Value) -> Result<(), TransformError> {
+        let opening = &element["openingElement"];
+        self.push("<");
+        self.jsx_name(&opening["name"])?;
+        for attribute in list_field(opening, "attributes") {
+            self.space();
+            self.mark(attribute);
+            match node_type(attribute) {
+                Some("JSXSpreadAttribute") => {
+                    self.push("{...");
+                    self.expression(&attribute["argument"], Prec::Assignment)?;
+                    self.push("}");
+                }
+                _ => {
+                    self.jsx_name(&attribute["name"])?;
+                    let value = &attribute["value"];
+                    if value.is_null() {
+                        continue;
+                    }
+                    self.push("=");
+                    match node_type(value) {
+                        Some("StringLiteral") => match value
+                            .get("extra")
+                            .and_then(|e| e.get("raw"))
+                            .and_then(Value::as_str)
+                        {
+                            Some(raw) => self.push(raw),
+                            None => {
+                                self.push("\"");
+                                self.push(
+                                    &str_field(value, "value")
+                                        .unwrap_or("")
+                                        .replace('"', "&quot;"),
+                                );
+                                self.push("\"");
+                            }
+                        },
+                        Some("JSXExpressionContainer") => self.jsx_container(value)?,
+                        Some("JSXElement") => self.jsx_element(value)?,
+                        Some("JSXFragment") => self.jsx_fragment(value)?,
+                        _ => return Err(Self::unknown(value, "JSX attribute value")),
+                    }
+                }
+            }
+        }
+        if bool_field(opening, "selfClosing") || element["closingElement"].is_null() {
+            self.push(" />");
+            return Ok(());
+        }
+        self.push(">");
+        self.jsx_children(element)?;
+        self.push("</");
+        self.jsx_name(&opening["name"])?;
+        self.push(">");
+        Ok(())
+    }
+
+    fn jsx_fragment(&mut self, fragment: &Value) -> Result<(), TransformError> {
+        self.push("<>");
+        self.jsx_children(fragment)?;
+        self.push("</>");
+        Ok(())
+    }
+
+    fn jsx_children(&mut self, parent: &Value) -> Result<(), TransformError> {
+        for child in list_field(parent, "children") {
+            match node_type(child) {
+                Some("JSXText") => {
+                    let raw = child
+                        .get("extra")
+                        .and_then(|e| e.get("raw"))
+                        .and_then(Value::as_str)
+                        .or_else(|| str_field(child, "value"))
+                        .unwrap_or("");
+                    self.push(raw);
+                }
+                Some("JSXExpressionContainer") => self.jsx_container(child)?,
+                Some("JSXSpreadChild") => {
+                    self.push("{...");
+                    self.expression(&child["expression"], Prec::Assignment)?;
+                    self.push("}");
+                }
+                Some("JSXElement") => self.jsx_element(child)?,
+                Some("JSXFragment") => self.jsx_fragment(child)?,
+                _ => return Err(Self::unknown(child, "JSX children")),
+            }
+        }
+        Ok(())
+    }
+
+    fn jsx_container(&mut self, container: &Value) -> Result<(), TransformError> {
+        self.push("{");
+        let expression = &container["expression"];
+        if node_type(expression) != Some("JSXEmptyExpression") {
+            self.expression(expression, Prec::Sequence)?;
+        }
+        self.push("}");
+        Ok(())
+    }
+}
+
+/// The precedence one step tighter than `prec`, for a left-associative
+/// operator's right operand.
+fn higher(prec: Prec) -> Prec {
+    match prec {
+        Prec::Sequence => Prec::Yield,
+        Prec::Yield => Prec::Assignment,
+        Prec::Assignment => Prec::Conditional,
+        Prec::Conditional => Prec::Coalesce,
+        Prec::Coalesce => Prec::LogicalOr,
+        Prec::LogicalOr => Prec::LogicalAnd,
+        Prec::LogicalAnd => Prec::BitOr,
+        Prec::BitOr => Prec::BitXor,
+        Prec::BitXor => Prec::BitAnd,
+        Prec::BitAnd => Prec::Equality,
+        Prec::Equality => Prec::Relational,
+        Prec::Relational => Prec::Shift,
+        Prec::Shift => Prec::Additive,
+        Prec::Additive => Prec::Multiplicative,
+        Prec::Multiplicative => Prec::Exponent,
+        Prec::Exponent => Prec::Unary,
+        Prec::Unary => Prec::Update,
+        Prec::Update => Prec::LeftHandSide,
+        Prec::LeftHandSide => Prec::Member,
+        Prec::Member | Prec::Primary => Prec::Primary,
+    }
+}
+
+/// Arrow functions, function expressions and classes in a member or call
+/// position need brackets even though their own precedence says "primary".
+fn needs_brackets_in_chain(node: &Value, required: Prec) -> bool {
+    required >= Prec::LeftHandSide
+        && matches!(
+            node_type(node),
+            Some("ArrowFunctionExpression" | "FunctionExpression" | "ClassExpression")
+        )
+        && required > Prec::LeftHandSide
+}
+
+/// Whether an expression statement would be read as a block, a function
+/// declaration, a class declaration or a `let` binding without brackets.
+fn starts_statement_ambiguously(expression: &Value) -> bool {
+    match node_type(expression) {
+        Some("ObjectExpression" | "FunctionExpression" | "ClassExpression") => true,
+        Some("AssignmentExpression") if node_type(&expression["left"]) == Some("ObjectPattern") => {
+            true
+        }
+        Some("Identifier") => str_field(expression, "name") == Some("let"),
+        Some("MemberExpression" | "OptionalMemberExpression") => {
+            starts_statement_ambiguously(&expression["object"])
+        }
+        Some("CallExpression" | "OptionalCallExpression") => {
+            starts_statement_ambiguously(&expression["callee"])
+        }
+        Some("TaggedTemplateExpression") => starts_statement_ambiguously(&expression["tag"]),
+        Some("BinaryExpression" | "LogicalExpression" | "AssignmentExpression") => {
+            starts_statement_ambiguously(&expression["left"])
+        }
+        Some("ConditionalExpression") => starts_statement_ambiguously(&expression["test"]),
+        Some("SequenceExpression") => list_field(expression, "expressions")
+            .first()
+            .is_some_and(starts_statement_ambiguously),
+        Some("UpdateExpression") if !bool_field(expression, "prefix") => {
+            starts_statement_ambiguously(&expression["argument"])
+        }
+        _ => false,
+    }
+}
+
+/// Whether an arrow body would be read as a block: it starts with `{`.
+fn starts_with_object(expression: &Value) -> bool {
+    match node_type(expression) {
+        Some("ObjectExpression") => true,
+        Some("MemberExpression" | "OptionalMemberExpression") => {
+            starts_with_object(&expression["object"])
+        }
+        Some("CallExpression" | "OptionalCallExpression") => {
+            starts_with_object(&expression["callee"])
+        }
+        Some("BinaryExpression" | "LogicalExpression" | "AssignmentExpression") => {
+            starts_with_object(&expression["left"])
+        }
+        Some("ConditionalExpression") => starts_with_object(&expression["test"]),
+        Some("TaggedTemplateExpression") => starts_with_object(&expression["tag"]),
+        _ => false,
+    }
+}
+
+/// Whether a `new` callee contains a call, which would otherwise bind to
+/// the `new`: `new (f())()` is not `new f()()`.
+fn contains_call(node: &Value) -> bool {
+    match node_type(node) {
+        Some("CallExpression" | "OptionalCallExpression" | "OptionalMemberExpression") => true,
+        Some("MemberExpression") => contains_call(&node["object"]),
+        Some("TaggedTemplateExpression") => contains_call(&node["tag"]),
+        _ => false,
+    }
+}
+
+/// A number literal without a recorded spelling, printed the shortest way
+/// that reads back to the same value.
+fn format_number(value: f64) -> String {
+    if value.is_finite() && value.fract() == 0.0 && value.abs() < 1e16 {
+        return format!("{}", value as i64);
+    }
+    let text = format!("{value}");
+    if value.is_finite() && value.abs() >= 1e21 {
+        return format!("{value:e}").replace("e", "e+").replace("e+-", "e-");
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+    use crate::lower;
+
+    fn printed(source: &str) -> String {
+        let mut program = parse(source).unwrap();
+        lower::lower(&mut program, source).unwrap();
+        let file = crate::babel::to_babel(program, source).unwrap();
+        print(&file).unwrap().code
+    }
+
+    fn reparses(code: &str) {
+        let outcome = parse(code);
+        assert!(
+            outcome.is_ok(),
+            "printed code does not parse: {outcome:?}\n{code}"
+        );
+    }
+
+    #[test]
+    fn prints_statements_and_reparses() {
+        let source = "import a, {b as c} from 'x';\nimport * as ns from 'y';\nexport let d = 1, e;\nexport default function f(g, {h, i: j = 2}, ...k) { if (g) { return h; } else if (j) return; else { throw new Error(); } }\nfor (let i = 0; i < 3; i++) { continue; }\nfor (const x of y) {}\nfor (const x in y) {}\nwhile (a) break;\ndo { a(); } while (b);\nswitch (x) { case 1: a(); break; default: b(); }\ntry { a(); } catch (e) { b(); } finally { c(); }\nlabel: for (;;) { break label; }\nclass K extends B { static s = 1; #p; constructor() { super(); } get x() { return 1; } static async *m() {} #q() {} static {} }\nexport { d as dd };\nexport * from 'z';\nexport * as w from 'z';\n";
+        let code = printed(source);
+        reparses(&code);
+        assert!(code.contains("import a, { b as c } from 'x';"), "{code}");
+        assert!(code.contains("export * as w from 'z';"), "{code}");
+        assert!(code.contains("static async *m()"), "{code}");
+    }
+
+    #[test]
+    fn brackets_follow_precedence_not_the_source() {
+        let source = "const a = (1 + 2) * 3;\nconst b = 1 + 2 * 3;\nconst c = (a, b);\nconst d = (() => ({}))();\nconst e = (function () {})();\nconst f = new (g())();\nconst h = (a ?? b) || c;\nconst i = (-1) ** 2;\nconst j = a ? (b, c) : d;\nconst k = (a = 1) ? 2 : 3;\nconst l = (1).toString();\nconst m = (a?.b).c;\n({ x } = y);\nconst n = typeof (a + b);\nconst o = -(-a);\nconst p = !(a && b);\n";
+        let code = printed(source);
+        reparses(&code);
+        assert!(code.contains("(1 + 2) * 3"), "{code}");
+        assert!(code.contains("1 + 2 * 3"), "{code}");
+        assert!(code.contains("(a, b)"), "{code}");
+        assert!(code.contains("(() => ({}))()"), "{code}");
+        assert!(code.contains("(function () {})()"), "{code}");
+        assert!(code.contains("new (g())()"), "{code}");
+        assert!(code.contains("(a ?? b) || c"), "{code}");
+        assert!(code.contains("(-1) ** 2"), "{code}");
+        assert!(code.contains("(1).toString()"), "{code}");
+        assert!(code.contains("(a?.b).c"), "{code}");
+        assert!(code.contains("({ x } = y);"), "{code}");
+        assert!(code.contains("typeof (a + b)"), "{code}");
+        assert!(code.contains("- -a"), "{code}");
+    }
+
+    #[test]
+    fn prints_jsx_and_templates_verbatim() {
+        let source = "const el = <Foo.Bar a=\"x\" b={1} {...rest}>text {value} <br /> &amp;</Foo.Bar>;\nconst frag = <>{items.map((i) => <li key={i}>{i}</li>)}</>;\nconst t = tag`a${b}c`;\n";
+        let code = printed(source);
+        reparses(&code);
+        assert!(
+            code.contains("<Foo.Bar a=\"x\" b={1} {...rest}>text {value} <br /> &amp;</Foo.Bar>"),
+            "{code}"
+        );
+        assert!(code.contains("tag`a${b}c`"), "{code}");
+    }
+
+    #[test]
+    fn lowered_flow_prints_as_javascript() {
+        let source = "component App(a: string, ...rest: R) { const y = match (a) { 'x' => 1, _ => 2 }; return <p>{y}</p>; }\nenum E { A }\n";
+        let code = printed(source);
+        reparses(&code);
+        assert!(code.contains("function App({ a, ...rest })"), "{code}");
+        assert!(code.contains("a === 'x' ? 1 : 2"), "{code}");
+        assert!(code.contains("$$ufEnumMirrored([\"A\"])"), "{code}");
+    }
+
+    #[test]
+    fn mappings_point_at_the_source() {
+        let source = "const a = 1;\n\nfunction f() {\n  return a;\n}\n";
+        let mut program = parse(source).unwrap();
+        lower::lower(&mut program, source).unwrap();
+        let file = crate::babel::to_babel(program, source).unwrap();
+        let printed = print(&file).unwrap();
+        let return_line = printed
+            .code
+            .lines()
+            .position(|line| line.contains("return"))
+            .unwrap();
+        let mapping = printed
+            .mappings
+            .iter()
+            .find(|m| m.generated_line as usize == return_line && m.generated_column == 2)
+            .expect("a mapping for the return statement");
+        assert_eq!(mapping.original_line, 3);
+        assert_eq!(mapping.original_column, 2);
+    }
+
+    #[test]
+    fn numbers_without_raw_text_print_shortest() {
+        assert_eq!(format_number(1.0), "1");
+        assert_eq!(format_number(0.5), "0.5");
+        assert_eq!(format_number(1e21), "1e+21");
+        assert_eq!(format_number(-3.0), "-3");
+    }
+}

--- a/crates/uf_transform/src/scope.rs
+++ b/crates/uf_transform/src/scope.rs
@@ -1,0 +1,924 @@
+//! Scope analysis in Babel's terms, for the React Compiler.
+//!
+//! The compiler does not resolve names itself; it is handed a
+//! [`ScopeInfo`] — scopes, the bindings each declares, and which binding every
+//! identifier reference resolves to — built by whichever front end parsed the
+//! file. Upstream that is `@babel/traverse`. This is the same analysis over
+//! the Babel-shaped tree from [`crate::babel`], following Babel's rules:
+//!
+//! * the program, every function, every block, `for`/`for-in`/`for-of`,
+//!   `switch`, `catch` and every class create a scope; a function's body
+//!   block does not create a second one;
+//! * `var` and function declarations hoist to the nearest function (or
+//!   program) scope, `let`/`const`/`class` belong to the block they are in,
+//!   parameters to their function, imports to the program;
+//! * a reference is an identifier in value position — never a non-computed
+//!   property key, a member name, a label, or the name of a declaration —
+//!   and resolves to the nearest enclosing declaration of its name, or to
+//!   nothing when it is a global.
+//!
+//! Nodes are addressed by the `_nodeId` the conversion assigned, with
+//! `start` offsets kept beside them for the compiler's range queries.
+
+use indexmap::IndexMap;
+use react_compiler_ast::scope::{
+    BindingData, BindingId, BindingKind, ImportBindingData, ImportBindingKind, ScopeData, ScopeId,
+    ScopeInfo, ScopeKind,
+};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use serde_json::Value;
+
+use crate::lower::{bool_field, list_field, node_type, str_field};
+
+/// Build the scope information for a Babel `File`.
+#[must_use]
+pub fn analyze(file: &Value) -> ScopeInfo {
+    let mut analyzer = Analyzer::default();
+    let program = &file["program"];
+    let root = analyzer.enter(program, ScopeKind::Program, None);
+    analyzer.declare_imports(program, root);
+    analyzer.hoist_statements(list_field(program, "body"), root, root);
+    for statement in list_field(program, "body") {
+        analyzer.visit_statement(statement, root, root);
+    }
+    analyzer.finish(root)
+}
+
+#[derive(Default)]
+struct Analyzer {
+    scopes: Vec<ScopeData>,
+    bindings: Vec<BindingData>,
+    node_to_scope: FxHashMap<u32, ScopeId>,
+    node_to_scope_end: FxHashMap<u32, u32>,
+    ref_node_id_to_binding: IndexMap<u32, BindingId, FxBuildHasher>,
+    node_id_to_scope: FxHashMap<u32, ScopeId>,
+}
+
+fn node_id(node: &Value) -> Option<u32> {
+    node.get("_nodeId")
+        .and_then(Value::as_u64)
+        .and_then(|id| u32::try_from(id).ok())
+}
+
+fn start(node: &Value) -> Option<u32> {
+    node.get("start")
+        .and_then(Value::as_u64)
+        .and_then(|id| u32::try_from(id).ok())
+}
+
+fn end(node: &Value) -> Option<u32> {
+    node.get("end")
+        .and_then(Value::as_u64)
+        .and_then(|id| u32::try_from(id).ok())
+}
+
+impl Analyzer {
+    fn finish(self, root: ScopeId) -> ScopeInfo {
+        ScopeInfo {
+            scopes: self.scopes,
+            bindings: self.bindings,
+            node_to_scope: self.node_to_scope,
+            node_to_scope_end: self.node_to_scope_end,
+            reference_to_binding: IndexMap::default(),
+            ref_node_id_to_binding: self.ref_node_id_to_binding,
+            node_id_to_scope: self.node_id_to_scope,
+            program_scope: root,
+        }
+    }
+
+    fn enter(&mut self, node: &Value, kind: ScopeKind, parent: Option<ScopeId>) -> ScopeId {
+        let id = ScopeId(u32::try_from(self.scopes.len()).unwrap_or(u32::MAX));
+        self.scopes.push(ScopeData {
+            id,
+            parent,
+            kind,
+            bindings: FxHashMap::default(),
+        });
+        if let Some(node_id) = node_id(node) {
+            self.node_id_to_scope.insert(node_id, id);
+        }
+        if let Some(start) = start(node) {
+            self.node_to_scope.insert(start, id);
+            if let Some(end) = end(node) {
+                self.node_to_scope_end.insert(start, end);
+            }
+        }
+        id
+    }
+
+    fn declare(
+        &mut self,
+        identifier: &Value,
+        scope: ScopeId,
+        kind: BindingKind,
+        declaration_type: &str,
+        import: Option<ImportBindingData>,
+    ) {
+        let Some(name) = str_field(identifier, "name") else {
+            return;
+        };
+        let existing = self.scopes[scope.0 as usize].bindings.get(name).copied();
+        if let Some(existing) = existing {
+            // A redeclaration — `var` twice, or a function after a `var` —
+            // keeps the first binding, which is what Babel does too.
+            let _ = existing;
+            return;
+        }
+        let id = BindingId(u32::try_from(self.bindings.len()).unwrap_or(u32::MAX));
+        self.bindings.push(BindingData {
+            id,
+            name: name.to_owned(),
+            kind,
+            scope,
+            declaration_type: declaration_type.to_owned(),
+            declaration_start: start(identifier),
+            declaration_node_id: node_id(identifier),
+            import,
+        });
+        self.scopes[scope.0 as usize]
+            .bindings
+            .insert(name.to_owned(), id);
+    }
+
+    fn resolve(&self, mut scope: ScopeId, name: &str) -> Option<BindingId> {
+        loop {
+            let data = &self.scopes[scope.0 as usize];
+            if let Some(id) = data.bindings.get(name) {
+                return Some(*id);
+            }
+            scope = data.parent?;
+        }
+    }
+
+    fn reference(&mut self, identifier: &Value, scope: ScopeId) {
+        let Some(name) = str_field(identifier, "name") else {
+            return;
+        };
+        if let (Some(binding), Some(node_id)) = (self.resolve(scope, name), node_id(identifier)) {
+            self.ref_node_id_to_binding.insert(node_id, binding);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Declarations
+    // ------------------------------------------------------------------
+
+    fn declare_imports(&mut self, program: &Value, scope: ScopeId) {
+        for statement in list_field(program, "body") {
+            if node_type(statement) != Some("ImportDeclaration") {
+                continue;
+            }
+            let source = str_field(&statement["source"], "value")
+                .unwrap_or("")
+                .to_owned();
+            for specifier in list_field(statement, "specifiers") {
+                let (kind, imported, declaration_type) = match node_type(specifier) {
+                    Some("ImportDefaultSpecifier") => {
+                        (ImportBindingKind::Default, None, "ImportDefaultSpecifier")
+                    }
+                    Some("ImportNamespaceSpecifier") => (
+                        ImportBindingKind::Namespace,
+                        None,
+                        "ImportNamespaceSpecifier",
+                    ),
+                    _ => {
+                        let imported = &specifier["imported"];
+                        let name = str_field(imported, "name")
+                            .or_else(|| str_field(imported, "value"))
+                            .map(str::to_owned);
+                        (ImportBindingKind::Named, name, "ImportSpecifier")
+                    }
+                };
+                self.declare(
+                    &specifier["local"],
+                    scope,
+                    BindingKind::Module,
+                    declaration_type,
+                    Some(ImportBindingData {
+                        source: source.clone(),
+                        kind,
+                        imported,
+                    }),
+                );
+            }
+        }
+    }
+
+    /// Register what a statement list declares in `scope`, hoisting `var`
+    /// into `function_scope`.
+    fn hoist_statements(&mut self, statements: &[Value], scope: ScopeId, function_scope: ScopeId) {
+        for statement in statements {
+            self.hoist_statement(statement, scope, function_scope);
+        }
+    }
+
+    fn hoist_statement(&mut self, statement: &Value, scope: ScopeId, function_scope: ScopeId) {
+        match node_type(statement) {
+            Some("VariableDeclaration") => self.declare_variables(statement, scope, function_scope),
+            Some("FunctionDeclaration") => {
+                self.declare(
+                    &statement["id"],
+                    scope,
+                    BindingKind::Hoisted,
+                    "FunctionDeclaration",
+                    None,
+                );
+            }
+            Some("ClassDeclaration") => {
+                self.declare(
+                    &statement["id"],
+                    scope,
+                    BindingKind::Let,
+                    "ClassDeclaration",
+                    None,
+                );
+            }
+            Some("ExportNamedDeclaration") => {
+                if let Some(declaration) = statement.get("declaration").filter(|d| !d.is_null()) {
+                    self.hoist_statement(declaration, scope, function_scope);
+                }
+            }
+            Some("ExportDefaultDeclaration") => {
+                let declaration = &statement["declaration"];
+                if matches!(
+                    node_type(declaration),
+                    Some("FunctionDeclaration" | "ClassDeclaration")
+                ) && !declaration["id"].is_null()
+                {
+                    self.hoist_statement(declaration, scope, function_scope);
+                }
+            }
+            // `var` declared anywhere below hoists to the function scope; walk
+            // the statement containers without entering functions.
+            Some("BlockStatement" | "StaticBlock") => {
+                self.hoist_vars(list_field(statement, "body"), function_scope)
+            }
+            Some("IfStatement") => {
+                self.hoist_var_statement(&statement["consequent"], function_scope);
+                self.hoist_var_statement(&statement["alternate"], function_scope);
+            }
+            Some("ForStatement") => {
+                self.hoist_var_statement(&statement["init"], function_scope);
+                self.hoist_var_statement(&statement["body"], function_scope);
+            }
+            Some("ForInStatement" | "ForOfStatement") => {
+                self.hoist_var_statement(&statement["left"], function_scope);
+                self.hoist_var_statement(&statement["body"], function_scope);
+            }
+            Some("WhileStatement" | "DoWhileStatement" | "LabeledStatement" | "WithStatement") => {
+                self.hoist_var_statement(&statement["body"], function_scope);
+            }
+            Some("TryStatement") => {
+                self.hoist_var_statement(&statement["block"], function_scope);
+                if !statement["handler"].is_null() {
+                    self.hoist_var_statement(&statement["handler"]["body"], function_scope);
+                }
+                self.hoist_var_statement(&statement["finalizer"], function_scope);
+            }
+            Some("SwitchStatement") => {
+                for case in list_field(statement, "cases") {
+                    self.hoist_vars(list_field(case, "consequent"), function_scope);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Hoist only the `var` declarations under `statement`.
+    fn hoist_var_statement(&mut self, statement: &Value, function_scope: ScopeId) {
+        if statement.is_null() {
+            return;
+        }
+        if node_type(statement) == Some("VariableDeclaration") {
+            if str_field(statement, "kind") == Some("var") {
+                self.declare_variables(statement, function_scope, function_scope);
+            }
+            return;
+        }
+        // Everything else: only the containers matter, and those are the
+        // same cases as hoisting, minus lexical declarations.
+        match node_type(statement) {
+            Some("FunctionDeclaration" | "ClassDeclaration") => {}
+            _ => self.hoist_statement_vars_only(statement, function_scope),
+        }
+    }
+
+    fn hoist_vars(&mut self, statements: &[Value], function_scope: ScopeId) {
+        for statement in statements {
+            self.hoist_var_statement(statement, function_scope);
+        }
+    }
+
+    fn hoist_statement_vars_only(&mut self, statement: &Value, function_scope: ScopeId) {
+        match node_type(statement) {
+            Some("BlockStatement" | "StaticBlock") => {
+                self.hoist_vars(list_field(statement, "body"), function_scope)
+            }
+            Some("IfStatement") => {
+                self.hoist_var_statement(&statement["consequent"], function_scope);
+                self.hoist_var_statement(&statement["alternate"], function_scope);
+            }
+            Some("ForStatement") => {
+                self.hoist_var_statement(&statement["init"], function_scope);
+                self.hoist_var_statement(&statement["body"], function_scope);
+            }
+            Some("ForInStatement" | "ForOfStatement") => {
+                self.hoist_var_statement(&statement["left"], function_scope);
+                self.hoist_var_statement(&statement["body"], function_scope);
+            }
+            Some("WhileStatement" | "DoWhileStatement" | "LabeledStatement" | "WithStatement") => {
+                self.hoist_var_statement(&statement["body"], function_scope);
+            }
+            Some("TryStatement") => {
+                self.hoist_var_statement(&statement["block"], function_scope);
+                if !statement["handler"].is_null() {
+                    self.hoist_var_statement(&statement["handler"]["body"], function_scope);
+                }
+                self.hoist_var_statement(&statement["finalizer"], function_scope);
+            }
+            Some("SwitchStatement") => {
+                for case in list_field(statement, "cases") {
+                    self.hoist_vars(list_field(case, "consequent"), function_scope);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn declare_variables(&mut self, declaration: &Value, scope: ScopeId, function_scope: ScopeId) {
+        let (kind, target) = match str_field(declaration, "kind") {
+            Some("var") => (BindingKind::Var, function_scope),
+            Some("let") => (BindingKind::Let, scope),
+            _ => (BindingKind::Const, scope),
+        };
+        for declarator in list_field(declaration, "declarations") {
+            self.declare_pattern(
+                &declarator["id"],
+                target,
+                kind.clone(),
+                "VariableDeclarator",
+            );
+        }
+    }
+
+    /// Register every binding identifier in a pattern.
+    fn declare_pattern(
+        &mut self,
+        pattern: &Value,
+        scope: ScopeId,
+        kind: BindingKind,
+        declaration_type: &str,
+    ) {
+        match node_type(pattern) {
+            Some("Identifier") => self.declare(pattern, scope, kind, declaration_type, None),
+            Some("ObjectPattern") => {
+                for property in list_field(pattern, "properties") {
+                    match node_type(property) {
+                        Some("RestElement") => {
+                            self.declare_pattern(
+                                &property["argument"],
+                                scope,
+                                kind.clone(),
+                                declaration_type,
+                            );
+                        }
+                        _ => self.declare_pattern(
+                            &property["value"],
+                            scope,
+                            kind.clone(),
+                            declaration_type,
+                        ),
+                    }
+                }
+            }
+            Some("ArrayPattern") => {
+                for element in list_field(pattern, "elements") {
+                    if !element.is_null() {
+                        self.declare_pattern(element, scope, kind.clone(), declaration_type);
+                    }
+                }
+            }
+            Some("AssignmentPattern") => {
+                self.declare_pattern(&pattern["left"], scope, kind, declaration_type)
+            }
+            Some("RestElement") => {
+                self.declare_pattern(&pattern["argument"], scope, kind, declaration_type)
+            }
+            _ => {}
+        }
+    }
+
+    /// Visit the expressions inside a pattern: defaults and computed keys.
+    fn visit_pattern_expressions(&mut self, pattern: &Value, scope: ScopeId) {
+        match node_type(pattern) {
+            Some("ObjectPattern") => {
+                for property in list_field(pattern, "properties") {
+                    match node_type(property) {
+                        Some("RestElement") => {
+                            self.visit_pattern_expressions(&property["argument"], scope)
+                        }
+                        _ => {
+                            if bool_field(property, "computed") {
+                                self.visit_expression(&property["key"], scope);
+                            }
+                            self.visit_pattern_expressions(&property["value"], scope);
+                        }
+                    }
+                }
+            }
+            Some("ArrayPattern") => {
+                for element in list_field(pattern, "elements") {
+                    if !element.is_null() {
+                        self.visit_pattern_expressions(element, scope);
+                    }
+                }
+            }
+            Some("AssignmentPattern") => {
+                self.visit_pattern_expressions(&pattern["left"], scope);
+                self.visit_expression(&pattern["right"], scope);
+            }
+            Some("RestElement") => self.visit_pattern_expressions(&pattern["argument"], scope),
+            _ => {}
+        }
+    }
+
+    /// A pattern in assignment position: every identifier is a reference.
+    fn visit_assignment_target(&mut self, target: &Value, scope: ScopeId) {
+        match node_type(target) {
+            Some("Identifier") => self.reference(target, scope),
+            Some("ObjectPattern") => {
+                for property in list_field(target, "properties") {
+                    match node_type(property) {
+                        Some("RestElement") => {
+                            self.visit_assignment_target(&property["argument"], scope)
+                        }
+                        _ => {
+                            if bool_field(property, "computed") {
+                                self.visit_expression(&property["key"], scope);
+                            }
+                            self.visit_assignment_target(&property["value"], scope);
+                        }
+                    }
+                }
+            }
+            Some("ArrayPattern") => {
+                for element in list_field(target, "elements") {
+                    if !element.is_null() {
+                        self.visit_assignment_target(element, scope);
+                    }
+                }
+            }
+            Some("AssignmentPattern") => {
+                self.visit_assignment_target(&target["left"], scope);
+                self.visit_expression(&target["right"], scope);
+            }
+            Some("RestElement") => self.visit_assignment_target(&target["argument"], scope),
+            _ => self.visit_expression(target, scope),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Statements
+    // ------------------------------------------------------------------
+
+    fn visit_statements(&mut self, statements: &[Value], scope: ScopeId, function_scope: ScopeId) {
+        for statement in statements {
+            self.visit_statement(statement, scope, function_scope);
+        }
+    }
+
+    fn visit_block(&mut self, block: &Value, parent: ScopeId, function_scope: ScopeId) {
+        let scope = self.enter(block, ScopeKind::Block, Some(parent));
+        self.hoist_statements(list_field(block, "body"), scope, function_scope);
+        self.visit_statements(list_field(block, "body"), scope, function_scope);
+    }
+
+    fn visit_statement(&mut self, statement: &Value, scope: ScopeId, function_scope: ScopeId) {
+        match node_type(statement) {
+            Some("ExpressionStatement") => self.visit_expression(&statement["expression"], scope),
+            Some("VariableDeclaration") => {
+                for declarator in list_field(statement, "declarations") {
+                    self.visit_pattern_expressions(&declarator["id"], scope);
+                    self.visit_expression(&declarator["init"], scope);
+                }
+            }
+            Some("FunctionDeclaration") => self.visit_function(statement, scope),
+            Some("ClassDeclaration" | "ClassExpression") => self.visit_class(statement, scope),
+            Some("ReturnStatement" | "ThrowStatement") => {
+                self.visit_expression(&statement["argument"], scope)
+            }
+            Some("BlockStatement") => self.visit_block(statement, scope, function_scope),
+            Some("StaticBlock") => {
+                let inner = self.enter(statement, ScopeKind::Block, Some(scope));
+                self.hoist_statements(list_field(statement, "body"), inner, inner);
+                self.visit_statements(list_field(statement, "body"), inner, inner);
+            }
+            Some("IfStatement") => {
+                self.visit_expression(&statement["test"], scope);
+                self.visit_statement(&statement["consequent"], scope, function_scope);
+                self.visit_statement(&statement["alternate"], scope, function_scope);
+            }
+            Some("ForStatement") => {
+                let inner = self.enter(statement, ScopeKind::For, Some(scope));
+                let init = &statement["init"];
+                if node_type(init) == Some("VariableDeclaration") {
+                    if str_field(init, "kind") != Some("var") {
+                        self.declare_variables(init, inner, function_scope);
+                    }
+                    self.visit_statement(init, inner, function_scope);
+                } else {
+                    self.visit_expression(init, inner);
+                }
+                self.visit_expression(&statement["test"], inner);
+                self.visit_expression(&statement["update"], inner);
+                self.visit_statement(&statement["body"], inner, function_scope);
+            }
+            Some("ForInStatement" | "ForOfStatement") => {
+                let inner = self.enter(statement, ScopeKind::For, Some(scope));
+                let left = &statement["left"];
+                if node_type(left) == Some("VariableDeclaration") {
+                    if str_field(left, "kind") != Some("var") {
+                        self.declare_variables(left, inner, function_scope);
+                    }
+                    self.visit_statement(left, inner, function_scope);
+                } else {
+                    self.visit_assignment_target(left, inner);
+                }
+                self.visit_expression(&statement["right"], inner);
+                self.visit_statement(&statement["body"], inner, function_scope);
+            }
+            Some("WhileStatement") => {
+                self.visit_expression(&statement["test"], scope);
+                self.visit_statement(&statement["body"], scope, function_scope);
+            }
+            Some("DoWhileStatement") => {
+                self.visit_statement(&statement["body"], scope, function_scope);
+                self.visit_expression(&statement["test"], scope);
+            }
+            Some("LabeledStatement") => {
+                self.visit_statement(&statement["body"], scope, function_scope)
+            }
+            Some("WithStatement") => {
+                self.visit_expression(&statement["object"], scope);
+                self.visit_statement(&statement["body"], scope, function_scope);
+            }
+            Some("SwitchStatement") => {
+                self.visit_expression(&statement["discriminant"], scope);
+                let inner = self.enter(statement, ScopeKind::Switch, Some(scope));
+                for case in list_field(statement, "cases") {
+                    self.hoist_statements(list_field(case, "consequent"), inner, function_scope);
+                }
+                for case in list_field(statement, "cases") {
+                    self.visit_expression(&case["test"], inner);
+                    self.visit_statements(list_field(case, "consequent"), inner, function_scope);
+                }
+            }
+            Some("TryStatement") => {
+                self.visit_statement(&statement["block"], scope, function_scope);
+                let handler = &statement["handler"];
+                if !handler.is_null() {
+                    let inner = self.enter(handler, ScopeKind::Catch, Some(scope));
+                    if !handler["param"].is_null() {
+                        self.declare_pattern(
+                            &handler["param"],
+                            inner,
+                            BindingKind::Let,
+                            "CatchClause",
+                        );
+                        self.visit_pattern_expressions(&handler["param"], inner);
+                    }
+                    self.visit_statement(&handler["body"], inner, function_scope);
+                }
+                self.visit_statement(&statement["finalizer"], scope, function_scope);
+            }
+            Some("ExportNamedDeclaration") => {
+                let declaration = &statement["declaration"];
+                if !declaration.is_null() {
+                    self.visit_statement(declaration, scope, function_scope);
+                }
+                if statement["source"].is_null() {
+                    for specifier in list_field(statement, "specifiers") {
+                        if node_type(specifier) == Some("ExportSpecifier") {
+                            self.reference(&specifier["local"], scope);
+                        }
+                    }
+                }
+            }
+            Some("ExportDefaultDeclaration") => {
+                let declaration = &statement["declaration"];
+                match node_type(declaration) {
+                    Some("FunctionDeclaration") => self.visit_function(declaration, scope),
+                    Some("ClassDeclaration") => self.visit_class(declaration, scope),
+                    _ => self.visit_expression(declaration, scope),
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Functions and classes
+    // ------------------------------------------------------------------
+
+    fn visit_function(&mut self, function: &Value, parent: ScopeId) {
+        let scope = self.enter(function, ScopeKind::Function, Some(parent));
+        if node_type(function) == Some("FunctionExpression") && !function["id"].is_null() {
+            self.declare(
+                &function["id"],
+                scope,
+                BindingKind::Local,
+                "FunctionExpression",
+                None,
+            );
+        }
+        for param in list_field(function, "params") {
+            let declaration_type = node_type(param).unwrap_or("Identifier").to_owned();
+            self.declare_pattern(param, scope, BindingKind::Param, &declaration_type);
+        }
+        let body = &function["body"];
+        if node_type(body) == Some("BlockStatement") {
+            self.hoist_statements(list_field(body, "body"), scope, scope);
+        }
+        for param in list_field(function, "params") {
+            self.visit_pattern_expressions(param, scope);
+        }
+        if node_type(body) == Some("BlockStatement") {
+            self.visit_statements(list_field(body, "body"), scope, scope);
+        } else {
+            self.visit_expression(body, scope);
+        }
+    }
+
+    fn visit_class(&mut self, class: &Value, parent: ScopeId) {
+        self.visit_expression(&class["superClass"], parent);
+        let scope = self.enter(class, ScopeKind::Class, Some(parent));
+        if node_type(class) == Some("ClassExpression") && !class["id"].is_null() {
+            self.declare(
+                &class["id"],
+                scope,
+                BindingKind::Local,
+                "ClassExpression",
+                None,
+            );
+        }
+        for member in list_field(&class["body"], "body") {
+            match node_type(member) {
+                Some("ClassMethod" | "ClassPrivateMethod") => {
+                    if bool_field(member, "computed") {
+                        self.visit_expression(&member["key"], scope);
+                    }
+                    self.visit_function(member, scope);
+                }
+                Some("ClassProperty" | "ClassPrivateProperty") => {
+                    if bool_field(member, "computed") {
+                        self.visit_expression(&member["key"], scope);
+                    }
+                    self.visit_expression(&member["value"], scope);
+                }
+                Some("StaticBlock") => self.visit_statement(member, scope, scope),
+                _ => {}
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Expressions
+    // ------------------------------------------------------------------
+
+    fn visit_expressions(&mut self, expressions: &[Value], scope: ScopeId) {
+        for expression in expressions {
+            self.visit_expression(expression, scope);
+        }
+    }
+
+    fn visit_expression(&mut self, expression: &Value, scope: ScopeId) {
+        if expression.is_null() {
+            return;
+        }
+        match node_type(expression) {
+            Some("Identifier") => self.reference(expression, scope),
+            Some("ArrowFunctionExpression" | "FunctionExpression") => {
+                self.visit_function(expression, scope)
+            }
+            Some("ClassExpression") => self.visit_class(expression, scope),
+            Some("MemberExpression" | "OptionalMemberExpression") => {
+                self.visit_expression(&expression["object"], scope);
+                if bool_field(expression, "computed") {
+                    self.visit_expression(&expression["property"], scope);
+                }
+            }
+            Some("CallExpression" | "OptionalCallExpression" | "NewExpression") => {
+                self.visit_expression(&expression["callee"], scope);
+                self.visit_expressions(list_field(expression, "arguments"), scope);
+            }
+            Some("AssignmentExpression") => {
+                self.visit_assignment_target(&expression["left"], scope);
+                self.visit_expression(&expression["right"], scope);
+            }
+            Some("UpdateExpression") => {
+                self.visit_assignment_target(&expression["argument"], scope)
+            }
+            Some("ObjectExpression") => {
+                for property in list_field(expression, "properties") {
+                    match node_type(property) {
+                        Some("SpreadElement") => {
+                            self.visit_expression(&property["argument"], scope)
+                        }
+                        Some("ObjectMethod") => {
+                            if bool_field(property, "computed") {
+                                self.visit_expression(&property["key"], scope);
+                            }
+                            self.visit_function(property, scope);
+                        }
+                        _ => {
+                            if bool_field(property, "computed") {
+                                self.visit_expression(&property["key"], scope);
+                            }
+                            self.visit_expression(&property["value"], scope);
+                        }
+                    }
+                }
+            }
+            Some("ArrayExpression") => {
+                for element in list_field(expression, "elements") {
+                    self.visit_expression(element, scope);
+                }
+            }
+            Some("TemplateLiteral") => {
+                self.visit_expressions(list_field(expression, "expressions"), scope)
+            }
+            Some("TaggedTemplateExpression") => {
+                self.visit_expression(&expression["tag"], scope);
+                self.visit_expression(&expression["quasi"], scope);
+            }
+            Some("JSXElement") => {
+                self.visit_jsx_name(&expression["openingElement"]["name"], scope);
+                for attribute in list_field(&expression["openingElement"], "attributes") {
+                    match node_type(attribute) {
+                        Some("JSXSpreadAttribute") => {
+                            self.visit_expression(&attribute["argument"], scope)
+                        }
+                        _ => self.visit_expression(&attribute["value"], scope),
+                    }
+                }
+                self.visit_expressions(list_field(expression, "children"), scope);
+            }
+            Some("JSXFragment") => {
+                self.visit_expressions(list_field(expression, "children"), scope)
+            }
+            Some("JSXExpressionContainer" | "JSXSpreadChild") => {
+                self.visit_expression(&expression["expression"], scope);
+            }
+            Some("SpreadElement" | "AwaitExpression" | "YieldExpression" | "UnaryExpression") => {
+                self.visit_expression(&expression["argument"], scope);
+            }
+            Some("ParenthesizedExpression") => {
+                self.visit_expression(&expression["expression"], scope)
+            }
+            Some("BinaryExpression" | "LogicalExpression") => {
+                self.visit_expression(&expression["left"], scope);
+                self.visit_expression(&expression["right"], scope);
+            }
+            Some("ConditionalExpression") => {
+                self.visit_expression(&expression["test"], scope);
+                self.visit_expression(&expression["consequent"], scope);
+                self.visit_expression(&expression["alternate"], scope);
+            }
+            Some("SequenceExpression") => {
+                self.visit_expressions(list_field(expression, "expressions"), scope)
+            }
+            Some("AssignmentPattern") => {
+                self.visit_assignment_target(&expression["left"], scope);
+                self.visit_expression(&expression["right"], scope);
+            }
+            Some("ObjectPattern" | "ArrayPattern" | "RestElement") => {
+                self.visit_assignment_target(expression, scope)
+            }
+            _ => {}
+        }
+    }
+
+    /// `<Foo>` and `<Foo.Bar>` reference `Foo`; `<div>` and `<foo:bar>` do not.
+    fn visit_jsx_name(&mut self, name: &Value, scope: ScopeId) {
+        match node_type(name) {
+            Some("JSXIdentifier") => {
+                if str_field(name, "name")
+                    .is_some_and(|text| text.chars().next().is_some_and(char::is_uppercase))
+                {
+                    self.reference(name, scope);
+                }
+            }
+            Some("JSXMemberExpression") => {
+                let mut object = &name["object"];
+                while node_type(object) == Some("JSXMemberExpression") {
+                    object = &object["object"];
+                }
+                self.reference(object, scope);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estree::parse;
+    use crate::lower;
+
+    fn analyzed(source: &str) -> (Value, ScopeInfo) {
+        let mut program = parse(source).unwrap();
+        lower::lower(&mut program, source).unwrap();
+        let file = crate::babel::to_babel(program, source).unwrap();
+        let info = analyze(&file);
+        (file, info)
+    }
+
+    fn binding_names(info: &ScopeInfo, scope: ScopeId) -> Vec<String> {
+        let mut names: Vec<String> = info.scopes[scope.0 as usize]
+            .bindings
+            .keys()
+            .cloned()
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn imports_and_top_level_declarations_live_in_the_program_scope() {
+        let (_, info) = analyzed(
+            "import {a} from 'a';\nimport b from 'b';\nconst c = 1;\nfunction d() {}\nclass E {}\n",
+        );
+        assert_eq!(binding_names(&info, ScopeId(0)), ["E", "a", "b", "c", "d"]);
+        let a = &info.bindings[info.scopes[0].bindings["a"].0 as usize];
+        assert!(matches!(a.kind, BindingKind::Module));
+        assert_eq!(a.import.as_ref().unwrap().source, "a");
+        assert_eq!(a.import.as_ref().unwrap().imported.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn var_hoists_to_the_function_and_let_stays_in_its_block() {
+        let (_, info) = analyzed("function f() { if (x) { var v = 1; let l = 2; } }\n");
+        let function = info
+            .scopes
+            .iter()
+            .find(|scope| matches!(scope.kind, ScopeKind::Function))
+            .unwrap();
+        assert_eq!(binding_names(&info, function.id), ["v"]);
+        let block = info
+            .scopes
+            .iter()
+            .find(|scope| matches!(scope.kind, ScopeKind::Block))
+            .unwrap();
+        assert_eq!(binding_names(&info, block.id), ["l"]);
+    }
+
+    #[test]
+    fn references_resolve_to_the_nearest_declaration() {
+        let (file, info) = analyzed("const n = 1;\nfunction f(n) { return n + m; }\n");
+        let function = &file["program"]["body"][1];
+        let returned = &function["body"]["body"][0]["argument"];
+        let inner_n = node_id(&returned["left"]).unwrap();
+        let m = node_id(&returned["right"]).unwrap();
+        let binding = info.ref_node_id_to_binding[&inner_n];
+        assert!(matches!(
+            info.bindings[binding.0 as usize].kind,
+            BindingKind::Param
+        ));
+        assert!(
+            !info.ref_node_id_to_binding.contains_key(&m),
+            "a global resolves to nothing"
+        );
+    }
+
+    #[test]
+    fn property_keys_and_member_names_are_not_references() {
+        let (file, info) = analyzed("const a = 1;\nconst o = { a: a.a };\n");
+        let property = &file["program"]["body"][1]["declarations"][0]["init"]["properties"][0];
+        let key = node_id(&property["key"]).unwrap();
+        let member_name = node_id(&property["value"]["property"]).unwrap();
+        let object = node_id(&property["value"]["object"]).unwrap();
+        assert!(!info.ref_node_id_to_binding.contains_key(&key));
+        assert!(!info.ref_node_id_to_binding.contains_key(&member_name));
+        assert!(info.ref_node_id_to_binding.contains_key(&object));
+    }
+
+    #[test]
+    fn a_component_s_scope_is_keyed_by_its_node() {
+        let (file, info) = analyzed(
+            "component App(title: string) { return <Title>{title}</Title>; }\nconst Title = null;\n",
+        );
+        let function = &file["program"]["body"][0];
+        let scope = info.resolve_scope_for_node(node_id(function)).unwrap();
+        assert!(matches!(
+            info.scopes[scope.0 as usize].kind,
+            ScopeKind::Function
+        ));
+        assert_eq!(binding_names(&info, scope), ["title"]);
+        let jsx = &function["body"]["body"][0]["argument"]["openingElement"]["name"];
+        assert!(
+            info.ref_node_id_to_binding
+                .contains_key(&node_id(jsx).unwrap())
+        );
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,7 @@ integrated feature coverage.
 - `uf_runtime`: Capability JS Host, WinterTC, and deploy-anywhere runtime contract
 - `uf_std`: native stdlib modules for WinterTC-compatible Flow wrappers
 - `uf_test`: native test discovery, scheduling, watch invalidation, and runner core
+- `uf_transform`: Flow → JavaScript — official parser, Flow's lowering rules, the official React Compiler, oxc for JSX and code generation
 - `uf_tui`: OpenTUI-compatible native TUI framework contracts
 
 These are the crates that survive. `uf` used to ship a Rust crate per library
@@ -121,6 +122,43 @@ the submodule has charged: `cargo fmt --all` visiting vendored code, every CI jo
 needing `tools/upstream/sync.sh` before cargo will parse the workspace at all,
 and the `include_str!` paths reaching outside `rust_port`. The trade is that the
 built code and the readable checkout stop being the same bytes by construction.
+
+## Flow To JavaScript
+
+Every host runs JavaScript, and `uf` projects are Flow. `uf_transform` is the
+one place that turns one into the other, and it is assembled from the code
+that owns each step rather than from anything `uf` invented. There is no Babel
+in the pipeline.
+
+| Step | Implementation |
+| --- | --- |
+| Parse | Meta's Flow Rust port (`flow_parser`), rendered as ESTree by its own translator |
+| Lower `component`/`hook`, `match`, enums; erase types | Ports of `hermes-parser`'s `TransformComponentSyntax`, `TransformMatchSyntax`, `TransformEnumSyntax` and `StripFlowTypes` — the rules Flow's own toolchain applies |
+| Babel AST + scopes | A port of `hermes-parser`'s `TransformESTreeToBabel`, plus a scope analysis in Babel's terms, because that is the contract the compiler consumes |
+| React Compiler | The official Rust implementation (`react_compiler` on crates.io) in `syntax` mode: only `component` and `hook` declarations are memoised |
+| JSX, Fast Refresh, code generation, source maps | oxc — the engine inside Vite and Rolldown — so a module is byte-identical whether Vite or `uf test` asked for it |
+
+The output is the JavaScript Flow documents: a `match` becomes the
+`typeof x === "object" && x !== null` and `"k" in x` tests Flow specifies, a
+`component Foo(a: A, ...rest: R)` becomes `function Foo({ a, ...rest })`, and
+an enum becomes a frozen object with the `flow-enums-runtime` contract
+(`cast`, `isValid`, `members`, `getName`), with the runtime prepended to the
+module so no import is needed.
+
+`uf transform` serves this as a long-lived process: newline-delimited JSON in,
+replies in request order out. `@uniflowed/vite`, the Node loader hook and the
+Bun preload all speak that protocol, and every one of them applies the same
+module policy first (`is_flow_module`): project `.js` files and `@uniflowed/*`
+under `node_modules` are uf's to transform, a third-party dependency is not,
+and a build driver's own virtual modules never are.
+
+Source maps point at the Flow source. The printer records a mapping for every
+node the author wrote and none for nodes the compiler or the lowering passes
+invented, and oxc's map over the printed text is composed with those, so a
+debugger lands on the author's line or nowhere — never on the wrong line.
+
+The compiler's panic threshold is `none`: a function it cannot compile is left
+as written and reported as a diagnostic on the reply, never a failed build.
 
 ## Type Checking
 


### PR DESCRIPTION
Flow becomes JavaScript in one Rust crate, `uf_transform`, and nothing in it is a grammar uf invented. There is no Babel anywhere.

| Step | Implementation |
| --- | --- |
| Parse | Meta's Flow Rust port (`flow_parser`), rendered as ESTree by its own translator |
| Lower `component`/`hook`, `match`, enums; erase types | Line-by-line ports of `hermes-parser`'s `TransformComponentSyntax`, `TransformMatchSyntax`, `TransformEnumSyntax`, `StripFlowTypes` — the rules Flow's own toolchain applies |
| Babel AST + scopes | Port of `TransformESTreeToBabel` plus a scope analysis in Babel's terms, which is the contract the compiler consumes |
| React Compiler | The **official Rust implementation** (`react_compiler` on crates.io) in `syntax` mode — only `component`/`hook` declarations are memoised, detected through the `__componentDeclaration`/`__hookDeclaration` flags the lowering sets, exactly as the Hermes front end does upstream |
| JSX, Fast Refresh, codegen, source maps | oxc, the engine inside Vite and Rolldown |

## What comes out

```js
// in
export component Toggle(label: string) {
  const [mode, setMode] = useState<Mode>(Mode.On);
  const text = match (mode) { Mode.On => 'on', Mode.Off => 'off' };
  return <button onClick={() => setMode(Mode.Off)}>{label}: {text}</button>;
}
```

comes out with `function Toggle({ label })`, the `match` as `mode === Mode.On ? "on" : mode === Mode.Off ? "off" : (() => { throw … })()`, the enum as a frozen object with the `flow-enums-runtime` contract inlined, the component memoised by the React Compiler (`react/compiler-runtime`), JSX as `jsx()` from `react/jsx-runtime` (`jsxDEV` + `$RefreshReg$` in development), and a source map that points at the Flow source.

## `uf transform`

The service from #57 keeps its shape (NDJSON, replies in order) and now runs this pipeline. Requests may carry `options: { development, refresh, sourceMap }`; replies carry `map` and the compiler's `diagnostics`, and an error carries its `line`/`column`. The service runs on a 512 MiB-stack thread so a pathological module fails with a message rather than a stack overflow.

The module policy (`is_flow_module`) lives in the crate: project `.js` and `@uniflowed/*` under `node_modules` are transformed, third-party dependencies and a driver's virtual modules are not.

## Guarantees and tests

- 57 unit tests across the stages: each lowering pass against the shapes the parser really emits, the Babel conversion round-trips into `react_compiler_ast::File`, scope analysis (hoisting, block scopes, parameters, JSX names, non-reference positions), the compiler compiling a component and leaving a plain function alone, the printer's bracketing decided by precedence alone (`(a ?? b) || c`, `new (g())()`, `(1).toString()`, `(a?.b).c`, `({ x } = y)`) and re-parsed by the official parser, and source maps composed back to Flow columns in UTF-16 code units.
- 7 integration tests drive the `uf transform` binary the way a plugin does.
- Every input has a ceiling: source size, tree depth.

## Known gaps (follow-ups)

- Comments are not carried into the output (minifiers drop them anyway; license comments will be preserved in a follow-up).
- `ref` is treated as an ordinary prop (React 19 semantics); no `forwardRef` wrapper for React 18 targets.
- `uf build`/`uf dev` still run the old Rolldown bundler and Rust dev server; the next PR in the stack routes them through Vite with `@uniflowed/vite` piping every module through this service, and deletes `uf_bundler`, `uf_devserver` and `uf_jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791007808&installation_model_id=422833&pr_number=68&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F68&signature=58e1ac4a3e0dfb1bcab56e3eaa9cfadc306ad8f0f02f2367d494a1f3621f14a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete Flow-to-JavaScript transformation pipeline.
  * Added support for lowering components, hooks, enums, `match`, JSX, and Flow types.
  * Added React Compiler integration and development-mode Fast Refresh support.
  * Added source map generation and improved syntax and transformation diagnostics.
  * `uf transform` now uses the new transformation pipeline with configurable output options.

* **Documentation**
  * Documented the transformation pipeline and architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->