### PR TITLE
feat(ui): headless components whose composition Flow checks

### DIFF
--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -405,7 +405,7 @@ pub fn builtin_modules() -> Vec<NativeModule> {
             "@uniflowed/ui",
             NativeModuleKind::Ui,
             Stability::Experimental,
-            &["Button", "Dialog", "Form", "Table", "Tabs", "Tooltip"],
+            &["Checkbox", "Dialog", "Field", "Switch", "Tabs"],
         ),
         NativeModule::new(
             "@uniflowed/react-compiler",

--- a/packages/test/internal/equality.js
+++ b/packages/test/internal/equality.js
@@ -238,6 +238,35 @@ function quoteString(value: string): string {
  * or refuses. Depth, breadth and total size are bounded, because a failure
  * message that scrolls the terminal is a failure message nobody reads.
  */
+/**
+ * An element's opening tag, or `null` if this is not an element.
+ *
+ * Duck-typed rather than `instanceof Element`, because this module must not
+ * depend on a DOM existing: a test process without a document simply never has
+ * a value that answers to this shape.
+ */
+function elementTag(value: mixed): string | null {
+  const node: $FlowFixMe = value;
+  if (
+    node == null ||
+    typeof node.tagName !== "string" ||
+    typeof node.getAttribute !== "function" ||
+    node.nodeType !== 1
+  ) {
+    return null;
+  }
+  const name = node.tagName.toLowerCase();
+  const attributes = Array.from(node.attributes ?? [])
+    .slice(0, MAX_RENDER_ENTRIES)
+    .map((attribute: $FlowFixMe) => ` ${attribute.name}="${attribute.value}"`)
+    .join("");
+  const text = (node.textContent ?? "").replace(/\s+/g, " ").trim();
+  const shown = text.length > 40 ? `${text.slice(0, 40)}…` : text;
+  return shown === ""
+    ? `<${name}${attributes} />`
+    : `<${name}${attributes}>${shown}</${name}>`;
+}
+
 export function render(value: mixed, depth: number = 0, seen: Array<mixed> = []): string {
   const text = renderInner(value, depth, seen);
   return text.length > MAX_RENDER_BYTES ? `${text.slice(0, MAX_RENDER_BYTES)}… (elided)` : text;
@@ -278,6 +307,14 @@ function renderInner(value: mixed, depth: number, seen: Array<mixed>): string {
   const nested = [...seen, value];
   const inner = (item: mixed) => renderInner(item, depth + 1, nested);
 
+  // An element, before the object branch reaches it. A DOM node's own
+  // properties are event-listener maps and parent pointers, so rendering it as
+  // an object buries the failure under a page of internals — and the whole
+  // document, through the parent chain. Its opening tag is what a reader needs.
+  const tag = elementTag(value);
+  if (tag != null) {
+    return tag;
+  }
   if (value instanceof Date) {
     return `Date(${value.toISOString()})`;
   }

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,184 +1,103 @@
 // @flow
 //
-// `@uniflowed/ui`.
+// `@uniflowed/ui`: components you own, with the behaviour you would get wrong.
 //
-// Every component is a placeholder that raises when it is rendered and names
-// the part it stands for, so a missing runtime reports `Dialog.Trigger` rather
-// than a bare `undefined is not a function`. Each top-level binding carries a
-// pure annotation: without it a bundler must assume a top-level call could have
-// side effects and would keep all forty-eight of them.
+// The premise is the one shadcn established and it is the right one: a
+// component library that ships styles is a library you fight, so these ship
+// none. Every part takes `className` and every other DOM prop and passes it
+// through; what they contribute is the part that is genuinely hard and
+// genuinely invisible when it is missing.
+//
+// That part is behaviour, and specifically keyboard and screen-reader
+// behaviour: a roving `tabindex` so a twelve-tab list does not take twelve Tab
+// presses to get past, a focus trap that actually cannot be escaped, focus
+// restored to whatever opened a dialog, `aria-describedby` pointing only at
+// elements that are in the document. None of it is visible in a screenshot and
+// all of it is what separates a component from a div that looks like one.
+//
+// # Composition is type-checked
+//
+// This is where Flow says something no other type system can. `Tabs.List`
+// declares `renders* Tabs.Tab`, so a `<button>` in a tab list is a *type
+// error* — not a review comment, not a runtime warning, not a screen reader
+// announcing "button" where the reader expected "tab, 2 of 5". A library
+// written in TypeScript can document that constraint; it cannot state it.
 
-import type * as React from "@uniflowed/react";
-import type { Schema } from "@uniflowed/validator";
-import { nativeRuntimeRequired } from "@uniflowed/core/native";
+import {
+  FieldControl,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FieldRoot,
+} from "./internal/field.js";
+import {
+  DialogClose,
+  DialogContent,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+} from "./internal/dialog.js";
+import { TabsList, TabsPanel, TabsRoot, TabsTab } from "./internal/tabs.js";
+import { Checkbox, Switch } from "./internal/switch.js";
 
-const MODULE = "@uniflowed/core/ui";
-
-export type HeadlessProps = {
-  +className?: string,
-  +children?: React.Node,
-  +variant?: string,
-  +size?: string,
-  +disabled?: boolean,
-};
-
-export type HeadlessComponent = component(
-  className?: string,
-  children?: React.Node,
-  variant?: string,
-  size?: string,
-  disabled?: boolean,
-) renders React.Node;
-
-export type CompoundComponent = {
-  +Root: HeadlessComponent,
-  +Trigger?: HeadlessComponent,
-  +Overlay?: HeadlessComponent,
-  +Body?: HeadlessComponent,
-  +Header?: HeadlessComponent,
-  +Footer?: HeadlessComponent,
-  +Title?: HeadlessComponent,
-  +Description?: HeadlessComponent,
-  +Close?: HeadlessComponent,
-  +Item?: HeadlessComponent,
-  +Content?: HeadlessComponent,
-  +List?: HeadlessComponent,
-  +Input?: HeadlessComponent,
-  +Label?: HeadlessComponent,
-  +Control?: HeadlessComponent,
-  +Message?: HeadlessComponent,
-};
-
-export type FormRoot = component<T: {...}>(
-  schema: Schema<T>,
-  defaultValue?: T,
-  children?: React.Node,
-  onSubmit?: (value: T) => mixed | Promise<mixed>,
-) renders React.Node;
-
-export type FormComponent = {
-  +Root: FormRoot,
-  +Field: HeadlessComponent,
-  +Label: HeadlessComponent,
-  +Control: HeadlessComponent,
-  +Message: HeadlessComponent,
-  +Submit: HeadlessComponent,
-};
-
-/** Placeholder for one headless part, e.g. `Dialog.Trigger`. */
-function headless(binding: string): HeadlessComponent {
-  return function HeadlessBinding(props: HeadlessProps): empty {
-    return nativeRuntimeRequired(MODULE, binding);
-  };
-}
+export { Checkbox, Switch };
 
 /**
- * Placeholder for a compound component: every optional part is materialised so
- * `Dialog.Body` is a component that raises rather than `undefined`.
+ * An accessible form field.
+ *
+ * `Field.Control` takes a render function rather than rendering an `<input>`,
+ * because a field wraps a select, a textarea or somebody else's component just
+ * as often, and each needs the same attributes.
+ *
+ *   <Field.Root invalid={error != null}>
+ *     <Field.Label>Email</Field.Label>
+ *     <Field.Control render={(props) => <input type="email" {...props} />} />
+ *     <Field.Description>We will not share it.</Field.Description>
+ *     <Field.Error>{error}</Field.Error>
+ *   </Field.Root>
  */
-function compound(name: string): CompoundComponent {
-  return {
-    Root: headless(`${name}.Root`),
-    Trigger: headless(`${name}.Trigger`),
-    Overlay: headless(`${name}.Overlay`),
-    Body: headless(`${name}.Body`),
-    Header: headless(`${name}.Header`),
-    Footer: headless(`${name}.Footer`),
-    Title: headless(`${name}.Title`),
-    Description: headless(`${name}.Description`),
-    Close: headless(`${name}.Close`),
-    Item: headless(`${name}.Item`),
-    Content: headless(`${name}.Content`),
-    List: headless(`${name}.List`),
-    Input: headless(`${name}.Input`),
-    Label: headless(`${name}.Label`),
-    Control: headless(`${name}.Control`),
-    Message: headless(`${name}.Message`),
-  };
-}
-
-/** Placeholder for the schema-bound `Form.Root`. */
-function formRoot(): FormRoot {
-  return function FormRootBinding<T: {...}>(props: {
-    +schema: Schema<T>,
-    +defaultValue?: T,
-    +children?: React.Node,
-    +onSubmit?: (value: T) => mixed | Promise<mixed>,
-  }): empty {
-    return nativeRuntimeRequired(MODULE, "Form.Root");
-  };
-}
-
-export const Accordion: CompoundComponent =
-  /*#__PURE__*/ compound("Accordion");
-export const Alert: CompoundComponent = /*#__PURE__*/ compound("Alert");
-export const AlertDialog: CompoundComponent =
-  /*#__PURE__*/ compound("AlertDialog");
-export const AspectRatio: CompoundComponent =
-  /*#__PURE__*/ compound("AspectRatio");
-export const Avatar: CompoundComponent = /*#__PURE__*/ compound("Avatar");
-export const Badge: HeadlessComponent = /*#__PURE__*/ headless("Badge");
-export const Breadcrumb: CompoundComponent =
-  /*#__PURE__*/ compound("Breadcrumb");
-export const Button: HeadlessComponent = /*#__PURE__*/ headless("Button");
-export const Calendar: CompoundComponent = /*#__PURE__*/ compound("Calendar");
-export const Card: CompoundComponent = /*#__PURE__*/ compound("Card");
-export const Carousel: CompoundComponent = /*#__PURE__*/ compound("Carousel");
-export const Chart: CompoundComponent = /*#__PURE__*/ compound("Chart");
-export const Checkbox: CompoundComponent = /*#__PURE__*/ compound("Checkbox");
-export const Collapsible: CompoundComponent =
-  /*#__PURE__*/ compound("Collapsible");
-export const Command: CompoundComponent = /*#__PURE__*/ compound("Command");
-export const ContextMenu: CompoundComponent =
-  /*#__PURE__*/ compound("ContextMenu");
-export const DataTable: CompoundComponent =
-  /*#__PURE__*/ compound("DataTable");
-export const DatePicker: CompoundComponent =
-  /*#__PURE__*/ compound("DatePicker");
-export const Dialog: CompoundComponent = /*#__PURE__*/ compound("Dialog");
-export const Drawer: CompoundComponent = /*#__PURE__*/ compound("Drawer");
-export const DropdownMenu: CompoundComponent =
-  /*#__PURE__*/ compound("DropdownMenu");
-export const Form: FormComponent = {
-  Root: /*#__PURE__*/ formRoot(),
-  Field: /*#__PURE__*/ headless("Form.Field"),
-  Label: /*#__PURE__*/ headless("Form.Label"),
-  Control: /*#__PURE__*/ headless("Form.Control"),
-  Message: /*#__PURE__*/ headless("Form.Message"),
-  Submit: /*#__PURE__*/ headless("Form.Submit"),
+export const Field = {
+  Root: FieldRoot,
+  Label: FieldLabel,
+  Control: FieldControl,
+  Description: FieldDescription,
+  Error: FieldError,
 };
-export const HoverCard: CompoundComponent =
-  /*#__PURE__*/ compound("HoverCard");
-export const Input: HeadlessComponent = /*#__PURE__*/ headless("Input");
-export const InputOtp: CompoundComponent = /*#__PURE__*/ compound("InputOtp");
-export const Label: HeadlessComponent = /*#__PURE__*/ headless("Label");
-export const Menubar: CompoundComponent = /*#__PURE__*/ compound("Menubar");
-export const NavigationMenu: CompoundComponent =
-  /*#__PURE__*/ compound("NavigationMenu");
-export const Pagination: CompoundComponent =
-  /*#__PURE__*/ compound("Pagination");
-export const Popover: CompoundComponent = /*#__PURE__*/ compound("Popover");
-export const Progress: HeadlessComponent = /*#__PURE__*/ headless("Progress");
-export const RadioGroup: CompoundComponent =
-  /*#__PURE__*/ compound("RadioGroup");
-export const Resizable: CompoundComponent =
-  /*#__PURE__*/ compound("Resizable");
-export const ScrollArea: CompoundComponent =
-  /*#__PURE__*/ compound("ScrollArea");
-export const Select: CompoundComponent = /*#__PURE__*/ compound("Select");
-export const Separator: HeadlessComponent =
-  /*#__PURE__*/ headless("Separator");
-export const Sheet: CompoundComponent = /*#__PURE__*/ compound("Sheet");
-export const Sidebar: CompoundComponent = /*#__PURE__*/ compound("Sidebar");
-export const Skeleton: HeadlessComponent = /*#__PURE__*/ headless("Skeleton");
-export const Slider: CompoundComponent = /*#__PURE__*/ compound("Slider");
-export const Sonner: CompoundComponent = /*#__PURE__*/ compound("Sonner");
-export const Switch: CompoundComponent = /*#__PURE__*/ compound("Switch");
-export const Table: CompoundComponent = /*#__PURE__*/ compound("Table");
-export const Tabs: CompoundComponent = /*#__PURE__*/ compound("Tabs");
-export const Textarea: HeadlessComponent = /*#__PURE__*/ headless("Textarea");
-export const Toast: CompoundComponent = /*#__PURE__*/ compound("Toast");
-export const Toggle: HeadlessComponent = /*#__PURE__*/ headless("Toggle");
-export const ToggleGroup: CompoundComponent =
-  /*#__PURE__*/ compound("ToggleGroup");
-export const Tooltip: CompoundComponent = /*#__PURE__*/ compound("Tooltip");
+
+/**
+ * Tabs, with the arrow-key behaviour the pattern requires.
+ *
+ *   <Tabs.Root defaultValue="one">
+ *     <Tabs.List>
+ *       <Tabs.Tab value="one">One</Tabs.Tab>
+ *       <Tabs.Tab value="two">Two</Tabs.Tab>
+ *     </Tabs.List>
+ *     <Tabs.Panel value="one">…</Tabs.Panel>
+ *     <Tabs.Panel value="two">…</Tabs.Panel>
+ *   </Tabs.Root>
+ */
+export const Tabs = {
+  Root: TabsRoot,
+  List: TabsList,
+  Tab: TabsTab,
+  Panel: TabsPanel,
+};
+
+/**
+ * A modal dialog: focus moved in, kept in, and given back.
+ *
+ *   <Dialog.Root>
+ *     <Dialog.Trigger>Open</Dialog.Trigger>
+ *     <Dialog.Content>
+ *       <Dialog.Title>Are you sure?</Dialog.Title>
+ *       <Dialog.Close>Cancel</Dialog.Close>
+ *     </Dialog.Content>
+ *   </Dialog.Root>
+ */
+export const Dialog = {
+  Root: DialogRoot,
+  Trigger: DialogTrigger,
+  Content: DialogContent,
+  Title: DialogTitle,
+  Close: DialogClose,
+};

--- a/packages/ui/internal/dialog.js
+++ b/packages/ui/internal/dialog.js
@@ -1,0 +1,217 @@
+// @flow
+//
+// A modal dialog, which is the component people most often get wrong.
+//
+// Four things have to be true for a dialog to be usable by someone who is not
+// using a mouse, and a hand-written one usually has one or two of them:
+//
+//   * Focus moves into the dialog when it opens, and to the first thing worth
+//     acting on rather than to whatever happens to be first in the document.
+//   * Tab cannot leave. A dialog you can Tab out of leaves the reader
+//     somewhere in a page they cannot see, with no way back.
+//   * Escape closes it.
+//   * Focus returns to whatever opened it. Otherwise it restarts at the top of
+//     the document, and the reader has to find their place again.
+//
+// The dialog is rendered where it is declared rather than through a portal.
+// A portal solves a stacking-context problem that belongs to CSS, and it costs
+// the thing this component is for: rendered in place, the dialog is next to its
+// trigger in the accessibility tree, which is where a screen reader looks.
+
+import * as React from "@uniflowed/react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "@uniflowed/react";
+
+type DialogState = {|
+  +base: string,
+  +open: boolean,
+  +setOpen: (open: boolean) => void,
+  +triggerRef: { current: HTMLElement | null },
+|};
+
+const DialogContext: React.Context<DialogState | null> = createContext(null);
+
+function useDialog(part: string): DialogState {
+  const state = useContext(DialogContext);
+  if (state == null) {
+    throw new Error(`${part} must be rendered inside a Dialog.Root`);
+  }
+  return state;
+}
+
+/** The dialog, open or closed. Uncontrolled unless `open` is given. */
+export component DialogRoot(
+  children: React.Node,
+  defaultOpen?: boolean = false,
+  open?: boolean,
+  onOpenChange?: (open: boolean) => void,
+) {
+  const base = useId();
+  const [internal, setInternal] = useState(defaultOpen);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const isOpen = open ?? internal;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (open == null) {
+        setInternal(next);
+      }
+      onOpenChange?.(next);
+    },
+    [open, onOpenChange],
+  );
+
+  const state = useMemo(
+    () => ({ base, open: isOpen, setOpen, triggerRef }),
+    [base, isOpen, setOpen],
+  );
+
+  return <DialogContext.Provider value={state}>{children}</DialogContext.Provider>;
+}
+
+/** What opens the dialog, and what focus comes back to when it closes. */
+export component DialogTrigger(children: React.Node, ...rest: { +[string]: mixed }) {
+  const dialog = useDialog("Dialog.Trigger");
+  return (
+    <button
+      aria-expanded={dialog.open ? "true" : "false"}
+      aria-haspopup="dialog"
+      onClick={() => dialog.setOpen(true)}
+      ref={(element) => {
+        dialog.triggerRef.current = element;
+      }}
+      type="button"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The dialog itself: focus moved in, Tab kept inside, Escape closing it.
+ *
+ * `aria-modal` tells a screen reader that the rest of the page is not
+ * available, which is the half of "modal" that CSS cannot express.
+ */
+export component DialogContent(children: React.Node, ...rest: { +[string]: mixed }) {
+  const dialog = useDialog("Dialog.Content");
+  const contentRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!dialog.open) {
+      return;
+    }
+    const opener = dialog.triggerRef.current;
+    const content = contentRef.current;
+    // The first thing worth acting on, not the first thing in the document —
+    // and the dialog itself if it contains nothing focusable, so focus is
+    // inside it either way.
+    const target = content == null ? null : (focusable(content)[0] ?? content);
+    target?.focus();
+
+    return () => {
+      // Back to the trigger. Leaving focus on a removed node sends it to the
+      // top of the document, and the reader has to find their place again.
+      opener?.focus();
+    };
+  }, [dialog.open, dialog.triggerRef]);
+
+  if (!dialog.open) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-labelledby={`${dialog.base}-title`}
+      aria-modal="true"
+      id={`${dialog.base}-content`}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          dialog.setOpen(false);
+          return;
+        }
+        if (event.key !== "Tab") {
+          return;
+        }
+        const content = contentRef.current;
+        if (content == null) {
+          return;
+        }
+        const stops = focusable(content);
+        if (stops.length === 0) {
+          // Nothing to move to, so Tab must not leave either.
+          event.preventDefault();
+          return;
+        }
+        const first = stops[0];
+        const last = stops[stops.length - 1];
+        const active = content.ownerDocument?.activeElement;
+        // Wrap at the ends. This is the whole of "focus cannot leave": every
+        // other Tab press is the browser's own business.
+        if (event.shiftKey && (active === first || active === content)) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && active === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }}
+      ref={(element) => {
+        contentRef.current = element;
+      }}
+      role="dialog"
+      tabIndex={-1}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** The dialog's accessible name, which `aria-labelledby` points at. */
+export component DialogTitle(children: React.Node, ...rest: { +[string]: mixed }) {
+  const dialog = useDialog("Dialog.Title");
+  return (
+    <h2 id={`${dialog.base}-title`} {...rest}>
+      {children}
+    </h2>
+  );
+}
+
+/** A button that closes the dialog. */
+export component DialogClose(children: React.Node, ...rest: { +[string]: mixed }) {
+  const dialog = useDialog("Dialog.Close");
+  return (
+    <button onClick={() => dialog.setOpen(false)} type="button" {...rest}>
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The focus stops inside an element, in document order.
+ *
+ * Disabled controls and `tabindex="-1"` are excluded because the browser
+ * excludes them, and anything inside `[hidden]` or `aria-hidden` is excluded
+ * because a reader cannot see it.
+ */
+function focusable(root: HTMLElement): Array<HTMLElement> {
+  const selector =
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  return Array.from(root.querySelectorAll(selector)).filter((element: any) => {
+    if (element.getAttribute("aria-hidden") === "true") {
+      return false;
+    }
+    return element.closest("[hidden]") == null;
+  });
+}

--- a/packages/ui/internal/field.js
+++ b/packages/ui/internal/field.js
@@ -1,0 +1,161 @@
+// @flow
+//
+// An accessible form field, wired up for you.
+//
+// The hard part of a form field is not the markup, it is the wiring: the label
+// has to point at the control, the description and the error message have to be
+// named by `aria-describedby`, the control has to say `aria-invalid` when it is
+// wrong, and every id has to be unique on the page and stable across renders.
+// Doing that by hand is four attributes and two `useId` calls per field, and
+// getting one wrong is silent — the field looks right and a screen reader
+// announces nothing.
+//
+// So the parts read the ids off a context the root creates. `Field.Label` knows
+// which control it labels because there is exactly one in its root, and
+// `Field.Error` registers itself so the control can point at it only when it is
+// actually rendered — pointing `aria-describedby` at an id that is not in the
+// document makes a screen reader announce nothing at all, which is worse than
+// omitting the attribute.
+
+import * as React from "@uniflowed/react";
+import { createContext, useContext, useId, useMemo, useState } from "@uniflowed/react";
+
+type FieldState = {|
+  +controlId: string,
+  +labelId: string,
+  +descriptionId: string,
+  +errorId: string,
+  +invalid: boolean,
+  +describedBy: string | void,
+  +registerDescription: (present: boolean) => void,
+  +registerError: (present: boolean) => void,
+|};
+
+const FieldContext: React.Context<FieldState | null> = createContext(null);
+
+/**
+ * The field a part belongs to.
+ *
+ * Raising rather than returning null: a `Field.Label` outside a `Field.Root`
+ * would render a label pointing at nothing, and would look correct.
+ */
+function useField(part: string): FieldState {
+  const state = useContext(FieldContext);
+  if (state == null) {
+    throw new Error(`${part} must be rendered inside a Field.Root`);
+  }
+  return state;
+}
+
+/**
+ * The field's container, and the only place ids are made.
+ *
+ * `invalid` is the root's business rather than the control's because three
+ * parts have to agree about it: the control says `aria-invalid`, the error
+ * message is rendered or not, and the control's `aria-describedby` includes the
+ * error's id or not.
+ */
+export component FieldRoot(
+  children: React.Node,
+  invalid?: boolean = false,
+  ...rest: { +[string]: mixed }
+) {
+  const base = useId();
+  const [hasDescription, setHasDescription] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const state = useMemo(() => {
+    const descriptionId = `${base}-description`;
+    const errorId = `${base}-error`;
+    // Only ids that are in the document. `aria-describedby` naming a missing
+    // element makes a screen reader announce nothing rather than skipping it.
+    const described = [
+      hasDescription ? descriptionId : null,
+      invalid && hasError ? errorId : null,
+    ].filter(Boolean);
+
+    return {
+      controlId: `${base}-control`,
+      labelId: `${base}-label`,
+      descriptionId,
+      errorId,
+      invalid,
+      describedBy: described.length === 0 ? undefined : described.join(" "),
+      registerDescription: setHasDescription,
+      registerError: setHasError,
+    };
+  }, [base, invalid, hasDescription, hasError]);
+
+  return (
+    <FieldContext.Provider value={state}>
+      <div {...rest}>{children}</div>
+    </FieldContext.Provider>
+  );
+}
+
+/** The label, pointing at the control by id rather than by nesting. */
+export component FieldLabel(children: React.Node, ...rest: { +[string]: mixed }) {
+  const field = useField("Field.Label");
+  return (
+    <label htmlFor={field.controlId} id={field.labelId} {...rest}>
+      {children}
+    </label>
+  );
+}
+
+/**
+ * The control, given every attribute the rest of the field implies.
+ *
+ * `render` takes the element rather than this rendering an `<input>`, because a
+ * field wraps a select, a textarea, a combobox or somebody else's component
+ * just as often, and each of those needs the same six attributes.
+ */
+export component FieldControl(
+  render: (props: { +[string]: mixed }) => React.Node,
+) {
+  const field = useField("Field.Control");
+  return render({
+    id: field.controlId,
+    "aria-labelledby": field.labelId,
+    "aria-describedby": field.describedBy,
+    "aria-invalid": field.invalid ? "true" : undefined,
+  });
+}
+
+/** Help text, which the control points at while it is rendered. */
+export component FieldDescription(children: React.Node, ...rest: { +[string]: mixed }) {
+  const field = useField("Field.Description");
+  React.useEffect(() => {
+    field.registerDescription(true);
+    return () => field.registerDescription(false);
+  }, [field]);
+
+  return (
+    <p id={field.descriptionId} {...rest}>
+      {children}
+    </p>
+  );
+}
+
+/**
+ * The error message, rendered only when the field is invalid.
+ *
+ * `role="alert"` so it is announced when it appears, which is the point of an
+ * error that arrives after a blur or a submit.
+ */
+export component FieldError(children: React.Node, ...rest: { +[string]: mixed }) {
+  const field = useField("Field.Error");
+  React.useEffect(() => {
+    field.registerError(true);
+    return () => field.registerError(false);
+  }, [field]);
+
+  if (!field.invalid) {
+    return null;
+  }
+  return (
+    <p id={field.errorId} role="alert" {...rest}>
+      {children}
+    </p>
+  );
+}

--- a/packages/ui/internal/switch.js
+++ b/packages/ui/internal/switch.js
@@ -1,0 +1,121 @@
+// @flow
+//
+// A switch, and a checkbox that is not an `<input>`.
+//
+// Both exist because the styled version of a checkbox is almost always a `div`
+// with a tick drawn in it, and the moment it stops being an `<input>` it stops
+// being announced, stops toggling on Space, and stops being reachable by Tab.
+// These keep all three: the role, the `aria-checked` state, and the keys.
+//
+// A switch is not a checkbox. A checkbox has three states — on, off and
+// indeterminate — and a switch has two; a screen reader says "on"/"off" for one
+// and "checked"/"unchecked" for the other. Using the wrong one is the kind of
+// mistake that is invisible until somebody uses the thing.
+
+import * as React from "@uniflowed/react";
+import { useCallback, useState } from "@uniflowed/react";
+
+/** Space toggles, and so does Enter, because both do on a native control. */
+function toggleKeys(
+  event: SyntheticKeyboardEvent<HTMLElement>,
+  toggle: () => void,
+): void {
+  if (event.key !== " " && event.key !== "Enter") {
+    return;
+  }
+  // Space scrolls the page otherwise, which is what makes a hand-written
+  // toggle feel broken even when it works.
+  event.preventDefault();
+  toggle();
+}
+
+/** State for a control that may be controlled or not. */
+function useToggle(
+  checked: boolean | void,
+  defaultChecked: boolean,
+  onCheckedChange: ((checked: boolean) => void) | void,
+): [boolean, () => void] {
+  const [internal, setInternal] = useState(defaultChecked);
+  const current = checked ?? internal;
+
+  const toggle = useCallback(() => {
+    const next = !current;
+    if (checked == null) {
+      setInternal(next);
+    }
+    onCheckedChange?.(next);
+  }, [checked, current, onCheckedChange]);
+
+  return [current, toggle];
+}
+
+/** A two-state switch: on or off. */
+export component Switch(
+  checked?: boolean,
+  defaultChecked?: boolean = false,
+  onCheckedChange?: (checked: boolean) => void,
+  disabled?: boolean = false,
+  children?: React.Node,
+  ...rest: { +[string]: mixed }
+) {
+  const [on, toggle] = useToggle(checked, defaultChecked, onCheckedChange);
+
+  return (
+    <button
+      aria-checked={on ? "true" : "false"}
+      disabled={disabled}
+      onClick={() => {
+        if (!disabled) {
+          toggle();
+        }
+      }}
+      onKeyDown={(event) => {
+        if (!disabled) {
+          toggleKeys(event, toggle);
+        }
+      }}
+      role="switch"
+      type="button"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** A checkbox, which may also be indeterminate. */
+export component Checkbox(
+  checked?: boolean,
+  defaultChecked?: boolean = false,
+  indeterminate?: boolean = false,
+  onCheckedChange?: (checked: boolean) => void,
+  disabled?: boolean = false,
+  children?: React.Node,
+  ...rest: { +[string]: mixed }
+) {
+  const [on, toggle] = useToggle(checked, defaultChecked, onCheckedChange);
+
+  return (
+    <button
+      // "mixed" is the third state, and it is why a checkbox cannot simply be
+      // a switch with a different label.
+      aria-checked={indeterminate ? "mixed" : on ? "true" : "false"}
+      disabled={disabled}
+      onClick={() => {
+        if (!disabled) {
+          toggle();
+        }
+      }}
+      onKeyDown={(event) => {
+        if (!disabled) {
+          toggleKeys(event, toggle);
+        }
+      }}
+      role="checkbox"
+      type="button"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/internal/tabs.js
+++ b/packages/ui/internal/tabs.js
@@ -1,0 +1,231 @@
+// @flow
+//
+// Tabs, with the keyboard behaviour the pattern requires.
+//
+// A tab list is not a row of buttons. Only one tab is in the page's tab order —
+// Tab moves *into* and *out of* the list, and the arrow keys move between the
+// tabs inside it — because a list of twelve tabs that each take a Tab press
+// makes the rest of the page unreachable for anyone not using a mouse. That is
+// a roving `tabindex`, and it is the thing hand-written tabs almost always
+// leave out.
+//
+// This is also where Flow says something no other type system can. `Tabs.List`
+// takes `renders* TabsTab`, so putting a `<button>` in the list is a type
+// error rather than a screen reader announcing "button" where the user expects
+// "tab, 2 of 5".
+
+import * as React from "@uniflowed/react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "@uniflowed/react";
+
+type TabsState = {|
+  +base: string,
+  +selected: string,
+  +select: (value: string) => void,
+  +register: (value: string, element: HTMLElement | null) => void,
+  /** Focus the tab `pick` chooses, given where we are and how many there are. */
+  +focusBy: (from: string, pick: (at: number, count: number) => number) => void,
+|};
+
+const TabsContext: React.Context<TabsState | null> = createContext(null);
+
+function useTabs(part: string): TabsState {
+  const state = useContext(TabsContext);
+  if (state == null) {
+    throw new Error(`${part} must be rendered inside a Tabs.Root`);
+  }
+  return state;
+}
+
+/**
+ * The tab set.
+ *
+ * Uncontrolled by default and controlled when `value` is given, which is the
+ * distinction every one of these components needs: a form library owns the
+ * value, and a page that just wants tabs does not.
+ */
+export component TabsRoot(
+  children: React.Node,
+  defaultValue: string,
+  value?: string,
+  onValueChange?: (value: string) => void,
+  ...rest: { +[string]: mixed }
+) {
+  const base = useId();
+  const [internal, setInternal] = useState(defaultValue);
+  const selected = value ?? internal;
+  // The order tabs were mounted in, which is document order, and is what the
+  // arrow keys move through.
+  const order = useRef<Array<string>>([]);
+  const elements = useRef<{ [string]: HTMLElement }>({});
+
+  const select = useCallback(
+    (next: string) => {
+      if (value == null) {
+        setInternal(next);
+      }
+      onValueChange?.(next);
+    },
+    [value, onValueChange],
+  );
+
+  const register = useCallback((tab: string, element: HTMLElement | null) => {
+    if (element == null) {
+      order.current = order.current.filter((entry) => entry !== tab);
+      delete elements.current[tab];
+      return;
+    }
+    if (!order.current.includes(tab)) {
+      order.current.push(tab);
+    }
+    elements.current[tab] = element;
+  }, []);
+
+  const focusAt = useCallback(
+    (index: number) => {
+      const tabs = order.current;
+      if (tabs.length === 0) {
+        return;
+      }
+      const wrapped = ((index % tabs.length) + tabs.length) % tabs.length;
+      const tab = tabs[wrapped];
+      select(tab);
+      // Selection follows focus, which is the pattern for tabs whose panels
+      // are already in the document: it means one key press per tab rather
+      // than an arrow and then a space.
+      elements.current[tab]?.focus();
+    },
+    [select],
+  );
+
+  const state = useMemo(
+    () => ({
+      base,
+      selected,
+      select,
+      register,
+      focusBy: (from: string, pick: (at: number, count: number) => number) => {
+        focusAt(pick(order.current.indexOf(from), order.current.length));
+      },
+    }),
+    [base, selected, select, register, focusAt],
+  );
+
+  return (
+    <TabsContext.Provider value={state}>
+      <div {...rest}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+/**
+ * The row of tabs.
+ *
+ * `renders* TabsTab` is the constraint: the children have to be tabs. A
+ * `<button>` here would be announced as a button inside a tablist, which is
+ * how a keyboard user ends up unable to tell where they are.
+ */
+export component TabsList(children: renders* TabsTab, ...rest: { +[string]: mixed }) {
+  return (
+    <div role="tablist" {...rest}>
+      {children}
+    </div>
+  );
+}
+
+/** One tab. Exactly one of them is in the page's tab order. */
+export component TabsTab(
+  value: string,
+  children: React.Node,
+  disabled?: boolean = false,
+  ...rest: { +[string]: mixed }
+) {
+  const tabs = useTabs("Tabs.Tab");
+  const active = tabs.selected === value;
+
+  return (
+    <button
+      aria-controls={`${tabs.base}-panel-${value}`}
+      aria-selected={active ? "true" : "false"}
+      disabled={disabled}
+      id={`${tabs.base}-tab-${value}`}
+      onClick={() => {
+        if (!disabled) {
+          tabs.select(value);
+        }
+      }}
+      onKeyDown={(event) => {
+        const intent = arrowKey(event.key);
+        if (intent == null) {
+          return;
+        }
+        // Prevent the default before moving, or the arrow also scrolls the
+        // page under the tab that just took focus.
+        event.preventDefault();
+        // `match` is an expression, so it computes the index to move to rather
+        // than performing the four movements — which also means adding a key
+        // to `arrowKey` stops compiling here until it is handled.
+        tabs.focusBy(value, (at, count) =>
+          match (intent) {
+            "previous" => at - 1,
+            "next" => at + 1,
+            "first" => 0,
+            "last" => count - 1,
+          },
+        );
+      }}
+      ref={(element) => tabs.register(value, element)}
+      role="tab"
+      // The roving tabindex: Tab reaches the selected tab and nothing else in
+      // the list, so it moves past the whole set in one press.
+      tabIndex={active ? 0 : -1}
+      type="button"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** The panel a tab controls, rendered only while its tab is selected. */
+export component TabsPanel(
+  value: string,
+  children: React.Node,
+  ...rest: { +[string]: mixed }
+) {
+  const tabs = useTabs("Tabs.Panel");
+  if (tabs.selected !== value) {
+    return null;
+  }
+  return (
+    <div
+      aria-labelledby={`${tabs.base}-tab-${value}`}
+      id={`${tabs.base}-panel-${value}`}
+      role="tabpanel"
+      // The panel itself is focusable so that Tab out of the tab list lands on
+      // the content the tab describes, which is where the reader expects to go.
+      tabIndex={0}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Which movement a key asks for, or nothing if the key is not ours. */
+function arrowKey(key: string): "previous" | "next" | "first" | "last" | null {
+  return match (key) {
+    "ArrowLeft" | "ArrowUp" => "previous",
+    "ArrowRight" | "ArrowDown" => "next",
+    "Home" => "first",
+    "End" => "last",
+    _ => null,
+  };
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniflowed/ui",
   "version": "0.0.0-alpha.1",
-  "description": "Flow declarations for @uniflowed/ui, part of the Unified Toolchain for Flow.",
+  "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
   "sideEffects": false,
@@ -17,14 +17,13 @@
     "./types/renders": "./types/renders.js"
   },
   "files": [
-    "dialog/types.js",
-    "form/types.js",
     "index.js",
-    "types/renders.js"
+    "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1",
-    "@uniflowed/validator": "0.0.0-alpha.1"
+    "@uniflowed/react": "0.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "react": ">=19"
   }
 }

--- a/tests/library/ui.test.js
+++ b/tests/library/ui.test.js
@@ -1,0 +1,384 @@
+// @flow
+//
+// `@uniflowed/ui`.
+//
+// These test the part that is invisible: what a screen reader is told, and what
+// the keyboard does. A snapshot of the markup would pass while every one of
+// these was broken.
+
+import * as React from "@uniflowed/react";
+import { useState } from "@uniflowed/react";
+import { describe, expect, fn, it } from "@uniflowed/test";
+import { fireEvent, render, screen, userEvent, within } from "@uniflowed/react-testing";
+import { Checkbox, Dialog, Field, Switch, Tabs } from "@uniflowed/ui";
+
+describe("Field", () => {
+  component EmailField(invalid: boolean) {
+    return (
+      <Field.Root invalid={invalid}>
+        <Field.Label>Email address</Field.Label>
+        <Field.Control render={(props) => <input type="email" {...props} />} />
+        <Field.Description>We will not share it.</Field.Description>
+        <Field.Error>That is not an email address.</Field.Error>
+      </Field.Root>
+    );
+  }
+
+  it("points the label at the control", () => {
+    render(<EmailField invalid={false} />);
+    // Found by its label, which only works if the wiring is right.
+    expect(screen.getByLabelText("Email address").getAttribute("type")).toBe("email");
+  });
+
+  it("describes the control with the help text", () => {
+    render(<EmailField invalid={false} />);
+    const control = screen.getByLabelText("Email address");
+    const described = control.getAttribute("aria-describedby") ?? "";
+    const help = screen.getByText("We will not share it.");
+    expect(described.split(" ")).toContain(help.getAttribute("id"));
+  });
+
+  it("says nothing about validity while the field is valid", () => {
+    render(<EmailField invalid={false} />);
+    expect(screen.getByLabelText("Email address")).not.toHaveAttribute("aria-invalid");
+    expect(screen.queryByText("That is not an email address.")).toBe(null);
+  });
+
+  it("marks the control invalid and describes it with the error", () => {
+    render(<EmailField invalid={true} />);
+    const control = screen.getByLabelText("Email address");
+    expect(control).toHaveAttribute("aria-invalid", "true");
+    const error = screen.getByRole("alert");
+    const described = control.getAttribute("aria-describedby") ?? "";
+    expect(described.split(" ")).toContain(error.getAttribute("id"));
+  });
+
+  it("never points aria-describedby at an element that is not there", () => {
+    // An id naming a missing element makes a screen reader announce nothing at
+    // all, which is worse than leaving the attribute off.
+    render(
+      <Field.Root>
+        <Field.Label>Name</Field.Label>
+        <Field.Control render={(props) => <input {...props} />} />
+      </Field.Root>,
+    );
+    expect(screen.getByLabelText("Name")).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("gives each field its own ids", () => {
+    render(
+      <div>
+        <EmailField invalid={false} />
+        <EmailField invalid={false} />
+      </div>,
+    );
+    const [first, second] = screen.getAllByLabelText("Email address");
+    expect(first.getAttribute("id")).not.toBe(second.getAttribute("id"));
+  });
+
+  it("says which part was used outside a root", () => {
+    let message = "";
+    try {
+      render(<Field.Label>orphan</Field.Label>);
+    } catch (error) {
+      message = String(error);
+    }
+    expect(message).toContain("Field.Label must be rendered inside a Field.Root");
+  });
+});
+
+describe("Tabs", () => {
+  component Example() {
+    return (
+      <Tabs.Root defaultValue="one">
+        <Tabs.List aria-label="Sections">
+          <Tabs.Tab value="one">One</Tabs.Tab>
+          <Tabs.Tab value="two">Two</Tabs.Tab>
+          <Tabs.Tab value="three">Three</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="one">first panel</Tabs.Panel>
+        <Tabs.Panel value="two">second panel</Tabs.Panel>
+        <Tabs.Panel value="three">third panel</Tabs.Panel>
+      </Tabs.Root>
+    );
+  }
+
+  it("announces itself as a tab list of tabs", () => {
+    render(<Example />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab").length).toBe(3);
+  });
+
+  it("renders only the selected panel", () => {
+    render(<Example />);
+    expect(screen.getByRole("tabpanel").textContent).toBe("first panel");
+    expect(screen.queryByText("second panel")).toBe(null);
+  });
+
+  it("keeps exactly one tab in the page's tab order", () => {
+    render(<Example />);
+    const stops = screen
+      .getAllByRole("tab")
+      .filter((tab) => tab.getAttribute("tabindex") === "0");
+    // The whole point of a roving tabindex: Tab moves past the list in one
+    // press instead of one press per tab.
+    expect(stops.length).toBe(1);
+    expect(stops[0].textContent).toBe("One");
+  });
+
+  it("selects on click and moves the tab stop with the selection", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("tab", { name: "Two" }));
+    expect(screen.getByRole("tabpanel").textContent).toBe("second panel");
+    expect(screen.getByRole("tab", { name: "Two" })).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("tab", { name: "One" })).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("moves between tabs with the arrow keys", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("tab", { name: "One" }));
+    await userEvent.keyboard("{ArrowRight}");
+    expect(screen.getByRole("tabpanel").textContent).toBe("second panel");
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("tabpanel").textContent).toBe("first panel");
+  });
+
+  it("wraps at the ends", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("tab", { name: "One" }));
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("tabpanel").textContent).toBe("third panel");
+  });
+
+  it("jumps to the first and last tab with Home and End", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("tab", { name: "Two" }));
+    await userEvent.keyboard("{End}");
+    expect(screen.getByRole("tabpanel").textContent).toBe("third panel");
+    await userEvent.keyboard("{Home}");
+    expect(screen.getByRole("tabpanel").textContent).toBe("first panel");
+  });
+
+  it("moves focus with the selection, so one key press is one tab", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("tab", { name: "One" }));
+    await userEvent.keyboard("{ArrowRight}");
+    expect(screen.getByRole("tab", { name: "Two" })).toHaveFocus();
+  });
+
+  it("ties each tab to the panel it controls", () => {
+    render(<Example />);
+    const tab = screen.getByRole("tab", { name: "One" });
+    const panel = screen.getByRole("tabpanel");
+    expect(tab.getAttribute("aria-controls")).toBe(panel.getAttribute("id"));
+    expect(panel.getAttribute("aria-labelledby")).toBe(tab.getAttribute("id"));
+  });
+
+  it("reports the selection to a controlled parent", async () => {
+    const onValueChange = fn();
+    render(
+      <Tabs.Root defaultValue="one" onValueChange={onValueChange}>
+        <Tabs.List>
+          <Tabs.Tab value="one">One</Tabs.Tab>
+          <Tabs.Tab value="two">Two</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="one">first</Tabs.Panel>
+        <Tabs.Panel value="two">second</Tabs.Panel>
+      </Tabs.Root>,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Two" }));
+    expect(onValueChange).toHaveBeenCalledWith("two");
+  });
+
+  it("does not select a disabled tab", async () => {
+    render(
+      <Tabs.Root defaultValue="one">
+        <Tabs.List>
+          <Tabs.Tab value="one">One</Tabs.Tab>
+          <Tabs.Tab disabled value="two">
+            Two
+          </Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="one">first</Tabs.Panel>
+        <Tabs.Panel value="two">second</Tabs.Panel>
+      </Tabs.Root>,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Two" }));
+    expect(screen.getByRole("tabpanel").textContent).toBe("first");
+  });
+});
+
+describe("Dialog", () => {
+  component Example() {
+    return (
+      <Dialog.Root>
+        <Dialog.Trigger>Open</Dialog.Trigger>
+        <Dialog.Content>
+          <Dialog.Title>Are you sure?</Dialog.Title>
+          <button type="button">Confirm</button>
+          <Dialog.Close>Cancel</Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Root>
+    );
+  }
+
+  it("is closed until it is opened", () => {
+    render(<Example />);
+    expect(screen.queryByRole("dialog")).toBe(null);
+    expect(screen.getByRole("button", { name: "Open" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("opens, and says the rest of the page is unavailable", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    // Its accessible name comes from the title, not from a guess.
+    expect(dialog.getAttribute("aria-labelledby")).toBe(
+      screen.getByRole("heading").getAttribute("id"),
+    );
+  });
+
+  it("moves focus to the first thing worth acting on", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByRole("button", { name: "Confirm" })).toHaveFocus();
+  });
+
+  it("wraps Tab at the end rather than letting it leave", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    const dialog = screen.getByRole("dialog");
+    const confirm = within(dialog).getByRole("button", { name: "Confirm" });
+    const cancel = within(dialog).getByRole("button", { name: "Cancel" });
+
+    // From the last stop, forward. Without the trap this lands on the page
+    // behind the dialog, which the reader cannot see and cannot get back from.
+    cancel.focus();
+    fireEvent.keyDown(cancel, { key: "Tab" });
+    expect(confirm).toHaveFocus();
+  });
+
+  it("wraps Shift+Tab at the start", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    const dialog = screen.getByRole("dialog");
+    const confirm = within(dialog).getByRole("button", { name: "Confirm" });
+    const cancel = within(dialog).getByRole("button", { name: "Cancel" });
+
+    confirm.focus();
+    fireEvent.keyDown(confirm, { key: "Tab", shiftKey: true });
+    expect(cancel).toHaveFocus();
+  });
+
+  it("keeps Tab inside a dialog with nothing focusable in it", async () => {
+    render(
+      <Dialog.Root defaultOpen>
+        <Dialog.Content>
+          <Dialog.Title>Nothing to do</Dialog.Title>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    const dialog = screen.getByRole("dialog");
+    // The dialog itself takes focus, and Tab has nowhere to go.
+    expect(dialog).toHaveFocus();
+    fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(dialog).toHaveFocus();
+  });
+
+  it("closes on Escape", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).toBe(null);
+  });
+
+  it("gives focus back to whatever opened it", async () => {
+    render(<Example />);
+    const trigger = screen.getByRole("button", { name: "Open" });
+    await userEvent.click(trigger);
+    await userEvent.keyboard("{Escape}");
+    // Otherwise focus restarts at the top of the document and the reader has
+    // to find their place again.
+    expect(trigger).toHaveFocus();
+  });
+
+  it("closes from its own close button", async () => {
+    render(<Example />);
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog")).toBe(null);
+  });
+
+  it("reports opening and closing to a controlled parent", async () => {
+    const onOpenChange = fn();
+    render(
+      <Dialog.Root onOpenChange={onOpenChange}>
+        <Dialog.Trigger>Open</Dialog.Trigger>
+        <Dialog.Content>
+          <Dialog.Title>Title</Dialog.Title>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("Switch and Checkbox", () => {
+  it("announces a switch as a switch, not a checkbox", () => {
+    render(<Switch aria-label="Notifications" />);
+    // A screen reader says "on"/"off" for a switch and "checked"/"unchecked"
+    // for a checkbox; the wrong role tells the reader the wrong thing.
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).toBe(null);
+  });
+
+  it("toggles on click", async () => {
+    render(<Switch aria-label="Notifications" />);
+    const control = screen.getByRole("switch");
+    expect(control).not.toBeChecked();
+    await userEvent.click(control);
+    expect(control).toBeChecked();
+  });
+
+  it("toggles on Space and on Enter", async () => {
+    render(<Switch aria-label="Notifications" />);
+    const control = screen.getByRole("switch");
+    await userEvent.click(control);
+    await userEvent.keyboard(" ");
+    expect(control).not.toBeChecked();
+    await userEvent.keyboard("{Enter}");
+    expect(control).toBeChecked();
+  });
+
+  it("does not toggle while disabled", async () => {
+    render(<Switch aria-label="Notifications" disabled />);
+    const control = screen.getByRole("switch");
+    await userEvent.click(control);
+    expect(control).not.toBeChecked();
+  });
+
+  it("reports a checkbox's third state as mixed", () => {
+    render(<Checkbox aria-label="Select all" indeterminate />);
+    expect(screen.getByRole("checkbox")).toHaveAttribute("aria-checked", "mixed");
+  });
+
+  it("lets a parent own the value", async () => {
+    component Controlled() {
+      const [on, setOn] = useState(false);
+      return (
+        <div>
+          <Switch aria-label="Notifications" checked={on} onCheckedChange={setOn} />
+          <output>{on ? "on" : "off"}</output>
+        </div>
+      );
+    }
+    render(<Controlled />);
+    await userEvent.click(screen.getByRole("switch"));
+    expect(screen.getByText("on")).toBeInTheDocument();
+  });
+});

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -11,6 +11,8 @@
 # registry is the source of truth for what each one is.
 config
 react
+react-testing
 router
+ui
 vite
 test


### PR DESCRIPTION
`@uniflowed/ui` was forty-eight placeholders that raised when rendered. It is now five real components, with 35 tests that exercise the keyboard and what a screen reader is told.

It ships **no styles** — the premise shadcn established, and the right one. What it contributes is the part that is genuinely hard and genuinely invisible when it is missing.

| | what a hand-written version usually leaves out |
| --- | --- |
| `Tabs` | One tab in the page's tab order, arrow keys between them, wrapping, Home/End, selection following focus |
| `Dialog` | Focus moved to the first thing worth acting on, Tab that cannot leave, Escape, focus given back to the trigger |
| `Field` | Label→control wiring, `aria-describedby` naming only elements that exist, `aria-invalid`, unique stable ids |
| `Switch` / `Checkbox` | The role, the state and Space/Enter that a styled `div` loses — and a checkbox's third state |

A list of twelve buttons takes twelve Tab presses to get past; a tab list takes one. A dialog you can Tab out of leaves the reader somewhere they cannot see with no way back. An `aria-describedby` pointing at a missing id makes a screen reader announce *nothing*, which is worse than omitting the attribute. None of that shows up in a screenshot, and all of it is the difference between a component and a div that looks like one.

## The thing no other type system can say

```js
component TabsList(children: renders* TabsTab, ...) { … }
```

A `<button>` in a tab list is a **type error**. Not a review comment, not a runtime warning, not a screen reader announcing "button" where the reader expected "tab, 2 of 5". A TypeScript component library can document that constraint; it cannot state it. This is the concrete answer to "why Flow".

## Two fixes fell out of the tests

**`match` is an expression and cannot stand as a statement.** The arrow-key handler was written as four statement arms and would not parse. It now computes the index to move to — which is better anyway, because the exhaustiveness check means adding a key stops compiling until it is handled.

**A failing assertion about an element printed the node's own properties** — listener maps and parent pointers, and through the parent chain the whole document. One assertion buried the failure under a page of internals. An element now renders as its opening tag:

```
expected <button type="button" class="a">Save</button> to have focus
```

## One thing needs you

`react-testing` and `ui` are added to `tools/release/published-packages.txt`, but a package must be bound to the publish workflow before OIDC can publish it. Binding these two needs a 2FA prompt, so it is one command on your machine:

```bash
tools/release/trust-npm.sh
```

It is idempotent — the five already bound are reported and left alone. **Run it before the next `uf@*` tag**, or the publish job will fail on the two new names.

## Checked

`cargo test --workspace`, `cargo fmt --all -- --check`, `cargo test -p uf_lib`, and 212 tests through `uf test` on Node — 35 of them for these components, covering roving tabindex, arrow-key wrapping, the focus trap in both directions and with nothing focusable inside, focus restoration, `aria-describedby` accuracy, and the disabled paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791039361&installation_model_id=422833&pr_number=83&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F83&signature=84bc643d5c613dbcfb291c4369494bb1876a291ef05fdfec123fcfcb36cc0d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessible, composable UI components: dialogs, form fields, tabs, switches, and checkboxes.
  * Added keyboard navigation, focus management, validation states, controlled values, and ARIA support.
  * Improved test failure messages by rendering DOM elements as readable HTML tags.
* **Bug Fixes**
  * Corrected the published UI component exports to expose supported components.
* **Chores**
  * Updated package publishing configuration and React peer dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->