### PR TITLE
ci(semver): exclude uf_fmt, which now reaches the submodule

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -34,10 +34,12 @@ jobs:
           # submodule no longer resolves. A path dependency is relative by
           # definition, so this is not something a crate can fix.
           #
-          # `uf_flow`, `uf_check` and `uf_transform` name the submodule; the other two reach it
-          # transitively, and cargo resolves a path dependency whether or not the
-          # feature using it is enabled. Excluding them keeps 37 of 43 crates
-          # gated, which is worth more than switching the gate off.
+          # `uf_flow`, `uf_check` and `uf_transform` name the submodule; the
+          # other three reach it transitively, and cargo resolves a path
+          # dependency whether or not the feature using it is enabled.
+          # Excluding them keeps most crates gated, which is worth more than
+          # switching the gate off. `uf_fmt` joined the list when the
+          # formatter started printing from the parser's syntax tree.
           #
           # Only a version change rebuilds the baseline outside the workspace,
           # so a crate missing from this list passes every PR until a release
@@ -46,4 +48,4 @@ jobs:
           #
           # The list grows as more crates use the parser. See
           # docs/architecture.md for what to do when it covers too little.
-          exclude: uf_check,uf_cli,uf_flow,uf_lint,uf_transform
+          exclude: uf_check,uf_cli,uf_flow,uf_fmt,uf_lint,uf_transform

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,10 +108,11 @@ copy of each crate, outside the workspace, where the relative path to
 `upstream/flow` no longer resolves — and a path dependency is relative by
 definition, so no crate can fix it from its own manifest.
 
-Five crates are excluded from that check: `uf_flow`, `uf_check` and
-`uf_transform` name the submodule, and `uf_cli` and `uf_lint` reach it
-transitively, because cargo resolves a path dependency whether or not the
-feature using it is enabled. That leaves most crates gated, which is worth more
+Six crates are excluded from that check: `uf_flow`, `uf_check` and
+`uf_transform` name the submodule, and `uf_cli`, `uf_fmt` and `uf_lint` reach
+it transitively, because cargo resolves a path dependency whether or not the
+feature using it is enabled. `uf_fmt` joined them when the formatter started
+printing from the parser's syntax tree. That leaves most crates gated, which is worth more
 than switching the gate off — but the list grows as more crates use the parser,
 and it already includes three of the more interesting public APIs.
 


### PR DESCRIPTION
`Cargo Semver Checks` has been red since #70: the formatter now prints from
the parser's syntax tree, so `uf_fmt` depends on `uf_flow`, and
`cargo-semver-checks` builds each crate from a copy outside the workspace
where the relative path to `upstream/flow` no longer resolves.

```
error: running 'cargo update' on crate 'uf_fmt' failed with output:
error: no matching package named `flow_parser` found
required by package `uf_flow v0.0.0-alpha.0 (…/semver-checks/…/crates/uf_flow)`
```

This is exactly the growth the exclude list's own comment predicted — "the
list grows as more crates use the parser" — so `uf_fmt` joins it, and the
architecture note that counts the excluded crates is updated to match.

The gate still covers every crate that does not reach the submodule. If it
ever covers too little, `docs/architecture.md` says what to do instead: make
the upstream dependency a rev-pinned git dependency, which cargo resolves
from any directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791024102&installation_model_id=422833&pr_number=73&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F73&signature=8b45c6b23af5113ca5fa22dd728aea1cd81095b5f989e432fc38fc266e868fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->