### PR TITLE
feat(router): route handlers, on the platform's own types

### DIFF
--- a/crates/uf_lint/src/tests/router.rs
+++ b/crates/uf_lint/src/tests/router.rs
@@ -5,7 +5,10 @@ use super::*;
 
 #[test]
 fn router_reserved_files_are_constrained() {
-    let diagnostics = lint_one("router/reserved-files", "app/_uf.route.js", "// @flow\n");
+    // `_uf.handler.js` looks like a reserved name and is not one. `_uf.route.js`
+    // used to be this test's example, and it became a real role when route
+    // handlers landed.
+    let diagnostics = lint_one("router/reserved-files", "app/_uf.handler.js", "// @flow\n");
 
     assert!(fired(&diagnostics, "router/reserved-files"));
 }
@@ -20,6 +23,7 @@ fn router_reserved_files_accepts_platform_and_test_variants() {
         "app/_uf.layout.js",
         "app/_uf.page.js",
         "app/_uf.middleware.js",
+        "app/api/_uf.route.js",
         "app/_uf.page.native.js",
         "app/_uf.page.ios.js",
         "app/_uf.page.android.js",
@@ -39,7 +43,7 @@ fn router_reserved_files_accepts_platform_and_test_variants() {
 #[test]
 fn router_reserved_files_still_rejects_names_uf_does_not_define() {
     for name in [
-        "app/_uf.route.js",
+        "app/_uf.handler.js",
         "app/_uf.page.server.js",
         "app/_uf.page.native.test.js",
         "app/_uf.page.jsx",

--- a/crates/uf_router/src/lib.rs
+++ b/crates/uf_router/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::reserved::{
 pub const RESERVED_LAYOUT: &str = "_uf.layout.js";
 pub const RESERVED_PAGE: &str = "_uf.page.js";
 pub const RESERVED_MIDDLEWARE: &str = "_uf.middleware.js";
+pub const RESERVED_ROUTE: &str = "_uf.route.js";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RouteParamKind {
@@ -344,16 +345,33 @@ mod tests {
     }
 
     #[test]
+    fn a_route_handler_is_a_reserved_file_rather_than_a_violation() {
+        // `_uf.route.js` answers a request instead of rendering a page. It was
+        // an unknown name until route handlers existed, and the two tests that
+        // used it as their example of an invalid one now use `_uf.handler.js`.
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        fs::create_dir_all(root.join("app/api")).unwrap();
+        fs::write(root.join("app/api/_uf.route.js"), "// @flow\n").unwrap();
+
+        let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
+        assert!(violations.is_empty(), "{violations:?}");
+
+        let classified = classify_reserved_file(RESERVED_ROUTE);
+        assert!(!classified.is_unknown());
+    }
+
+    #[test]
     fn finds_invalid_reserved_files() {
         let dir = tempfile::tempdir().unwrap();
         let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
         fs::create_dir_all(root.join("app")).unwrap();
-        fs::write(root.join("app/_uf.route.js"), "// @flow\n").unwrap();
+        fs::write(root.join("app/_uf.handler.js"), "// @flow\n").unwrap();
 
         let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
 
         assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].path.file_name(), Some("_uf.route.js"));
+        assert_eq!(violations[0].path.file_name(), Some("_uf.handler.js"));
     }
 
     #[test]

--- a/crates/uf_router/src/reserved.rs
+++ b/crates/uf_router/src/reserved.rs
@@ -21,6 +21,8 @@ pub enum ReservedRole {
     Page,
     /// Runs before a route resolves.
     Middleware,
+    /// Answers a request instead of rendering a page.
+    Route,
 }
 
 impl ReservedRole {
@@ -31,6 +33,7 @@ impl ReservedRole {
             Self::Layout => "layout",
             Self::Page => "page",
             Self::Middleware => "middleware",
+            Self::Route => "route",
         }
     }
 
@@ -49,6 +52,7 @@ impl FromStr for ReservedRole {
             "layout" => Ok(Self::Layout),
             "page" => Ok(Self::Page),
             "middleware" => Ok(Self::Middleware),
+            "route" => Ok(Self::Route),
             _ => Err(()),
         }
     }
@@ -309,7 +313,7 @@ mod tests {
     #[test]
     fn an_unknown_role_is_rejected() {
         for name in [
-            "_uf.route.js",
+            "_uf.handler.js",
             "_uf.loader.js",
             "_uf.js",
             "_uf.page",

--- a/docs/app/guide/routing/_uf.page.mdx
+++ b/docs/app/guide/routing/_uf.page.mdx
@@ -21,6 +21,7 @@ Four names are reserved. Everything else in `app/` is an ordinary module.
 | `_uf.layout.js` | Wraps this path and everything under it. Receives the page as `children`. |
 | `_uf.not-found.js` | Rendered when nothing under this path matches. |
 | `_uf.middleware.js` | Runs before the route resolves — redirects, auth, headers. |
+| `_uf.route.js` | Answers a request instead of rendering a page. |
 
 Any of them may be `.mdx` instead of `.js`. A directory whose name starts with
 `_` is not a route, which is where shared components belong — this site keeps
@@ -98,6 +99,53 @@ import { Link } from "@uniflowed/router";
 `prefetch="off"` never does. `useRouter()` navigates imperatively;
 `useRoute()` gives the current path, params and search — which is what the
 sidebar on this page uses to mark the open entry.
+
+## Route handlers
+
+A path can answer a request instead of rendering. `app/api/users/[id]/_uf.route.js`
+serves `/api/users/42`:
+
+```js
+// @flow
+import type { HandlerContext } from "@uniflowed/router/handler";
+
+export async function GET(request: Request, context: HandlerContext): Promise<Response> {
+  const user = await find(context.params.id);
+  return user == null
+    ? new Response("not found", { status: 404 })
+    : Response.json(user);
+}
+
+export async function POST(request: Request, context: HandlerContext): Promise<Response> {
+  return Response.json(await request.json(), { status: 201 });
+}
+```
+
+A handler takes a `Request` and returns a `Response` — the platform's own
+types, not a framework's wrapper. That is what runs unchanged on Node.js, Bun,
+Deno and a Cloudflare Worker, which is the whole point of treating the host as
+a capability rather than a target.
+
+One export per method: `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`,
+`OPTIONS`. Anything else a module exports is a helper, not a method — a
+dispatcher that treated every export as one would answer requests with your
+utility functions.
+
+Three things the dispatcher does so every handler does not have to:
+
+- **`HEAD` falls back to `GET`**, with the body dropped. A client asking for
+  headers expects that, and nobody remembers to write it.
+- **`405` carries `Allow`.** When the path matches and the method does not,
+  the response names the methods that do — which is what lets a client tell
+  "you may not do that here" from "there is nothing here".
+- **The most specific path wins.** `/api/users/new` beats `/api/users/[id]`,
+  which beats `/api/[...rest]`, whatever order the files are in.
+
+What it deliberately does not do is catch your errors. A handler that throws is
+a bug, and turning it into a 500 here would hide it from the host's own error
+reporting — and leave you unable to tell a 500 you meant from one you caused.
+
+A handler is not prerendered and its module never reaches the browser.
 
 ## Types for routes
 

--- a/packages/router/handler.js
+++ b/packages/router/handler.js
@@ -1,0 +1,207 @@
+// @flow
+//
+// Route handlers: a path that answers a request instead of rendering a page.
+//
+// `app/api/users/_uf.route.js` exporting `GET` and `POST` serves
+// `/api/users`. A handler takes a `Request` and returns a `Response` — the
+// platform's own types, not a framework's wrapper — because that is what runs
+// unchanged on Node.js, Bun, Deno and a Cloudflare Worker, and uf's whole
+// position is that the host is a capability rather than a target.
+//
+//   // app/api/users/[id]/_uf.route.js
+//   // @flow
+//   export async function GET(request: Request, context: HandlerContext) {
+//     const user = await find(context.params.id);
+//     return user == null
+//       ? new Response("not found", { status: 404 })
+//       : Response.json(user);
+//   }
+//
+// # What the dispatcher decides, and what it does not
+//
+// It matches a path and a method and calls a function. It does not catch the
+// handler's errors, because a handler that throws is a bug the host's own
+// error reporting should see, and swallowing it into a 500 here would hide it.
+// It does answer `405` itself when the path matches and the method does not,
+// with the `Allow` header the specification requires — that is not the
+// handler's business, and every handler would otherwise write it.
+
+import type { RouteParams } from "./internal/runtime.js";
+
+/** What a handler is given besides the request. */
+export type HandlerContext = {|
+  /** The `[param]` and `[...rest]` segments of the matched path. */
+  +params: RouteParams,
+  /** The parsed query string, for the common case of reading one value. */
+  +searchParams: URLSearchParams,
+|};
+
+/** One exported method of a handler module. */
+export type Handler = (
+  request: Request,
+  context: HandlerContext,
+) => Response | Promise<Response>;
+
+/** A handler module, as the generated table loads it. */
+export type HandlerModule = { +[method: string]: mixed };
+
+/** One entry of the generated handler table. */
+export type HandlerRecord = {|
+  +path: string,
+  +params: $ReadOnlyArray<{| +name: string, +catchAll: boolean |}>,
+  +file: string,
+  +load: () => Promise<HandlerModule>,
+|};
+
+/**
+ * The methods a handler may export.
+ *
+ * A closed list, because the alternative is treating every export as a method
+ * — and a module that exports a helper would then answer requests with it.
+ * `HEAD` falls back to `GET` with the body dropped, which is what a client
+ * asking for headers expects and what nobody remembers to write.
+ */
+const METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
+
+/**
+ * Match a request against the handler table and run it.
+ *
+ * Returns `null` when no path matches, which is the caller's signal to carry
+ * on — a request for `/about` is a page, and the dispatcher declining is how
+ * it says so.
+ */
+export function createDispatcher(options: {|
+  +handlers: $ReadOnlyArray<HandlerRecord>,
+|}): (request: Request) => Promise<Response | null> {
+  // Longest path first, so `/api/users/new` wins over `/api/users/[id]` and a
+  // catch-all is the last thing tried.
+  const table = [...options.handlers].sort(
+    (a, b) => specificity(b.path) - specificity(a.path),
+  );
+
+  return async function dispatch(request: Request): Promise<Response | null> {
+    const url = new URL(request.url);
+    for (const record of table) {
+      const params = matchPath(record.path, url.pathname);
+      if (params == null) {
+        continue;
+      }
+
+      const module = await record.load();
+      const method = request.method.toUpperCase();
+      const handler = pick(module, method);
+      if (handler == null) {
+        return methodNotAllowed(module);
+      }
+
+      const response = await handler(request, {
+        params,
+        searchParams: url.searchParams,
+      });
+
+      // A `HEAD` answered by `GET` must not carry the body. The test is
+      // against the module's own `HEAD`, not `pick`'s — `pick` falls back to
+      // `GET`, so asking it whether a `HEAD` exists always said yes and the
+      // body went out anyway.
+      if (method === "HEAD" && typeof module.HEAD !== "function") {
+        return new Response(null, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+      }
+      return response;
+    }
+    return null;
+  };
+}
+
+/** The function for a method, falling back to `GET` for `HEAD`. */
+function pick(module: HandlerModule, method: string): Handler | null {
+  const own = module[method];
+  if (typeof own === "function") {
+    return (own: $FlowFixMe);
+  }
+  if (method === "HEAD" && typeof module.GET === "function") {
+    return (module.GET: $FlowFixMe);
+  }
+  return null;
+}
+
+/**
+ * `405`, with the `Allow` header naming what the path does accept.
+ *
+ * Required by the specification, and the reason a client can tell "you may not
+ * do that here" from "there is nothing here".
+ */
+function methodNotAllowed(module: HandlerModule): Response {
+  const own = new Set(METHODS.filter((method) => typeof module[method] === "function"));
+  // A module exporting `GET` also answers `HEAD`, so `Allow` has to say so.
+  if (own.has("GET")) {
+    own.add("HEAD");
+  }
+  // Filtered through `METHODS` rather than listed in insertion order, so the
+  // header reads in the conventional order however the module was written.
+  return new Response(null, {
+    status: 405,
+    headers: { allow: METHODS.filter((method) => own.has(method)).join(", ") },
+  });
+}
+
+/**
+ * Match one route path against a pathname, returning its parameters.
+ *
+ * `null` rather than an empty object when it does not match, so a route with
+ * no parameters is still distinguishable from a miss.
+ */
+function matchPath(routePath: string, pathname: string): RouteParams | null {
+  const wanted = segmentsOf(routePath);
+  const given = segmentsOf(pathname);
+  const params: { [string]: string | Array<string> } = {};
+
+  for (let index = 0; index < wanted.length; index += 1) {
+    const segment = wanted[index];
+    if (segment.startsWith(":") && segment.endsWith("*")) {
+      // A catch-all takes the rest, and matches zero segments as well as many.
+      params[segment.slice(1, -1)] = given.slice(index);
+      return (params: $FlowFixMe);
+    }
+    if (index >= given.length) {
+      return null;
+    }
+    if (segment.startsWith(":")) {
+      params[segment.slice(1)] = given[index];
+      continue;
+    }
+    if (segment !== given[index]) {
+      return null;
+    }
+  }
+
+  return wanted.length === given.length ? (params: $FlowFixMe) : null;
+}
+
+function segmentsOf(value: string): Array<string> {
+  return value.split("/").filter((segment) => segment !== "");
+}
+
+/**
+ * How specific a path is, so the table can be tried in the right order.
+ *
+ * A literal segment is worth more than a parameter and a parameter more than a
+ * catch-all, and a longer path outranks a shorter one — which is what makes
+ * `/api/users/new` win over `/api/users/[id]`.
+ */
+function specificity(routePath: string): number {
+  let score = 0;
+  for (const segment of segmentsOf(routePath)) {
+    if (segment.startsWith(":") && segment.endsWith("*")) {
+      score += 1;
+    } else if (segment.startsWith(":")) {
+      score += 10;
+    } else {
+      score += 100;
+    }
+  }
+  return score;
+}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -14,13 +14,15 @@
     ".": "./index.js",
     "./client": "./client.js",
     "./server": "./server.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./handler": "./handler.js"
   },
   "files": [
-    "index.js",
     "client.js",
-    "server.js",
-    "internal"
+    "handler.js",
+    "index.js",
+    "internal",
+    "server.js"
   ],
   "peerDependencies": {
     "react": ">=19",

--- a/packages/router/server.js
+++ b/packages/router/server.js
@@ -42,6 +42,9 @@ export const DATA_ID = "__uf_data";
 /**
  * Build a `render(url, assets)` for one app.
  */
+export type { Handler, HandlerContext, HandlerModule, HandlerRecord } from "./handler.js";
+export { createDispatcher } from "./handler.js";
+
 export function createRenderer(options: {|
   +App: React.ComponentType<AppProps>,
   +routes: RouteTable["routes"],

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -138,13 +138,27 @@ async function dev() {
   const assets = { scripts: [`/@id/${VIRTUAL.client}`], styles: [], preloads: [] };
 
   server.middlewares.use(async (request, response, next) => {
-    if (request.method !== "GET" && request.method !== "HEAD") {
-      next();
-      return;
-    }
     const url = request.originalUrl ?? request.url ?? "/";
     try {
       const entry = await server.ssrLoadModule(VIRTUAL.server);
+
+      // Route handlers first, and for every method: a handler is the only
+      // thing that answers a POST, and it may also answer a GET for a path
+      // that has no page.
+      const handled = await entry.dispatch(await toRequest(request, server.config));
+      if (handled != null) {
+        await send(response, handled);
+        return;
+      }
+
+      // Only a navigation reaches the renderer. A page cannot answer a POST,
+      // and letting one try would turn a missing handler into a rendered page
+      // with a 200 rather than a 404.
+      if (request.method !== "GET" && request.method !== "HEAD") {
+        next();
+        return;
+      }
+
       const result = await entry.render(url, assets);
       const html = await server.transformIndexHtml(url, result.html);
       response.statusCode = result.status ?? 200;
@@ -171,6 +185,62 @@ async function dev() {
   };
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
+}
+
+/**
+ * A Node request as a `Request`.
+ *
+ * The handler contract is the platform's, so the adapter belongs here rather
+ * than in every handler. The body is read as a stream where the host supports
+ * it, because a handler that accepts an upload should not need the whole thing
+ * buffered before it starts.
+ */
+async function toRequest(incoming, config) {
+  const host = incoming.headers.host ?? "localhost";
+  const protocol = config?.server?.https == null ? "http" : "https";
+  const url = new URL(incoming.originalUrl ?? incoming.url ?? "/", `${protocol}://${host}`);
+
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(incoming.headers)) {
+    if (value == null) continue;
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      headers.append(name, entry);
+    }
+  }
+
+  const method = (incoming.method ?? "GET").toUpperCase();
+  const init = { method, headers };
+  if (method !== "GET" && method !== "HEAD") {
+    // `duplex` is required by the specification whenever a body is a stream,
+    // and Node throws without it.
+    init.body = incoming;
+    init.duplex = "half";
+  }
+  return new Request(url, init);
+}
+
+/** Write a `Response` to a Node response. */
+async function send(outgoing, result) {
+  outgoing.statusCode = result.status;
+  if (result.statusText !== "") {
+    outgoing.statusMessage = result.statusText;
+  }
+  for (const [name, value] of result.headers) {
+    outgoing.setHeader(name, value);
+  }
+  if (result.body == null) {
+    outgoing.end();
+    return;
+  }
+  // Streamed rather than buffered, so a handler returning a large or
+  // open-ended body is not read into memory first.
+  const reader = result.body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    outgoing.write(value);
+  }
+  outgoing.end();
 }
 
 async function preview() {

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -21,6 +21,7 @@ export const RESERVED = Object.freeze({
   page: "_uf.page",
   middleware: "_uf.middleware",
   notFound: "_uf.not-found",
+  route: "_uf.route",
 });
 
 /** Extensions a page or layout may use; `.mdx` is a page written as content. */
@@ -44,6 +45,16 @@ const MAX_DEPTH = 32;
  */
 
 /**
+ * One route handler — a path that answers a request instead of rendering.
+ *
+ * @typedef {object} Handler
+ * @property {string} path route path such as `/api/users/:id`
+ * @property {string} pattern the same path with `*` for catch-alls
+ * @property {ReadonlyArray<{name: string, catchAll: boolean}>} params
+ * @property {string} module absolute path of the handler module
+ */
+
+/**
  * Scan `appRoot` for routes.
  *
  * Returns routes sorted by path, which is the order `uf_router` uses too.
@@ -55,8 +66,9 @@ const MAX_DEPTH = 32;
  */
 export function scanRoutes(appRoot) {
   const routes = [];
+  const handlers = [];
   let notFound = null;
-  if (!isDirectory(appRoot)) return { routes, notFound };
+  if (!isDirectory(appRoot)) return { routes, handlers, notFound };
 
   const walk = (directory, segments, layouts, middleware, depth) => {
     if (depth > MAX_DEPTH) return;
@@ -82,6 +94,15 @@ export function scanRoutes(appRoot) {
         mdx: page.endsWith(".mdx"),
       });
     }
+    // A handler answers the request itself, so it takes no layouts and is not
+    // MDX. It may sit beside a page: `/feed` can render for a browser and
+    // `/feed.xml` answer for a reader, and both are the same directory tree.
+    const handler = findModule(directory, RESERVED.route, MODULE_EXTENSIONS);
+    if (handler) {
+      const { path: routePath, pattern, params } = routeFromSegments(segments);
+      handlers.push({ path: routePath, pattern, params, module: handler });
+    }
+
     if (depth === 0) {
       const own = findModule(directory, RESERVED.notFound, PAGE_EXTENSIONS);
       if (own) notFound = { page: own, layouts: nextLayouts, mdx: own.endsWith(".mdx") };
@@ -103,8 +124,10 @@ export function scanRoutes(appRoot) {
   };
 
   walk(appRoot, [], [], [], 0);
-  routes.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
-  return { routes, notFound };
+  const byPath = (a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+  routes.sort(byPath);
+  handlers.sort(byPath);
+  return { routes, handlers, notFound };
 }
 
 function isDirectory(candidate) {
@@ -206,9 +229,24 @@ export function routesModuleSource(table) {
 }`
     : "null";
 
+  // Handlers are a separate table because nothing on the client wants them:
+  // a route handler answers a request, so shipping its module to the browser
+  // would ship server code to the page.
+  const handlerEntries = (table.handlers ?? []).map(
+    (handler) => `  {
+    path: ${JSON.stringify(handler.path)},
+    params: ${JSON.stringify(handler.params)},
+    file: ${JSON.stringify(handler.module)},
+    load: () => import(${JSON.stringify(handler.module)}),
+  }`,
+  );
+
   return `${layoutImports.join("\n")}
 export const routes = [
 ${entries.join(",\n")}
+];
+export const handlers = [
+${handlerEntries.join(",\n")}
 ];
 export const notFound = ${notFound};
 export default routes;
@@ -234,10 +272,11 @@ hydrate({ App, routes, notFound });
  * The source of `virtual:uf/server`: render one URL to HTML.
  */
 export function serverModuleSource(appEntry) {
-  return `import { createRenderer } from "@uniflowed/router/server";
-import { routes, notFound } from ${JSON.stringify(VIRTUAL.routes)};
+  return `import { createDispatcher, createRenderer } from "@uniflowed/router/server";
+import { routes, handlers, notFound } from ${JSON.stringify(VIRTUAL.routes)};
 import App from ${JSON.stringify(appEntry)};
-export { routes, notFound };
+export { routes, handlers, notFound };
 export const render = createRenderer({ App, routes, notFound });
+export const dispatch = createDispatcher({ handlers });
 `;
 }

--- a/tests/library/route-handler.test.js
+++ b/tests/library/route-handler.test.js
@@ -1,0 +1,211 @@
+// @flow
+//
+// `@uniflowed/router/handler`.
+//
+// The dispatcher is where every decision about a route handler is made: which
+// path wins, which method runs, what happens when neither does. It takes a
+// table and a `Request` and returns a `Response`, so all of that is testable
+// without a server, a port or a build — which is also why it is a separate
+// module rather than something inside the dev server's middleware.
+
+import { describe, expect, it } from "@uniflowed/test";
+import { createDispatcher } from "@uniflowed/router/handler";
+
+/** A table entry whose module is given inline. */
+const record = (path, module) => ({
+  path,
+  params: [],
+  file: `${path}/_uf.route.js`,
+  load: async () => module,
+});
+
+const get = (url, init) => new Request(`http://localhost${url}`, init);
+
+describe("matching", () => {
+  it("answers a literal path", async () => {
+    const dispatch = createDispatcher({
+      handlers: [record("/api/health", { GET: () => new Response("ok") })],
+    });
+
+    const response = await dispatch(get("/api/health"));
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe("ok");
+  });
+
+  it("declines a path it does not have, so the caller can render a page", async () => {
+    const dispatch = createDispatcher({
+      handlers: [record("/api/health", { GET: () => new Response("ok") })],
+    });
+
+    // `null` rather than a 404: `/about` is a page, and the dispatcher saying
+    // nothing is how it gets out of the way.
+    expect(await dispatch(get("/about"))).toBe(null);
+  });
+
+  it("passes the path parameters", async () => {
+    const dispatch = createDispatcher({
+      handlers: [
+        record("/api/users/:id", {
+          GET: (request, context) => Response.json({ id: context.params.id }),
+        }),
+      ],
+    });
+
+    const response = await dispatch(get("/api/users/42"));
+    expect(await response?.json()).toEqual({ id: "42" });
+  });
+
+  it("gives a catch-all the rest of the path", async () => {
+    const dispatch = createDispatcher({
+      handlers: [
+        record("/files/:path*", {
+          GET: (request, context) => Response.json(context.params.path),
+        }),
+      ],
+    });
+
+    expect(await (await dispatch(get("/files/a/b/c")))?.json()).toEqual(["a", "b", "c"]);
+    // Zero segments as well as many: `/files` is the collection.
+    expect(await (await dispatch(get("/files")))?.json()).toEqual([]);
+  });
+
+  it("prefers the more specific path", async () => {
+    const dispatch = createDispatcher({
+      handlers: [
+        record("/api/users/:id", { GET: () => new Response("by id") }),
+        record("/api/users/new", { GET: () => new Response("new") }),
+        record("/api/:rest*", { GET: () => new Response("catch all") }),
+      ],
+    });
+
+    // A literal beats a parameter and a parameter beats a catch-all, whatever
+    // order the table happens to be in.
+    expect(await (await dispatch(get("/api/users/new")))?.text()).toBe("new");
+    expect(await (await dispatch(get("/api/users/42")))?.text()).toBe("by id");
+    expect(await (await dispatch(get("/api/anything/else")))?.text()).toBe("catch all");
+  });
+
+  it("does not match a longer path against a shorter route", async () => {
+    const dispatch = createDispatcher({
+      handlers: [record("/api/users", { GET: () => new Response("list") })],
+    });
+    expect(await dispatch(get("/api/users/42"))).toBe(null);
+  });
+
+  it("hands the query string over parsed", async () => {
+    const dispatch = createDispatcher({
+      handlers: [
+        record("/api/search", {
+          GET: (request, context) => new Response(context.searchParams.get("q") ?? ""),
+        }),
+      ],
+    });
+    expect(await (await dispatch(get("/api/search?q=flow")))?.text()).toBe("flow");
+  });
+});
+
+describe("methods", () => {
+  const table = () =>
+    createDispatcher({
+      handlers: [
+        record("/api/thing", {
+          GET: () => new Response("read"),
+          POST: async (request) => Response.json(await request.json(), { status: 201 }),
+          helper: () => new Response("not a method"),
+        }),
+      ],
+    });
+
+  it("routes each method to its own export", async () => {
+    expect(await (await table()(get("/api/thing")))?.text()).toBe("read");
+
+    const created = await table()(
+      get("/api/thing", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "ada" }),
+      }),
+    );
+    expect(created?.status).toBe(201);
+    expect(await created?.json()).toEqual({ name: "ada" });
+  });
+
+  it("answers 405 with Allow when the path matches and the method does not", async () => {
+    const response = await table()(get("/api/thing", { method: "DELETE" }));
+    expect(response?.status).toBe(405);
+    // The header is what lets a client tell "you may not do that here" from
+    // "there is nothing here", and the specification requires it.
+    expect(response?.headers.get("allow")).toBe("GET, HEAD, POST");
+  });
+
+  it("does not treat an ordinary export as a method", async () => {
+    // `helper` is exported by that module. Treating every export as a method
+    // would answer requests with it.
+    const response = await table()(get("/api/thing", { method: "HELPER" }));
+    expect(response?.status).toBe(405);
+  });
+
+  it("answers HEAD with GET, minus the body", async () => {
+    const response = await table()(get("/api/thing", { method: "HEAD" }));
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe("");
+  });
+
+  it("lets a module answer HEAD itself", async () => {
+    const dispatch = createDispatcher({
+      handlers: [
+        record("/api/thing", {
+          GET: () => new Response("body"),
+          HEAD: () => new Response(null, { status: 204 }),
+        }),
+      ],
+    });
+    expect((await dispatch(get("/api/thing", { method: "HEAD" })))?.status).toBe(204);
+  });
+
+  it("takes the method case-insensitively", async () => {
+    const response = await table()(get("/api/thing", { method: "get" }));
+    expect(await response?.text()).toBe("read");
+  });
+});
+
+describe("errors", () => {
+  it("lets a handler's error out rather than turning it into a 500", async () => {
+    const dispatch = createDispatcher({
+      handlers: [
+        record("/api/broken", {
+          GET: () => {
+            throw new Error("bug in the handler");
+          },
+        }),
+      ],
+    });
+
+    // Swallowing it would hide a bug the host's own error reporting should
+    // see, and the handler cannot tell the difference between a 500 it meant
+    // and one it caused.
+    await expect(dispatch(get("/api/broken"))).rejects.toThrow("bug in the handler");
+  });
+
+  it("loads a module only when its path is asked for", async () => {
+    let loaded = 0;
+    const dispatch = createDispatcher({
+      handlers: [
+        {
+          path: "/api/lazy",
+          params: [],
+          file: "app/api/lazy/_uf.route.js",
+          load: async () => {
+            loaded += 1;
+            return { GET: () => new Response("ok") };
+          },
+        },
+      ],
+    });
+
+    await dispatch(get("/elsewhere"));
+    expect(loaded).toBe(0);
+    await dispatch(get("/api/lazy"));
+    expect(loaded).toBe(1);
+  });
+});


### PR DESCRIPTION
uf could render pages and nothing else, which meant a project needed a second server for anything a browser was not asking to look at. `app/api/users/[id]/_uf.route.js` exporting `GET` and `POST` now serves `/api/users/42`.

```js
// @flow
import type { HandlerContext } from "@uniflowed/router/handler";

export async function GET(request: Request, context: HandlerContext): Promise<Response> {
  const user = await find(context.params.id);
  return user == null
    ? new Response("not found", { status: 404 })
    : Response.json(user);
}
```

A handler takes a `Request` and returns a `Response` — the platform's own types, not a framework's wrapper. That is what runs unchanged on Node.js, Bun, Deno and a Cloudflare Worker, and treating the host as a capability rather than a target is the whole position.

## What the dispatcher decides so a handler does not have to

- **`HEAD` falls back to `GET`**, with the body dropped. A client asking for headers expects that, and nobody remembers to write it.
- **`405` carries `Allow`**, naming the methods the path does accept — the difference between "you may not do that here" and "there is nothing here", and required by the specification.
- **The most specific path wins**: `/api/users/new` over `/api/users/[id]` over `/api/[...rest]`, whatever order the files happen to be in.

What it deliberately does *not* do is catch a handler's errors. A handler that throws is a bug; turning it into a 500 here would hide it from the host's own error reporting and leave the author unable to tell a 500 they meant from one they caused. A test pins that.

Only a closed list of exports counts as a method, so a module exporting a helper does not answer requests with it. A handler is never prerendered and its module never reaches the browser — the client route table and the handler table are generated separately for exactly that reason.

## Two bugs the tests found in it

**`HEAD` sent the body.** The check for "does this module have its own `HEAD`" went through the same lookup that falls back to `GET`, so it always said yes and the strip never happened.

**`Allow` listed methods in discovery order.** `GET, POST, HEAD` rather than `GET, HEAD, POST`. It is filtered through the canonical list now, so the header reads the same however the module was written.

## Verified

15 tests on the dispatcher itself — matching, parameters, catch-alls with zero and many segments, specificity ordering, per-method routing, 405 with `Allow`, `HEAD` both ways, case-insensitive methods, lazy module loading, and an error passing through.

The dispatcher is a separate module rather than something inside the dev server's middleware precisely so all of that is testable without a server or a port. The dev server path was also checked by hand against a real project:

| | |
| --- | --- |
| `GET /api/users/42` | `{"id":"42","from":"handler"}` 200 |
| `POST /api/users/7` with JSON | `{"id":"7","received":{"n":1}}` 201 |
| `HEAD /api/echo` | 200, 0 bytes |
| `DELETE /api/echo` | 405, `Allow: GET, HEAD` |
| `GET /` | 200, the page still renders |
| `GET /api/nope` | 404 |

I attempted this as an automated dev-server test too and could not make it pass while the same project worked by hand from three different invocations; rather than land a test I could not explain, the dispatcher is covered directly and the integration path is recorded above. `crates/uf_cli/tests/vite.rs` keeps the improvement that came out of the attempt: a failing dev-server assertion now includes what the server said.

Plus `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and 227 tests in `tests/library`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791041135&installation_model_id=422833&pr_number=86&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F86&signature=ffcdd2037911a07a8c696af5c9cdea91426b7dd136d82718edcfa31d4ef0dbae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->