### PR TITLE
feat(cli): this repository is a uf project, and the mark to prove it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,33 @@ permissions:
   contents: read
 
 jobs:
+  toolchain:
+    name: Toolchain
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: tools/upstream/sync.sh
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: nightly-2026-08-01
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - run: cargo install wild-linker --version 0.10.0 --locked
+      - run: wild --version
+      # Built once and shared, because every job below runs its checks through
+      # `uf run` — this repository is a uf project, and its pipeline uses the
+      # toolchain it ships rather than a second description of the same checks.
+      - run: cargo build --release --bin uf
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: uf-ci
+          path: target/release/uf
+          retention-days: 1
+
   format:
     name: Format
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,10 +51,16 @@ jobs:
           toolchain: nightly-2026-08-01
           components: rustfmt
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: cargo fmt --all -- --check
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run rust:fmt:check
 
   clippy:
     name: Clippy
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -43,10 +74,16 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run rust:clippy
 
   test:
     name: Test
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -66,10 +103,16 @@ jobs:
       - run: npm ci --no-audit --no-fund
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo test --workspace
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run rust:test
 
   library:
     name: Library
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -89,11 +132,16 @@ jobs:
       # The `@uniflowed/*` packages are Flow, so `cargo test` cannot run a line
       # of them — their tests are uf tests, run by the runner this repository
       # ships. Without this job the library has a suite nothing executes.
-      - run: cargo build --release --bin uf
-      - run: ./target/release/uf --cwd tests/library test
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run test:lib
 
   installer:
     name: Installer
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -111,10 +159,16 @@ jobs:
       # Packages a release and installs it with the real installer. Keeps
       # install.sh and package-binaries.sh from drifting apart between releases,
       # when the only thing that notices is a user running `curl … | sh`.
-      - run: tools/release/test-install.sh
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run install:test
 
   bench-compile:
     name: Bench Compile
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -127,10 +181,16 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo bench --workspace --no-run
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run rust:bench
 
   metadata:
     name: Metadata
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -143,13 +203,19 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: cargo metadata --format-version 1 --locked
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run rust:metadata
       # Every package manifest, not just one: there are 44 of them now, and a
       # manifest that does not parse is a package that cannot be installed.
-      - run: node -e "for (const f of require('node:fs').globSync('packages/*/package.json')) JSON.parse(require('node:fs').readFileSync(f, 'utf8'))"
+      - run: ./target/release/uf run manifests
 
   upstream-flow:
     name: Upstream Flow
+    needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     env:
       # `rust-toolchain.toml` pins the release nightly and overrides
@@ -172,6 +238,11 @@ jobs:
       # than discovered when it breaks. Only the parser: the typing crates need
       # `box_patterns`, which the current nightly no longer has, which is
       # exactly what this job is here to tell us about.
-      - run: cargo clippy -p uf_flow --all-targets -- -D warnings
-      - run: cargo test -p uf_flow
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run flow:clippy
+      - run: ./target/release/uf run flow:test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -46,7 +46,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
           components: rustfmt
@@ -67,7 +67,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
           components: clippy
@@ -90,7 +90,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -119,7 +119,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -148,7 +148,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -175,7 +175,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -197,7 +197,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       # `uf run` — this repository is a uf project, and its pipeline uses the
       # toolchain it ships rather than a second description of the same checks.
       - run: cargo build --release --bin uf
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: uf-ci
           path: target/release/uf
@@ -51,7 +51,7 @@ jobs:
           toolchain: nightly-2026-08-01
           components: rustfmt
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release
@@ -74,7 +74,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release
@@ -103,7 +103,7 @@ jobs:
       - run: npm ci --no-audit --no-fund
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release
@@ -132,7 +132,7 @@ jobs:
       # The `@uniflowed/*` packages are Flow, so `cargo test` cannot run a line
       # of them — their tests are uf tests, run by the runner this repository
       # ships. Without this job the library has a suite nothing executes.
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release
@@ -159,7 +159,7 @@ jobs:
       # Packages a release and installs it with the real installer. Keeps
       # install.sh and package-binaries.sh from drifting apart between releases,
       # when the only thing that notices is a user running `curl … | sh`.
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release
@@ -181,7 +181,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release
@@ -203,7 +203,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release
@@ -238,7 +238,7 @@ jobs:
       # than discovered when it breaks. Only the parser: the typing crates need
       # `box_patterns`, which the current nightly no longer has, which is
       # exactly what this job is here to tell us about.
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uf-ci
           path: target/release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,12 @@ jobs:
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
       - run: npm ci --no-audit --no-fund
-      - run: tools/docs/build.sh
+      # This repository is a uf project: the site is built by the task in
+      # `uf.config.js`, with the toolchain it ships.
+      - run: cargo build --release --bin uf
+      - run: ./target/release/uf run docs:build
+        env:
+          UF_BIN: ./target/release/uf
       - run: npx --yes wrangler@4.128.0 deploy --dry-run --config infra/cloudflare/wrangler.docs.jsonc
       - run: npx --yes wrangler@4.128.0 deploy --dry-run --config infra/cloudflare/wrangler.setup.jsonc
 
@@ -88,6 +93,11 @@ jobs:
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
       - run: npm ci --no-audit --no-fund
-      - run: tools/docs/build.sh
+      # This repository is a uf project: the site is built by the task in
+      # `uf.config.js`, with the toolchain it ships.
+      - run: cargo build --release --bin uf
+      - run: ./target/release/uf run docs:build
+        env:
+          UF_BIN: ./target/release/uf
       - run: npx --yes wrangler@4.128.0 deploy --config infra/cloudflare/wrangler.docs.jsonc
       - run: npx --yes wrangler@4.128.0 deploy --config infra/cloudflare/wrangler.setup.jsonc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -82,7 +82,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/crates/uf_cli/src/brand.rs
+++ b/crates/uf_cli/src/brand.rs
@@ -1,6 +1,6 @@
 //! Brand-aware terminal snippets shared by human-facing CLI commands.
 
-use uf_term::{Cell, Color, Column, Renderer, Style, Table, Tone, push_repeat};
+use uf_term::{Cell, Color, Column, GlyphSet, Renderer, Style, Table, Tone, push_repeat};
 
 pub(crate) const HEADLINE: &str = "Unified Toolchain for Flow";
 pub(crate) const TAGLINE: &str = "All-in-one toolchain for Flow and React.";
@@ -26,6 +26,71 @@ pub(crate) const PALETTE: &[(&str, &str)] = &[
     ("--uf-color-slate-600", "#475569"),
     ("--uf-color-mist-50", "#F8FAFC"),
 ];
+
+/// The mark, five rows tall, in the brand's five stops.
+///
+/// One colour per row rather than per character: a per-character gradient
+/// would have to slice a string made of multi-byte block characters, and the
+/// result is worth less than the cost. Top to bottom is also the direction the
+/// documentation site runs its own gradient, so the two read as one thing.
+const MARK: [&str; 5] = [
+    "██    ██   ████████",
+    "██    ██   ██",
+    "██    ██   ██████",
+    "██    ██   ██",
+    " ██████    ██",
+];
+
+/// The same mark where block characters cannot be drawn.
+///
+/// A terminal in a non-UTF-8 locale, or one calling itself `dumb`, gets `#` —
+/// which is not as handsome and is legible, and the second matters more. The
+/// rest of this CLI already falls back the same way, so a mark that did not
+/// would be the one thing on screen printing replacement characters.
+const ASCII_MARK: [&str; 5] = [
+    "##    ##   ########",
+    "##    ##   ##",
+    "##    ##   ######",
+    "##    ##   ##",
+    " ######    ##",
+];
+
+/// The mark and the headline, for the moments that deserve it.
+///
+/// Not on every command. `uf test` printing a five-row logo before a hundred
+/// test results is not beautiful, it is in the way — this is for first contact
+/// (`uf create`) and for the command whose whole job is to say what you have
+/// (`uf info`).
+pub(crate) fn render_mark(renderer: &Renderer, out: &mut String, context: &str) {
+    let stops = [CYAN, BLUE, INDIGO, VIOLET, MAGENTA];
+    let rows = match renderer.glyph_set() {
+        GlyphSet::Ascii => &ASCII_MARK,
+        GlyphSet::Unicode => &MARK,
+    };
+
+    out.push('\n');
+    for (row, colour) in rows.iter().zip(stops) {
+        out.push_str("  ");
+        Style::new()
+            .fg(colour)
+            .bold()
+            .paint(renderer.color(), row, out);
+        out.push('\n');
+    }
+    out.push('\n');
+
+    out.push_str("  ");
+    renderer
+        .theme()
+        .title
+        .paint(renderer.color(), HEADLINE, out);
+    out.push_str("  ");
+    renderer
+        .theme()
+        .subtitle
+        .paint(renderer.color(), context, out);
+    out.push('\n');
+}
 
 pub(crate) fn render_product_card(renderer: &Renderer, out: &mut String, context: &str) {
     let title = renderer.theme().title;

--- a/crates/uf_cli/src/commands/create.rs
+++ b/crates/uf_cli/src/commands/create.rs
@@ -5,6 +5,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use uf_project::{CreateKind, CreateOptions, create_project};
 use uf_term::{Status, Tree};
 
+use crate::brand;
 use crate::cli::{AppTemplate, CreateCommand};
 use crate::support::{plural, project_label, relative_to};
 use crate::ui::Ui;
@@ -52,6 +53,10 @@ pub(crate) fn create(cwd: &Utf8Path, ui: &mut Ui, command: CreateCommand) -> Res
     });
 
     ui.render(|renderer, out| {
+        // First contact with the toolchain, which is the one moment a mark
+        // earns its five rows.
+        brand::render_mark(renderer, out, "uf create");
+        renderer.blank(out);
         renderer.banner(out, "uf create", Some(&label));
         renderer.blank(out);
         renderer.tree(out, 2, &Tree::from_paths(&root, paths.iter().copied()));

--- a/crates/uf_cli/src/commands/info.rs
+++ b/crates/uf_cli/src/commands/info.rs
@@ -13,7 +13,7 @@ pub(crate) fn info(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
     let host = format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS);
 
     ui.render(|renderer, out| {
-        brand::render_product_card(renderer, out, "uf info");
+        brand::render_mark(renderer, out, "uf info");
         renderer.blank(out);
 
         renderer.heading(out, 2, "distribution");

--- a/crates/uf_cli/src/commands/task.rs
+++ b/crates/uf_cli/src/commands/task.rs
@@ -46,13 +46,22 @@ fn run_named_task(
     execute_task(resolved, script, task, args)
 }
 
+/// Run one task.
+///
+/// A task that names a command is run by uf, because `uf.config.js` is where
+/// its meaning is written down and Vite Task has no way to read it — handing
+/// `ci` to `vp run ci` asked Vite+ for a script it had never heard of, so
+/// every task defined here failed on a machine that had `vp` and on one that
+/// did not. A task with no command of its own is Vite+'s, and is handed over.
 fn execute_task(
     resolved: &ResolvedConfig,
     script: &str,
     task: &TaskDefinition,
     args: &[String],
 ) -> Result<()> {
-    if resolved.config.task_runner.engine == TaskRunnerEngine::ViteTask {
+    if task.command().trim().is_empty()
+        && resolved.config.task_runner.engine == TaskRunnerEngine::ViteTask
+    {
         return execute_vite_task(resolved, script, args);
     }
 

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -49,10 +49,49 @@ fn ufr_keeps_version_flags_after_the_task_name_as_task_args() {
         "#,
     )
     .unwrap();
+
+    let output = binary("ufr")
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["show", "--", "--version"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // `--version` after the task name belongs to the task, not to `ufr`.
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "--version");
+}
+
+/// A task uf can run is run by uf, whatever the task runner engine says.
+///
+/// `uf.config.js` is where the task's meaning is written down, and Vite Task
+/// has no way to read it — handing `ci` to `vp run ci` asked Vite+ for a
+/// script it had never heard of, so every task defined here failed both on a
+/// machine that had `vp` and on one that did not.
+#[test]
+fn a_task_with_a_command_is_run_by_uf_rather_than_handed_to_vite_task() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: {
+                show: { command: "printf ours" },
+              },
+            });
+        "#,
+    )
+    .unwrap();
     let runner = dir.path().join("vp");
     fs::write(
         &runner,
-        "#!/bin/sh\n[ \"$1\" = run ] && [ \"$2\" = show ] && [ \"$3\" = -- ] && [ \"$4\" = --version ] && printf payload-version\n",
+        "#!/bin/sh
+printf vite-task
+",
     )
     .unwrap();
     let mut permissions = fs::metadata(&runner).unwrap().permissions();
@@ -62,7 +101,7 @@ fn ufr_keeps_version_flags_after_the_task_name_as_task_args() {
     let output = binary("ufr")
         .arg("--cwd")
         .arg(dir.path())
-        .args(["show", "--", "--version"])
+        .arg("show")
         .env("UF_VITE_TASK_BIN", &runner)
         .output()
         .unwrap();
@@ -72,7 +111,50 @@ fn ufr_keeps_version_flags_after_the_task_name_as_task_args() {
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(String::from_utf8(output.stdout).unwrap(), "payload-version");
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "ours");
+}
+
+/// A task with no command of its own is Vite+'s, and is handed over.
+#[test]
+fn a_task_without_a_command_is_handed_to_vite_task() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: {
+                show: { command: "" },
+              },
+            });
+        "#,
+    )
+    .unwrap();
+    let runner = dir.path().join("vp");
+    fs::write(
+        &runner,
+        "#!/bin/sh
+[ \"$1\" = run ] && [ \"$2\" = show ] && printf vite-task
+",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&runner).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&runner, permissions).unwrap();
+
+    let output = binary("ufr")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("show")
+        .env("UF_VITE_TASK_BIN", &runner)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "vite-task");
 }
 
 #[test]

--- a/docs/app/guide/format/_uf.page.mdx
+++ b/docs/app/guide/format/_uf.page.mdx
@@ -70,3 +70,22 @@ whole toolchain exists to avoid.
 <div className="command"><code>uf fmt --check && uf lint && uf check && uf test</code></div>
 
 Four commands, no configuration, and each one exits non-zero when it should.
+
+Better still, name them once. `uf.config.js` takes tasks, `uf run ci` runs
+them, and the pipeline calls the same thing:
+
+```js
+export default defineConfig({
+  tasks: {
+    "fmt:check": "uf fmt --check",
+    lint: "uf lint",
+    check: "uf check",
+    test: "uf test",
+    ci: { command: "echo ok", dependsOn: ["fmt:check", "lint", "check", "test"] },
+  },
+});
+```
+
+A check that is in the pipeline and not in `uf.config.js` is a check a
+contributor cannot run before pushing. uf's own repository is set up this way —
+its CI builds `uf` once and every job runs `uf run <task>`.

--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -10,12 +10,44 @@ requested_version="${UF_VERSION:-latest}"
 install_root="${UF_INSTALL_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/uf}"
 bin_dir="${UF_BIN_DIR:-$HOME/.local/bin}"
 
+# Colour, unless the terminal or the reader has said not to.
+#
+# `NO_COLOR` is the convention, and a redirected stream is not a terminal — an
+# installer whose output is being piped into a log should not fill it with
+# escape sequences.
+if [ -n "${NO_COLOR:-}" ] || [ ! -t 2 ]; then
+  uf_colour=""
+else
+  uf_colour="yes"
+fi
+
+uf_paint() {
+  if [ -z "$uf_colour" ]; then
+    printf '%s\n' "$2" >&2
+  else
+    printf '\033[38;2;%sm%s\033[0m\n' "$1" "$2" >&2
+  fi
+}
+
+# The mark, in the brand's five stops from top to bottom.
+#
+# One colour per row rather than per character: a per-character gradient means
+# slicing a string that is full of multi-byte block characters, and `cut -c`
+# counts bytes — it cuts them in half and prints replacement characters.
 uf_brand() {
-  printf '%s\n' \
-    "uf  Unified Toolchain for Flow" \
-    "    All-in-one toolchain for Flow and React." \
-    "    ----------------------------------------" \
-    "    Unified  Fast  Elegant  Modern  Developer-first" >&2
+  printf '\n' >&2
+  uf_paint '53;214;246'  "  ██    ██   ████████"
+  uf_paint '38;119;255'  "  ██    ██   ██"
+  uf_paint '92;73;255'   "  ██    ██   ██████"
+  uf_paint '143;75;255'  "  ██    ██   ██"
+  uf_paint '216;75;255'  "   ██████    ██"
+  printf '\n' >&2
+  if [ -z "$uf_colour" ]; then
+    printf '  %s\n\n' "Unified Toolchain for Flow" >&2
+  else
+    printf '  \033[1m%s\033[0m \033[2m%s\033[0m\n\n' \
+      "Unified Toolchain for Flow" "· one binary for Flow and React" >&2
+  fi
 }
 
 uf_step() {

--- a/tools/docs/build.sh
+++ b/tools/docs/build.sh
@@ -37,5 +37,12 @@ done
   if [ ! -d node_modules ]; then
     npm ci --no-audit --no-fund
   fi
-  cargo run --release --package uf_cli --bin uf -- --cwd docs build --size-report
+  # `UF_BIN` is set by anything that has already built the toolchain — CI
+  # builds it once and shares it, and rebuilding here would cost minutes for
+  # a binary that is already on disk.
+  if [ -n "${UF_BIN:-}" ]; then
+    "$UF_BIN" --cwd docs build --size-report
+  else
+    cargo run --release --package uf_cli --bin uf -- --cwd docs build --size-report
+  fi
 )

--- a/uf.config.js
+++ b/uf.config.js
@@ -1,0 +1,82 @@
+// @flow
+//
+// uf's own project.
+//
+// This repository is a uf project, and every check that runs in CI is a task
+// here — so `uf run ci` on a laptop is the same thing the pipeline runs, and a
+// check cannot be added to one without the other noticing.
+//
+// It is also the only honest way to find out what using uf is like. The
+// `Library` job runs `uf test`, the documentation is built by `uf build`, and
+// the formatter and linter that check the JavaScript in this repository are
+// `uf fmt` and `uf lint`. When one of them is wrong, it is wrong here first.
+//
+// The Rust half is still cargo's, because that is cargo's job. uf runs the
+// tasks; it does not pretend to be a Rust build system.
+
+import { defineConfig } from "@uniflowed/config";
+
+export default defineConfig({
+  // Not an application: this repository is the toolchain, and the sites it
+  // builds live in `docs/` with configs of their own.
+  app: {
+    router: { enabled: false },
+  },
+
+  lint: {
+    // `upstream/` is Meta's and React's source, vendored as submodules. It is
+    // not ours to format or lint, and a diff there would be lost on the next
+    // sync.
+    ignore: ["upstream", "dist", "target", "node_modules"],
+  },
+
+  tasks: {
+    // --- Rust ----------------------------------------------------------
+    "rust:fmt": "cargo fmt --all",
+    "rust:fmt:check": "cargo fmt --all -- --check",
+    "rust:clippy": "cargo clippy --workspace --all-targets -- -D warnings",
+    "rust:test": "cargo test --workspace",
+    "rust:bench": "cargo bench --workspace --no-run",
+    "rust:metadata": "cargo metadata --format-version 1 --locked",
+
+    // The parser and the checker are vendored, and they are the thing
+    // everything else reads, so they get a pass of their own.
+    "flow:clippy": "cargo clippy -p uf_flow --all-targets -- -D warnings",
+    "flow:test": "cargo test -p uf_flow",
+
+    // --- The toolchain, used on itself ---------------------------------
+    build: "cargo build --release --bin uf",
+
+    // Every `@uniflowed/*` package is Flow, so `cargo test` cannot run a line
+    // of it. These are uf tests, run by the runner this repository ships.
+    "test:lib": {
+      command: "./target/release/uf --cwd tests/library test",
+      dependsOn: ["build"],
+    },
+    "docs:build": {
+      command: "tools/docs/build.sh",
+      dependsOn: ["build"],
+    },
+    "install:test": "tools/release/test-install.sh",
+
+    // --- Manifests -----------------------------------------------------
+    manifests:
+      "node -e \"for (const f of require('node:fs').globSync('packages/*/package.json')) JSON.parse(require('node:fs').readFileSync(f, 'utf8'))\"",
+
+    // --- The whole thing -----------------------------------------------
+    //
+    // What CI runs, in one command. A check that is in the pipeline and not
+    // here is a check a contributor cannot run before pushing.
+    ci: {
+      command: "echo 'every check passed'",
+      dependsOn: [
+        "rust:fmt:check",
+        "rust:clippy",
+        "rust:test",
+        "test:lib",
+        "rust:metadata",
+        "manifests",
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## uf runs its own tasks

`uf run` handed **every** task to Vite Task, so `vp run ci` asked Vite+ for a script it had never heard of. Every task defined in `uf.config.js` failed — on a machine with `vp` and on one without.

A task that names a command is run by uf, because `uf.config.js` is where its meaning is written down. A task with no command of its own is Vite+'s, and is handed over. Two tests pin both halves.

## The repository is a uf project

A root `uf.config.js` names every check CI runs, so `uf run ci` on a laptop is the same thing the pipeline runs — and a check cannot be added to one without the other noticing.

CI builds `uf` once in a `Toolchain` job, shares it as an artifact, and **every other job runs `uf run <task>`**:

| job | was | now |
| --- | --- | --- |
| Format | `cargo fmt --all -- --check` | `uf run rust:fmt:check` |
| Clippy | `cargo clippy …` | `uf run rust:clippy` |
| Test | `cargo test --workspace` | `uf run rust:test` |
| Library | `cargo build` + `uf --cwd tests/library test` | `uf run test:lib` |
| Installer | `tools/release/test-install.sh` | `uf run install:test` |
| Bench, Metadata, Upstream Flow | cargo invocations | `uf run …` |
| Docs | `tools/docs/build.sh` | `uf run docs:build` |

That is also the only honest way to find out what using uf is like. The `Library` job runs `uf test`, the site is built by `uf build`, the JavaScript here is checked by `uf fmt` and `uf lint` — and when one of them is wrong, it is wrong here first. Two bugs in this PR were found exactly that way.

`tools/docs/build.sh` takes `UF_BIN` from the environment, so a caller that already built the toolchain does not build it again.

## A mark worth looking at

The installer opened with four lines of plain text. It now draws the mark in the brand's five stops:

```
  ██    ██   ████████     ← #35D6F6
  ██    ██   ██           ← #2677FF
  ██    ██   ██████       ← #5C49FF
  ██    ██   ██           ← #8F4BFF
   ██████    ██           ← #D84BFF
```

One colour per row rather than per character — per character means slicing strings full of multi-byte block characters, and `cut -c` counts *bytes*: it cuts them in half and prints replacement characters. It respects `NO_COLOR` and a redirected stream.

The same mark is in the CLI, on the two commands that earn five rows: `uf create`, which is first contact, and `uf info`, whose whole job is to say what you have. Deliberately **not** on `uf test` — a logo before a hundred test results is not beautiful, it is in the way.

A terminal in a non-UTF-8 locale, or one calling itself `dumb`, gets the same mark in `#`. The three glyph-fallback tests caught that omission, which is what they are for.

## Checked

`uf run rust:fmt:check`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `uf run test:lib` (259 tests), and `uf run docs:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791044811&installation_model_id=422833&pr_number=88&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F88&signature=f0812920b8f6144d2919a7ff0e24420f4eca31eee281aa2d8363ae8f3bb6210e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->