### PR TITLE
docs: say why Flow, and be readable on a phone

### DIFF
--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -31,6 +31,16 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb: "The argument for one toolchain, and what it costs you.",
       },
       {
+        href: "/guide/why",
+        title: "Why Flow",
+        blurb: "What Flow says about React that nothing else can, and what it costs.",
+      },
+      {
+        href: "/guide/vite-plus",
+        title: "uf and Vite+",
+        blurb: "Where uf sits next to the toolchain it will be compared to.",
+      },
+      {
         href: "/guide/install",
         title: "Install",
         blurb: "One binary, three runtimes, no plugins to add.",

--- a/docs/app/_design/parts.js
+++ b/docs/app/_design/parts.js
@@ -87,6 +87,7 @@ export component ManualNav() {
 
   return (
     <nav className="manual-nav" aria-label="Documentation">
+      <h2 className="manual-nav-title">All pages</h2>
       {sections.map((section) => (
         <React.Fragment key={section.title}>
           <h2>{section.title}</h2>

--- a/docs/app/_design/seam.css
+++ b/docs/app/_design/seam.css
@@ -130,19 +130,28 @@ h1 {
   letter-spacing: -0.03em;
 }
 
+/* A heading owns the space under it. Leaving that to the next element's own
+   margin gave a section heading the same gap as an ordinary paragraph break,
+   which read as though the heading belonged to the text above it. */
 h2 {
   font-size: 1.55rem;
-  margin-top: 3.2rem;
+  margin-block: 3.6rem 1.35rem;
 }
 
 h3 {
   font-size: 1.15rem;
-  margin-top: 2.2rem;
+  margin-block: 2.6rem 0.9rem;
 }
 
 h4 {
   font-size: 1rem;
-  margin-top: 1.8rem;
+  margin-block: 2rem 0.7rem;
+}
+
+/* The first element after a heading has no margin of its own to add: the
+   heading has already set the distance. */
+:is(h2, h3, h4) + :is(p, ul, ol, pre, table, blockquote, .command, .terminal) {
+  margin-top: 0;
 }
 
 p,
@@ -368,16 +377,52 @@ strong {
   .manual {
     grid-template-columns: 15rem minmax(0, 1fr);
   }
-}
 
-@media (min-width: 84rem) {
-  .manual {
-    grid-template-columns: 15rem minmax(0, 1fr) 13rem;
+  /* The sidebar is second in the document and first on screen. */
+  .manual-nav {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .manual > .prose {
+    grid-column: 2;
+    grid-row: 1;
   }
 }
 
 .manual-nav {
+  border-top: 1px solid var(--doc-rule);
   font-size: 0.92rem;
+  margin-top: 3rem;
+  padding-top: 1.75rem;
+}
+
+.manual-nav-title {
+  font-family: var(--uf-font-display);
+  font-size: 1.05rem;
+  font-weight: 620;
+  letter-spacing: -0.015em;
+  margin: 0 0 1.25rem;
+  text-transform: none;
+}
+
+@media (min-width: 60rem) {
+  .manual-nav {
+    border-top: 0;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  /* On a wide screen the sidebar is the navigation and needs no title; the
+     section headings inside it already say what it is. */
+  .manual-nav-title {
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
 }
 
 @media (min-width: 60rem) {
@@ -824,6 +869,105 @@ tbody tr:last-child :is(td, th) {
 @media (prefers-reduced-motion: no-preference) {
   html {
     scroll-behavior: smooth;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Phones
+ * ------------------------------------------------------------------ */
+
+@media (max-width: 40rem) {
+  html {
+    font-size: 16px;
+  }
+
+  :root {
+    /* The seam still runs down the page, but it may not take a fifth of the
+       width to do it. */
+    --doc-gutter: 1.1rem;
+  }
+
+  .seam {
+    padding-left: 1.1rem;
+  }
+
+  .seam-mark::before {
+    left: calc(-1.1rem - 3px);
+  }
+
+  .masthead {
+    gap: 0.75rem 1.1rem;
+    padding: 1rem 0;
+  }
+
+  .masthead-nav {
+    font-size: 0.88rem;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  /* The theme control goes last and to the end of the row, so the three
+     destinations read as one group. */
+  .theme-toggle {
+    margin-left: auto;
+  }
+
+  .manual {
+    padding-top: 1.75rem;
+  }
+
+  .hero {
+    padding-block: 2rem 0;
+  }
+
+  .hero .lede {
+    font-size: 1.1rem;
+  }
+
+  .hero-actions {
+    gap: 0.75rem;
+  }
+
+  .button {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+
+  /* A code block on a phone is read by scrolling it, so it may use the full
+     width of the screen rather than sitting inside the gutter. */
+  pre,
+  .command,
+  .terminal {
+    border-radius: 0;
+    margin-inline: calc(-1 * var(--doc-gutter) - 1.1rem) calc(-1 * var(--doc-gutter));
+    padding-inline: calc(var(--doc-gutter) + 1.1rem) var(--doc-gutter);
+  }
+
+  pre {
+    font-size: 0.8rem;
+  }
+
+  .terminal {
+    font-size: 0.72rem;
+  }
+
+  /* A definition list cannot be two columns in 375px. */
+  .claims > div {
+    gap: 0.3rem;
+  }
+
+  table {
+    font-size: 0.86rem;
+  }
+
+  th,
+  td {
+    padding-right: 0.9rem;
+  }
+
+  .colophon {
+    gap: 0.6rem;
+    margin-top: 3rem;
   }
 }
 

--- a/docs/app/_uf.page.js
+++ b/docs/app/_uf.page.js
@@ -84,8 +84,8 @@ export default component Home() {
           <Link className="button" to="/guide/install">
             Install uf
           </Link>
-          <Link className="button button-quiet" to="/guide">
-            Read the guide
+          <Link className="button button-quiet" to="/guide/why">
+            Why Flow
           </Link>
         </div>
 

--- a/docs/app/guide/_uf.layout.js
+++ b/docs/app/guide/_uf.layout.js
@@ -18,11 +18,19 @@ export component Layout(children: React.Node) {
 
   return (
     <div className="manual">
-      <ManualNav />
+      {/*
+        The article comes first in the document and the sidebar second, with
+        the grid putting the sidebar on the left at reading widths. On a phone
+        there is one column, so a reader lands on the heading they followed a
+        link to rather than scrolling past thirteen navigation links to reach
+        it — and the contents are still there, below, where "what else is
+        there" is the question being asked.
+      */}
       <main className="prose seam" id="content">
         {children}
         {next != null ? <NextPage href={next.href} title={next.title} /> : null}
       </main>
+      <ManualNav />
     </div>
   );
 }

--- a/docs/app/guide/vite-plus/_uf.page.mdx
+++ b/docs/app/guide/vite-plus/_uf.page.mdx
@@ -1,0 +1,92 @@
+---
+title: "uf and Vite+ · uf"
+---
+
+<p className="eyebrow">Getting started</p>
+
+# uf and Vite+
+
+<div className="lede">
+Vite+ is the toolchain uf will be compared to, and the comparison is simpler
+than it looks: they answer different questions. Vite+ unifies the JavaScript
+and TypeScript toolchain. uf makes Flow's React syntax usable.
+</div>
+
+## uf is not a competitor to Vite
+
+Start here, because it is the thing most often assumed the other way round.
+
+uf's dev server **is** Vite. Its production build **is** Vite. uf resolves your
+config, decides what Vite should be handed, starts it on a JavaScript host and
+drives it over a JSON protocol. Vite's plugin ecosystem keeps working, because
+it is really Vite — `plugins` in `uf.config.js` is a list of Vite plugins.
+
+Replacing Vite would have meant rebuilding the best-tested bundler pipeline in
+the ecosystem in order to change one thing about it. The one thing uf changes
+is what happens to a module before Vite sees it.
+
+## Where they differ
+
+| | Vite+ | uf |
+| --- | --- | --- |
+| Language it is built around | TypeScript | Flow |
+| React syntax it understands | JSX and TypeScript | `component`, `hook`, `renders`, `match`, Flow `enum` |
+| Transform | Oxc | Meta's Flow parser → Hermes lowering passes → the React Compiler crate → oxc |
+| Bundler and dev server | Vite and Rolldown | Vite |
+| Config | `vite.config.ts` | `uf.config.js`, in Flow |
+| Maturity | a funded product with a team behind it | `0.0.0-alpha`, and it says so on every page |
+
+The row that matters is the first one. Everything else follows from it.
+
+## What "TypeScript-first" costs you if you write Flow
+
+A TypeScript-first toolchain does not refuse Flow — it simply has no path for
+it, so you build one. That means Babel back in the pipeline: a preset to strip
+the types, a plugin to understand `component` and `hook`, another for the React
+Compiler, and then the same syntax explained again to the test runner, the
+linter and the formatter, each in its own configuration.
+
+Every one of those is a place two tools can disagree about what your code
+means, and the disagreement shows up somewhere unrelated: a test that passes
+and a build that fails, or a formatter that reflows syntax the linter then
+rejects.
+
+uf's answer is that the parse should happen once, in the binary, and everything
+should read that tree. [Why Flow](/guide/why) is the longer form of the
+argument.
+
+## What Vite+ has that uf does not
+
+Being straight about this is more useful than a feature table.
+
+**A team, a company and a support contract.** uf is pre-release software with
+no stability guarantee. If you are choosing a toolchain for work that has to
+keep running in three years, that difference is the whole decision.
+
+**The TypeScript ecosystem.** Every typed package on npm, every editor
+integration, every answer to every question. uf inherits Flow's ecosystem,
+which is much smaller. [Why Flow](/guide/why#and-what-it-does-not-say) does not
+pretend otherwise.
+
+**Monorepo tooling at scale.** uf runs tasks and builds a project. It has not
+been near a thousand-package repository.
+
+## When uf is the right choice
+
+- You write React and you want the syntax Flow has for it: props inferred from
+  a parameter list, the rules of hooks enforced by the checker, components that
+  can require particular children, exhaustive `match`, real enums.
+- You would rather have one binary and one config file than six tools that have
+  to be taught the same thing.
+- You can live with pre-release software, and with an ecosystem where a package
+  without Flow types is `any` until somebody writes them.
+
+If you write TypeScript, Vite+ is a better answer than uf will ever be for you,
+and this page is not trying to talk you out of it.
+
+## Can they be used together?
+
+Partly, today. uf's task runner is Vite's, and uf drives standard Vite, so a
+project already using Vite's ecosystem keeps it. What does not compose is the
+transform: a module is Flow or it is TypeScript, and uf's pipeline is the Flow
+one.

--- a/docs/app/guide/why/_uf.page.mdx
+++ b/docs/app/guide/why/_uf.page.mdx
@@ -1,0 +1,135 @@
+---
+title: "Why Flow · uf"
+---
+
+<p className="eyebrow">Getting started</p>
+
+# Why Flow
+
+<div className="lede">
+React is written in Flow. The type system that describes React best is the one
+React is built with — and it is the one with no toolchain. That gap is the
+whole reason this project exists.
+</div>
+
+## The argument in one paragraph
+
+Flow has spent the last few years growing syntax that exists specifically to
+describe React: component and hook declarations, render types, pattern
+matching, enums. Nothing else has any of it. But using that syntax means
+assembling Babel, a preset, a plugin for the React Compiler, and then teaching
+your bundler, your test runner, your linter and your formatter about the same
+syntax, separately, in four more config files. The most expressive way to write
+React is the least pleasant to set up. uf is the removal of that tax and
+nothing else.
+
+## What Flow says that other type systems cannot
+
+### A component is a kind of declaration, not a shape you annotate
+
+```js
+component Avatar(src: string, size: number = 32, alt?: string) {
+  return <img src={src} width={size} height={size} alt={alt ?? ""} />;
+}
+```
+
+The props type *is* the parameter list. There is no second declaration to keep
+in step with the signature, defaults live where the parameter is declared, and
+a missing prop is an error at the call site naming the parameter. The
+equivalent elsewhere is a separate interface, a destructuring pattern, and a
+defaults object — three places that describe one thing and can disagree.
+
+It also means the compiler *knows* this is a component. React's own compiler
+is told so directly rather than inferring it from a capital letter.
+
+### The rules of hooks are a type error
+
+```js
+hook useNow(interval: number): Date { … }
+```
+
+Flow will not let you call that from anything but a component or another hook.
+Not a lint rule you remember to install and configure — a type error, from the
+same checker that checks everything else. The most common class of React bug
+stops being a matter of discipline.
+
+### A component can require its children
+
+```js
+component Tab(label: string) renders React.Node { … }
+component Tabs(children: renders* Tab) { … }
+```
+
+`renders Tab` is exactly one, `renders? Tab` zero or one, `renders* Tab` any
+number. `<Tabs><Button /></Tabs>` does not compile. "These two components only
+make sense together" becomes something the type system enforces instead of
+something the documentation asks for.
+
+### Exhaustiveness you cannot forget
+
+```js
+enum Status { Idle, Loading, Failed }
+
+const label = match (status) {
+  Status.Idle => "Ready",
+  Status.Loading => "Working…",
+  Status.Failed => "Failed",
+};
+```
+
+Add a member to the enum and every `match` over it stops compiling until it is
+handled. Flow enums are real runtime values too — iterable, castable, and not
+comparable to a bare string by accident — which a union of string literals is
+not.
+
+### Exactness and variance are the default, not a flag
+
+Flow object types are exact unless you say otherwise, and property variance is
+written down: `+field` is covariant, `-field` contravariant. A read-only prop
+is expressible as a property of the type rather than as a convention. These are
+the places where a type system quietly lies to you, and Flow's answers are
+stricter.
+
+## And what it does not say
+
+Being honest about this matters more than the list above.
+
+**The ecosystem is TypeScript's.** Most libraries ship `.d.ts` and no libdef.
+`flow-typed` exists and Flow can read some TypeScript declarations, but a
+package with no Flow types is `any` until somebody writes them. If your project
+lives on twenty typed dependencies, this is the cost you are paying.
+
+**Editor support is thinner.** Flow's language server is good and uf ships
+`uf lsp`, but the number of people working on TypeScript tooling is not a
+number Flow will match.
+
+**Fewer people know it.** Hiring, Stack Overflow answers, and the odds that a
+contributor has seen `renders` before all favour TypeScript.
+
+uf does not argue that Flow wins on those. It argues that if you are writing
+React — and if the type system's job is to describe *React* precisely rather
+than to describe JavaScript generally — Flow says things nothing else can say,
+and the only thing standing between you and them was the toolchain.
+
+## Why a whole toolchain, rather than a plugin
+
+Because a plugin is the problem restated. The moment two tools have to agree
+about what `component` means, they have to be configured to agree, and they
+can be configured to disagree — silently, until a build fails where a test
+passed.
+
+uf compiles Meta's own Flow parser into a single binary and everything reads
+that one tree: the dev server, the production build, the test runner, the
+formatter, the linter. There is one answer to "what does this file mean"
+because there is one implementation of the question.
+
+That is also why `uf.config.js` is the only config file, and why it is written
+in Flow — the configuration for your type system should be checked by your type
+system.
+
+## Where to go next
+
+[Flow, the modern parts](/guide/flow) is the same syntax with the lowering
+explained: what each construct becomes, and which upstream implementation does
+it. [uf and Vite+](/guide/vite-plus) is where uf sits next to the toolchain
+most people will compare it to.


### PR DESCRIPTION
## The argument was missing

The site said what uf does and never said why anyone should want it.

**[Why Flow](/guide/why)** — what Flow's React syntax expresses that nothing else can: props inferred from a parameter list rather than declared twice, the rules of hooks as a type error rather than a lint rule, `renders` types so a component can require particular children, exhaustive `match`, enums that exist at runtime. Then why that needs a whole toolchain rather than a plugin: the moment two tools must agree what `component` means, they can be configured to disagree, and the disagreement surfaces somewhere unrelated.

It ends with what Flow does **not** win — the ecosystem is TypeScript's, editor support is thinner, fewer people know it — because a page that only lists advantages is an advert.

**[uf and Vite+](/guide/vite-plus)** — the comparison people will make. It opens by correcting the assumption behind it: uf's dev server *is* Vite and its build *is* Vite; uf changes what happens to a module before Vite sees it. Then where they actually differ (the language they are built around, and everything downstream of that), what Vite+ has that uf does not (a team, a support contract, the TypeScript ecosystem, monorepo scale), and when uf is the wrong choice.

## A phone showed the navigation, not the page

The sidebar came first in the document, so on a 375px screen a reader following a link scrolled past thirteen navigation entries before reaching the heading they asked for.

The article is now first in the document and the grid places the sidebar on the left at reading widths, so the phone gets the page and the contents land under it — where "what else is there" is the question being asked. Also: code blocks run to the edge of the screen instead of sitting inside the gutter, the masthead fits one row plus a wrapped nav, buttons share a row, and the base size drops to 16px.

## A heading owned no space under it

`h2`/`h3`/`h4` set only `margin-top`, so the gap below a section heading was whatever the next element's own margin happened to be — the same gap as a paragraph break. A heading now sets both, and the element immediately after it drops its own top margin so the two do not add up.

## Checked

`cargo fmt --all -- --check`, `cargo test -p uf_cli --test vite` (the real fixture, not a skip), 16 pages prerendered, and both new pages read at 375px and 1440px in light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791031890&installation_model_id=422833&pr_number=78&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F78&signature=1489b65f708addf6b03a27982b07ef0e59bf8224360b5a4b2cadb7aa3d547bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->