### PR TITLE
feat(data): typed HTTP and a query cache, as React means them

### DIFF
--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -152,13 +152,20 @@ pub fn builtin_modules() -> Vec<NativeModule> {
             "@uniflowed/query",
             NativeModuleKind::Data,
             Stability::Experimental,
-            &["createQuery", "createMutation", "QueryClient", "useQuery"],
+            &[
+                "QueryCache",
+                "QueryProvider",
+                "hash",
+                "useMutation",
+                "useQuery",
+                "useQueryCache",
+            ],
         ),
         NativeModule::new(
             "@uniflowed/fetch",
             NativeModuleKind::Data,
             Stability::Experimental,
-            &["createFetch", "request"],
+            &["FetchError", "createFetch"],
         ),
         NativeModule::new(
             "@uniflowed/loader",

--- a/packages/fetch/index.js
+++ b/packages/fetch/index.js
@@ -1,33 +1,19 @@
 // @flow
 //
-// `@uniflowed/fetch`.
+// `@uniflowed/fetch`: typed HTTP over the platform's own `fetch`.
+//
+// The platform's `fetch` is the right primitive and this does not replace it:
+// `raw` hands the `Response` straight back. What it adds is the three things
+// every application writes around it and gets subtly wrong — a failed response
+// being a resolved promise, no timeout at all, and retrying things that must
+// not be retried.
 
-import type { NativeHandle } from "@uniflowed/core/native";
-import { nativeRuntimeRequired } from "@uniflowed/core/native";
+export type {
+  FetchClient,
+  FetchConfig,
+  FetchFailure,
+  Parse,
+  RequestOptions,
+} from "./internal/client.js";
 
-const MODULE = "@uniflowed/core/fetch";
-
-export opaque type FetchClient = NativeHandle<"@uniflowed/core/fetch#FetchClient">;
-
-export type FetchConfig = {
-  +baseURL?: string,
-  +headers?: { +[string]: string },
-};
-
-export type RequestOptions = {
-  +method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
-  +body?: mixed,
-  +headers?: { +[string]: string },
-};
-
-export function createFetch(config?: FetchConfig): FetchClient {
-  return nativeRuntimeRequired(MODULE, "createFetch");
-}
-
-export function request<T>(
-  client: FetchClient,
-  path: string,
-  init?: RequestOptions,
-): Promise<T> {
-  return nativeRuntimeRequired(MODULE, "request");
-}
+export { FetchError, createFetch } from "./internal/client.js";

--- a/packages/fetch/internal/client.js
+++ b/packages/fetch/internal/client.js
@@ -1,0 +1,335 @@
+// @flow
+//
+// Typed HTTP over the platform's `fetch`.
+//
+// Not a wrapper for its own sake. Three things every application writes by
+// hand around `fetch`, each of which is easy to get subtly wrong:
+//
+//   * **A failed response is not a failed promise.** `fetch` resolves for a
+//     500. Code that forgets to check `response.ok` treats an error page as
+//     data, and the failure surfaces later as an unrelated type error.
+//   * **A timeout.** `fetch` has none. A request to a host that accepts the
+//     connection and never answers hangs until the process ends.
+//   * **Retrying the right things.** A 500 is worth retrying and a 400 is not,
+//     and retrying a POST that may have succeeded is how you charge a card
+//     twice.
+//
+// A schema is optional and, when given, is applied to the parsed body — so a
+// response that does not match is a failure at the boundary rather than a
+// `TypeError` three call frames later.
+
+/** What went wrong, as a value rather than a string. */
+export type FetchFailure =
+  | {| +kind: "http", +status: number, +statusText: string, +response: Response |}
+  | {| +kind: "network", +cause: mixed |}
+  | {| +kind: "timeout", +millis: number |}
+  | {| +kind: "parse", +cause: mixed |}
+  | {| +kind: "invalid", +issues: $ReadOnlyArray<mixed> |};
+
+/**
+ * A request that failed, carrying why.
+ *
+ * One error class with a typed `failure`, rather than a class per case: a
+ * caller that wants to branch reads `failure.kind`, and one that does not gets
+ * a message that already says what happened.
+ */
+export class FetchError extends Error {
+  +failure: FetchFailure;
+  +url: string;
+
+  constructor(url: string, failure: FetchFailure) {
+    super(describe(url, failure));
+    this.name = "FetchError";
+    this.failure = failure;
+    this.url = url;
+  }
+
+  /** Whether another attempt could plausibly settle this. */
+  get retriable(): boolean {
+    return match (this.failure.kind) {
+      "network" => true,
+      "timeout" => true,
+      // 408 is a timeout the server noticed, 429 is "slow down", and 5xx is
+      // the server's problem rather than the request's. Nothing else is worth
+      // sending again: a 400 will be a 400 next time too.
+      "http" =>
+        this.failure.status === 408 ||
+        this.failure.status === 429 ||
+        this.failure.status >= 500,
+      _ => false,
+    };
+  }
+}
+
+function describe(url: string, failure: FetchFailure): string {
+  return match (failure.kind) {
+    "http" => `${url} answered ${failure.status} ${failure.statusText}`,
+    "network" => `${url} could not be reached: ${String(failure.cause)}`,
+    "timeout" => `${url} did not answer within ${failure.millis}ms`,
+    "parse" => `${url} did not return the body it said it would: ${String(failure.cause)}`,
+    "invalid" => `${url} returned ${failure.issues.length} value(s) the schema rejected`,
+  };
+}
+
+/**
+ * A function that checks what arrived and narrows it.
+ *
+ * A function rather than a schema object, so this module depends on no
+ * validator: `@uniflowed/validator`'s `parser(User)` is exactly this shape,
+ * and so is a hand-written check.
+ */
+export type Parse<T> = (
+  value: mixed,
+) => {| +ok: true, +value: T |} | {| +ok: false, +issues: $ReadOnlyArray<mixed> |};
+
+/** How a client behaves for every request it makes. */
+export type FetchConfig = {|
+  +baseURL?: string,
+  +headers?: { +[string]: string },
+  /** Abort a request that has not answered. Defaults to 30 seconds. */
+  +timeout?: number,
+  /** How many further attempts a retriable failure gets. Defaults to none. */
+  +retries?: number,
+  /** Milliseconds before the first retry; doubles each time. Defaults to 200. */
+  +retryDelay?: number,
+  /** Swap in a different `fetch`, which is how a test avoids the network. */
+  +fetch?: typeof fetch,
+|};
+
+/** One request. */
+export type RequestOptions<T> = {|
+  +method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE",
+  /** Sent as JSON unless it is already a `BodyInit`. */
+  +body?: mixed,
+  +headers?: { +[string]: string },
+  +searchParams?: { +[string]: string | number | boolean },
+  +signal?: AbortSignal,
+  +timeout?: number,
+  +retries?: number,
+  /** Checked against the parsed body; its failure is the request's failure. */
+  +parse?: Parse<T>,
+|};
+
+/** A configured client. */
+export type FetchClient = {|
+  +request: <T>(path: string, options?: RequestOptions<T>) => Promise<T>,
+  +raw: (path: string, options?: RequestOptions<mixed>) => Promise<Response>,
+  /** A client with more defaults applied on top of this one's. */
+  +extend: (config: FetchConfig) => FetchClient,
+|};
+
+const DEFAULTS = { timeout: 30_000, retries: 0, retryDelay: 200 };
+
+/** Methods that may be retried without asking whether they were applied. */
+const IDEMPOTENT = new Set(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"]);
+
+/**
+ * A client with these defaults.
+ *
+ * Creating a client rather than exporting a function per verb, because the
+ * base URL, the headers and the retry policy belong to a *service* — and an
+ * application talks to more than one.
+ */
+export function createFetch(config?: FetchConfig): FetchClient {
+  const settings = { ...DEFAULTS, ...(config ?? {}) };
+
+  const raw = async (path: string, options?: RequestOptions<mixed>): Promise<Response> =>
+    send(settings, path, options ?? {});
+
+  return {
+    raw,
+    request: async <T>(path: string, options?: RequestOptions<T>): Promise<T> => {
+      const given = options ?? {};
+      const response = await send(settings, path, given);
+      return (parse(response, given, resolveUrl(settings, path, given)): $FlowFixMe);
+    },
+    extend: (extra: FetchConfig) =>
+      createFetch({
+        ...settings,
+        ...extra,
+        headers: { ...(settings.headers ?? {}), ...(extra.headers ?? {}) },
+      }),
+  };
+}
+
+/** Send, with the timeout and the retry policy applied. */
+async function send(
+  settings: $FlowFixMe,
+  path: string,
+  options: RequestOptions<mixed>,
+): Promise<Response> {
+  const url = resolveUrl(settings, path, options);
+  const method = (options.method ?? "GET").toUpperCase();
+  const attempts = 1 + Math.max(0, options.retries ?? settings.retries);
+  const timeout = options.timeout ?? settings.timeout;
+  const doFetch = settings.fetch ?? globalThis.fetch;
+
+  let failure: FetchError | null = null;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (attempt > 0) {
+      await pause(settings.retryDelay * 2 ** (attempt - 1));
+    }
+    try {
+      const response = await withTimeout(
+        (signal) => doFetch(url, requestInit(settings, options, method, signal)),
+        timeout,
+        options.signal,
+        url,
+      );
+      if (response.ok) {
+        return response;
+      }
+      failure = new FetchError(url, {
+        kind: "http",
+        status: response.status,
+        statusText: response.statusText,
+        response,
+      });
+    } catch (error) {
+      failure =
+        error instanceof FetchError
+          ? error
+          : new FetchError(url, { kind: "network", cause: error });
+    }
+
+    // A method that may have been applied is not retried, however retriable
+    // the failure looks: a POST that timed out may have succeeded, and sending
+    // it again is how an order is placed twice.
+    if (!failure.retriable || !IDEMPOTENT.has(method)) {
+      throw failure;
+    }
+  }
+  throw failure ?? new FetchError(url, { kind: "network", cause: "no attempt was made" });
+}
+
+function requestInit(
+  settings: $FlowFixMe,
+  options: RequestOptions<mixed>,
+  method: string,
+  signal: AbortSignal,
+): RequestOptions<mixed> {
+  const headers: { [string]: string } = {
+    ...(settings.headers ?? {}),
+    ...(options.headers ?? {}),
+  };
+
+  let body = options.body;
+  if (body != null && !isBodyInit(body)) {
+    // JSON unless the caller already made it something the platform accepts,
+    // and the header set only if they did not choose one.
+    body = JSON.stringify(body);
+    if (headers["content-type"] == null && headers["Content-Type"] == null) {
+      headers["content-type"] = "application/json";
+    }
+  }
+
+  return ({ method, headers, body, signal }: $FlowFixMe);
+}
+
+/** Whether the platform can send this as-is. */
+function isBodyInit(body: mixed): boolean {
+  return (
+    typeof body === "string" ||
+    body instanceof URLSearchParams ||
+    body instanceof FormData ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    (globalThis.ReadableStream != null && body instanceof globalThis.ReadableStream)
+  );
+}
+
+/**
+ * Race the request against the clock, and against the caller's own signal.
+ *
+ * A timeout has to abort the request rather than merely stop waiting for it:
+ * leaving it in flight holds a connection and, worse, lets its result arrive
+ * after the caller has moved on.
+ */
+async function withTimeout(
+  run: (signal: AbortSignal) => Promise<Response>,
+  millis: number,
+  external: AbortSignal | void,
+  url: string,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), millis);
+  const forward = () => controller.abort();
+  external?.addEventListener("abort", forward);
+
+  try {
+    return await run(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted && external?.aborted !== true) {
+      throw new FetchError(url, { kind: "timeout", millis });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    external?.removeEventListener("abort", forward);
+  }
+}
+
+/** The body, parsed by content type, then checked against the schema. */
+async function parse<T>(
+  response: Response,
+  options: RequestOptions<T>,
+  url: string,
+): Promise<mixed> {
+  const type = response.headers.get("content-type") ?? "";
+  let value: mixed;
+  try {
+    if (response.status === 204 || response.headers.get("content-length") === "0") {
+      value = undefined;
+    } else if (type.includes("json")) {
+      value = await response.json();
+    } else if (type.startsWith("text/") || type === "") {
+      value = await response.text();
+    } else {
+      value = await response.arrayBuffer();
+    }
+  } catch (cause) {
+    throw new FetchError(url, { kind: "parse", cause });
+  }
+
+  const check = options.parse;
+  if (check == null) {
+    return value;
+  }
+  const checked = check(value);
+  if (!checked.ok) {
+    // At the boundary, where the shape came from outside — not three frames
+    // later as a `TypeError` about a property of undefined.
+    throw new FetchError(url, { kind: "invalid", issues: checked.issues });
+  }
+  return checked.value;
+}
+
+function resolveUrl(
+  settings: $FlowFixMe,
+  path: string,
+  options: RequestOptions<mixed>,
+): string {
+  const base = settings.baseURL;
+  const joined =
+    base == null || /^[a-z][a-z0-9+.-]*:/i.test(path)
+      ? path
+      : `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+
+  const search = options.searchParams;
+  if (search == null) {
+    return joined;
+  }
+  const query = new URLSearchParams();
+  for (const key of Object.keys(search)) {
+    query.set(key, String(search[key]));
+  }
+  const text = query.toString();
+  if (text === "") {
+    return joined;
+  }
+  return joined.includes("?") ? `${joined}&${text}` : `${joined}?${text}`;
+}
+
+function pause(millis: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, millis));
+}

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniflowed/fetch",
   "version": "0.0.0-alpha.1",
-  "description": "Flow declarations for @uniflowed/fetch, part of the Unified Toolchain for Flow.",
+  "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
   "sideEffects": false,
@@ -14,9 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "internal"
   ],
-  "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
-  }
+  "dependencies": {}
 }

--- a/packages/hooks/internal/async.js
+++ b/packages/hooks/internal/async.js
@@ -2,15 +2,18 @@
 //
 // Running a promise from a component.
 //
-// The two bugs a hand-written version has: it sets state after the component
-// has gone, and a slow first request overwrites a fast second one. The first is
-// a warning; the second is a wrong answer on screen, which is worse and much
-// harder to notice. A generation counter fixes both — a result is only used if
-// it belongs to the newest run.
+// Two bugs a hand-written version has, and only one of them is a warning:
+// setting state after the component has gone, and a slow first request
+// overwriting a fast second one. The second is the dangerous one — it puts a
+// wrong answer on screen and nothing says so.
+//
+// Both are fixed by the effect's own cleanup rather than by a ref: the effect
+// that started a request is the thing that knows it has been superseded,
+// because React runs its cleanup before running it again. That is the shape
+// React's own documentation uses, and it means there is no "latest" anything
+// to keep in a ref and no generation counter to keep in step.
 
-import { useCallback, useEffect, useRef, useState } from "@uniflowed/react";
-
-import { useStableCallback } from "./lifecycle.js";
+import { useCallback, useEffect, useState } from "@uniflowed/react";
 
 /** What an in-flight, settled or failed call looks like. */
 export type Async<T> = {|
@@ -32,50 +35,46 @@ export function useAsync<T>(
   body: () => Promise<T>,
   deps: $ReadOnlyArray<mixed>,
 ): Async<T> {
-  const stable = useStableCallback(body);
-  const [state, setState] = useState<{| value: T | null, error: Error | null, pending: boolean |}>(
-    { value: null, error: null, pending: true },
-  );
+  const [state, setState] = useState<{|
+    value: T | null,
+    error: Error | null,
+    pending: boolean,
+  |}>({ value: null, error: null, pending: true });
 
-  // Which run is allowed to write. Incremented on every start, so a result
-  // from an older run is dropped rather than overwriting a newer one.
-  const generation = useRef(0);
-  const live = useRef(true);
+  // Changing this is what re-runs the effect, so `reload` is a state change
+  // rather than a function the effect has to be told about.
+  const [attempt, setAttempt] = useState(0);
+  const reload = useCallback(() => setAttempt((current) => current + 1), []);
 
   useEffect(() => {
-    live.current = true;
-    return () => {
-      live.current = false;
-    };
-  }, []);
-
-  const run = useCallback(() => {
-    generation.current += 1;
-    const mine = generation.current;
+    // Set when this effect is superseded — by a dependency change, a reload,
+    // or an unmount. React runs the cleanup before the next run, so the
+    // request that is no longer wanted knows not to write.
+    let ignore = false;
     setState((current) => ({ ...current, pending: true }));
 
-    stable().then(
+    body().then(
       (value) => {
-        if (live.current && generation.current === mine) {
+        if (!ignore) {
           setState({ value, error: null, pending: false });
         }
       },
-      (error) => {
-        if (live.current && generation.current === mine) {
+      (thrown) => {
+        if (!ignore) {
           setState({
             value: null,
-            error: error instanceof Error ? error : new Error(String(error)),
+            error: thrown instanceof Error ? thrown : new Error(String(thrown)),
             pending: false,
           });
         }
       },
     );
-  }, [stable]);
 
-  useEffect(() => {
-    run();
-    // eslint-disable-next-line
-  }, deps);
+    return () => {
+      ignore = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, attempt]);
 
-  return { ...state, reload: run };
+  return { ...state, reload };
 }

--- a/packages/query/index.js
+++ b/packages/query/index.js
@@ -1,39 +1,34 @@
 // @flow
 //
-// `@uniflowed/query`.
+// `@uniflowed/query`: asking for the same thing twice should cost once.
+//
+// Three behaviours an application writes by hand around `fetch` and gets
+// wrong, and which are the reason a query library exists at all:
+//
+//   * **De-duplication.** A header and a sidebar both showing the current user
+//     make one request, not two, and cannot disagree about the answer.
+//   * **Stale-while-revalidate.** A cached value is shown at once and
+//     refreshed behind it, so navigating back does not flash a spinner over
+//     data that is already there.
+//   * **Invalidation by prefix.** After creating a user, `["users"]`
+//     invalidates `["users", 1]` and `["users", 2]` without listing them.
+//
+// The cache is a plain object graph with no React in it, and `useQuery` is a
+// `useSyncExternalStore` over it — so a value is correct during a prerender,
+// two components reading one key cannot render different versions of it, and
+// the cache is testable without rendering anything.
 
-import { nativeRuntimeRequired } from "@uniflowed/core/native";
+export type { Entry, QueryKey } from "./internal/cache.js";
+export type {
+  MutationResult,
+  QueryOptions,
+  QueryResult,
+} from "./internal/react.js";
 
-const MODULE = "@uniflowed/core/query";
-
-export type QueryKey = $ReadOnlyArray<string | number | boolean>;
-
-export interface QueryState<T> {
-  value: null | T,
-  error: null | Error,
-  pending: boolean,
-  refetch(): Promise<T>,
-}
-
-export interface QueryResource<T> {
-  key: QueryKey,
-  use(): QueryState<T>,
-  prefetch(): Promise<T>,
-}
-
-export interface Mutation<TInput, TOutput> {
-  run(input: TInput): Promise<TOutput>,
-}
-
-export function createQuery<T>(config: {
-  +key: QueryKey,
-  +query: () => T | Promise<T>,
-}): QueryResource<T> {
-  return nativeRuntimeRequired(MODULE, "createQuery");
-}
-
-export function createMutation<TInput, TOutput>(config: {
-  +mutation: (input: TInput) => TOutput | Promise<TOutput>,
-}): Mutation<TInput, TOutput> {
-  return nativeRuntimeRequired(MODULE, "createMutation");
-}
+export { QueryCache, hash } from "./internal/cache.js";
+export {
+  QueryProvider,
+  useMutation,
+  useQuery,
+  useQueryCache,
+} from "./internal/react.js";

--- a/packages/query/internal/cache.js
+++ b/packages/query/internal/cache.js
@@ -1,0 +1,280 @@
+// @flow
+//
+// The cache a query reads from, and who else is reading it.
+//
+// This is the part that makes a query library worth having rather than a
+// `useEffect` and a `useState`:
+//
+//   * **Two components asking for the same thing make one request.** Without
+//     that, a page with a header and a sidebar both showing the current user
+//     fetches the user twice, and they can disagree.
+//   * **A cached answer is shown immediately and refreshed behind it.** The
+//     alternative is a spinner every time a reader navigates back, which is
+//     the single most common way an application feels slow while being fast.
+//   * **An answer that is old enough is refetched; one that is merely used is
+//     not.** Those are different questions, and conflating them either
+//     hammers the server or shows stale data forever.
+//
+// The store is deliberately not React-aware: it is a map, a set of listeners
+// per key, and a promise per in-flight request. `useQuery` is a
+// `useSyncExternalStore` over it, which is what makes a cached value correct
+// during a prerender and free of tearing on the client.
+
+/** A key, as a caller writes it. */
+export type QueryKey = $ReadOnlyArray<mixed>;
+
+/** What the cache holds for one key. */
+export type Entry<T> = {|
+  +value: T | void,
+  +error: Error | null,
+  /** When the value arrived, so staleness is a question the reader can ask. */
+  +updatedAt: number,
+  +pending: boolean,
+  /** Bumped on every change, so a snapshot can be compared by identity. */
+  +version: number,
+|};
+
+type Slot = {
+  entry: Entry<mixed>,
+  listeners: Set<() => void>,
+  inFlight: Promise<mixed> | null,
+  /** Cleared when the last listener goes and the entry has outlived its use. */
+  collect: TimeoutID | null,
+  /**
+   * How to fetch this key again, recorded by `watch`.
+   *
+   * Without it, invalidation can only mark an entry stale — and a component
+   * already watching would re-render, see that it is stale, and do nothing,
+   * because nothing was asked to fetch. Keeping the query here is what lets
+   * the store refresh what somebody is looking at.
+   */
+  query: (() => Promise<mixed>) | null,
+};
+
+/** How long an unused entry is kept, so a quick navigation back is free. */
+const DEFAULT_GARBAGE_MILLIS = 5 * 60_000;
+
+const EMPTY: Entry<mixed> = {
+  value: undefined,
+  error: null,
+  updatedAt: 0,
+  pending: false,
+  version: 0,
+};
+
+/**
+ * A cache. An application usually has one, and a test has one per test.
+ *
+ * Explicit rather than a module-level singleton, because a singleton is shared
+ * with every other test in the process and one test's cached answer then
+ * decides another's result.
+ */
+export class QueryCache {
+  +slots: Map<string, Slot> = new Map();
+  +garbageMillis: number;
+
+  constructor(options?: {| +garbageMillis?: number |}) {
+    this.garbageMillis = options?.garbageMillis ?? DEFAULT_GARBAGE_MILLIS;
+  }
+
+  /** What is known about `key` right now. */
+  read(key: QueryKey): Entry<mixed> {
+    return this.slots.get(hash(key))?.entry ?? EMPTY;
+  }
+
+  /** Watch `key`. Returns the unsubscribe. */
+  subscribe(key: QueryKey, listener: () => void): () => void {
+    const id = hash(key);
+    const slot = this.slot(id);
+    slot.listeners.add(listener);
+    if (slot.collect != null) {
+      clearTimeout(slot.collect);
+      slot.collect = null;
+    }
+    return () => {
+      slot.listeners.delete(listener);
+      this.maybeCollect(id);
+    };
+  }
+
+  /**
+   * Watch `key`, and keep it fresh while anybody is watching.
+   *
+   * Subscribing *is* the signal that a value is wanted, so the fetch belongs
+   * here rather than in an effect beside it. That is what lets `useQuery` be a
+   * plain `useSyncExternalStore` over this store — no effect to trigger the
+   * request, no ref to hold the latest query function, and no dependency array
+   * to argue with. The store owns its own freshness, which is what an external
+   * store is for.
+   *
+   * The query function is captured per subscription, which is per key: a
+   * component re-rendering with a new closure does not re-subscribe, and the
+   * request for a given key does not change meaning between renders.
+   */
+  watch<T>(
+    key: QueryKey,
+    query: () => Promise<T>,
+    options: {| +listener: () => void, +staleTime: number |},
+  ): () => void {
+    const id = hash(key);
+    const slot = this.slot(id);
+    slot.query = (query: $FlowFixMe);
+
+    const unsubscribe = this.subscribe(key, options.listener);
+    if (this.isStale(key, options.staleTime)) {
+      // The rejection is recorded on the entry, and every watcher is told.
+      // Letting it reach the console as well would report it twice.
+      this.fetch(key, query).catch(() => {});
+    }
+    return unsubscribe;
+  }
+
+  /**
+   * Run `query` for `key`, or join the request already in flight.
+   *
+   * The de-duplication is the whole point: two components mounting in the same
+   * tick both call this, and one request is made.
+   */
+  fetch<T>(key: QueryKey, query: () => Promise<T>): Promise<T> {
+    const id = hash(key);
+    const slot = this.slot(id);
+    if (slot.inFlight != null) {
+      return (slot.inFlight: $FlowFixMe);
+    }
+
+    this.write(id, { pending: true });
+    const promise = query().then(
+      (value) => {
+        slot.inFlight = null;
+        this.write(id, { value, error: null, updatedAt: now(), pending: false });
+        return value;
+      },
+      (thrown) => {
+        slot.inFlight = null;
+        const error = thrown instanceof Error ? thrown : new Error(String(thrown));
+        // The previous value is kept beside the error. A failed refresh should
+        // not blank a page that was showing something.
+        this.write(id, { error, pending: false });
+        throw error;
+      },
+    );
+    slot.inFlight = promise;
+    return promise;
+  }
+
+  /** Whether `key`'s value is older than `millis`. */
+  isStale(key: QueryKey, millis: number): boolean {
+    const entry = this.read(key);
+    if (entry.updatedAt === 0) {
+      return true;
+    }
+    return now() - entry.updatedAt >= millis;
+  }
+
+  /** Put a value in without running a query, for an optimistic update. */
+  set<T>(key: QueryKey, value: T): void {
+    this.write(hash(key), { value, error: null, updatedAt: now(), pending: false });
+  }
+
+  /**
+   * Mark matching keys stale so their watchers refetch.
+   *
+   * A key *prefix* matches, because that is how invalidation is actually
+   * expressed: after a mutation, `["users"]` should refresh `["users", 1]` and
+   * `["users", 2]` without the caller listing them.
+   */
+  invalidate(prefix: QueryKey): void {
+    const wanted = hash(prefix);
+    for (const [id, slot] of Array.from(this.slots)) {
+      if (id !== wanted && !id.startsWith(`${wanted.slice(0, -1)},`)) {
+        continue;
+      }
+      // `updatedAt: 0` is "never fetched", which is what makes every reader
+      // treat it as stale without inventing a separate flag.
+      this.write(id, { updatedAt: 0 });
+
+      // And refetch what somebody is looking at. Marking it stale alone would
+      // leave a mounted component re-rendering, seeing that it is stale, and
+      // doing nothing — the freshness is this store's job, not the
+      // component's.
+      const query = slot.query;
+      if (query != null && slot.listeners.size > 0) {
+        this.fetch(JSON.parse(id), query).catch(() => {});
+      }
+    }
+  }
+
+  /** Forget everything. */
+  clear(): void {
+    for (const slot of this.slots.values()) {
+      if (slot.collect != null) {
+        clearTimeout(slot.collect);
+      }
+    }
+    this.slots.clear();
+  }
+
+  slot(id: string): Slot {
+    let slot = this.slots.get(id);
+    if (slot == null) {
+      slot = {
+        entry: EMPTY,
+        listeners: new Set(),
+        inFlight: null,
+        collect: null,
+        query: null,
+      };
+      this.slots.set(id, slot);
+    }
+    return slot;
+  }
+
+  write(id: string, patch: { +[string]: mixed }): void {
+    const slot = this.slot(id);
+    slot.entry = ({
+      ...slot.entry,
+      ...patch,
+      version: slot.entry.version + 1,
+    }: $FlowFixMe);
+    for (const listener of Array.from(slot.listeners)) {
+      if (slot.listeners.has(listener)) {
+        listener();
+      }
+    }
+  }
+
+  maybeCollect(id: string): void {
+    const slot = this.slots.get(id);
+    if (slot == null || slot.listeners.size > 0 || slot.collect != null) {
+      return;
+    }
+    // Kept for a while after the last watcher goes: navigating away and back
+    // is the common case, and it should not cost a request.
+    slot.collect = setTimeout(() => {
+      const current = this.slots.get(id);
+      if (current != null && current.listeners.size === 0) {
+        this.slots.delete(id);
+      }
+    }, this.garbageMillis);
+    // A timer must not hold the process open — a test that finishes before the
+    // collection is due should still exit.
+    if (typeof (slot.collect: $FlowFixMe)?.unref === "function") {
+      (slot.collect: $FlowFixMe).unref();
+    }
+  }
+}
+
+/**
+ * A key as a string.
+ *
+ * `JSON.stringify` of the array, so `["users", 1]` and `["users", "1"]` are
+ * different keys — they are different requests, and treating them as one is a
+ * bug that shows up as the wrong data rather than as an error.
+ */
+export function hash(key: QueryKey): string {
+  return JSON.stringify(key);
+}
+
+function now(): number {
+  return Date.now();
+}

--- a/packages/query/internal/react.js
+++ b/packages/query/internal/react.js
@@ -1,0 +1,181 @@
+// @flow
+//
+// The React binding: `useQuery`, `useMutation`, and the provider they read.
+//
+// Deliberately thin. The cache is an external store, so `useQuery` is a
+// `useSyncExternalStore` over it and nothing else — no effect to trigger the
+// request, no ref holding the latest query function, no dependency array to
+// argue with. Subscribing is the signal that a value is wanted, so keeping it
+// fresh is the store's job; the component only reads.
+//
+// That is not a stylistic preference. A component that reads an external store
+// through the API React provides for it gets the value React commits with,
+// which is what stops two components sharing a key from rendering different
+// versions of it, and it states the server's value rather than falling through
+// to it.
+
+import * as React from "@uniflowed/react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "@uniflowed/react";
+
+import { useStableCallback } from "@uniflowed/hooks";
+
+import { QueryCache, hash } from "./cache.js";
+import type { Entry, QueryKey } from "./cache.js";
+
+const CacheContext: React.Context<QueryCache | null> = createContext(null);
+
+/**
+ * Make a cache available to the tree.
+ *
+ * Required rather than falling back to a module-level default: a default is
+ * shared with every test in the process, and one test's cached answer then
+ * decides another's result.
+ */
+export component QueryProvider(cache: QueryCache, children: React.Node) {
+  return <CacheContext.Provider value={cache}>{children}</CacheContext.Provider>;
+}
+
+/** The cache this subtree uses. */
+export function useQueryCache(): QueryCache {
+  const cache = useContext(CacheContext);
+  if (cache == null) {
+    throw new Error(
+      "useQuery needs a QueryProvider above it; render <QueryProvider cache={new QueryCache()}>",
+    );
+  }
+  return cache;
+}
+
+/** What a query looks like to a component. */
+export type QueryResult<T> = {|
+  +value: T | void,
+  +error: Error | null,
+  /** A request is in flight. True on the first load and on a refresh. */
+  +pending: boolean,
+  /** There has never been a value, so there is nothing to show yet. */
+  +loading: boolean,
+  /** The value is older than `staleTime`. */
+  +stale: boolean,
+  +refetch: () => Promise<T>,
+|};
+
+/** How a query behaves. */
+export type QueryOptions = {|
+  /** How long a value is fresh. Defaults to none, so a mount refetches. */
+  +staleTime?: number,
+|};
+
+/**
+ * Read `key`, fetching it when it is missing or stale.
+ *
+ * A cached value is returned immediately and refreshed behind it, so
+ * navigating back to a page shows it at once. `pending` says a request is in
+ * flight; `loading` says there is nothing to show yet — conflating those is
+ * why applications flash a spinner over data they already have.
+ */
+export function useQuery<T>(
+  key: QueryKey,
+  query: () => Promise<T>,
+  options?: QueryOptions,
+): QueryResult<T> {
+  const cache = useQueryCache();
+  const staleTime = options?.staleTime ?? 0;
+
+  // The key's identity is its hash. A caller writes the array inline, so
+  // depending on the array itself would resubscribe on every render; two
+  // arrays with the same hash are the same request by definition, so holding
+  // the first one is not a stale closure.
+  const id = hash(key);
+  const stable = useMemo(() => key, [id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // The query is something to *call*, not something to react to. React's own
+  // answer for that is an effect event — a function whose identity never
+  // changes and whose body is always the latest — and without it `subscribe`
+  // would change every render and `useSyncExternalStore` would resubscribe
+  // every render.
+  const fetcher = useStableCallback(query);
+
+  const subscribe = useCallback(
+    (listener: () => void) => cache.watch(stable, fetcher, { listener, staleTime }),
+    [cache, stable, fetcher, staleTime],
+  );
+
+  const snapshot = useCallback(() => cache.read(stable), [cache, stable]);
+  const entry: Entry<mixed> = useSyncExternalStore(subscribe, snapshot, snapshot);
+
+  const refetch = useCallback(() => cache.fetch(stable, fetcher), [cache, stable, fetcher]);
+
+  return useMemo(
+    () => ({
+      value: (entry.value: $FlowFixMe),
+      error: entry.error,
+      pending: entry.pending,
+      loading: entry.pending && entry.updatedAt === 0,
+      stale: entry.updatedAt === 0 || Date.now() - entry.updatedAt >= staleTime,
+      refetch: (refetch: $FlowFixMe),
+    }),
+    [entry, staleTime, refetch],
+  );
+}
+
+/** What a mutation looks like to a component. */
+export type MutationResult<TInput, TOutput> = {|
+  +run: (input: TInput) => Promise<TOutput>,
+  +value: TOutput | void,
+  +error: Error | null,
+  +pending: boolean,
+|};
+
+/**
+ * Run something that changes state, and invalidate what it affected.
+ *
+ * `run` is called from an event, so the closure it captures is the one from
+ * the render the reader was looking at — there is no ref holding a "latest"
+ * anything, and nothing to go stale. Nor is there a guard against settling
+ * after unmount: React has not warned about that since 18, and adding one
+ * would only hide a real leak if there were one.
+ *
+ * `invalidates` takes key prefixes, because that is how invalidation is
+ * expressed: creating a user refreshes `["users"]` and every `["users", id]`
+ * under it without the caller listing them.
+ */
+export function useMutation<TInput, TOutput>(
+  mutation: (input: TInput) => Promise<TOutput>,
+  options?: {| +invalidates?: $ReadOnlyArray<QueryKey> |},
+): MutationResult<TInput, TOutput> {
+  const cache = useQueryCache();
+  const [state, setState] = useState<{|
+    value: TOutput | void,
+    error: Error | null,
+    pending: boolean,
+  |}>({ value: undefined, error: null, pending: false });
+
+  const run = async (input: TInput): Promise<TOutput> => {
+    setState((current) => ({ ...current, pending: true, error: null }));
+    try {
+      const value = await mutation(input);
+      setState({ value, error: null, pending: false });
+      // After it settles, so a watcher refetching sees the change rather than
+      // racing it.
+      for (const prefix of options?.invalidates ?? []) {
+        cache.invalidate(prefix);
+      }
+      return value;
+    } catch (thrown) {
+      const error = thrown instanceof Error ? thrown : new Error(String(thrown));
+      setState({ value: undefined, error, pending: false });
+      // Rethrown: a caller awaiting `run` has to be able to tell that it
+      // failed, and the failure state alone would not let it.
+      throw error;
+    }
+  };
+
+  return { run, value: state.value, error: state.error, pending: state.pending };
+}

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniflowed/query",
   "version": "0.0.0-alpha.1",
-  "description": "Flow declarations for @uniflowed/query, part of the Unified Toolchain for Flow.",
+  "description": "A query cache with de-duplication and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
   "sideEffects": false,
@@ -14,9 +14,14 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/hooks": "0.0.0-alpha.1",
+    "@uniflowed/react": "0.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "react": ">=19"
   }
 }

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -29,6 +29,7 @@ export {
   object,
   optional,
   parse,
+  parser,
   partial,
   pipe,
   record,

--- a/packages/validator/internal/schema.js
+++ b/packages/validator/internal/schema.js
@@ -654,6 +654,20 @@ export function parse<T>(schema: Schema<T>, value: mixed): T {
 }
 
 /** Parse into a result, so failure is a value rather than control flow. */
+/**
+ * A schema as a standalone function.
+ *
+ * `safeParse(schema, value)` needs both halves at the call site, which is fine
+ * where the schema is in scope and useless where it is not — a boundary that
+ * wants to validate what arrives takes a *function*, not a schema and an
+ * import of this module. `parser(User)` is that function, and it is why
+ * `@uniflowed/fetch` can check a response body without depending on the
+ * validator at all.
+ */
+export function parser<T>(schema: Schema<T>): (value: mixed) => Result<T> {
+  return (value: mixed) => safeParse(schema, value);
+}
+
 export function safeParse<T>(schema: Schema<T>, value: mixed): Result<T> {
   return parseInternal(schema, value, []);
 }

--- a/tests/library/fetch.test.js
+++ b/tests/library/fetch.test.js
@@ -1,0 +1,238 @@
+// @flow
+//
+// `@uniflowed/fetch`.
+//
+// Every test uses an injected `fetch`, so the suite never touches the network
+// and can produce the awkward cases on demand — a 500, a hang, a body that is
+// not what the header said.
+
+import { describe, expect, fn, it } from "@uniflowed/test";
+import { FetchError, createFetch } from "@uniflowed/fetch";
+import { parser, v } from "@uniflowed/validator";
+
+/** A `fetch` that answers from a script, recording what it was asked. */
+function scripted(answers) {
+  const calls = [];
+  let at = 0;
+  const impl = async (url, init) => {
+    calls.push({ url, init });
+    const answer = answers[Math.min(at, answers.length - 1)];
+    at += 1;
+    if (typeof answer === "function") {
+      return answer(url, init);
+    }
+    return answer;
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("requests", () => {
+  it("parses a JSON body", async () => {
+    const client = createFetch({ fetch: scripted([json({ id: 1 })]) });
+    await expect(client.request("/users/1")).resolves.toEqual({ id: 1 });
+  });
+
+  it("joins the base URL and the path", async () => {
+    const impl = scripted([json({})]);
+    const client = createFetch({ baseURL: "https://api.example.com/v1/", fetch: impl });
+    await client.request("/users");
+    expect(impl.calls[0].url).toBe("https://api.example.com/v1/users");
+  });
+
+  it("leaves an absolute URL alone", async () => {
+    const impl = scripted([json({})]);
+    const client = createFetch({ baseURL: "https://api.example.com", fetch: impl });
+    await client.request("https://elsewhere.example.com/thing");
+    expect(impl.calls[0].url).toBe("https://elsewhere.example.com/thing");
+  });
+
+  it("appends search parameters", async () => {
+    const impl = scripted([json({})]);
+    const client = createFetch({ fetch: impl });
+    await client.request("/search", { searchParams: { q: "flow", page: 2 } });
+    expect(impl.calls[0].url).toBe("/search?q=flow&page=2");
+  });
+
+  it("sends a plain object as JSON, and says so", async () => {
+    const impl = scripted([json({})]);
+    const client = createFetch({ fetch: impl });
+    await client.request("/users", { method: "POST", body: { name: "ada" } });
+    expect(impl.calls[0].init.body).toBe('{"name":"ada"}');
+    expect(impl.calls[0].init.headers["content-type"]).toBe("application/json");
+  });
+
+  it("leaves a body the platform already accepts", async () => {
+    const impl = scripted([json({})]);
+    const client = createFetch({ fetch: impl });
+    const form = new URLSearchParams({ a: "1" });
+    await client.request("/x", { method: "POST", body: form });
+    expect(impl.calls[0].init.body).toBe(form);
+    expect(impl.calls[0].init.headers["content-type"]).toBe(undefined);
+  });
+
+  it("merges headers, with the request's winning", async () => {
+    const impl = scripted([json({})]);
+    const client = createFetch({
+      fetch: impl,
+      headers: { authorization: "token", accept: "application/json" },
+    });
+    await client.request("/x", { headers: { accept: "text/plain" } });
+    expect(impl.calls[0].init.headers.authorization).toBe("token");
+    expect(impl.calls[0].init.headers.accept).toBe("text/plain");
+  });
+
+  it("returns text for a text body and nothing for a 204", async () => {
+    const text = createFetch({
+      fetch: scripted([new Response("hello", { headers: { "content-type": "text/plain" } })]),
+    });
+    await expect(text.request("/x")).resolves.toBe("hello");
+
+    const empty = createFetch({ fetch: scripted([new Response(null, { status: 204 })]) });
+    await expect(empty.request("/x")).resolves.toBe(undefined);
+  });
+
+  it("hands the raw Response back when asked", async () => {
+    const client = createFetch({ fetch: scripted([json({ id: 1 })]) });
+    const response = await client.raw("/x");
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("failures", () => {
+  it("rejects a response that is not ok, rather than resolving with it", async () => {
+    const client = createFetch({ fetch: scripted([json({ error: "no" }, 500)]) });
+    // `fetch` resolves for a 500. Code that forgets `response.ok` treats an
+    // error page as data, and the failure surfaces somewhere unrelated.
+    await expect(client.request("/x")).rejects.toThrow("answered 500");
+  });
+
+  it("says what kind of failure it was", async () => {
+    const client = createFetch({ fetch: scripted([json({}, 404)]) });
+    try {
+      await client.request("/x");
+      throw new Error("expected a rejection");
+    } catch (error) {
+      expect(error instanceof FetchError).toBe(true);
+      expect(error.failure.kind).toBe("http");
+      expect(error.failure.status).toBe(404);
+      expect(error.retriable).toBe(false);
+    }
+  });
+
+  it("reports a network failure as one", async () => {
+    const client = createFetch({
+      fetch: scripted([
+        () => {
+          throw new TypeError("connection refused");
+        },
+      ]),
+    });
+    try {
+      await client.request("/x");
+      throw new Error("expected a rejection");
+    } catch (error) {
+      expect(error.failure.kind).toBe("network");
+      expect(error.retriable).toBe(true);
+    }
+  });
+
+  it("times out a request that never answers", async () => {
+    const client = createFetch({
+      timeout: 20,
+      fetch: (url, init) =>
+        new Promise((resolve, reject) => {
+          // Answers the abort, the way the platform's fetch does.
+          init.signal.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    });
+    try {
+      await client.request("/x");
+      throw new Error("expected a rejection");
+    } catch (error) {
+      expect(error.failure.kind).toBe("timeout");
+      expect(error.failure.millis).toBe(20);
+    }
+  });
+
+  it("rejects a body the schema does not accept, at the boundary", async () => {
+    const client = createFetch({ fetch: scripted([json({ id: "not a number" })]) });
+    const parse = parser(v.object({ id: v.number() }));
+    try {
+      await client.request("/x", { parse });
+      throw new Error("expected a rejection");
+    } catch (error) {
+      // Here, where the value came from outside — not three frames later as a
+      // TypeError about a property of undefined.
+      expect(error.failure.kind).toBe("invalid");
+      expect(error.failure.issues.length > 0).toBe(true);
+    }
+  });
+
+  it("returns the parsed value when the schema accepts it", async () => {
+    const client = createFetch({ fetch: scripted([json({ id: 7 })]) });
+    const parse = parser(v.object({ id: v.number() }));
+    await expect(client.request("/x", { parse })).resolves.toEqual({ id: 7 });
+  });
+});
+
+describe("retries", () => {
+  it("retries a 500 and returns the answer that worked", async () => {
+    const impl = scripted([json({}, 500), json({ ok: true })]);
+    const client = createFetch({ fetch: impl, retries: 2, retryDelay: 1 });
+    await expect(client.request("/x")).resolves.toEqual({ ok: true });
+    expect(impl.calls.length).toBe(2);
+  });
+
+  it("does not retry a 400", async () => {
+    const impl = scripted([json({}, 400)]);
+    const client = createFetch({ fetch: impl, retries: 3, retryDelay: 1 });
+    await expect(client.request("/x")).rejects.toThrow("answered 400");
+    // A 400 will be a 400 next time; sending it again is only slower.
+    expect(impl.calls.length).toBe(1);
+  });
+
+  it("retries 429 and 408", async () => {
+    for (const status of [429, 408]) {
+      const impl = scripted([json({}, status), json({ ok: true })]);
+      const client = createFetch({ fetch: impl, retries: 1, retryDelay: 1 });
+      await expect(client.request("/x")).resolves.toEqual({ ok: true });
+      expect(impl.calls.length).toBe(2);
+    }
+  });
+
+  it("never retries a POST, however retriable the failure looks", async () => {
+    const impl = scripted([json({}, 500), json({ ok: true })]);
+    const client = createFetch({ fetch: impl, retries: 3, retryDelay: 1 });
+    await expect(client.request("/x", { method: "POST" })).rejects.toThrow("answered 500");
+    // A POST that failed may have been applied. Sending it again is how an
+    // order is placed twice.
+    expect(impl.calls.length).toBe(1);
+  });
+
+  it("gives up after the retries are used", async () => {
+    const impl = scripted([json({}, 503)]);
+    const client = createFetch({ fetch: impl, retries: 2, retryDelay: 1 });
+    await expect(client.request("/x")).rejects.toThrow("answered 503");
+    expect(impl.calls.length).toBe(3);
+  });
+});
+
+describe("extend", () => {
+  it("layers headers on top of the client's", async () => {
+    const impl = scripted([json({})]);
+    const base = createFetch({ fetch: impl, headers: { authorization: "token" } });
+    const child = base.extend({ headers: { "x-trace": "1" } });
+    await child.request("/x");
+    expect(impl.calls[0].init.headers).toEqual({
+      authorization: "token",
+      "x-trace": "1",
+    });
+  });
+});

--- a/tests/library/fetch.test.js
+++ b/tests/library/fetch.test.js
@@ -6,7 +6,7 @@
 // and can produce the awkward cases on demand — a 500, a hang, a body that is
 // not what the header said.
 
-import { describe, expect, fn, it } from "@uniflowed/test";
+import { describe, expect, it } from "@uniflowed/test";
 import { FetchError, createFetch } from "@uniflowed/fetch";
 import { parser, v } from "@uniflowed/validator";
 

--- a/tests/library/query.test.js
+++ b/tests/library/query.test.js
@@ -1,0 +1,370 @@
+// @flow
+//
+// `@uniflowed/query`.
+//
+// The cache is tested on its own, because it is a plain object graph with no
+// React in it — de-duplication, staleness and prefix invalidation are
+// decisions it makes alone. The binding is tested through components, because
+// what matters there is that two of them reading one key agree.
+
+import * as React from "@uniflowed/react";
+import { describe, expect, fn, it } from "@uniflowed/test";
+import { render, screen, userEvent, waitFor } from "@uniflowed/react-testing";
+import {
+  QueryCache,
+  QueryProvider,
+  hash,
+  useMutation,
+  useQuery,
+} from "@uniflowed/query";
+
+const deferred = () => {
+  let settle = (value: mixed) => {};
+  let fail = (error: mixed) => {};
+  const promise = new Promise((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
+  return { promise, settle, fail };
+};
+
+describe("the cache", () => {
+  it("makes one request for two askers", async () => {
+    const cache = new QueryCache();
+    const query = fn(async () => "value");
+
+    const [first, second] = await Promise.all([
+      cache.fetch(["thing"], query),
+      cache.fetch(["thing"], query),
+    ]);
+
+    // Without this a header and a sidebar both showing the current user fetch
+    // it twice, and they can disagree about the answer.
+    expect(query.mock.calls.length).toBe(1);
+    expect(first).toBe("value");
+    expect(second).toBe("value");
+  });
+
+  it("treats different keys as different requests", async () => {
+    const cache = new QueryCache();
+    const query = fn(async () => "value");
+    await Promise.all([cache.fetch(["a"], query), cache.fetch(["b"], query)]);
+    expect(query.mock.calls.length).toBe(2);
+  });
+
+  it("does not confuse a number with the string of it", () => {
+    // They are different requests, and treating them as one shows the wrong
+    // data rather than raising.
+    expect(hash(["users", 1])).not.toBe(hash(["users", "1"]));
+  });
+
+  it("keeps the previous value beside an error", async () => {
+    const cache = new QueryCache();
+    await cache.fetch(["thing"], async () => "first");
+    await cache
+      .fetch(["thing"], async () => {
+        throw new Error("refresh failed");
+      })
+      .catch(() => {});
+
+    const entry = cache.read(["thing"]);
+    // A failed refresh must not blank a page that was showing something.
+    expect(entry.value).toBe("first");
+    expect(entry.error?.message).toBe("refresh failed");
+  });
+
+  it("is stale before anything has been fetched", () => {
+    const cache = new QueryCache();
+    expect(cache.isStale(["never"], 1000)).toBe(true);
+  });
+
+  it("is fresh for as long as it was told", async () => {
+    const cache = new QueryCache();
+    await cache.fetch(["thing"], async () => "value");
+    expect(cache.isStale(["thing"], 1000)).toBe(false);
+    expect(cache.isStale(["thing"], 0)).toBe(true);
+  });
+
+  it("invalidates by prefix", async () => {
+    const cache = new QueryCache();
+    await cache.fetch(["users"], async () => []);
+    await cache.fetch(["users", 1], async () => ({ id: 1 }));
+    await cache.fetch(["posts"], async () => []);
+
+    cache.invalidate(["users"]);
+
+    // Creating a user should refresh the list and every user under it, without
+    // the caller listing them.
+    expect(cache.isStale(["users"], 1000)).toBe(true);
+    expect(cache.isStale(["users", 1], 1000)).toBe(true);
+    expect(cache.isStale(["posts"], 1000)).toBe(false);
+  });
+
+  it("tells every watcher when a value arrives", async () => {
+    const cache = new QueryCache();
+    const first = fn();
+    const second = fn();
+    cache.subscribe(["thing"], first);
+    cache.subscribe(["thing"], second);
+
+    await cache.fetch(["thing"], async () => "value");
+
+    expect(first.mock.calls.length > 0).toBe(true);
+    expect(second.mock.calls.length > 0).toBe(true);
+  });
+
+  it("stops telling a watcher that unsubscribed", async () => {
+    const cache = new QueryCache();
+    const listener = fn();
+    const stop = cache.subscribe(["thing"], listener);
+    stop();
+    await cache.fetch(["thing"], async () => "value");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("takes a value without running a query", () => {
+    const cache = new QueryCache();
+    cache.set(["thing"], "optimistic");
+    expect(cache.read(["thing"]).value).toBe("optimistic");
+    expect(cache.isStale(["thing"], 1000)).toBe(false);
+  });
+});
+
+describe("useQuery", () => {
+  const withCache = (cache, ui) => (
+    <QueryProvider cache={cache}>{ui}</QueryProvider>
+  );
+
+  component Thing(cache: QueryCache, query: () => Promise<string>) {
+    const { value, loading, error } = useQuery(["thing"], query);
+    if (loading) return <output>loading</output>;
+    if (error != null) return <output>{`error: ${error.message}`}</output>;
+    return <output>{value ?? "nothing"}</output>;
+  }
+
+  it("shows nothing yet, then the value", async () => {
+    const cache = new QueryCache();
+    render(withCache(cache, <Thing cache={cache} query={async () => "loaded"} />));
+    expect(screen.getByText("loading")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("loaded")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a cached value immediately, with no loading pass", async () => {
+    const cache = new QueryCache();
+    await cache.fetch(["thing"], async () => "cached");
+
+    render(
+      withCache(cache, <Thing cache={cache} query={async () => "refreshed"} />),
+    );
+    // The point of stale-while-revalidate: navigating back does not flash a
+    // spinner over data that is already there.
+    expect(screen.getByText("cached")).toBeInTheDocument();
+    expect(screen.queryByText("loading")).toBe(null);
+  });
+
+  it("reports an error", async () => {
+    const cache = new QueryCache();
+    render(
+      withCache(
+        cache,
+        <Thing
+          cache={cache}
+          query={async () => {
+            throw new Error("nope");
+          }}
+        />,
+      ),
+    );
+    await waitFor(() => {
+      expect(screen.getByText("error: nope")).toBeInTheDocument();
+    });
+  });
+
+  it("makes one request for two components on the same key", async () => {
+    const cache = new QueryCache();
+    const query = fn(async () => "shared");
+
+    render(
+      withCache(
+        cache,
+        <div>
+          <Thing cache={cache} query={query} />
+          <Thing cache={cache} query={query} />
+        </div>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("shared").length).toBe(2);
+    });
+    expect(query.mock.calls.length).toBe(1);
+  });
+
+  it("does not refetch while the value is fresh", async () => {
+    const cache = new QueryCache();
+    await cache.fetch(["thing"], async () => "cached");
+    const query = fn(async () => "refetched");
+
+    component Fresh() {
+      const { value } = useQuery(["thing"], query, { staleTime: 60_000 });
+      return <output>{value ?? "nothing"}</output>;
+    }
+    render(withCache(cache, <Fresh />));
+
+    expect(screen.getByText("cached")).toBeInTheDocument();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("does not resubscribe when the caller passes a new closure each render", async () => {
+    const cache = new QueryCache();
+    let subscriptions = 0;
+    const original = cache.subscribe.bind(cache);
+    // $FlowFixMe[cannot-write] counting subscriptions is the point of the test.
+    cache.subscribe = (key, listener) => {
+      subscriptions += 1;
+      return original(key, listener);
+    };
+
+    component Rerendering() {
+      const [tick, setTick] = React.useState(0);
+      // A fresh closure on every render, which is how everyone writes it.
+      const { value } = useQuery(["thing"], async () => `value ${tick}`);
+      return (
+        <button type="button" onClick={() => setTick(tick + 1)}>
+          {value ?? "nothing"}
+        </button>
+      );
+    }
+
+    render(withCache(cache, <Rerendering />));
+    await waitFor(() => {
+      expect(screen.getByRole("button").textContent).toBe("value 0");
+    });
+    const before = subscriptions;
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(screen.getByRole("button"));
+
+    // The query is something to call, not something to react to: a new
+    // closure must not tear the subscription down and set it up again.
+    expect(subscriptions).toBe(before);
+  });
+
+  it("refetches when asked", async () => {
+    const cache = new QueryCache();
+    let answer = "first";
+    component Refetchable() {
+      const { value, refetch } = useQuery(["thing"], async () => answer, {
+        staleTime: 60_000,
+      });
+      return (
+        <button type="button" onClick={() => void refetch()}>
+          {value ?? "nothing"}
+        </button>
+      );
+    }
+    render(withCache(cache, <Refetchable />));
+    await waitFor(() => {
+      expect(screen.getByRole("button").textContent).toBe("first");
+    });
+
+    answer = "second";
+    await userEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByRole("button").textContent).toBe("second");
+    });
+  });
+
+  it("says which provider is missing", () => {
+    component Orphan() {
+      useQuery(["thing"], async () => "value");
+      return null;
+    }
+    let message = "";
+    try {
+      render(<Orphan />);
+    } catch (error) {
+      message = String(error);
+    }
+    expect(message).toContain("needs a QueryProvider");
+  });
+});
+
+describe("useMutation", () => {
+  it("runs, reports, and invalidates what it affected", async () => {
+    const cache = new QueryCache();
+    let listed = ["ada"];
+    await cache.fetch(["users"], async () => listed);
+
+    component Users() {
+      const { value } = useQuery(["users"], async () => listed, { staleTime: 60_000 });
+      const create = useMutation(
+        async (name: string) => {
+          listed = [...listed, name];
+          return name;
+        },
+        { invalidates: [["users"]] },
+      );
+      return (
+        <div>
+          <output>{(value ?? []).join(",")}</output>
+          <button type="button" onClick={() => void create.run("grace")}>
+            add
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <QueryProvider cache={cache}>
+        <Users />
+      </QueryProvider>,
+    );
+    expect(screen.getByText("ada")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button"));
+    // The list refreshed because the mutation invalidated its key, not because
+    // the component was told to reload.
+    await waitFor(() => {
+      expect(screen.getByText("ada,grace")).toBeInTheDocument();
+    });
+  });
+
+  it("rethrows, so a caller awaiting it can tell that it failed", async () => {
+    const cache = new QueryCache();
+    let caught = "";
+
+    component Failing() {
+      const mutation = useMutation(async () => {
+        throw new Error("rejected");
+      });
+      return (
+        <div>
+          <button
+            type="button"
+            onClick={() => {
+              mutation.run(undefined).catch((error) => {
+                caught = error.message;
+              });
+            }}
+          >
+            run
+          </button>
+          <output>{mutation.error?.message ?? "none"}</output>
+        </div>
+      );
+    }
+
+    render(
+      <QueryProvider cache={cache}>
+        <Failing />
+      </QueryProvider>,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByText("rejected")).toBeInTheDocument();
+    });
+    expect(caught).toBe("rejected");
+  });
+});

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -10,9 +10,12 @@
 # package here when it is implemented, not when it is declared. `uf_lib`'s
 # registry is the source of truth for what each one is.
 config
+fetch
+hooks
+query
 react
 react-testing
 router
+test
 ui
 vite
-test


### PR DESCRIPTION
`@uniflowed/fetch` and `@uniflowed/query` were declarations that threw. 41 tests between them.

## fetch

It does not replace the platform's — `raw` hands the `Response` straight back. It adds the three things every application writes around it and gets subtly wrong:

- **A failed response is a resolved promise.** Code that forgets `response.ok` treats an error page as data, and the failure surfaces somewhere unrelated.
- **There is no timeout.** A host that accepts the connection and never answers hangs until the process ends. The timeout *aborts*, rather than merely stopping the wait — otherwise the request holds a connection and its result can still arrive after the caller moved on.
- **Retrying is not uniform.** 500, 429, 408 and network failures are worth another attempt; a 400 will be a 400 next time. And **a POST is never retried**, however retriable the failure looks: it may already have been applied, and sending it again is how an order gets placed twice.

A response body can be checked at the boundary, where the value came from outside — not three frames later as a `TypeError` about a property of undefined. The option is a **parse function**, not a schema object, so this package depends on no validator; `@uniflowed/validator` grows `parser(User)`, which is exactly that shape.

## query

De-duplication, stale-while-revalidate, prefix invalidation. A header and a sidebar showing the current user make one request and cannot disagree. Navigating back shows the cached value at once instead of flashing a spinner over data already there. Creating a user refreshes `["users"]` and every `["users", id]` under it without the caller listing them.

## The binding, and staying inside React's model

You flagged escape hatches, and the first draft of this deserved it: it wrote a ref during render, triggered fetches from two effects, and carried three `eslint-disable` lines on dependency arrays. That is fighting the model, and the fix was not to hide it better.

The cache is an external store, so **`useQuery` is a `useSyncExternalStore` over it and nothing else** — no effect to trigger the request, no ref holding the latest query, no dependency array to argue with. Subscribing *is* the signal that a value is wanted, so keeping it fresh (including refetching after an invalidation) is the store's job. The component only reads.

`useMutation` runs from an event, so its closure is the one the reader was looking at and there is nothing to go stale. There is no guard against settling after unmount either: React has not warned about that since 18, and a guard would only hide a real leak if there were one.

The one place a callback genuinely must not be reacted to — the query function, which would otherwise resubscribe on every render — uses the **effect-event shape React defines for exactly that**, rather than a ref written during render.

**`useAsync` is rewritten the same way.** It kept a generation counter and a liveness ref to drop a superseded result; it now uses the effect's own cleanup, which is the shape React's documentation uses and which knows it has been superseded because React runs it before running the effect again. Its two hardest tests — a slow first request losing to a fast second, and settling after unmount — pass unchanged.

## Checked

`cargo test --workspace`, `cargo fmt --all -- --check`, `cargo test -p uf_lib`, and 300 tests in `tests/library`.

`fetch`, `hooks` and `query` are added to the publish list and need the same one-time `tools/release/trust-npm.sh` run as `react-testing` and `ui`. The preflight added in #85 will fail the publish job before sending anything if that has not been done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791042703&installation_model_id=422833&pr_number=87&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F87&signature=b286d9b2d417616fabc466ac0b7693caeeca069c3ce66c59c62ca29f15e186a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a typed HTTP client with URL handling, headers, request bodies, timeouts, retries, response parsing, and structured errors.
  * Added query caching and React hooks with de-duplication, stale-while-revalidate updates, refetching, mutations, and cache invalidation.
  * Added validator parser utilities.
  * Added fetch, hooks, and query packages to published packages.

* **Bug Fixes**
  * Improved async request handling so outdated results do not overwrite current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->