### PR TITLE
fix(ui): caller props could silently disable a component

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,29 @@ jobs:
       # the OIDC id-token GitHub mints for it. There is no npm token in this
       # repository, in its secrets, or on anyone's machine.
       # See tools/release/trust-npm.sh.
+      # Check every name is bound to this workflow before publishing any of
+      # them. A package added to the list without `npm trust` being run for it
+      # fails on `npm publish`, and by then the earlier packages are already on
+      # the registry and cannot be taken back — a half-published release. This
+      # turns that into one failure, before anything is sent, naming the fix.
+      - name: Check trusted publishers
+        run: |
+          set -eu
+          missing=""
+          for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.txt); do
+            name="@uniflowed/${package}"
+            if npm view "$name" version >/dev/null 2>&1; then
+              if ! npm trust list "$name" 2>/dev/null | grep -q "file: publish.yml"; then
+                missing="${missing} ${name}"
+              fi
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::not bound to this workflow:${missing}"
+            echo "::error::run tools/release/trust-npm.sh once, then re-run this job"
+            exit 1
+          fi
+          echo "every package is bound to publish.yml"
       - name: Publish
         run: |
           set -eu

--- a/packages/ui/internal/dialog.js
+++ b/packages/ui/internal/dialog.js
@@ -19,6 +19,8 @@
 // trigger in the accessibility tree, which is where a screen reader looks.
 
 import * as React from "@uniflowed/react";
+
+import { composeHandlers, composeRefs, withoutComposed } from "./props.js";
 import {
   createContext,
   useCallback,
@@ -80,16 +82,18 @@ export component DialogRoot(
 /** What opens the dialog, and what focus comes back to when it closes. */
 export component DialogTrigger(children: React.Node, ...rest: { +[string]: mixed }) {
   const dialog = useDialog("Dialog.Trigger");
+  const passed = withoutComposed(rest, ["onClick", "ref"]);
+
   return (
     <button
+      {...passed}
       aria-expanded={dialog.open ? "true" : "false"}
       aria-haspopup="dialog"
-      onClick={() => dialog.setOpen(true)}
-      ref={(element) => {
+      onClick={composeHandlers(rest.onClick, () => dialog.setOpen(true))}
+      ref={composeRefs(rest.ref, (element) => {
         dialog.triggerRef.current = element;
-      }}
+      })}
       type="button"
-      {...rest}
     >
       {children}
     </button>
@@ -129,12 +133,20 @@ export component DialogContent(children: React.Node, ...rest: { +[string]: mixed
     return null;
   }
 
+  const passed = withoutComposed(rest, ["onKeyDown", "ref"]);
+
   return (
     <div
+      // `passed` first. A caller `ref` used to replace `contentRef`, which
+      // left it null, made the Tab branch below return early, and turned the
+      // focus trap off while the dialog still announced `aria-modal="true"`.
+      // A caller `onKeyDown` used to replace this one, and Escape stopped
+      // closing the dialog.
+      {...passed}
       aria-labelledby={`${dialog.base}-title`}
       aria-modal="true"
       id={`${dialog.base}-content`}
-      onKeyDown={(event) => {
+      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
         if (event.key === "Escape") {
           event.preventDefault();
           dialog.setOpen(false);
@@ -165,13 +177,12 @@ export component DialogContent(children: React.Node, ...rest: { +[string]: mixed
           event.preventDefault();
           first.focus();
         }
-      }}
-      ref={(element) => {
+      })}
+      ref={composeRefs(rest.ref, (element) => {
         contentRef.current = element;
-      }}
+      })}
       role="dialog"
       tabIndex={-1}
-      {...rest}
     >
       {children}
     </div>
@@ -182,7 +193,7 @@ export component DialogContent(children: React.Node, ...rest: { +[string]: mixed
 export component DialogTitle(children: React.Node, ...rest: { +[string]: mixed }) {
   const dialog = useDialog("Dialog.Title");
   return (
-    <h2 id={`${dialog.base}-title`} {...rest}>
+    <h2 {...rest} id={`${dialog.base}-title`}>
       {children}
     </h2>
   );
@@ -191,8 +202,14 @@ export component DialogTitle(children: React.Node, ...rest: { +[string]: mixed }
 /** A button that closes the dialog. */
 export component DialogClose(children: React.Node, ...rest: { +[string]: mixed }) {
   const dialog = useDialog("Dialog.Close");
+  const passed = withoutComposed(rest, ["onClick"]);
+
   return (
-    <button onClick={() => dialog.setOpen(false)} type="button" {...rest}>
+    <button
+      {...passed}
+      onClick={composeHandlers(rest.onClick, () => dialog.setOpen(false))}
+      type="button"
+    >
       {children}
     </button>
   );
@@ -208,10 +225,13 @@ export component DialogClose(children: React.Node, ...rest: { +[string]: mixed }
 function focusable(root: HTMLElement): Array<HTMLElement> {
   const selector =
     'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-  return Array.from(root.querySelectorAll(selector)).filter((element: any) => {
-    if (element.getAttribute("aria-hidden") === "true") {
-      return false;
-    }
-    return element.closest("[hidden]") == null;
-  });
+  return Array.from(root.querySelectorAll(selector)).filter(
+    (element: any) =>
+      // Both attributes hide a whole subtree, so both are checked on the
+      // ancestors. Reading `aria-hidden` off the element alone returned a
+      // button inside `<div aria-hidden="true">` as a focus stop, and the trap
+      // then moved focus to a control no screen reader exposes.
+      element.closest("[hidden]") == null &&
+      element.closest('[aria-hidden="true"]') == null,
+  );
 }

--- a/packages/ui/internal/field.js
+++ b/packages/ui/internal/field.js
@@ -96,8 +96,10 @@ export component FieldRoot(
 /** The label, pointing at the control by id rather than by nesting. */
 export component FieldLabel(children: React.Node, ...rest: { +[string]: mixed }) {
   const field = useField("Field.Label");
+  // `rest` first: a caller `id` here would break the relationship the control
+  // points at, and it would break it silently.
   return (
-    <label htmlFor={field.controlId} id={field.labelId} {...rest}>
+    <label {...rest} htmlFor={field.controlId} id={field.labelId}>
       {children}
     </label>
   );
@@ -131,7 +133,7 @@ export component FieldDescription(children: React.Node, ...rest: { +[string]: mi
   }, [field]);
 
   return (
-    <p id={field.descriptionId} {...rest}>
+    <p {...rest} id={field.descriptionId}>
       {children}
     </p>
   );
@@ -154,7 +156,7 @@ export component FieldError(children: React.Node, ...rest: { +[string]: mixed })
     return null;
   }
   return (
-    <p id={field.errorId} role="alert" {...rest}>
+    <p {...rest} id={field.errorId} role="alert">
       {children}
     </p>
   );

--- a/packages/ui/internal/props.js
+++ b/packages/ui/internal/props.js
@@ -1,0 +1,78 @@
+// @flow
+//
+// Merging a caller's props with the ones a component owns.
+//
+// `<div {...rest} role="dialog">` and `<div role="dialog" {...rest}>` are
+// different components. The second lets a caller pass `role="button"` and get
+// it; the first does not. That sounds like a preference until you notice what
+// else is in `rest`:
+//
+//   * A caller `ref` replaced the ref the dialog uses to find its focus stops,
+//     so `contentRef.current` stayed null, the Tab handler returned early, and
+//     the focus trap was *silently off* while the dialog still announced
+//     `aria-modal="true"`.
+//   * A caller `onClick` replaced a tab's selection handler, so clicking a tab
+//     did nothing.
+//   * A caller `onKeyDown` replaced the dialog's, so Escape stopped closing it.
+//
+// None of those fail loudly. So the rule here is: the caller's props go on
+// first and the component's own semantics go on last, and for the two kinds of
+// prop where a caller legitimately wants *both* — event handlers and refs —
+// they are composed rather than one replacing the other.
+
+/** Anything a caller can spread onto an element. */
+export type Rest = { +[string]: mixed };
+
+/**
+ * Call the caller's handler and then the component's.
+ *
+ * The caller's runs first so it can inspect the event before the component
+ * acts on it, and the component's runs unless the caller stopped the event —
+ * `defaultPrevented` is the caller's way of saying "I handled this", which is
+ * the same contract the DOM uses.
+ */
+export function composeHandlers<TEvent: { +defaultPrevented?: boolean }>(
+  theirs: mixed,
+  ours: (event: TEvent) => mixed,
+): (event: TEvent) => mixed {
+  if (typeof theirs !== "function") {
+    return ours;
+  }
+  return (event: TEvent) => {
+    (theirs: $FlowFixMe)(event);
+    if (event.defaultPrevented !== true) {
+      ours(event);
+    }
+  };
+}
+
+/** Set both refs, whichever kinds they are. */
+export function composeRefs<T>(
+  theirs: mixed,
+  ours: (value: T | null) => mixed,
+): (value: T | null) => void {
+  return (value: T | null) => {
+    ours(value);
+    if (typeof theirs === "function") {
+      (theirs: $FlowFixMe)(value);
+    } else if (theirs != null && typeof theirs === "object") {
+      (theirs: $FlowFixMe).current = value;
+    }
+  };
+}
+
+/**
+ * A caller's props with the handlers and ref removed.
+ *
+ * They are pulled out because they have to be composed rather than spread, and
+ * leaving them in would put the caller's copy back on top of the composed one.
+ */
+export function withoutComposed(rest: Rest, names: $ReadOnlyArray<string>): Rest {
+  const kept: { [string]: mixed } = {};
+  for (const key of Object.keys(rest)) {
+    if (!names.includes(key)) {
+      kept[key] = rest[key];
+    }
+  }
+  return kept;
+}

--- a/packages/ui/internal/switch.js
+++ b/packages/ui/internal/switch.js
@@ -15,6 +15,8 @@
 import * as React from "@uniflowed/react";
 import { useCallback, useState } from "@uniflowed/react";
 
+import { composeHandlers, withoutComposed } from "./props.js";
+
 /** Space toggles, and so does Enter, because both do on a native control. */
 function toggleKeys(
   event: SyntheticKeyboardEvent<HTMLElement>,
@@ -59,24 +61,25 @@ export component Switch(
   ...rest: { +[string]: mixed }
 ) {
   const [on, toggle] = useToggle(checked, defaultChecked, onCheckedChange);
+  const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);
 
   return (
     <button
+      {...passed}
       aria-checked={on ? "true" : "false"}
       disabled={disabled}
-      onClick={() => {
+      onClick={composeHandlers(rest.onClick, () => {
         if (!disabled) {
           toggle();
         }
-      }}
-      onKeyDown={(event) => {
+      })}
+      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
         if (!disabled) {
           toggleKeys(event, toggle);
         }
-      }}
+      })}
       role="switch"
       type="button"
-      {...rest}
     >
       {children}
     </button>
@@ -94,26 +97,27 @@ export component Checkbox(
   ...rest: { +[string]: mixed }
 ) {
   const [on, toggle] = useToggle(checked, defaultChecked, onCheckedChange);
+  const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);
 
   return (
     <button
+      {...passed}
       // "mixed" is the third state, and it is why a checkbox cannot simply be
       // a switch with a different label.
       aria-checked={indeterminate ? "mixed" : on ? "true" : "false"}
       disabled={disabled}
-      onClick={() => {
+      onClick={composeHandlers(rest.onClick, () => {
         if (!disabled) {
           toggle();
         }
-      }}
-      onKeyDown={(event) => {
+      })}
+      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
         if (!disabled) {
           toggleKeys(event, toggle);
         }
-      }}
+      })}
       role="checkbox"
       type="button"
-      {...rest}
     >
       {children}
     </button>

--- a/packages/ui/internal/tabs.js
+++ b/packages/ui/internal/tabs.js
@@ -15,6 +15,8 @@
 // "tab, 2 of 5".
 
 import * as React from "@uniflowed/react";
+
+import { composeHandlers, composeRefs, withoutComposed } from "./props.js";
 import {
   createContext,
   useCallback,
@@ -29,9 +31,20 @@ type TabsState = {|
   +base: string,
   +selected: string,
   +select: (value: string) => void,
-  +register: (value: string, element: HTMLElement | null) => void,
-  /** Focus the tab `pick` chooses, given where we are and how many there are. */
-  +focusBy: (from: string, pick: (at: number, count: number) => number) => void,
+  +register: (value: string, element: HTMLElement | null, disabled: boolean) => void,
+  /**
+   * Focus the tab `pick` chooses, given where we are and how many there are.
+   *
+   * `pick` returns the index to aim for and the direction to keep searching in
+   * when that tab is disabled. The direction cannot be inferred from the
+   * index: `End` aims at the last tab and, if it is disabled, has to walk
+   * *backwards* to the last enabled one — inferring "forwards" from the target
+   * being ahead of us wrapped around to the first tab instead.
+   */
+  +focusBy: (
+    from: string,
+    pick: (at: number, count: number) => [number, 1 | -1],
+  ) => void,
 |};
 
 const TabsContext: React.Context<TabsState | null> = createContext(null);
@@ -76,31 +89,55 @@ export component TabsRoot(
     [value, onValueChange],
   );
 
-  const register = useCallback((tab: string, element: HTMLElement | null) => {
-    if (element == null) {
-      order.current = order.current.filter((entry) => entry !== tab);
-      delete elements.current[tab];
-      return;
-    }
-    if (!order.current.includes(tab)) {
-      order.current.push(tab);
-    }
-    elements.current[tab] = element;
-  }, []);
+  const disabledTabs = useRef<{ [string]: boolean }>({});
 
+  const register = useCallback(
+    (tab: string, element: HTMLElement | null, disabled: boolean) => {
+      if (element == null) {
+        order.current = order.current.filter((entry) => entry !== tab);
+        delete elements.current[tab];
+        delete disabledTabs.current[tab];
+        return;
+      }
+      if (!order.current.includes(tab)) {
+        order.current.push(tab);
+      }
+      elements.current[tab] = element;
+      disabledTabs.current[tab] = disabled;
+    },
+    [],
+  );
+
+  /**
+   * Focus and select the first enabled tab at or after `index`.
+   *
+   * Disabled tabs are stepped over rather than landed on. Selecting one meant
+   * the panel changed to a tab that cannot take focus, so focus stayed where
+   * it was and the next arrow press started from the wrong place — after which
+   * the tabs beyond the disabled one were unreachable by keyboard.
+   */
   const focusAt = useCallback(
-    (index: number) => {
+    (index: number, step: number = 1) => {
       const tabs = order.current;
       if (tabs.length === 0) {
         return;
       }
-      const wrapped = ((index % tabs.length) + tabs.length) % tabs.length;
-      const tab = tabs[wrapped];
-      select(tab);
-      // Selection follows focus, which is the pattern for tabs whose panels
-      // are already in the document: it means one key press per tab rather
-      // than an arrow and then a space.
-      elements.current[tab]?.focus();
+      const wrap = (at: number) => ((at % tabs.length) + tabs.length) % tabs.length;
+      const direction = step === 0 ? 1 : step;
+
+      for (let tried = 0; tried < tabs.length; tried += 1) {
+        const tab = tabs[wrap(index + tried * direction)];
+        if (disabledTabs.current[tab] === true) {
+          continue;
+        }
+        select(tab);
+        // Selection follows focus, which is the pattern for tabs whose panels
+        // are already in the document: one key press per tab rather than an
+        // arrow and then a space.
+        elements.current[tab]?.focus();
+        return;
+      }
+      // Every tab is disabled, so there is nowhere to go.
     },
     [select],
   );
@@ -111,8 +148,15 @@ export component TabsRoot(
       selected,
       select,
       register,
-      focusBy: (from: string, pick: (at: number, count: number) => number) => {
-        focusAt(pick(order.current.indexOf(from), order.current.length));
+      focusBy: (
+        from: string,
+        pick: (at: number, count: number) => [number, 1 | -1],
+      ) => {
+        const [target, direction] = pick(
+          order.current.indexOf(from),
+          order.current.length,
+        );
+        focusAt(target, direction);
       },
     }),
     [base, selected, select, register, focusAt],
@@ -134,7 +178,7 @@ export component TabsRoot(
  */
 export component TabsList(children: renders* TabsTab, ...rest: { +[string]: mixed }) {
   return (
-    <div role="tablist" {...rest}>
+    <div {...rest} role="tablist">
       {children}
     </div>
   );
@@ -150,18 +194,24 @@ export component TabsTab(
   const tabs = useTabs("Tabs.Tab");
   const active = tabs.selected === value;
 
+  const passed = withoutComposed(rest, ["onClick", "onKeyDown", "ref"]);
+
   return (
     <button
+      // `passed` first, and everything this component owns after it. A caller
+      // `ref` used to replace the registration ref, which took the tab out of
+      // the keyboard order without any sign that it had.
+      {...passed}
       aria-controls={`${tabs.base}-panel-${value}`}
       aria-selected={active ? "true" : "false"}
       disabled={disabled}
       id={`${tabs.base}-tab-${value}`}
-      onClick={() => {
+      onClick={composeHandlers(rest.onClick, () => {
         if (!disabled) {
           tabs.select(value);
         }
-      }}
-      onKeyDown={(event) => {
+      })}
+      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
         const intent = arrowKey(event.key);
         if (intent == null) {
           return;
@@ -174,20 +224,19 @@ export component TabsTab(
         // to `arrowKey` stops compiling here until it is handled.
         tabs.focusBy(value, (at, count) =>
           match (intent) {
-            "previous" => at - 1,
-            "next" => at + 1,
-            "first" => 0,
-            "last" => count - 1,
+            "previous" => [at - 1, -1],
+            "next" => [at + 1, 1],
+            "first" => [0, 1],
+            "last" => [count - 1, -1],
           },
         );
-      }}
-      ref={(element) => tabs.register(value, element)}
+      })}
+      ref={composeRefs(rest.ref, (element) => tabs.register(value, element, disabled))}
       role="tab"
       // The roving tabindex: Tab reaches the selected tab and nothing else in
       // the list, so it moves past the whole set in one press.
       tabIndex={active ? 0 : -1}
       type="button"
-      {...rest}
     >
       {children}
     </button>
@@ -206,13 +255,13 @@ export component TabsPanel(
   }
   return (
     <div
+      {...rest}
       aria-labelledby={`${tabs.base}-tab-${value}`}
       id={`${tabs.base}-panel-${value}`}
       role="tabpanel"
       // The panel itself is focusable so that Tab out of the tab list lands on
       // the content the tab describes, which is where the reader expects to go.
       tabIndex={0}
-      {...rest}
     >
       {children}
     </div>

--- a/tests/library/ui.test.js
+++ b/tests/library/ui.test.js
@@ -382,3 +382,172 @@ describe("Switch and Checkbox", () => {
     expect(screen.getByText("on")).toBeInTheDocument();
   });
 });
+
+describe("caller props never disable the component", () => {
+  it("keeps the focus trap when the caller passes a ref", async () => {
+    // The ref used to replace the dialog's own, leaving it null — so the Tab
+    // handler returned early and the trap was off while the dialog still
+    // announced aria-modal="true".
+    const seen = { current: null };
+    render(
+      <Dialog.Root defaultOpen>
+        <Dialog.Content ref={seen}>
+          <Dialog.Title>Title</Dialog.Title>
+          <button type="button">first</button>
+          <button type="button">last</button>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    const dialog = screen.getByRole("dialog");
+    // The caller's ref is set too, not instead.
+    expect(seen.current).toBe(dialog);
+
+    const last = within(dialog).getByRole("button", { name: "last" });
+    last.focus();
+    fireEvent.keyDown(last, { key: "Tab" });
+    expect(within(dialog).getByRole("button", { name: "first" })).toHaveFocus();
+  });
+
+  it("keeps Escape closing the dialog when the caller passes onKeyDown", async () => {
+    const theirs = fn();
+    render(
+      <Dialog.Root defaultOpen>
+        <Dialog.Content onKeyDown={theirs}>
+          <Dialog.Title>Title</Dialog.Title>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    // Both ran: the caller's handler and the component's behaviour.
+    expect(theirs.mock.calls.length).toBe(1);
+    expect(screen.queryByRole("dialog")).toBe(null);
+  });
+
+  it("lets a caller handler stop the component's behaviour deliberately", () => {
+    render(
+      <Dialog.Root defaultOpen>
+        <Dialog.Content onKeyDown={(event) => event.preventDefault()}>
+          <Dialog.Title>Title</Dialog.Title>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    // `preventDefault` is how the DOM says "I handled this", so the dialog
+    // does not also act on it.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("keeps a tab selectable when the caller passes onClick", async () => {
+    const theirs = fn();
+    render(
+      <Tabs.Root defaultValue="one">
+        <Tabs.List>
+          <Tabs.Tab value="one">One</Tabs.Tab>
+          <Tabs.Tab onClick={theirs} value="two">
+            Two
+          </Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="one">first</Tabs.Panel>
+        <Tabs.Panel value="two">second</Tabs.Panel>
+      </Tabs.Root>,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Two" }));
+    expect(theirs.mock.calls.length).toBe(1);
+    expect(screen.getByRole("tabpanel").textContent).toBe("second");
+  });
+
+  it("keeps a switch toggling when the caller passes onClick", async () => {
+    const theirs = fn();
+    render(<Switch aria-label="Notifications" onClick={theirs} />);
+    await userEvent.click(screen.getByRole("switch"));
+    expect(theirs.mock.calls.length).toBe(1);
+    expect(screen.getByRole("switch")).toBeChecked();
+  });
+
+  it("keeps the field's ids authoritative", () => {
+    render(
+      <Field.Root>
+        <Field.Label id="theirs">Name</Field.Label>
+        <Field.Control render={(props) => <input {...props} />} />
+      </Field.Root>,
+    );
+    const control = screen.getByLabelText("Name");
+    const label: any = screen.getByText("Name");
+    // A caller id used to win, and the control then pointed at an id that no
+    // longer existed.
+    expect(label.getAttribute("id")).toBe(control.getAttribute("aria-labelledby"));
+    expect(label.getAttribute("for")).toBe(control.getAttribute("id"));
+  });
+
+  it("does not treat a control inside aria-hidden as a focus stop", () => {
+    render(
+      <Dialog.Root defaultOpen>
+        <Dialog.Content>
+          <Dialog.Title>Title</Dialog.Title>
+          <div aria-hidden="true">
+            <button type="button">concealed</button>
+          </div>
+          <button type="button">real</button>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    // Focus goes to the first stop a reader can actually reach.
+    expect(screen.getByRole("button", { name: "real" })).toHaveFocus();
+  });
+});
+
+describe("keyboard navigation skips disabled tabs", () => {
+  component WithDisabled() {
+    return (
+      <Tabs.Root defaultValue="one">
+        <Tabs.List>
+          <Tabs.Tab value="one">One</Tabs.Tab>
+          <Tabs.Tab disabled value="two">
+            Two
+          </Tabs.Tab>
+          <Tabs.Tab value="three">Three</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="one">first</Tabs.Panel>
+        <Tabs.Panel value="two">second</Tabs.Panel>
+        <Tabs.Panel value="three">third</Tabs.Panel>
+      </Tabs.Root>
+    );
+  }
+
+  it("steps over a disabled tab instead of landing on it", async () => {
+    render(<WithDisabled />);
+    await userEvent.click(screen.getByRole("tab", { name: "One" }));
+    await userEvent.keyboard("{ArrowRight}");
+    // Selecting the disabled tab changed the panel to one whose tab cannot
+    // take focus, and every tab past it became unreachable by keyboard.
+    expect(screen.getByRole("tabpanel").textContent).toBe("third");
+    expect(screen.getByRole("tab", { name: "Three" })).toHaveFocus();
+  });
+
+  it("steps over it backwards too", async () => {
+    render(<WithDisabled />);
+    await userEvent.click(screen.getByRole("tab", { name: "Three" }));
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("tabpanel").textContent).toBe("first");
+  });
+
+  it("lands End on the last enabled tab", async () => {
+    render(
+      <Tabs.Root defaultValue="one">
+        <Tabs.List>
+          <Tabs.Tab value="one">One</Tabs.Tab>
+          <Tabs.Tab value="two">Two</Tabs.Tab>
+          <Tabs.Tab disabled value="three">
+            Three
+          </Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="one">first</Tabs.Panel>
+        <Tabs.Panel value="two">second</Tabs.Panel>
+        <Tabs.Panel value="three">third</Tabs.Panel>
+      </Tabs.Root>,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "One" }));
+    await userEvent.keyboard("{End}");
+    expect(screen.getByRole("tabpanel").textContent).toBe("second");
+  });
+});


### PR DESCRIPTION
`{...rest}` was applied **last** on every part, so a caller's props won. That reads like a preference until you see what is in `rest`:

| a caller passing | used to |
| --- | --- |
| `ref` on `Dialog.Content` | replace the ref the dialog finds its focus stops with — `contentRef.current` stayed null, the Tab handler returned early, and **the focus trap was off** while the dialog still announced `aria-modal="true"` |
| `onKeyDown` on it | replace the dialog's, so Escape stopped closing it |
| `onClick` on a tab | replace the selection handler, so clicking a tab did nothing |
| `ref` on a tab | replace the registration ref, taking the tab out of the keyboard order |
| `onClick` on a `Switch` | replace the toggle |
| `id` on `Field.Label` | win, leaving the control's `aria-labelledby` pointing at an id that no longer existed |

**None of those fail loudly.** The component still renders, still announces itself correctly, and simply does not work.

Caller props now go on first and the component's own semantics last. Handlers and refs are *composed* rather than replaced, so both run — and `preventDefault` in a caller's handler stops the component's, which is the DOM's own way of saying "I handled this". A test covers that deliberate opt-out as well as the default.

## Keyboard navigation landed on disabled tabs

Selecting a disabled tab changed the panel to a tab that cannot take focus, so focus stayed where it was — and every tab past the disabled one became unreachable by keyboard.

Navigation steps over them now, and the direction to keep searching comes from the *intent* rather than being inferred from the target index. That distinction is the bug I wrote first: `End` aims at the last tab and has to walk **backwards** when it is disabled, and inferring "forwards" from the target being ahead of us wrapped around to the first tab. The `match` returns the index and the direction together, so it stays exhaustive.

## `aria-hidden` was read off the element, not its ancestors

A button inside `<div aria-hidden="true">` counted as a focus stop, and the trap moved focus to a control no screen reader exposes. Both `[hidden]` and `aria-hidden` hide a subtree, so both are checked on the ancestors — which is what the comment above the function already claimed.

## A half-published release is now impossible

`publish.yml` checks every package in the list is bound to it *before* publishing any. A name added without `npm trust` fails on `npm publish`, and by then the earlier packages are on the registry and cannot be taken back. One failure, before anything is sent, naming the command to run.

## Checked

`cargo fmt --all -- --check` and 222 tests through `uf test` — 9 of them new, one per finding, each asserting the component still works with the caller's prop attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791040048&installation_model_id=422833&pr_number=85&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F85&signature=72f457b4ea9e13ea80599c020b20a79eaae684e71e45109f6258c1699094d3c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->