### PR TITLE
chore(release): 0.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,7 +3292,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "brotli",
  "camino",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "compact_str",
  "dupe",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "compact_str",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "criterion",
  "memchr",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "compact_str",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "criterion",
  "phf",
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "compact_str",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "compact_str",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "compact_str",
  "serde",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "tempfile",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "compact_str",
  "serde",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "compact_str",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "compact_str",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "serde",
  "smallvec",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3600,14 +3600,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "camino",
  "compact_str",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.0"
+version = "0.0.0-alpha.1"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/crates/uf_cli/tests/workflow.rs
+++ b/crates/uf_cli/tests/workflow.rs
@@ -108,13 +108,21 @@ fn publish_and_release_report_trusted_publish_plan() {
         String::from_utf8_lossy(&release.stderr)
     );
     let stdout = String::from_utf8(release.stdout).unwrap();
-    // `uf release` bumps this crate's own version, so a literal tag here fails
-    // on the next version bump rather than when the plan is wrong. The bump
-    // arithmetic is pinned by the unit tests next to `bump_semver`.
+    // `uf release` bumps this crate's own version, so a literal tag here would
+    // fail on the next version bump rather than when the plan is wrong. The
+    // bump arithmetic itself is pinned by the unit tests next to
+    // `bump_semver`; this only has to predict the same answer for whatever
+    // version the workspace is on right now — including one that is already a
+    // prerelease, which the previous `strip_suffix(".0")` got wrong the first
+    // time a release moved off `0.0.0-alpha.0`.
     let current = env!("CARGO_PKG_VERSION");
-    let expected = current
-        .strip_suffix(".0")
-        .map_or(format!("{current}-alpha.0"), |prefix| format!("{prefix}.1"));
+    let expected = match current.split_once("-alpha.") {
+        Some((core, count)) => {
+            let count: u64 = count.parse().expect("the alpha count is numeric");
+            format!("{core}-alpha.{}", count + 1)
+        }
+        None => format!("{current}-alpha.0"),
+    };
     assert!(stdout.contains("bump             Alpha"));
     assert!(stdout.contains(&format!("tag              uf@{expected}")));
     assert!(stdout.contains("command          uf release alpha"));

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.0",
-    "@uniflowed/config": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0",
-    "@uniflowed/router": "0.0.0-alpha.0",
-    "@uniflowed/vite": "0.0.0-alpha.0",
-    "@uniflowed/web": "0.0.0-alpha.0",
+    "@uniflowed/brand": "0.0.0-alpha.1",
+    "@uniflowed/config": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1",
+    "@uniflowed/router": "0.0.0-alpha.1",
+    "@uniflowed/vite": "0.0.0-alpha.1",
+    "@uniflowed/web": "0.0.0-alpha.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.0",
-        "@uniflowed/config": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0",
-        "@uniflowed/router": "0.0.0-alpha.0",
-        "@uniflowed/vite": "0.0.0-alpha.0",
-        "@uniflowed/web": "0.0.0-alpha.0",
+        "@uniflowed/brand": "0.0.0-alpha.1",
+        "@uniflowed/config": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1",
+        "@uniflowed/router": "0.0.0-alpha.1",
+        "@uniflowed/vite": "0.0.0-alpha.1",
+        "@uniflowed/web": "0.0.0-alpha.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -3683,183 +3683,183 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/fetch": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/fetch": "0.0.0-alpha.1"
       }
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.0",
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/fetch": "0.0.0-alpha.0"
+        "@uniflowed/cell": "0.0.0-alpha.1",
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/fetch": "0.0.0-alpha.1"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.0",
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/config": "0.0.0-alpha.1",
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -3867,50 +3867,50 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.0",
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/config": "0.0.0-alpha.1",
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -3919,104 +3919,104 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.0"
+        "@uniflowed/cell": "0.0.0-alpha.1"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.0",
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/mock": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/browser": "0.0.0-alpha.1",
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/mock": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.0",
-        "@uniflowed/test": "0.0.0-alpha.0"
+        "@uniflowed/react-testing": "0.0.0-alpha.1",
+        "@uniflowed/test": "0.0.0-alpha.1"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0",
-        "@uniflowed/validator": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1",
+        "@uniflowed/validator": "0.0.0-alpha.1"
       }
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
@@ -4033,20 +4033,20 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.0",
-        "@uniflowed/core": "0.0.0-alpha.0"
+        "@uniflowed/browser": "0.0.0-alpha.1",
+        "@uniflowed/core": "0.0.0-alpha.1"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.0",
-        "@uniflowed/react": "0.0.0-alpha.0"
+        "@uniflowed/core": "0.0.0-alpha.1",
+        "@uniflowed/react": "0.0.0-alpha.1"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow implementation for @uniflowed/cell, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/graphql, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/fetch": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/fetch": "0.0.0-alpha.1"
   }
 }

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/hooks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/cell": "0.0.0-alpha.0",
-    "@uniflowed/fetch": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/cell": "0.0.0-alpha.1",
+    "@uniflowed/fetch": "0.0.0-alpha.1"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/mock, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.0",
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/config": "0.0.0-alpha.1",
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/query, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/react-testing, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/relay, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.0",
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/config": "0.0.0-alpha.1",
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/server, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.0"
+    "@uniflowed/cell": "0.0.0-alpha.1"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/story, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,9 +17,9 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.0",
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/mock": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/browser": "0.0.0-alpha.1",
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/mock": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.0",
-    "@uniflowed/test": "0.0.0-alpha.0"
+    "@uniflowed/react-testing": "0.0.0-alpha.1",
+    "@uniflowed/test": "0.0.0-alpha.1"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/tui, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/ui, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,8 +23,8 @@
     "types/renders.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0",
-    "@uniflowed/validator": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1",
+    "@uniflowed/validator": "0.0.0-alpha.1"
   }
 }

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow implementation for @uniflowed/validator, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.0",
-    "@uniflowed/core": "0.0.0-alpha.0"
+    "@uniflowed/browser": "0.0.0-alpha.1",
+    "@uniflowed/core": "0.0.0-alpha.1"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0-alpha.1",
   "description": "Flow declarations for @uniflowed/web, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.0",
-    "@uniflowed/react": "0.0.0-alpha.0"
+    "@uniflowed/core": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
   }
 }


### PR DESCRIPTION
Five things landed since `0.0.0-alpha.0`, and none of them are in a release yet:

- **Flow to JavaScript without Babel** (#68) — the official Flow parser, ports of Hermes' lowering passes, the official React Compiler crate and oxc, in one Rust pipeline.
- **Vite as the dev server and the build** (#57, #69) — driven from Rust over a JSON protocol, not forked.
- **A Prettier-compatible Flow formatter** (#70, #71) — the official parser and a Rust printer; 7.8 MB/s end to end, with the parse measured beside the format.
- **A test runner that runs the tests** (#72) — Rust owns discovery, ordering, the pool and the report; the host runs the bodies. About 9× Vitest, about a third of Bun.
- **A documentation site** (#74) — twelve pages of guide and reference, built by `uf build` from Flow and MDX.

`tools/release/bump-version.sh 0.0.0-alpha.1` set the workspace version, every `packages/*/package.json` and its pinned `@uniflowed/*` dependencies, and the docs manifest, then refreshed both lockfiles.

Tag `uf@0.0.0-alpha.1` after this merges.

**The npm half will still fail.** `@uniflowed/*` has never been published, and the first publish of a scoped package needs the account's own credentials — the tag-triggered OIDC publish 404s until that happens once by hand. The GitHub release and its binaries are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791026532&installation_model_id=422833&pr_number=75&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F75&signature=8c55d09a542b157b0ecfde1010c86ed15d55d4f86e61bed43ee44ae24c920264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->