### PR TITLE
docs: the lines uf will not cross, and where it already has

### DIFF
--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -36,6 +36,11 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb: "What Flow says about React that nothing else can, and what it costs.",
       },
       {
+        href: "/guide/architecture",
+        title: "Architecture",
+        blurb: "What went wrong with create-react-app, and the lines uf will not cross.",
+      },
+      {
         href: "/guide/vite-plus",
         title: "uf and Vite+",
         blurb: "Where uf sits next to the toolchain it will be compared to.",

--- a/docs/app/guide/architecture/_uf.page.mdx
+++ b/docs/app/guide/architecture/_uf.page.mdx
@@ -1,0 +1,127 @@
+---
+title: "Architecture · uf"
+---
+
+<p className="eyebrow">Getting started</p>
+
+# Architecture
+
+<div className="lede">
+uf is an all-in-one toolchain, which is the same shape as create-react-app.
+This page is the list of things uf will not do, and where it does not yet
+comply with its own rules.
+</div>
+
+## What went wrong with create-react-app
+
+CRA was not a bad tool. It was the right design for 2016 that could not keep up
+with what React applications came to need, and the way it failed is close to a
+specification for how uf could fail.
+
+`react-scripts` hid webpack, Babel, ESLint, Jest and PostCSS behind one
+dependency. That was its whole appeal and it worked — right up until you needed
+one webpack plugin it had not anticipated. Then the only route was `eject`,
+which wrote the entire hidden configuration into your repository and could not
+be undone. Between *zero config* and *fully customisable* there was nothing.
+
+The second failure was structural. Every upgrade in the ecosystem had to travel
+through one package:
+
+```
+ecosystem change  →  react-scripts  →  you
+```
+
+A vulnerability in a transitive dependency could not be fixed by updating it;
+you waited for a `react-scripts` release. One package serialised the upgrade
+path of everything it contained.
+
+The third is the one React's own deprecation notice leads with: CRA solved the
+build and stopped. Routing, data fetching and code splitting turned out not to
+be three problems but one — a router that knows a route's data can fetch the
+code and the data in parallel instead of discovering the second after the first
+has rendered. CRA could not integrate them, so every production application
+built its own framework on top of CRA, which is the problem CRA existed to
+remove.
+
+The one-line lesson:
+
+> Abstraction without composability eventually becomes a bottleneck.
+
+## uf's position
+
+**uf owns orchestration, not implementation.** It decides what runs, when, and
+how the pieces connect. It does not own the bundler, the dev server, the
+formatter or the runtime.
+
+> Unified interface, federated implementation.
+
+Those are different things, and assuming they must match is what turns an
+integrated tool into a monolith. `uf dev`, `uf build`, `uf test` is an
+all-in-one experience; underneath, Vite is Vite and the Flow parser is Meta's.
+
+## The red lines
+
+1. Never fork Vite or Rolldown behaviour unless it is unavoidable.
+2. Never mirror the complete configuration schema of an upstream tool.
+3. Every built-in provider must be replaceable.
+4. No `eject` command.
+5. No single package controls ecosystem dependency versions.
+6. Core must not depend on a specific JavaScript runtime.
+7. All orchestration must be inspectable.
+8. Provider-specific functionality must remain accessible.
+9. Defaults are conveniences, never architectural requirements.
+10. uf's core owns the graph, not the tools.
+
+### The continuum that replaces `eject`
+
+```
+convention  →  configuration  →  provider replacement  →  raw provider API
+```
+
+Each step is a smaller decision than the one before it, and none is a door that
+locks behind you. A project that needs one Vite plugin adds one Vite plugin. It
+does not inherit a build system.
+
+### Three runtimes, not one
+
+"Runtime" is three questions, and collapsing them is how a toolchain ends up
+unable to target anything new:
+
+| | |
+| --- | --- |
+| Orchestration host | where uf itself runs — a native binary |
+| Plugin runtime | where JavaScript plugins run — Node.js, Bun, Deno |
+| Target runtime | where the output runs — a browser, a worker, a server |
+
+All three differ in an ordinary build: a native binary driving Vite on Node.js
+to produce a bundle for a Cloudflare Worker.
+
+## Where uf does not yet comply
+
+A list of rules with no audit against it is decoration.
+
+**Mirroring Vite's schema (2).** `dev` and `build` in `uf.config.js` re-declare
+Vite's options one at a time, and the driver maps them across by hand. A Vite
+option uf has not heard of is unreachable — exactly the `react-scripts`
+failure. uf should keep only what it genuinely owns and pass the rest through.
+
+**Replaceability is aspirational (3).** The lint engine, the formatter's
+parser, the task runner and the package resolver are each an enumeration with
+exactly one variant. The shape exists; nothing is actually replaceable yet.
+
+**Lockstep versions (5).** Every `@uniflowed/*` package pins its siblings
+exactly and one script sets them all. That is right while the packages are one
+thing, and it is the beginning of the chokepoint. Adapters need to move
+independently before 1.0.
+
+**Inspectability is partial (7).** `uf inspect --json` prints the resolved
+configuration. Nothing yet says which provider runs each stage of `uf dev`, at
+what version, and which files the configuration came from.
+
+**uf owns two tools (10).** The formatter and the test runner are uf's own
+implementations rather than orchestrated providers — a deliberate choice, since
+a Flow-aware version of neither existed. Each has to stay replaceable, or it
+becomes the thing this page is about.
+
+The full record, including the reasoning, is
+[`docs/red-lines.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/red-lines.md).

--- a/docs/app/guide/architecture/_uf.page.mdx
+++ b/docs/app/guide/architecture/_uf.page.mdx
@@ -59,6 +59,12 @@ Those are different things, and assuming they must match is what turns an
 integrated tool into a monolith. `uf dev`, `uf build`, `uf test` is an
 all-in-one experience; underneath, Vite is Vite and the Flow parser is Meta's.
 
+This is the target, and uf does not meet it today: the formatter and the test
+runner are uf's own. That is deliberate — a Flow-aware version of neither
+existed, and "orchestrate the provider that does not exist" is not a plan — but
+it is an exception rather than a revision of the principle, and the audit below
+treats it as one. An exception stays an exception by staying replaceable.
+
 ## The red lines
 
 1. Never fork Vite or Rolldown behaviour unless it is unavoidable.

--- a/docs/red-lines.md
+++ b/docs/red-lines.md
@@ -29,6 +29,13 @@ experience is all-in-one; the implementation is federated.
 
 Those are different things, and CRA's mistake was assuming they had to match.
 
+This is the target, and uf does not meet it today: `uf_fmt` and `uf_test` are
+uf's own implementations. That is deliberate — a Flow-aware formatter and a
+Flow-aware test runner did not exist, and "orchestrate the provider that does
+not exist" is not a plan — but it is an exception rather than a revision of the
+principle, and the audit below treats it as one. An exception stays an
+exception by staying replaceable.
+
 ## The red lines
 
 1. **Never fork Vite or Rolldown behaviour unless it is unavoidable.**
@@ -53,7 +60,7 @@ Those are different things, and CRA's mistake was assuming they had to match.
 
 ## The continuum that replaces `eject`
 
-```
+```text
 convention  →  configuration  →  provider replacement  →  raw provider API
 ```
 

--- a/docs/red-lines.md
+++ b/docs/red-lines.md
@@ -1,0 +1,120 @@
+# Architecture red lines
+
+uf is an all-in-one toolchain, which is the same shape as `create-react-app`.
+CRA was not a bad tool — it was the right design for 2016 that could not keep
+up — and the way it failed is a specification for how uf could fail. This
+document is the list of things uf will not do, and an honest account of where
+it does not yet comply.
+
+The one-line version of CRA's lesson:
+
+> Abstraction without composability eventually becomes a bottleneck.
+
+`react-scripts` succeeded completely at hiding configuration and failed at
+letting anyone peel that abstraction back a layer at a time. Between "zero
+config" and "eject" there was nothing — a cliff, and an irreversible one. uf is
+in a more dangerous position than CRA was, because CRA integrated a build
+setup and uf integrates the language toolchain, the build, the dev server, the
+test runner, the formatter and the linter.
+
+## The principle
+
+**uf owns orchestration, not implementation.**
+
+uf decides what runs, when, and how the pieces connect. It does not own the
+bundler, the dev server, the formatter, the linter or the runtime. The user's
+experience is all-in-one; the implementation is federated.
+
+> Unified interface, federated implementation.
+
+Those are different things, and CRA's mistake was assuming they had to match.
+
+## The red lines
+
+1. **Never fork Vite or Rolldown behaviour unless it is unavoidable.**
+2. **Never mirror the complete configuration schema of an upstream tool.**
+   Every option uf re-declares is an option that needs a uf release before
+   anyone can use it.
+3. **Every built-in provider must be replaceable.** A default is a
+   convenience, not an architecture.
+4. **No `eject` command.** The path from convention to raw provider access is
+   a continuum, not a cliff with a one-way door at the end of it.
+5. **No single package controls ecosystem dependency versions.** CRA's fatal
+   structure was `ecosystem change → react-scripts → user`: one chokepoint,
+   serialising every upgrade in the ecosystem through one release.
+6. **Core must not depend on a specific JavaScript runtime.**
+7. **All orchestration must be inspectable.** An integrated tool that cannot
+   say what it is doing is a black box, and a black box is where the CRA
+   problems became unfixable rather than merely annoying.
+8. **Provider-specific functionality must remain accessible.** If Vite can do
+   it, a uf project can do it, without waiting for uf.
+9. **Defaults are conveniences, never architectural requirements.**
+10. **uf's core owns the graph, not the tools.**
+
+## The continuum that replaces `eject`
+
+```
+convention  →  configuration  →  provider replacement  →  raw provider API
+```
+
+Each step is a smaller decision than the one before it, and none of them is a
+door that locks behind you. A project that needs one Vite plugin adds one Vite
+plugin; it does not inherit a build system.
+
+## Three runtimes, not one
+
+"Runtime" is three separate questions, and collapsing them is how a toolchain
+ends up unable to target anything new:
+
+| | |
+| --- | --- |
+| **Orchestration host** | where uf itself runs — a native binary |
+| **Plugin runtime** | where JavaScript plugins run — Node.js, Bun, Deno |
+| **Target runtime** | where the output runs — a browser, a worker, a server |
+
+All three can differ in one build: a native binary orchestrating Vite on
+Node.js to produce a bundle for Cloudflare Workers is an ordinary case, not an
+exotic one.
+
+## Where uf does not yet comply
+
+Writing the list is worth nothing without saying where we stand against it.
+
+**Red line 2 is violated today.** `uf_config`'s `dev` and `build` re-declare
+Vite's options one at a time — `host`, `port`, `strictPort`, `allowedHosts`,
+`fs.allow`, `fs.deny`, `outDir`, `sourcemap` — and `viteConfig()` in
+`@uniflowed/vite` maps them across by hand. A Vite option uf has not heard of
+is unreachable, which is precisely the `react-scripts` failure. Fixing this
+means uf keeping only the settings it genuinely owns (the ones with
+cross-tool meaning, or that uf *enforces*, such as the `allowedHosts` gate on
+binding a routable address) and passing everything else through natively.
+
+**Red line 3 is aspirational.** `LintEngine`, `FlowFormatParser`,
+`TaskRunnerEngine` and `PackageManagerResolver` are enumerations with exactly
+one variant each. The shape of replaceability exists; nothing is actually
+replaceable. Until a second provider exists for at least one of them, this
+line is a statement of intent.
+
+**Red line 5 is at risk.** `tools/release/bump-version.sh` sets every version
+in the repository to one value, and every `@uniflowed/*` package pins its
+siblings exactly. That is right for a pre-release where the packages are one
+thing, and it is the beginning of lockstep. Adapters need to be able to move
+independently before 1.0.
+
+**Red line 7 is partly met.** `uf inspect --json` prints the resolved
+configuration and the route table. There is no `uf explain <command>` yet:
+nothing says which provider will run each stage, at which version, and which
+files the configuration came from.
+
+**Red line 10 is the one to watch.** `uf_fmt` and `uf_test` are uf's own
+implementations rather than orchestrated providers. That is a deliberate
+choice — a Flow-aware formatter and a Flow-aware test runner did not exist —
+but each is a place where uf owns a tool rather than the graph, and each has
+to stay replaceable or it becomes the thing this document is about.
+
+## Why this is written down
+
+Every one of these is easy to cross for a good local reason, and each crossing
+is invisible until the toolchain is the bottleneck. CRA's maintainers did not
+decide to become a chokepoint; they made a series of individually reasonable
+decisions with no line to notice they had crossed.


### PR DESCRIPTION
uf is an all-in-one toolchain, which is the shape `create-react-app` had — and uf is in a *more* dangerous position, because CRA integrated a build setup while uf integrates the language toolchain, the build, the dev server, the test runner, the formatter and the linter.

CRA was not a bad tool. It was the right design for 2016 that could not keep up, and the way it failed reads as a specification for how uf could fail:

- **A cliff instead of a continuum.** Hiding webpack behind one dependency worked until you needed one plugin it had not anticipated; then the only route was `eject`, which was irreversible. Between zero-config and fully-customisable there was nothing.
- **One chokepoint.** `ecosystem change → react-scripts → you`. A vulnerability in a transitive dependency could not be fixed by updating it — you waited for a release.
- **It solved the build and stopped.** Routing, data fetching and code splitting turned out to be one problem, not three, so every production app built its own framework on top of CRA — the problem CRA existed to remove.

> Abstraction without composability eventually becomes a bottleneck.

## The principle

**uf owns orchestration, not implementation.** It decides what runs, when, and how the pieces connect; it does not own the bundler, the dev server, the formatter or the runtime.

> Unified interface, federated implementation.

Those are different things, and assuming they must match is what turns an integrated tool into a monolith.

## The ten

1. Never fork Vite or Rolldown behaviour unless unavoidable.
2. Never mirror the complete configuration schema of an upstream tool.
3. Every built-in provider must be replaceable.
4. No `eject` command.
5. No single package controls ecosystem dependency versions.
6. Core must not depend on a specific JavaScript runtime.
7. All orchestration must be inspectable.
8. Provider-specific functionality must remain accessible.
9. Defaults are conveniences, never architectural requirements.
10. uf's core owns the graph, not the tools.

Plus the continuum that replaces `eject` — convention → configuration → provider replacement → raw provider API — and the three separate runtimes (orchestration host, plugin runtime, target runtime) that "runtime" collapses if you let it.

## The audit, which is not comfortable reading

A list of rules with no audit against it is decoration. Both documents say where uf stands **today**:

| line | status |
| --- | --- |
| 2 — mirroring upstream schemas | **violated.** `dev` and `build` re-declare Vite's options one at a time (`host`, `port`, `strictPort`, `allowedHosts`, `fs.allow`, `outDir`, `sourcemap`) and the driver maps them by hand. A Vite option uf has not heard of is unreachable — the `react-scripts` failure exactly. |
| 3 — replaceable providers | **aspirational.** `LintEngine`, `FlowFormatParser`, `TaskRunnerEngine` and `PackageManagerResolver` are enums with exactly one variant. The shape exists; nothing is replaceable. |
| 5 — no version chokepoint | **at risk.** One script sets every version and every package pins its siblings exactly. Right for a pre-release; the beginning of lockstep. |
| 7 — inspectable | **partial.** `uf inspect --json` prints the resolved config. Nothing says which provider runs each stage, at what version, from which config files. |
| 10 — core owns the graph | **watch this.** `uf_fmt` and `uf_test` are uf's own implementations rather than orchestrated providers — deliberate, since a Flow-aware version of neither existed, but each must stay replaceable. |

Fixing 2 and 7 is next.

Written down because each line is easy to cross for a good local reason and invisible until the toolchain is the bottleneck. CRA's maintainers did not decide to become a chokepoint; they made a series of individually reasonable decisions with no line to notice they had crossed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791049769&installation_model_id=422833&pr_number=89&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F89&signature=ada92257a5e1c1ca713a4f024d094c47e40c16444408a24b8067ce1bd76d415b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an Architecture guide explaining the toolchain’s orchestration model, configuration approach, runtime boundaries, and current limitations.
  - Added detailed architectural constraints covering provider replaceability, inspectability, runtime independence, dependency management, and ownership boundaries.
  - Linked the new Architecture page from the Getting started navigation with a descriptive summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->