### PR TITLE
feat(mdx): highlight fenced code, Flow's keywords included

### DIFF
--- a/crates/uf_config/src/app.rs
+++ b/crates/uf_config/src/app.rs
@@ -305,6 +305,51 @@ pub enum MdxPipelinePluginConfig {
     BuiltIn,
 }
 
+/// Build-time syntax highlighting for fenced code in Markdown and MDX.
+///
+/// On by default: a documentation page whose samples are undifferentiated grey
+/// is not "MDX works out of the box". The colours are computed during the build
+/// and written into the HTML, so nothing is shipped to the browser to do it,
+/// and both themes are emitted together as CSS variables because a build
+/// cannot know whether the reader prefers light or dark.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct HighlightConfig {
+    pub enabled: bool,
+    pub themes: HighlightThemes,
+    /// Grammars to load beyond the ones a uf project uses by default.
+    pub langs: Vec<CompactString>,
+}
+
+impl Default for HighlightConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            themes: HighlightThemes::default(),
+            langs: Vec::new(),
+        }
+    }
+}
+
+/// The theme used for each of the reader's two preferences.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct HighlightThemes {
+    pub light: CompactString,
+    pub dark: CompactString,
+}
+
+impl Default for HighlightThemes {
+    fn default() -> Self {
+        Self {
+            light: CompactString::const_new("github-light"),
+            dark: CompactString::const_new("github-dark-dimmed"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -14,11 +14,12 @@ mod runtime;
 
 pub use app::{
     AppConfig, BuiltinConfig, CacheConfig, CacheModeConfig, ComponentBoundary, DataEngine,
-    EffectEngine, FetchConfig, FrameworkPreset, GraphQlConfig, LinkPrefetchMode, LoaderConfig,
-    MarkdownConfig, MarkdownEngineConfig, MdxConfig, MdxPipelinePluginConfig, MotionConfig,
-    MotionEngineConfig, OrmConfig, PwaConfig, ReactCompilerConfig, ReactCompilerImplementation,
-    ReactCompilerMode, ReactConfig, RenderingConfig, RenderingMode, RouterConfig, RouterConvention,
-    RuntimeTarget, StyleEngine, TemporalConfig, TuiConfig, TuiStandardConfig, WebConfig,
+    EffectEngine, FetchConfig, FrameworkPreset, GraphQlConfig, HighlightConfig, HighlightThemes,
+    LinkPrefetchMode, LoaderConfig, MarkdownConfig, MarkdownEngineConfig, MdxConfig,
+    MdxPipelinePluginConfig, MotionConfig, MotionEngineConfig, OrmConfig, PwaConfig,
+    ReactCompilerConfig, ReactCompilerImplementation, ReactCompilerMode, ReactConfig,
+    RenderingConfig, RenderingMode, RouterConfig, RouterConvention, RuntimeTarget, StyleEngine,
+    TemporalConfig, TuiConfig, TuiStandardConfig, WebConfig,
 };
 pub use lint::{
     FlowBuiltinLintMode, FlowLintConfig, FlowLintParser, LintConfig, LintEngine, RuleLevel,

--- a/docs/app/_design/seam.css
+++ b/docs/app/_design/seam.css
@@ -1035,3 +1035,76 @@ tbody tr:last-child :is(td, th) {
 .home-section > :is(p, pre, .command, .terminal) {
   max-width: var(--doc-measure);
 }
+
+/* ------------------------------------------------------------------ *
+ * Highlighted code
+ * ------------------------------------------------------------------ */
+
+/*
+ * The build writes both themes into every token as CSS variables, because it
+ * cannot know which the reader prefers. These rules pick one — and only the
+ * token colours: the block keeps this site's own paper ground and hairline
+ * rather than the theme's background, so a code sample sits in the page
+ * instead of on top of it.
+ */
+.prose .shiki,
+.home-section .shiki {
+  background: var(--doc-code-ground) !important;
+  color: var(--shiki-light);
+}
+
+.shiki span {
+  color: var(--shiki-light);
+}
+
+:root:not([data-theme="light"]) {
+  @media (prefers-color-scheme: dark) {
+    .prose .shiki,
+    .home-section .shiki,
+    .shiki span {
+      color: var(--shiki-dark);
+    }
+  }
+}
+
+:root[data-theme="dark"] .prose .shiki,
+:root[data-theme="dark"] .home-section .shiki,
+:root[data-theme="dark"] .shiki span {
+  color: var(--shiki-dark);
+}
+
+/*
+ * Flow's own keywords.
+ *
+ * A JavaScript grammar reads `component`, `hook`, `renders` and `match` as
+ * identifiers, so the build marks them and the colour is decided here. Two
+ * values, because a build cannot know which theme the reader will get; they
+ * are the keyword colours of the two default themes, so Flow's keywords look
+ * like the keywords beside them. A project that configures different
+ * `highlight.themes` sets these to match.
+ */
+.uf-flow-keyword {
+  --doc-keyword-light: #d73a49;
+  --doc-keyword-dark: #f47067;
+  color: var(--doc-keyword-light) !important;
+}
+
+:root:not([data-theme="light"]) {
+  @media (prefers-color-scheme: dark) {
+    .uf-flow-keyword {
+      color: var(--doc-keyword-dark) !important;
+    }
+  }
+}
+
+:root[data-theme="dark"] .uf-flow-keyword {
+  color: var(--doc-keyword-dark) !important;
+}
+
+/* Shiki wraps each line in a span, so a long line has to be allowed to scroll
+   with the block rather than wrapping mid-token. */
+.shiki code {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+}

--- a/docs/app/guide/styling/_uf.page.mdx
+++ b/docs/app/guide/styling/_uf.page.mdx
@@ -55,6 +55,44 @@ markdown, front matter and heading ids. `app.builtins.markdown` in
 [the config](/reference/config) turns pieces of it off or points them
 elsewhere.
 
+## Syntax highlighting
+
+Fenced code is highlighted during the build, so the colours are in the HTML and
+no highlighter is shipped to the browser:
+
+```mdx
+```js
+component Counter(initial: number) { … }
+```
+```
+
+Both a light and a dark theme are emitted together as CSS variables, because a
+build cannot know which the reader prefers; the stylesheet picks one. Flow's own
+keywords — `component`, `hook`, `renders`, `match` — are marked as keywords even
+though no highlighter has a Flow grammar and a JavaScript one reads them as
+plain names.
+
+To change the themes, or to add a language:
+
+```js
+export default defineConfig({
+  app: {
+    builtins: {
+      markdown: {
+        mdx: {
+          highlight: {
+            themes: { light: "min-light", dark: "vitesse-dark" },
+            langs: ["python", "sql"],
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+`highlight.enabled: false` turns it off.
+
 ## Public files
 
 Anything in `public/` is served from the root and copied into the build

--- a/docs/app/reference/config/_uf.page.mdx
+++ b/docs/app/reference/config/_uf.page.mdx
@@ -55,6 +55,9 @@ which is the fastest way to answer "what is it actually using".
 | `runtime.capabilityJsHost.autoDetect` | `true` | Pick a host by what is installed |
 | `react.*` | — | React Compiler mode and React-specific options |
 | `builtins.markdown` | on | Markdown and MDX |
+| `builtins.markdown.mdx.highlight.enabled` | `true` | Highlight fenced code during the build |
+| `builtins.markdown.mdx.highlight.themes` | `github-light` / `github-dark-dimmed` | The theme for each of the reader's two preferences |
+| `builtins.markdown.mdx.highlight.langs` | `[]` | Grammars beyond the ones a uf project uses |
 | `builtins.reactCompiler` | on | The official React Compiler |
 | `builtins.style` | — | The style engine |
 | `targets` | — | Runtime targets the build must satisfy |

--- a/package-lock.json
+++ b/package-lock.json
@@ -789,6 +789,87 @@
       ],
       "peer": true
     },
+    "node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/rehype": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-3.23.0.tgz",
+      "integrity": "sha512-GepKJxXHbXFfAkiZZZ+4V7x71Lw3s0ALYmydUxJRdvpKjSx9FOMSaunv6WRLFBXR6qjYerUq1YZQno+2gLEPwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "shiki": "3.23.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1458,6 +1539,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -1509,6 +1613,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inline-style-parser": {
@@ -2928,6 +3042,23 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -3096,6 +3227,30 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/rehype-recma": {
       "version": "1.0.0",
@@ -3326,6 +3481,22 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -4020,10 +4191,12 @@
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
+        "@shikijs/rehype": "^3.23.0",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
         "remark-mdx-frontmatter": "^5.2.0",
+        "shiki": "^3.23.0",
         "vite": "^8.2.2"
       },
       "peerDependencies": {

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -15,7 +15,8 @@
 //                 development it also renders every HTML request on the
 //                 server, so `uf dev` serves the same markup `uf build` writes.
 // * `uf:mdx`    — `@mdx-js/rollup`, configured for React with GitHub-flavoured
-//                 markdown, front matter and heading ids, so `.mdx` works with
+//                 markdown, front matter, heading ids and build-time syntax
+//                 highlighting, so `.mdx` works with
 //                 no configuration.
 //
 // `uniflowed(options)` returns the array; a project that wants to add a plugin
@@ -26,6 +27,8 @@ import path from "node:path";
 
 import mdx from "@mdx-js/rollup";
 import rehypeSlug from "rehype-slug";
+
+import { highlightPlugin } from "./internal/highlight.js";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
@@ -248,12 +251,19 @@ function flowPlugin({ routerRoot, appEntry, command }) {
 function mdxPlugin(markdown) {
   const mdxConfig = markdown.mdx ?? {};
   if (mdxConfig.enabled === false) return { name: "uf:mdx" };
+
+  // Highlighting is on unless a project turns it off, and it happens here
+  // rather than in the browser: the colours are in the HTML, so a code sample
+  // is readable before any JavaScript loads and no highlighter is shipped.
+  const highlight = highlightPlugin(mdxConfig.highlight);
+  const rehypePlugins = highlight == null ? [rehypeSlug] : [rehypeSlug, highlight];
+
   return {
     enforce: "pre",
     ...mdx({
       jsxImportSource: "react",
       remarkPlugins: [remarkGfm, remarkFrontmatter, [remarkMdxFrontmatter, { name: "frontmatter" }]],
-      rehypePlugins: [rehypeSlug],
+      rehypePlugins,
     }),
     name: "uf:mdx",
   };

--- a/packages/vite/internal/highlight.js
+++ b/packages/vite/internal/highlight.js
@@ -1,0 +1,188 @@
+// Syntax highlighting for fenced code, at build time.
+//
+// uf's claim is that MDX works without a plugin list, and a documentation page
+// whose code samples are undifferentiated grey does not meet it. So this is on
+// by default, it runs during the build rather than shipping a highlighter to
+// the browser, and it knows about Flow.
+//
+// # Flow
+//
+// No highlighter has a Flow grammar, and Flow's declaration keywords —
+// `component`, `hook`, `renders`, `match`, `enum` — are ordinary identifiers to
+// a JavaScript one. They would be the only uncoloured words in a uf code
+// sample, which is the wrong way round: they are the reason the sample is
+// there.
+//
+// Rather than write and maintain a TextMate grammar, `flowKeywords` re-tags
+// those tokens after the JavaScript grammar has run. It only recolours a token
+// whose whole text is one of the words, so `components` and `matcher` are left
+// alone, and it does not touch tokens inside a string or a comment because the
+// grammar has already given those their own colour.
+
+import rehypeShiki from "@shikijs/rehype";
+
+/**
+ * Flow's declaration keywords, which a JavaScript grammar reads as names.
+ *
+ * Whole words only, so `components`, `matcher` and `hooks` stay identifiers,
+ * and never after a dot, so `text.match(…)` and `list.hook` are left alone.
+ * The grammar splits a line into tokens wherever it likes — `match` arrives at
+ * the end of its own token, with the `(` that follows it in the next one — so
+ * the rule has to be decidable from the characters around the word alone,
+ * which is why it looks behind rather than ahead.
+ *
+ * `enum` is not here: every JavaScript grammar already treats it as a keyword.
+ */
+const FLOW_KEYWORD_PATTERN =
+  /(?<![.\w$])(?:component|hook|renders|match|opaque|mixed|empty)(?![\w$])/g;
+
+
+
+/**
+ * The languages a documentation page actually uses.
+ *
+ * Loading every grammar Shiki ships would cost seconds and megabytes for
+ * languages nobody writes here; `highlight.langs` extends this.
+ */
+const DEFAULT_LANGS = [
+  "javascript",
+  "jsx",
+  "json",
+  "css",
+  "html",
+  "markdown",
+  "mdx",
+  "shellscript",
+  "rust",
+  "toml",
+  "yaml",
+  "diff",
+];
+
+/**
+ * `flow` and the shorthands people type in a fence, mapped to a real grammar.
+ *
+ * Only names that are *not* grammars in their own right: Shiki rejects an
+ * alias pointing at itself, and `jsx`, `md` and `yml` are already loaded
+ * languages or aliases it knows.
+ */
+const ALIASES = {
+  flow: "javascript",
+  console: "shellscript",
+};
+
+/**
+ * Give Flow's keywords a class the stylesheet can colour.
+ *
+ * A JavaScript grammar reads `component` as a name, and does not even put it in
+ * a token of its own: `export component Avatar(…) {` arrives as the keyword
+ * `export` followed by one long token holding all the rest. So `tokens` splits
+ * that token around each Flow keyword, on whole-word boundaries, and `span`
+ * marks the resulting pieces.
+ *
+ * Marking rather than recolouring, because the colour is not knowable here.
+ * Copying the colour from another keyword in the same block was the first
+ * attempt and it fails exactly where it matters: a snippet that is nothing but
+ * `component Tab(label: string) renders React.Node` contains no keyword the
+ * grammar recognises, so there was nothing to copy from. A class moves the
+ * decision to CSS, which is where the theme's colours already live.
+ */
+function flowKeywords() {
+  return {
+    name: "uf:flow-keywords",
+    tokens(lines) {
+      return lines.map((line) => line.flatMap(split));
+    },
+    span(node, _line, _col, _lineElement, token) {
+      if (!isFlowKeyword(token.content)) {
+        return;
+      }
+      const existing = node.properties.class;
+      node.properties.class =
+        existing == null ? KEYWORD_CLASS : `${existing} ${KEYWORD_CLASS}`;
+    },
+  };
+}
+
+/** The class a Flow keyword's span carries. */
+const KEYWORD_CLASS = "uf-flow-keyword";
+
+/** Whether a token is exactly one Flow keyword, after splitting. */
+function isFlowKeyword(content) {
+  return [...content.matchAll(FLOW_KEYWORD_PATTERN)].some(
+    (match) => match[0].length === content.length,
+  );
+}
+
+/**
+ * One token, split around any Flow keyword inside it.
+ *
+ * `offset` is carried through for every piece, because Shiki and any other
+ * transformer use it to map a token back to the source; a piece with the wrong
+ * offset breaks anything that reads positions, such as line highlighting.
+ */
+function split(token) {
+  const text = token.content;
+  // `matchAll` works on its own copy of the pattern. `test` would not: on a
+  // global regex it advances `lastIndex`, so every second call would start
+  // partway through an unrelated string and miss.
+  const matches = text.length === 0 ? [] : [...text.matchAll(FLOW_KEYWORD_PATTERN)];
+  if (matches.length === 0) {
+    return [token];
+  }
+
+  const pieces = [];
+  let index = 0;
+  for (const match of matches) {
+    const at = match.index ?? 0;
+    if (at > index) {
+      pieces.push(piece(token, text.slice(index, at), index));
+    }
+    pieces.push(piece(token, match[0], at));
+    index = at + match[0].length;
+  }
+  if (index < text.length) {
+    pieces.push(piece(token, text.slice(index), index));
+  }
+  return pieces;
+}
+
+function piece(token, content, at) {
+  return {
+    ...token,
+    content,
+    offset: (token.offset ?? 0) + at,
+  };
+}
+
+/**
+ * The rehype plugin entry, or `null` when a project turns highlighting off.
+ *
+ * Two themes rather than one, emitted as CSS variables (`defaultColor: false`),
+ * because a page follows the reader's light or dark preference and a build-time
+ * highlighter cannot know it. The stylesheet picks between them.
+ *
+ * @param {{enabled?: boolean, themes?: {light: string, dark: string}, langs?: string[]}} options
+ */
+export function highlightPlugin(options) {
+  const config = options ?? {};
+  if (config.enabled === false) {
+    return null;
+  }
+  const themes = config.themes ?? { light: "github-light", dark: "github-dark-dimmed" };
+  const langs = [...new Set([...DEFAULT_LANGS, ...(config.langs ?? [])])];
+
+  return [
+    rehypeShiki,
+    {
+      themes,
+      langs,
+      langAlias: ALIASES,
+      defaultColor: false,
+      // A fence naming a language Shiki does not have should render as plain
+      // code, not fail the build.
+      fallbackLanguage: "text",
+      transformers: [flowKeywords()],
+    },
+  ];
+}

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -28,10 +28,12 @@
   ],
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
+    "@shikijs/rehype": "^3.23.0",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
+    "shiki": "^3.23.0",
     "vite": "^8.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Code samples on the documentation site were undifferentiated grey. "MDX works out of the box" has to include that.

Highlighting is now **on by default** and runs at build time, so the colours are in the HTML and no highlighter reaches the browser. Next.js makes you add `rehype-pretty-code`; this needed no configuration.

## Flow was the actual work

No highlighter has a Flow grammar, and a JavaScript one reads `component`, `hook`, `renders` and `match` as ordinary identifiers — so they would have been the only uncoloured words in a uf code sample, which is exactly backwards: they are the reason the sample is there.

Rather than write and maintain a TextMate grammar, a Shiki transformer splits the tokens the grammar produced around those words and marks them, and the stylesheet colours them like the keywords beside them.

Two things had to be right, and neither was obvious until it was wrong:

**The grammar does not put `component` in a token of its own.** `export component Avatar(…) {` arrives as the keyword `export` followed by *one* token holding all the rest, so a transformer comparing token text to a keyword list never matches. The tokens have to be split first, carrying `offset` through so anything reading positions still works.

**`match` ends its own token**, with the `(` that follows it in the next one — so a lookahead for the paren never sees one. The rule looks *behind* for a dot instead, which also means `text.match(…)` and `list.hook` are left alone.

An earlier attempt copied the colour from another keyword in the same block. It fails exactly where it matters: a snippet that is only `component Tab(label: string) renders React.Node` has no keyword the grammar recognises, so there was nothing to copy. A class moves the decision to CSS, where the theme's colours already live.

## Themes

Both themes are emitted together as CSS variables, because a build cannot know whether the reader prefers light or dark — the stylesheet picks one, and the block keeps the site's own paper ground rather than the theme's background.

```js
markdown: {
  mdx: {
    highlight: {
      themes: { light: "min-light", dark: "vitesse-dark" },
      langs: ["python", "sql"],
    },
  },
}
```

`highlight.enabled: false` turns it off. Twelve grammars load by default rather than everything Shiki ships, so a build does not pay seconds for languages nobody writes here. A fence naming an unknown language renders as plain code instead of failing the build.

## Checked

`cargo fmt --all -- --check`, `cargo test -p uf_config`, `cargo test -p uf_cli --test vite`, 16 pages built, and read in both themes at 720px and 1280px — `component` sits in the same colour as `export` beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791035871&installation_model_id=422833&pr_number=81&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F81&signature=25e0f8f48196b4cfffc5d329361ef073829d0926f87ae2c5eb90686a57a9c5d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->