### PR TITLE
fix: make install, the scaffold and the dev server actually work

### DIFF
--- a/crates/uf_cli/src/commands/pm.rs
+++ b/crates/uf_cli/src/commands/pm.rs
@@ -6,50 +6,62 @@ use anyhow::{Context, Result, anyhow};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde_json::json;
 use uf_config::load_config;
-use uf_pm::{PackageManagerPlan, install_workspace};
+use uf_pm::{PackageManagerPlan, install_workspace, run_install};
 use uf_rm::{RuntimeManagerPlan, RuntimeReference, RuntimeUsePlan, XdgEnv, XdgLayout};
 use uf_term::{KeyValue, Status, Tone};
 
 use crate::brand;
-use crate::support::{enabled, plural, project_label, write_json_file};
+use crate::support::{enabled, project_label, write_json_file};
 use crate::ui::Ui;
 
+/// `uf install`.
+///
+/// The install itself is done by the package manager that drives the project.
+/// uf's own resolver records what a workspace declares but reaches no registry,
+/// so running it alone would create no `node_modules` and report success — which
+/// is what it used to do. See `uf_pm::run` for why npm stands in when a project
+/// evidences no manager at all.
 pub(crate) fn install(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
-    let mut progress = ui.progress();
-    progress.draw("resolving packages");
     let resolved = load_config(cwd)?;
     let plan = PackageManagerPlan::infer_from_config(&resolved.config);
-    let report = install_workspace(&resolved.root, &resolved.config)?;
-    progress.finish();
-    drop(progress);
 
-    let resolver = format!("{:?}", plan.resolver);
-    let scripts = format!("{:?}", plan.scripts);
-    let lockfile = report.lockfile.to_string();
-    let store = report.store_manifest.to_string();
-    let packages = report.packages.len().to_string();
-    let entries = report.store_entries.len().to_string();
-    let summary = format!("installed {}", plural(report.packages.len(), "package"));
+    // A manifest that declares scripts is refused before anything is fetched,
+    // the way it was when uf planned the install itself. `--ignore-scripts`
+    // below covers the dependencies; this covers the project.
+    install_workspace(&resolved.root, &resolved.config)?;
 
+    // The manager writes to the terminal itself, so nothing of uf's may be on
+    // screen while it runs — including a progress line waiting to be erased.
     ui.render(|renderer, out| {
         brand::render_product_card(renderer, out, "uf install");
         renderer.blank(out);
         renderer.banner(out, "uf install", Some(project_label(&resolved.root)));
         renderer.blank(out);
+    });
+
+    let run = run_install(&resolved.root, !plan.forbids_npm_scripts())?;
+
+    let manager = run.manager.to_string();
+    let command = run.invocation.to_string();
+    let chosen = if run.substituted {
+        "no lockfile or packageManager field; npm".to_owned()
+    } else {
+        format!("{:?}", run.source)
+    };
+
+    ui.render(|renderer, out| {
+        renderer.blank(out);
         renderer.key_values(
             out,
             2,
             &[
-                KeyValue::new("resolver", &resolver),
-                KeyValue::new("scripts", &scripts),
-                KeyValue::toned("lockfile", &lockfile, Tone::Path),
-                KeyValue::toned("store", &store, Tone::Path),
-                KeyValue::toned("packages", &packages, Tone::Number),
-                KeyValue::toned("store entries", &entries, Tone::Number),
+                KeyValue::new("manager", &manager),
+                KeyValue::new("chosen by", &chosen),
+                KeyValue::toned("command", &command, Tone::Path),
             ],
         );
         renderer.blank(out);
-        renderer.status(out, Status::Success, &summary);
+        renderer.status(out, Status::Success, "dependencies installed");
     });
     Ok(())
 }

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -139,7 +139,7 @@ fn ufx_alias_runs_uniflowed_create_package() {
     assert!(stdout.contains("ufx  @uniflowed/create"));
     assert!(stdout.contains("UfNative"));
     assert!(stdout.contains("exec-cache"));
-    assert!(stdout.contains("created 12 files"));
+    assert!(stdout.contains("created 8 files"));
     assert!(dir.path().join("app.js").exists());
     assert!(
         dir.path()
@@ -158,8 +158,8 @@ fn creates_react_app_from_cli() {
     assert!(app.join("app.js").exists());
     assert!(app.join("uf.config.js").exists());
     assert!(app.join("app/_uf.page.js").exists());
-    assert!(app.join("app/_uf.page.native.js").exists());
-    assert!(app.join("server/actions.js").exists());
+    assert!(app.join("app/Counter.js").exists());
+    assert!(app.join("app/useCounter.js").exists());
 
     let package = fs::read_to_string(app.join("package.json")).unwrap();
     assert!(!package.contains(r#""scripts""#));
@@ -167,13 +167,12 @@ fn creates_react_app_from_cli() {
     // The generated files are shown as a tree, not as a flat count.
     assert!(stdout.contains("uf create"));
     assert!(stdout.contains("├─ app"));
-    assert!(stdout.contains("│  ├─ client"));
     assert!(stdout.contains("└─ uf.config.js"));
     assert!(stdout.contains("next steps"));
     assert!(stdout.contains("1. cd app"));
     assert!(stdout.contains("2. uf install"));
     assert!(stdout.contains("3. uf dev"));
-    assert!(stdout.contains("✓ created 12 files"));
+    assert!(stdout.contains("✓ created 8 files"));
 }
 
 #[test]

--- a/crates/uf_cli/tests/output.rs
+++ b/crates/uf_cli/tests/output.rs
@@ -194,12 +194,14 @@ fn install_renders_the_brand_header() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    // This is about how the header renders, not about whether the install
+    // succeeds — uf now really runs a package manager, and a scaffolded project
+    // depends on `@uniflowed/*`, which is not published yet. The header is
+    // printed before the manager is spawned, so it is there either way.
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert_plain(&stdout);
     assert!(stdout.contains("Unified Toolchain for Flow"), "{stdout}");
     assert!(stdout.contains("uf install"), "{stdout}");
-    assert!(stdout.contains("store entries"), "{stdout}");
 }
 
 #[test]
@@ -264,7 +266,7 @@ fn no_color_also_falls_back_to_ascii_glyphs() {
     assert!(stdout.is_ascii(), "NO_COLOR must not print box drawing");
     assert!(stdout.contains("|- app"));
     assert!(stdout.contains("`- uf.config.js"));
-    assert!(stdout.contains("+ created 12 files"));
+    assert!(stdout.contains("+ created 8 files"));
 }
 
 #[test]

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -28,20 +28,37 @@ fn docs_root() -> PathBuf {
 
 /// Whether the fixture can be built here: Node on PATH and the workspace
 /// installed.
+///
+/// A missing fixture is a failure, not a skip. These two tests are the only
+/// thing standing between a broken dev server or build and a release, and when
+/// they skipped themselves they did it silently — cargo hides a passing test's
+/// output, so "1 passed" was printed for a `uf dev` that answered every request
+/// with "Cannot GET /". Set `UF_ALLOW_FIXTURE_SKIP=1` to opt out on a machine
+/// that genuinely cannot run them; CI sets nothing and so can never skip.
 fn fixture_ready() -> bool {
-    let node = Command::new("node")
+    let mut missing = Vec::new();
+    if !Command::new("node")
         .arg("--version")
         .output()
-        .is_ok_and(|o| o.status.success());
-    let installed = docs_root()
-        .join("../node_modules/@uniflowed/vite/driver.js")
-        .is_file();
-    if !node || !installed {
-        eprintln!(
-            "skipping: the docs fixture needs `node` on PATH and `npm ci` at the workspace root"
-        );
+        .is_ok_and(|output| output.status.success())
+    {
+        missing.push("`node` is not on PATH".to_owned());
     }
-    node && installed
+    let driver = docs_root().join("../node_modules/@uniflowed/vite/driver.js");
+    if !driver.is_file() {
+        missing.push(format!("{} does not exist; run `npm ci`", driver.display()));
+    }
+
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        std::env::var_os("UF_ALLOW_FIXTURE_SKIP").is_some(),
+        "the docs fixture is not available, so this test would prove nothing: {}",
+        missing.join("; ")
+    );
+    eprintln!("skipping: {}", missing.join("; "));
+    false
 }
 
 #[test]
@@ -158,11 +175,12 @@ fn dev_serves_the_docs_site_through_vite() {
         return;
     }
     let root = docs_root();
+    let port = free_port();
 
     let mut child = Command::new(uf_path())
         .arg("--cwd")
         .arg(&root)
-        .args(["dev", "--port", "0"])
+        .args(["dev", "--port", &port.to_string()])
         .env_remove("NO_COLOR")
         .env("TERM", "xterm-256color")
         .stdin(Stdio::piped())
@@ -173,30 +191,21 @@ fn dev_serves_the_docs_site_through_vite() {
     let stdout = child.stdout.take().unwrap();
     let server = DevServer(child);
 
-    // Read the banner until the server reports where it listens.
+    // Wait for the port to answer rather than for a line of the banner to look
+    // a particular way. Parsing the rendered banner made this test depend on
+    // colour and on the exact wording, and a parse that quietly found nothing
+    // ended the test before it asserted anything — which is how a dev server
+    // that answered every request with "Cannot GET /" passed it.
     let mut lines = BufReader::new(stdout).lines();
-    let mut url = None;
-    let started = Instant::now();
-    while started.elapsed() < Duration::from_secs(60) {
-        let Some(Ok(line)) = lines.next() else {
-            break;
-        };
-        if let Some(rest) = line.trim().strip_prefix("local") {
-            url = Some(rest.trim().to_owned());
-        }
-        if line.contains("dev server ready") {
-            break;
-        }
-    }
-    let url = url.expect("the dev server reported a local URL");
-    let (host, port) = {
-        let without_scheme = url.trim_start_matches("http://").trim_end_matches('/');
-        let (host, port) = without_scheme.rsplit_once(':').unwrap();
-        (host.to_owned(), port.parse::<u16>().unwrap())
-    };
+    std::thread::spawn(move || while let Some(Ok(_)) = lines.next() {});
 
-    let body = http_get(&host, port, "/");
-    assert!(body.starts_with("HTTP/1.1 200"), "{body}");
+    let body = wait_for_http(port, "/", Duration::from_secs(90))
+        .expect("the dev server never answered on its port");
+
+    assert!(
+        body.starts_with("HTTP/1.1 200"),
+        "the dev server must render the page, not 404:\n{body}"
+    );
     assert!(body.contains("<!doctype html>"), "{body}");
     assert!(
         body.contains("Unified Toolchain for Flow"),
@@ -211,7 +220,40 @@ fn dev_serves_the_docs_site_through_vite() {
         "the refresh preamble was not injected:\n{body}"
     );
 
+    // A nested route proves the router ran, not just that something answered.
+    let guide = http_get("127.0.0.1", port, "/guide/");
+    assert!(guide.starts_with("HTTP/1.1 200"), "{guide}");
+    assert!(guide.contains("What uf is"), "{guide}");
+
+    // And a path with no route must not be answered with somebody else's page.
+    let missing = http_get("127.0.0.1", port, "/definitely-not-a-page/");
+    assert!(
+        missing.starts_with("HTTP/1.1 404"),
+        "an unrouted path must be a 404:\n{missing}"
+    );
+
     drop(server);
+}
+
+/// A port nothing is listening on, released before the server binds it.
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// Poll until the server answers, or give up.
+fn wait_for_http(port: u16, path: &str, budget: Duration) -> Option<String> {
+    let started = Instant::now();
+    while started.elapsed() < budget {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            let body = http_get("127.0.0.1", port, path);
+            if !body.is_empty() {
+                return Some(body);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    None
 }
 
 /// One plain HTTP/1.1 request, so the test depends on nothing but the server.

--- a/crates/uf_cli/tests/workflow.rs
+++ b/crates/uf_cli/tests/workflow.rs
@@ -132,14 +132,14 @@ fn publish_and_release_report_trusted_publish_plan() {
 }
 
 #[test]
-fn install_reports_native_package_manager_plan() {
+fn install_runs_the_package_manager_that_drives_the_project() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(
         dir.path().join("package.json"),
         r#"{
   "name": "install-demo",
   "dependencies": {
-    "@uniflowed/core": "latest"
+    "definitely-not-a-real-package-ufsdfkj": "1.0.0"
   }
 }
 "#,
@@ -153,22 +153,20 @@ fn install_reports_native_package_manager_plan() {
         .output()
         .unwrap();
 
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    // The point of the test is that something really tried to install. uf used
+    // to write a lockfile, print "installed 1 package" and exit 0 without
+    // reaching a registry, so a green exit proved nothing; a dependency that
+    // cannot exist must now make the command fail.
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("resolver       UfNative"));
-    assert!(stdout.contains("scripts        Forbid"));
-    assert!(stdout.contains("uf.lock"));
-    assert!(stdout.contains(".uf/store/manifest.json"));
-    assert!(stdout.contains("packages       1"));
-    assert!(stdout.contains("store entries  1"));
-    assert!(stdout.contains("✓ installed 1 package"));
-    assert!(dir.path().join("uf.lock").exists());
-    assert!(dir.path().join(".uf/store/manifest.json").exists());
-    assert!(dir.path().join(".uf/store/packages").exists());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        !output.status.success(),
+        "installing a package that does not exist must fail:\n{stdout}{stderr}"
+    );
+    assert!(
+        stdout.contains("uf install"),
+        "the banner should still be rendered:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/uf_pm/src/lib.rs
+++ b/crates/uf_pm/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod command;
 pub mod detect;
+pub mod run;
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -30,6 +31,7 @@ pub use crate::detect::{
     WorkspaceMarker, YarnEdition, detect_package_manager, detect_package_manager_with,
     parse_package_manager_field, scan_lockfiles, yarn_edition_in,
 };
+pub use crate::run::{InstallRun, InstallRunError, run_install};
 
 /// JSON object keys that must never be treated as data.
 ///

--- a/crates/uf_pm/src/run.rs
+++ b/crates/uf_pm/src/run.rs
@@ -1,0 +1,145 @@
+//! Actually installing dependencies.
+//!
+//! [`crate::install_workspace`] records what a workspace declares; it reaches
+//! no registry and creates no `node_modules`. Everything a uf project imports —
+//! React, Vite, the `@uniflowed/*` packages — has to come from somewhere, and
+//! until uf's own resolver can fetch and link a dependency tree, that somewhere
+//! is the package manager the project already uses.
+//!
+//! So `uf install` detects the manager, maps [`Operation::Install`] through the
+//! table in [`crate::command`], and spawns it. The program name comes from that
+//! table and never from a manifest, and the child inherits stdio so its own
+//! progress and errors reach the terminal unedited rather than being summarised
+//! by uf.
+//!
+//! # Why a detected manager and not uf's own
+//!
+//! [`PackageManager::Uf`] is what detection reports when a project shows no
+//! evidence of any manager. Spawning `uf install` for it would be a loop, and
+//! uf's resolver cannot fetch yet, so that case falls back to npm — present
+//! wherever Node.js is, which a uf project needs regardless. The report says
+//! which manager ran and why, because "uf installed your dependencies" is not
+//! true and should not be printed.
+
+use std::process::Command;
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::command::{Invocation, Operation, command_for};
+use crate::detect::{Detection, DetectionSource, PackageManager, detect_package_manager};
+
+/// What `uf install` did.
+#[derive(Debug, Clone)]
+pub struct InstallRun {
+    /// The manager that ran.
+    pub manager: PackageManager,
+    /// The command it ran, for display. Never shell syntax.
+    pub invocation: Invocation,
+    /// How the manager was chosen.
+    pub source: DetectionSource,
+    /// Whether uf substituted npm because detection found no real manager.
+    pub substituted: bool,
+    /// Directory the command ran in.
+    pub root: Utf8PathBuf,
+}
+
+/// Installing failed.
+#[derive(Debug, thiserror::Error)]
+pub enum InstallRunError {
+    /// The manager could not be started at all.
+    #[error("could not run `{invocation}`: {source}\n{hint}")]
+    Spawn {
+        /// The command uf tried to run.
+        invocation: String,
+        /// Why the spawn failed.
+        #[source]
+        source: std::io::Error,
+        /// What the user can do about it.
+        hint: String,
+    },
+    /// The manager ran and reported failure. Its own output is already on the
+    /// terminal, so this carries the status and nothing else.
+    #[error("`{invocation}` exited with {status}")]
+    Failed {
+        /// The command that ran.
+        invocation: String,
+        /// How it described its failure.
+        status: String,
+    },
+}
+
+/// Install `root`'s dependencies with the package manager that drives it.
+///
+/// `allow_scripts` is the project's `pm.allowLifecycleScripts`; when it is
+/// false the manager is told not to run any, which is the only way to keep
+/// that guarantee once the install is somebody else's process.
+///
+/// Blocks until the manager exits, with the child's stdio connected to uf's, so
+/// the caller must have finished any progress rendering of its own first.
+///
+/// # Errors
+///
+/// [`InstallRunError::Spawn`] when the manager is not installed, and
+/// [`InstallRunError::Failed`] when it runs and fails.
+pub fn run_install(root: &Utf8Path, allow_scripts: bool) -> Result<InstallRun, InstallRunError> {
+    let detection = detect_package_manager(root);
+    let (manager, substituted) = installable(&detection);
+    let mut invocation = command_for(manager, Operation::Install);
+
+    // A dependency's `postinstall` is the supply-chain hole uf's own resolver
+    // was going to close by never running one. Delegating to a manager that
+    // runs them by default would have quietly reopened it, so the project's
+    // `pm.allowLifecycleScripts` is passed through to the manager. Every
+    // manager in the table spells the flag the same way.
+    if !allow_scripts {
+        invocation
+            .args
+            .push(std::borrow::Cow::Borrowed("--ignore-scripts"));
+    }
+
+    let status = Command::new(invocation.program)
+        .args(invocation.args.iter().map(AsRef::as_ref))
+        .current_dir(root)
+        .status()
+        .map_err(|source| InstallRunError::Spawn {
+            invocation: invocation.to_string(),
+            source,
+            hint: missing_hint(manager),
+        })?;
+
+    if !status.success() {
+        return Err(InstallRunError::Failed {
+            invocation: invocation.to_string(),
+            status: status.to_string(),
+        });
+    }
+
+    Ok(InstallRun {
+        manager,
+        invocation,
+        source: detection.source,
+        substituted,
+        root: root.to_path_buf(),
+    })
+}
+
+/// The manager to actually spawn, and whether it was substituted.
+///
+/// Detection reports [`PackageManager::Uf`] both when a project pins uf and
+/// when it shows no evidence at all. Neither can install anything today, so
+/// both become npm.
+fn installable(detection: &Detection) -> (PackageManager, bool) {
+    match detection.package_manager {
+        PackageManager::Uf => (PackageManager::Npm, true),
+        other => (other, false),
+    }
+}
+
+fn missing_hint(manager: PackageManager) -> String {
+    match manager {
+        PackageManager::Npm => "npm comes with Node.js; install Node.js and try again".to_owned(),
+        other => format!(
+            "this project is pinned to {other}; install it, or change the lockfile and `packageManager` field to a manager you have"
+        ),
+    }
+}

--- a/crates/uf_project/src/template.rs
+++ b/crates/uf_project/src/template.rs
@@ -6,20 +6,24 @@
 //! template doubles as the crate's worked example of idiomatic `// @flow` uf
 //! source.
 
+/// The files `uf create app react` writes.
+///
+/// Every import here resolves to a package that is implemented, so a freshly
+/// created project runs. This used to be a showcase — it imported the effect
+/// library, the validator, the query client, the UI kit, Relay, StyleX and
+/// React Native — and ten of those packages are declarations that throw when
+/// called, so the project it produced could not start. A starter that does not
+/// start teaches nothing.
 pub(crate) fn app_react_files(name: &str) -> Vec<(&'static str, String)> {
     vec![
         ("package.json", app_package_json(name)),
         ("uf.config.js", app_config()),
         ("app.js", app_entry()),
         ("app/_uf.layout.js", app_layout()),
-        ("app/_uf.middleware.js", app_middleware()),
         ("app/_uf.page.js", app_page()),
-        ("app/_uf.page.native.js", app_native_page()),
         ("app/_uf.page.test.js", app_test()),
-        ("app/client/Counter.js", app_client_counter()),
-        ("app/client/useCounter.js", app_client_hook()),
-        ("app/styles/tokens.stylex.js", stylex_tokens()),
-        ("server/actions.js", app_server_actions()),
+        ("app/Counter.js", app_counter()),
+        ("app/useCounter.js", app_counter_hook()),
     ]
 }
 
@@ -39,12 +43,15 @@ fn app_package_json(name: &str) -> String {
   "private": true,
   "type": "module",
   "dependencies": {{
-    "@uniflowed/core": "latest",
+    "@uniflowed/config": "latest",
     "@uniflowed/react": "latest",
     "@uniflowed/router": "latest",
     "@uniflowed/vite": "latest",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
+  }},
+  "devDependencies": {{
+    "@uniflowed/test": "latest"
   }}
 }}
 "#
@@ -134,160 +141,79 @@ export component Layout(children: mixed) {
     .to_string()
 }
 
-fn app_middleware() -> String {
-    r#"// @flow
-import { next } from "@uniflowed/router";
-
-export default function middleware() {
-  return next();
-}
-"#
-    .to_string()
-}
-
 fn app_page() -> String {
     r#"// @flow
 import * as React from "@uniflowed/react";
-import { use } from "@uniflowed/react";
-import { createFetch, request } from "@uniflowed/fetch";
-import { effect, call } from "@uniflowed/effect";
-import { createLoader, useLoader } from "@uniflowed/loader";
-import { cell } from "@uniflowed/state";
-import { createQuery } from "@uniflowed/query";
-import { graphql, useLazyLoadQuery } from "@uniflowed/relay";
-import { stylex } from "@uniflowed/stylex";
-import { Button, Dialog, Form } from "@uniflowed/ui";
-import { v } from "@uniflowed/validator";
-import { refreshGreeting } from "../server/actions.js";
-import Counter from "./client/Counter.js";
-import { tokens } from "./styles/tokens.stylex.js";
 
-const selectedTone = cell<"calm" | "sharp">("calm");
-const HomeQuery = graphql("query HomeQuery { viewer { name } }");
-const apiBase = "/api";
-const api = createFetch({ baseURL: apiBase });
-const viewerLoader = createLoader<{| name: string |}>("viewer", () => request(api, "/viewer"));
-const contactSchema = v.object({
-  name: v.pipe(v.string(), v.minLength(1)),
-});
+import Counter from "./Counter.js";
 
-const greetingQuery = createQuery<string>({
-  key: ["home", "greeting", apiBase],
-  query: () =>
-    effect(function* () {
-      return yield call(refreshGreeting);
-    }),
-});
+/// The states this page can be in. An enum rather than a union of strings so
+/// the `match` below is exhaustive: adding a member here stops compiling until
+/// every place that reads it has been updated.
+enum Mood {
+  Calm,
+  Sharp,
+}
 
-const styles = stylex.create({
-  shell: {
-    minHeight: "100vh",
-    display: "grid",
-    placeItems: "center",
-    backgroundColor: tokens.canvas,
-    color: tokens.ink,
-  },
-});
+component Headline(mood: Mood) {
+  const tone = match (mood) {
+    Mood.Calm => "at native speed",
+    Mood.Sharp => "without the pile of tools",
+  };
 
-component Page() {
-  const greeting = greetingQuery.use();
-  const viewerState = useLoader(viewerLoader);
-  const viewer = use(useLazyLoadQuery<{| viewer: {| name: string |} |}>(HomeQuery, {}));
-  const viewerName = viewerState.status === "ready" ? viewerState.value.name : viewer.viewer.name;
+  return <h1>Flow {tone}</h1>;
+}
 
+export default component Page() {
   return (
-    <main {...stylex.props(styles.shell)}>
-      <h1>{greeting.value ?? viewerName}</h1>
-      <p>tone: {selectedTone.get()}</p>
-      <Counter initial={1} />
-      <Form.Root schema={contactSchema}>
-        <Form.Field>
-          <Form.Label>Name</Form.Label>
-          <Form.Control />
-          <Form.Message />
-        </Form.Field>
-        <Form.Submit>Send</Form.Submit>
-      </Form.Root>
-      <Dialog.Root>
-        <Dialog.Trigger>Open</Dialog.Trigger>
-        <Dialog.Body>
-          <Button>Native UI, preset styles, RSC split</Button>
-        </Dialog.Body>
-      </Dialog.Root>
+    <main>
+      <Headline mood={Mood.Calm} />
+      <p>
+        Edit <code>app/_uf.page.js</code> and this page reloads. There is no second config file to
+        keep in step with this one.
+      </p>
+      <Counter initial={0} />
     </main>
   );
 }
-
-export default Page;
 "#
     .to_string()
 }
 
-fn app_server_actions() -> String {
-    r#""use server";
-// @flow
-import { serverAction } from "@uniflowed/server";
-
-export const refreshGreeting = serverAction(async (): Promise<string> => {
-  return "Flow at native speed";
-});
-"#
-    .to_string()
-}
-
-fn app_native_page() -> String {
-    r#"// @flow
-import * as React from "@uniflowed/react";
-import { Text, View } from "@uniflowed/react-native";
-import { stylex } from "@uniflowed/stylex";
-
-const styles = stylex.create({
-  shell: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});
-
-component Page() {
-  return (
-    <View {...stylex.props(styles.shell)}>
-      <Text>Flow at native speed</Text>
-    </View>
-  );
-}
-
-export default Page;
-"#
-    .to_string()
-}
-
-fn app_client_counter() -> String {
+fn app_counter() -> String {
     r#""use client";
 // @flow
 import * as React from "@uniflowed/react";
-import { Button } from "@uniflowed/ui";
+
 import { useCounter } from "./useCounter.js";
 
-component Counter(initial: number) {
+/// A component declaration: Flow reads the parameter list as the props, so
+/// there is no separate props type to keep in step with the signature.
+export default component Counter(initial: number) {
   const [count, increment] = useCounter(initial);
 
-  return <Button onClick={increment}>count: {count}</Button>;
+  return (
+    <button type="button" onClick={increment}>
+      count: {count}
+    </button>
+  );
 }
-
-export default Counter;
 "#
     .to_string()
 }
 
-fn app_client_hook() -> String {
+fn app_counter_hook() -> String {
     r#""use client";
 // @flow
-import { useState } from "@uniflowed/react";
+import { useCallback, useState } from "@uniflowed/react";
 
+/// A hook declaration. Flow refuses a call to this from anywhere that is not a
+/// component or another hook, so the rules of hooks are a type error rather
+/// than a lint rule you have to remember to install.
 export hook useCounter(initial: number): [number, () => void] {
   const [count, setCount] = useState(initial);
-  return [count, () => setCount(count + 1)];
+  const increment = useCallback(() => setCount((value) => value + 1), []);
+  return [count, increment];
 }
 "#
     .to_string()
@@ -295,30 +221,16 @@ export hook useCounter(initial: number): [number, () => void] {
 
 fn app_test() -> String {
     r#"// @flow
-import * as React from "@uniflowed/react";
 import { describe, expect, it } from "@uniflowed/test";
-import { render, screen } from "@uniflowed/react-testing";
-import Page from "./_uf.page.js";
 
-describe("Page", () => {
-  it("renders the starter headline", async () => {
-    render(<Page />);
-    await expect(screen.findByText("Flow at native speed")).resolves.toBeVisible();
+import { useCounter } from "./useCounter.js";
+
+describe("useCounter", () => {
+  it("is a hook, so it is only callable from a component or another hook", () => {
+    expect(typeof useCounter).toBe("function");
   });
 });
 "#
-    .to_string()
-}
-
-fn stylex_tokens() -> String {
-    r##"// @flow
-import { stylex } from "@uniflowed/stylex";
-
-export const tokens = stylex.defineVars({
-  canvas: "#f7f7f2",
-  ink: "#151b1f",
-});
-"##
     .to_string()
 }
 

--- a/crates/uf_project/src/tests.rs
+++ b/crates/uf_project/src/tests.rs
@@ -15,29 +15,48 @@ fn creates_zero_config_react_flow_app() {
     )
     .unwrap();
 
-    assert_eq!(report.files.len(), 12);
+    assert_eq!(report.files.len(), 8);
     assert!(root.join("app.js").exists());
     assert!(root.join("uf.config.js").exists());
     assert!(root.join("app/_uf.page.js").exists());
-    assert!(root.join("app/_uf.page.native.js").exists());
-    assert!(root.join("server/actions.js").exists());
+    assert!(root.join("app/Counter.js").exists());
 
     let package = fs::read_to_string(root.join("package.json")).unwrap();
     assert!(!package.contains(r#""scripts""#));
 
+    // Every dependency a scaffolded project declares has to be a package that
+    // is actually implemented, or the project cannot start. The declaration
+    // packages that throw when called must not appear here.
+    for stub in [
+        "@uniflowed/core",
+        "@uniflowed/effect",
+        "@uniflowed/fetch",
+        "@uniflowed/loader",
+        "@uniflowed/query",
+        "@uniflowed/react-native",
+        "@uniflowed/react-testing",
+        "@uniflowed/relay",
+        "@uniflowed/server",
+        "@uniflowed/stylex",
+        "@uniflowed/ui",
+    ] {
+        assert!(!package.contains(stub), "{stub} is not implemented yet");
+        for file in &report.files {
+            let contents = fs::read_to_string(file).unwrap();
+            assert!(
+                !contents.contains(stub),
+                "{file} imports {stub}, which is not implemented yet"
+            );
+        }
+    }
+
     let page = fs::read_to_string(root.join("app/_uf.page.js")).unwrap();
     assert!(page.contains("component Page()"));
-    assert!(page.contains("@uniflowed/query"));
-    assert!(page.contains("@uniflowed/effect"));
-    assert!(page.contains("@uniflowed/state"));
-    assert!(page.contains("@uniflowed/fetch"));
-    assert!(page.contains("@uniflowed/loader"));
-    assert!(page.contains("@uniflowed/validator"));
-    assert!(page.contains("@uniflowed/stylex"));
-    assert!(page.contains("@uniflowed/relay"));
-    assert!(page.contains("Form.Root"));
-    assert!(page.contains("Dialog.Body"));
-    assert!(root.join("app/client/useCounter.js").exists());
+    assert!(page.contains("enum Mood"));
+    assert!(page.contains("match (mood)"));
+
+    let hook = fs::read_to_string(root.join("app/useCounter.js")).unwrap();
+    assert!(hook.contains("hook useCounter"));
 }
 
 #[test]

--- a/docs/app/_design/seam.css
+++ b/docs/app/_design/seam.css
@@ -570,9 +570,14 @@ pre code {
 }
 
 /* A command a reader is meant to run. The `$` is generated, so copying the
-   line copies the command and not the prompt. */
+   line copies the command and not the prompt.
+
+   It carries its own block margin because it is a `div` rather than a `pre`,
+   and so is not covered by the block-margin rule near the top of this file —
+   without this it sits flush against the heading above it. */
 .command {
   background: var(--doc-code-ground);
+  margin: 1.25rem 0;
   border-left: 2px solid var(--uf-color-blue-500);
   display: flex;
   gap: 0.7rem;
@@ -666,12 +671,41 @@ tbody tr:last-child :is(td, th) {
 .hero {
   /* Block only: the inline padding belongs to `.seam` and a shorthand here
      would silently reset it. */
-  padding-block: 4.5rem 1rem;
+  align-items: center;
+  column-gap: 3rem;
+  display: flex;
+  flex-wrap: wrap-reverse;
+  justify-content: space-between;
+  padding-block: 4.5rem 0;
+}
+
+.hero-copy {
+  flex: 1 1 26rem;
+}
+
+/* The mark is the one place on the site the brand is stated at size, so it
+   gets to be as large as the row allows. It shrinks with the viewport and
+   drops above the copy — the `wrap-reverse` above — before it would squeeze
+   the headline. The width here and the `sizes` attribute on the element have
+   to agree, or the browser picks its file from the wrong number. */
+.hero-mark {
+  flex: 0 1 auto;
+  height: auto;
+  margin-bottom: 1.5rem;
+  width: clamp(9rem, 46vw, 26rem);
+}
+
+.hero-tail {
+  padding-block: 0 1rem;
 }
 
 .hero .lede {
   font-size: 1.32rem;
   max-width: 46ch;
+}
+
+.hero h1 {
+  margin-top: 0;
 }
 
 .hero-actions {
@@ -847,7 +881,11 @@ tbody tr:last-child :is(td, th) {
 }
 
 .home-section {
-  margin-top: 3.5rem;
+  margin-top: 4.5rem;
+}
+
+.home-section > h2 {
+  margin-bottom: 1.75rem;
 }
 
 .home-section > :is(p, pre, .command, .terminal) {

--- a/docs/app/_uf.page.js
+++ b/docs/app/_uf.page.js
@@ -42,18 +42,44 @@ export default component Home() {
   return (
     <div className="home seam" id="content">
       <section className="hero">
-        <Eyebrow>Unified toolchain for Flow</Eyebrow>
-        <h1>
-          One binary between
-          <br />
-          your code and the web.
-        </h1>
-        <Lede>
-          uf runs, builds, tests, formats and lints Flow and React from a single
-          command. No Babel in the pipeline, no plugin list to assemble, and one
-          config file for all of it.
-        </Lede>
+        <div className="hero-copy">
+          <Eyebrow>Unified toolchain for Flow</Eyebrow>
+          <h1>
+            One binary between
+            <br />
+            your code and the web.
+          </h1>
+          <Lede>
+            uf runs, builds, tests, formats and lints Flow and React from a
+            single command. No Babel in the pipeline, no plugin list to
+            assemble, and one config file for all of it.
+          </Lede>
+        </div>
 
+        {/*
+          Decorative: the name is already in the heading and in the masthead,
+          so announcing the mark again would only repeat it.
+
+          The mark exists at two sizes and neither is a vector — the `.svg` in
+          `brand/` is a PNG in an SVG wrapper. `srcset` lets a phone take the
+          512px file and a retina desktop take the 1254px one, rather than
+          every visitor paying 400 kB or every retina screen getting a soft
+          mark. The intrinsic size is declared so the row does not reflow when
+          it arrives.
+        */}
+        <img
+          className="hero-mark"
+          src="/brand/uniflowed-mark.png"
+          srcSet="/brand/uniflowed-mark.png 512w, /brand/uf.png 1254w"
+          sizes="(max-width: 48rem) 46vw, 26rem"
+          alt=""
+          width="1254"
+          height="1254"
+          fetchPriority="high"
+        />
+      </section>
+
+      <section className="hero-tail">
         <div className="hero-actions">
           <Link className="button" to="/guide/install">
             Install uf
@@ -70,6 +96,27 @@ export default component Home() {
           <Link to="/guide/testing">where it loses</Link> to the tools it means
           to replace.
         </div>
+      </section>
+
+      <section className="home-section">
+        <h2 className="seam-mark">Install it</h2>
+        <p>
+          One binary. It reads the checksum from the release manifest before it
+          writes anything, and it is short enough to read first.
+        </p>
+        <Command>curl -fsSL https://setup.uniflowed.dev | sh</Command>
+        <p>
+          Then a project, and a dev server, with nothing to configure in
+          between:
+        </p>
+        <Command>uf create app my-site</Command>
+        <Command>cd my-site &amp;&amp; uf dev</Command>
+        <p>
+          That is the whole setup. No <code>npm install</code> of a toolchain,
+          no config to copy from somewhere. If you would rather build from
+          source, or pin the project to Bun or Deno,{" "}
+          <Link to="/guide/install">the install page</Link> covers both.
+        </p>
       </section>
 
       <section className="home-section">

--- a/docs/app/guide/install/_uf.page.mdx
+++ b/docs/app/guide/install/_uf.page.mdx
@@ -17,11 +17,16 @@ through one.
 Every tagged release publishes binaries for macOS and Linux, on both x86-64 and
 ARM64:
 
-<div className="command"><code>curl -fsSL https://github.com/ubugeeei-prod/uf/releases/latest/download/uf-install.sh | sh</code></div>
+<div className="command"><code>curl -fsSL https://setup.uniflowed.dev | sh</code></div>
 
-The script downloads the binary for your platform, verifies its checksum against
-the release manifest, and puts it on your `PATH`. Read it before you run it; it
-is short.
+The script picks the binary for your platform, checks it against the checksum in
+the release manifest, and puts it on your `PATH`. It works under `sh`, `bash`
+and `zsh`. Read it before you run it — it is short, and it is served from
+`https://setup.uniflowed.dev/install.sh` if you would rather fetch it first.
+
+On Windows, PowerShell:
+
+<div className="command"><code>irm https://setup.uniflowed.dev/install.ps1 | iex</code></div>
 
 ## From source
 

--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -61,22 +61,54 @@ case "$requested_version" in
   uf@*) requested_version="${requested_version#uf@}" ;;
 esac
 
-if [ -n "$release_base" ]; then
-  channel_url="${release_base}/${requested_version}"
-elif [ "$requested_version" = "latest" ]; then
-  channel_url="https://github.com/${repo}/releases/latest/download"
-else
-  channel_url="https://github.com/${repo}/releases/download/uf@${requested_version}"
-fi
+# The newest release including prereleases.
+#
+# `releases/latest` is GitHub's *stable* channel: it has no answer while every
+# release so far is a prerelease, which is every release uf has published. So
+# `latest` resolves in two steps — the stable channel first, because that is
+# what `latest` should mean the day a stable release exists, then the releases
+# list, which includes prereleases and is ordered newest first. Drafts are not
+# in that list for an anonymous caller, so the first entry is the answer.
+#
+# Parsed with sed rather than jq, because an installer cannot require a JSON
+# parser to be installed before it can install anything.
+newest_prerelease_tag() {
+  curl -fsSL -H 'accept: application/vnd.github+json' \
+    "https://api.github.com/repos/${repo}/releases?per_page=1" 2>/dev/null |
+    tr ',' '\n' |
+    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+    head -1
+}
 
 version="$requested_version"
-if [ "$requested_version" = "latest" ]; then
-  if ! version="$(curl -fsSL "${channel_url}/VERSION" | tr -d '[:space:]')" \
-    || [ -z "$version" ]; then
-    echo "uf installer: could not resolve the latest version from ${channel_url}/VERSION" >&2
-    echo "uf installer: set UF_VERSION to install a specific release" >&2
-    exit 1
+if [ -n "$release_base" ]; then
+  channel_url="${release_base}/${requested_version}"
+  if [ "$requested_version" = "latest" ]; then
+    if ! version="$(curl -fsSL "${channel_url}/VERSION" | tr -d '[:space:]')" \
+      || [ -z "$version" ]; then
+      echo "uf installer: could not resolve the latest version from ${channel_url}/VERSION" >&2
+      echo "uf installer: set UF_VERSION to install a specific release" >&2
+      exit 1
+    fi
   fi
+elif [ "$requested_version" = "latest" ]; then
+  stable_url="https://github.com/${repo}/releases/latest/download"
+  if version="$(curl -fsSL "${stable_url}/VERSION" 2>/dev/null | tr -d '[:space:]')" \
+    && [ -n "$version" ]; then
+    channel_url="$stable_url"
+  else
+    uf_step "no stable release yet, taking the newest prerelease"
+    tag="$(newest_prerelease_tag)"
+    version="${tag#uf@}"
+    if [ -z "$version" ]; then
+      echo "uf installer: could not resolve a release for ${repo}" >&2
+      echo "uf installer: set UF_VERSION to install a specific release" >&2
+      exit 1
+    fi
+    channel_url="https://github.com/${repo}/releases/download/uf@${version}"
+  fi
+else
+  channel_url="https://github.com/${repo}/releases/download/uf@${requested_version}"
 fi
 uf_step "version ${version}"
 

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -108,10 +108,55 @@ async function viteConfig(config, mode) {
   };
 }
 
+/**
+ * The dev server.
+ *
+ * Vite in middleware mode serves nothing on its own: with no `index.html` at
+ * the project root it answers every navigation with "Cannot GET /", which is
+ * what `uf dev` used to do for every project it started. A uf project has no
+ * `index.html` — the document comes from a layout — so the server has to render
+ * it, which is what this middleware does:
+ *
+ *   1. load the server entry through `ssrLoadModule`, so it is transformed the
+ *      same way the browser's copy is and picks up edits without a restart;
+ *   2. render the URL, pointing the client script at the dev entry rather than
+ *      at a built asset;
+ *   3. hand the HTML to `transformIndexHtml`, which is what injects the HMR
+ *      client and lets any Vite plugin see the document.
+ *
+ * Anything Vite already serves — a module, a public file — never reaches this,
+ * because the middleware runs after Vite's own.
+ */
 async function dev() {
   const { createServer } = await import("vite");
   const config = await loadConfig();
-  const server = await createServer(await viteConfig(config, "development"));
+  const inline = await viteConfig(config, "development");
+  const server = await createServer({ ...inline, appType: "custom" });
+
+  // In dev the browser loads the client entry from Vite, not from a manifest;
+  // its stylesheets arrive through that module rather than as <link> tags.
+  const assets = { scripts: [`/@id/${VIRTUAL.client}`], styles: [], preloads: [] };
+
+  server.middlewares.use(async (request, response, next) => {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      next();
+      return;
+    }
+    const url = request.originalUrl ?? request.url ?? "/";
+    try {
+      const entry = await server.ssrLoadModule(VIRTUAL.server);
+      const result = await entry.render(url, assets);
+      const html = await server.transformIndexHtml(url, result.html);
+      response.statusCode = result.status ?? 200;
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.end(html);
+    } catch (error) {
+      // Map the stack back onto the Flow source before it reaches the overlay.
+      if (error instanceof Error) server.ssrFixStacktrace(error);
+      next(error);
+    }
+  });
+
   await server.listen();
   const urls = server.resolvedUrls ?? { local: [], network: [] };
   emit("listening", {


### PR DESCRIPTION
Four things a stranger hits in their first five minutes. None of them worked, and each was verified broken by running it, not by reading it.

## `curl -fsSL https://setup.uniflowed.dev | sh` could never succeed

The installer resolved `latest` through `releases/latest/download/VERSION`. That is GitHub's **stable** channel, and it has no answer while every release is a prerelease — which is every release uf has published. `curl | sh` 404'd for everyone, always.

It now tries the stable channel first, so `latest` still means the stable release the day there is one, and otherwise takes the newest release from the list endpoint, which includes prereleases. Verified against the live release:

```
uf installer: no stable release yet, taking the newest prerelease
uf installer: version 0.0.0-alpha.0
uf installer: checksum verified
$ uf --version → uf_cli 0.0.0-alpha.0
```

## `uf install` installed nothing

It recorded the workspace's own manifests into a lockfile, printed `installed 1 package` for six dependencies, and exited 0 — without contacting a registry or creating `node_modules`. Every "it works" in this repo was really the root npm workspace linking `@uniflowed/*` into place.

It now detects the manager that drives the project and runs it, through the table that already mapped `Operation::Install` for every manager. A project evidencing no manager gets npm, and the report says so rather than claiming uf did it.

**`pm.allowLifecycleScripts` is passed through as `--ignore-scripts`.** Handing the install to npm would otherwise have quietly reopened the dependency `postinstall` hole that uf's own resolver was going to close by never running one. The manifest pre-flight that refuses a project's own `scripts` is kept as well.

## `uf create app` wrote a project that could not start

Its page imported `@uniflowed/effect`, `fetch`, `loader`, `query`, `relay`, `state`, `stylex`, `ui`, `validator`, `core`, `server`, `react-testing` and `react-native`. Ten of those are declaration packages that throw `nativeRuntimeRequired` when called. The starter could not run.

The scaffold is now four dependencies — `config`, `react`, `router`, `vite` — all implemented, plus `@uniflowed/test` for the test file. The page is smaller but real: a Flow `enum`, an exhaustive `match`, a `component` declaration, a `hook` declaration. A test asserts that no unimplemented package can reappear in the scaffold.

## `uf dev` answered every request with "Cannot GET /"

Vite in middleware mode serves nothing on its own, and a uf project has no `index.html` — the document comes from a layout. The driver now loads the server entry through `ssrLoadModule`, renders the URL, and hands the HTML to `transformIndexHtml` so the HMR client and the refresh preamble are injected. Verified on the docs site: `/`, `/guide/` and `/reference/cli/` all 200 and render; an unrouted path 404s.

## The test that should have caught it

`dev_serves_the_docs_site_through_vite` existed and asserted a 200. It skipped itself when its fixture was missing, and cargo hides a passing test's output, so `1 passed` was printed for a dev server that served nothing.

A missing fixture is now a failure that names what is missing, unless `UF_ALLOW_FIXTURE_SKIP=1` is set for a machine that genuinely cannot run it; CI sets nothing, so CI can never skip. The test also stops parsing the coloured banner for a port, and now asserts a nested route and a 404 alongside the home page.

**Honest caveat:** with the fixture available the test takes 20s and passes on the fix, but I was not able to make it go red against the pre-fix driver inside `cargo test`, while the same invocation by hand reliably 404s. I have not explained that difference, so treat the strengthened assertions as a better test, not as proof this specific regression is now guarded.

## Still blocked

`uf install` on a scaffolded project now fails with npm's own `E404` for `@uniflowed/core` — correctly, because nothing is published. That is the next thing, and its first step needs an npm login rather than a token: npm cannot do a package's *first* publish over OIDC, since a trusted publisher can only be configured on a package that already exists.

## Checked

`cargo test --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, plus a scaffolded project built, tested and served by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791029996&installation_model_id=422833&pr_number=76&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F76&signature=79819994b28e889cdfcef513b05c92aa19b9569a14a2c4c24a9393f6439089d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `uf install` now runs the project’s detected package manager and reports the selected tool and command.
  * React app scaffolds now provide a smaller, working starter with counter functionality and updated dependencies.
  * Vite development servers now render application routes, including nested routes, and return proper 404 responses.
  * Install documentation adds setup instructions for macOS, Linux, and Windows.
  * The installer can fall back to the newest prerelease when no stable version is available.

* **Style**
  * Documentation pages received refreshed hero layouts, branding, spacing, and installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->