### PR TITLE
ci(publish): install the workspace before running the suite

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,11 @@ jobs:
           package-manager-cache: false
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
+      # The suite drives the docs site through the real `@uniflowed/vite`, and
+      # those tests now fail rather than skip when the workspace is not
+      # installed. Without this the publish job failed on a missing fixture
+      # while the packages it was about to publish were fine.
+      - run: npm ci --no-audit --no-fund
       - run: cargo test --workspace
       # Only the packages in `tools/release/published-packages.txt`, which is
       # the set that is implemented. Publishing a declaration module whose


### PR DESCRIPTION
The `uf@0.0.0-alpha.1` publish job failed, and not because anything was wrong with the packages.

`publish.yml` runs `cargo test --workspace` but never `npm ci`, so `build_renders_the_docs_site_through_vite` and `dev_serves_the_docs_site_through_vite` had no `@uniflowed/vite` to drive the docs site with. Until #76 those two skipped themselves silently; now a missing fixture is a failure, which is the point — it just needs the fixture to be there. `ci.yml` already installs the workspace for exactly this reason.

The five packages are on npm at `0.0.0-alpha.1` (published by hand before this landed), and each is bound to this workflow by `npm trust`, so the next `uf@*` tag publishes over OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791032951&installation_model_id=422833&pr_number=79&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F79&signature=c2a0b6b4ec68bfdba4a8e8ba212d745e8f3fdd80cfb1609452d076d500bb1878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->