### PR TITLE
feat(config): reach Vite directly, without waiting for uf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,6 +3378,7 @@ dependencies = [
  "criterion",
  "json5",
  "serde",
+ "serde_json",
  "similar-asserts",
  "tempfile",
  "thiserror",

--- a/crates/uf_config/Cargo.toml
+++ b/crates/uf_config/Cargo.toml
@@ -14,6 +14,7 @@ compact_str.workspace = true
 json5.workspace = true
 uf_bundle = { path = "../uf_bundle" }
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -60,6 +60,14 @@ pub struct UniflowedConfig {
     pub task_runner: TaskRunnerConfig,
     pub tasks: BTreeMap<CompactString, TaskDefinition>,
     pub test: TestConfig,
+    /// The project's own Vite configuration, passed through untouched.
+    ///
+    /// uf does not read this and does not need to. Re-declaring an upstream
+    /// tool's options — as `dev` and `build` still do — makes every option uf
+    /// has not enumerated unreachable until uf ships a release naming it,
+    /// which is the structure that made `react-scripts` the bottleneck every
+    /// ecosystem upgrade had to pass through. See `docs/red-lines.md`.
+    pub vite: Option<serde_json::Value>,
     pub vrt: VrtConfig,
 }
 

--- a/docs/app/reference/config/_uf.page.mdx
+++ b/docs/app/reference/config/_uf.page.mdx
@@ -39,6 +39,7 @@ which is the fastest way to answer "what is it actually using".
 | `lint` | `uf lint` and Flow's built-in lints |
 | `test` | `uf test` |
 | `plugins` | Vite plugins, appended to uf's own |
+| `vite` | Vite's own configuration, merged over uf's |
 | `tasks` | Named tasks for `uf run` |
 | `package`, `publish`, `release`, `pm` | Packaging and releasing |
 | `server`, `story`, `std`, `vrt` | The server adapter, stories, the standard library, visual tests |
@@ -129,6 +130,34 @@ uf's rule table, and a test asserts the table matches the descriptors.
 | `runner.scheduler` | `"native-work-stealing"` | How files are handed to workers |
 | `runner.officialFlowParser` | `true` | Discovery reads Flow with the official parser |
 | `reactTestingLibraryNative` | `false` | Whether component tests can run without a DOM |
+
+## vite
+
+Vite's own configuration, merged over the one uf generates. uf does not read
+it, which is the point: an option added to Vite tomorrow works in a uf project
+tomorrow rather than after a uf release that names it.
+
+```js
+export default defineConfig({
+  vite: {
+    server: { warmup: { clientFiles: ["./src/big-module.js"] } },
+    build: { target: "es2022" },
+    resolve: { alias: { "~": "/src" } },
+  },
+});
+```
+
+Objects merge key by key and arrays replace, so `server.fs.allow` means that
+list rather than that list plus uf's. Three things stay uf's whatever this
+says: `root` and `configFile`, because a `vite.config.ts` beside
+`uf.config.js` is two files disagreeing about one project; and uf's own
+plugins, which are kept and put first — dropping the Flow transform would
+leave a project whose source no longer compiles, which is not something anyone
+means to configure.
+
+Everything else is yours to set, **including options uf sets itself**. A
+default is a convenience, not an architecture. The reasoning is in
+[Architecture](/guide/architecture).
 
 ## tasks and plugins
 

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -23,6 +23,7 @@ import { pathToFileURL } from "node:url";
 
 import { emit, errorEvent, eventLogger } from "./internal/events.js";
 import { loadUfConfig, projectConfig } from "./internal/config.js";
+import { withProjectConfig } from "./merge.js";
 import { VIRTUAL, scanRoutes } from "./internal/routes.js";
 
 function argument(name) {
@@ -80,14 +81,18 @@ async function viteConfig(config, mode) {
   const port = Number(argument("--port") ?? dev.port ?? 5173);
   const allowedHosts = Array.isArray(dev.allowedHosts) && dev.allowedHosts.length > 0 ? dev.allowedHosts : undefined;
 
-  return {
+  // What uf generates from the semantics it owns: where the project is, which
+  // plugins make Flow compile, and the few settings uf enforces rather than
+  // merely passes on — `allowedHosts` gates binding a routable address, and
+  // `manifest` is how the prerender finds its assets.
+  const generated = {
     root,
     configFile: false,
     envFile: false,
     mode,
     clearScreen: false,
     customLogger: eventLogger(argument("--log-level") ?? "info"),
-    plugins: [uniflowed({ root, config }), ...userPlugins],
+    plugins: [uniflowed({ root, config })],
     server: {
       host,
       port,
@@ -106,6 +111,14 @@ async function viteConfig(config, mode) {
       emptyOutDir: true,
     },
   };
+
+  // Then the project's own Vite configuration, merged over it. uf does not
+  // read this and does not need to: an option added to Vite tomorrow works in
+  // a uf project tomorrow, rather than after a uf release that names it.
+  return withProjectConfig(generated, {
+    ...(config.vite ?? {}),
+    plugins: [...(config.vite?.plugins ?? []), ...userPlugins],
+  });
 }
 
 /**

--- a/packages/vite/merge.js
+++ b/packages/vite/merge.js
@@ -1,0 +1,87 @@
+// Plain JavaScript: executed by the host that runs Vite, before any transform.
+//
+// Merging a project's own Vite configuration over the one uf generates.
+//
+// This exists because of a specific failure. uf's config re-declared Vite's
+// options one at a time — `host`, `port`, `strictPort`, `outDir`, `sourcemap`
+// — and the driver copied them across by hand. Anything Vite could do that uf
+// had not enumerated was unreachable until uf shipped a release naming it.
+// That is `react-scripts`: an integrated tool becoming the chokepoint every
+// upgrade in the ecosystem has to pass through.
+//
+// So `vite` in `uf.config.js` is Vite's own configuration, merged over uf's,
+// and uf makes no attempt to understand it. An option added to Vite tomorrow
+// works in a uf project tomorrow.
+//
+// # What uf still decides
+//
+// Three things are uf's rather than the project's, and the merge protects
+// them:
+//
+//   * `plugins`, which are concatenated rather than replaced — dropping uf's
+//     Flow transform would leave a project whose source no longer compiles,
+//     which is not a thing anyone means to configure.
+//   * `configFile`, because a `vite.config.ts` beside `uf.config.js` is two
+//     files disagreeing about one project.
+//   * `root`, which is the project uf resolved.
+//
+// Everything else is the project's to set, including options uf sets itself:
+// a default is a convenience, not an architecture.
+
+/** Keys uf owns outright, whatever the project's Vite config says. */
+const RESERVED = ["root", "configFile"];
+
+/**
+ * Deep-merge `overrides` onto `base`.
+ *
+ * Plain objects merge key by key; arrays and everything else replace, which is
+ * what a caller setting `build.rollupOptions.input` means. `plugins` is the
+ * exception and is handled by the caller, because concatenating is right there
+ * and replacing is right everywhere else.
+ */
+export function mergeConfig(base, overrides) {
+  if (overrides == null) return base;
+  const merged = { ...base };
+  for (const key of Object.keys(overrides)) {
+    const value = overrides[key];
+    if (value === undefined) continue;
+    merged[key] = isPlainObject(value) && isPlainObject(base[key])
+      ? mergeConfig(base[key], value)
+      : value;
+  }
+  return merged;
+}
+
+/**
+ * uf's generated config, with the project's Vite config merged over it.
+ *
+ * @param {object} generated what uf built from the semantics it owns
+ * @param {object | undefined} overrides `vite` from `uf.config.js`
+ */
+export function withProjectConfig(generated, overrides) {
+  if (overrides == null) return generated;
+
+  const owned = {};
+  for (const key of RESERVED) owned[key] = generated[key];
+
+  const merged = mergeConfig(generated, { ...overrides, ...owned });
+
+  // uf's plugins first, then the project's. First because the Flow transform
+  // has to see a module before anything that expects JavaScript does.
+  merged.plugins = [
+    ...(generated.plugins ?? []),
+    ...(Array.isArray(overrides.plugins) ? overrides.plugins : []),
+  ];
+  return merged;
+}
+
+function isPlainObject(value) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    // A plugin, a logger or a URL is a value to replace, not a shape to merge.
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  );
+}

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -16,15 +16,17 @@
     "./register": "./register.js",
     "./bun-preload": "./bun-preload.js",
     "./transform": "./transform.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./merge": "./merge.js"
   },
   "files": [
-    "index.js",
-    "driver.js",
-    "register.js",
     "bun-preload.js",
-    "transform.js",
-    "internal"
+    "driver.js",
+    "index.js",
+    "internal",
+    "merge.js",
+    "register.js",
+    "transform.js"
   ],
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",

--- a/tests/library/vite-config.test.js
+++ b/tests/library/vite-config.test.js
@@ -1,0 +1,93 @@
+// @flow
+//
+// `@uniflowed/vite`'s configuration merge.
+//
+// This is the red line that matters most (`docs/red-lines.md`, line 2): uf
+// must not re-declare an upstream tool's options, because every option it
+// enumerates is one nobody can use until uf ships a release naming it. These
+// tests are the guarantee that a project can reach Vite directly.
+
+import { describe, expect, it } from "@uniflowed/test";
+import { mergeConfig, withProjectConfig } from "@uniflowed/vite/merge";
+
+const generated = () => ({
+  root: "/project",
+  configFile: false,
+  mode: "development",
+  server: { host: "127.0.0.1", port: 5173, fs: { allow: ["."] } },
+  build: { outDir: "dist", manifest: true, sourcemap: true },
+  plugins: ["uf:flow"],
+});
+
+describe("reaching Vite directly", () => {
+  it("passes through an option uf has never heard of", () => {
+    const merged = withProjectConfig(generated(), {
+      server: { warmup: { clientFiles: ["./src/big.js"] } },
+    });
+    // The whole point: uf does not know what `warmup` is, and a project can
+    // still use it without waiting for a uf release.
+    expect(merged.server.warmup).toEqual({ clientFiles: ["./src/big.js"] });
+  });
+
+  it("lets a project override what uf chose", () => {
+    const merged = withProjectConfig(generated(), { server: { port: 4000 } });
+    // A default is a convenience, not an architecture.
+    expect(merged.server.port).toBe(4000);
+    expect(merged.server.host).toBe("127.0.0.1");
+  });
+
+  it("merges deeply rather than replacing a whole section", () => {
+    const merged = withProjectConfig(generated(), { build: { target: "es2022" } });
+    expect(merged.build).toEqual({
+      outDir: "dist",
+      manifest: true,
+      sourcemap: true,
+      target: "es2022",
+    });
+  });
+
+  it("replaces an array rather than concatenating it", () => {
+    const merged = withProjectConfig(generated(), {
+      server: { fs: { allow: ["/elsewhere"] } },
+    });
+    // `fs.allow: ["/elsewhere"]` means that list, not that list plus uf's.
+    expect(merged.server.fs.allow).toEqual(["/elsewhere"]);
+  });
+
+  it("keeps uf's plugins and adds the project's after them", () => {
+    const merged = withProjectConfig(generated(), { plugins: ["svgr"] });
+    // uf's first: the Flow transform has to see a module before anything that
+    // expects JavaScript does. And a project cannot drop it by accident —
+    // that would leave source that no longer compiles.
+    expect(merged.plugins).toEqual(["uf:flow", "svgr"]);
+  });
+
+  it("keeps the project root and the config file uf resolved", () => {
+    const merged = withProjectConfig(generated(), {
+      root: "/somewhere-else",
+      configFile: "./vite.config.ts",
+    });
+    // A `vite.config.ts` beside `uf.config.js` is two files disagreeing about
+    // one project, and `root` is what uf resolved.
+    expect(merged.root).toBe("/project");
+    expect(merged.configFile).toBe(false);
+  });
+
+  it("changes nothing when a project sets nothing", () => {
+    expect(withProjectConfig(generated(), undefined)).toEqual(generated());
+  });
+});
+
+describe("mergeConfig", () => {
+  it("ignores an explicit undefined rather than erasing a value", () => {
+    expect(mergeConfig({ a: 1 }, { a: undefined })).toEqual({ a: 1 });
+  });
+
+  it("does not merge into a value that is not a plain object", () => {
+    // A logger, a plugin or a URL is a value to replace, not a shape to walk.
+    const logger = { info: () => {} };
+    expect(mergeConfig({ customLogger: logger }, { customLogger: null })).toEqual({
+      customLogger: null,
+    });
+  });
+});


### PR DESCRIPTION
Red line 2 from #89, and the one that matters most.

uf re-declared Vite's options one at a time — `host`, `port`, `strictPort`, `outDir`, `sourcemap` — and `viteConfig()` copied them across by hand. **Anything Vite could do that uf had not enumerated was unreachable** until uf shipped a release naming it.

That is not *similar to* `react-scripts`. It is the same structure: an integrated tool becomes the chokepoint every ecosystem upgrade passes through, and a user who needs one option waits for a maintainer.

## The fix

`vite` in `uf.config.js` is Vite's own configuration, merged over the one uf generates:

```js
export default defineConfig({
  vite: {
    server: { warmup: { clientFiles: ["./src/big-module.js"] } },
    build: { target: "es2022" },
    resolve: { alias: { "~": "/src" } },
  },
});
```

uf does not read it and does not need to. An option added to Vite tomorrow works in a uf project tomorrow.

Verified end to end: a real project setting `server.warmup` and `build.assetsInlineLimit` — neither of which uf has ever heard of — builds and renders.

## What uf keeps, and why

| | |
| --- | --- |
| `root`, `configFile` | A `vite.config.ts` beside `uf.config.js` is two files disagreeing about one project, and `root` is what uf resolved. |
| uf's plugins | Kept and put **first**: the Flow transform has to see a module before anything expecting JavaScript does, and dropping it would leave source that no longer compiles — not something anyone means to configure. A project's plugins are appended. |

Everything else is the project's to set, **including options uf sets itself**. A default is a convenience, not an architecture.

Objects merge key by key; arrays replace, because a project writing `server.fs.allow` means *that* list, not that list plus uf's. A logger or a plugin instance is a value to replace, not a shape to walk into.

## Not fixed yet

`dev` and `build` stay as they are. They hold settings uf genuinely owns — `allowedHosts` *gates* binding a routable address rather than merely being forwarded — but they also still mirror options that are Vite's. Separating those two kinds is the rest of this red line, and it is a breaking change to the config shape, so it wants its own PR.

## Checked

9 new tests on the merge (passthrough of an unknown option, overriding a uf default, deep merge, array replacement, plugin ordering, the `root`/`configFile` hijack, and the no-op case), plus `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, 309 library tests, and a real project built with passthrough options.

`merge.js` sits on the package's public surface rather than in `internal/` — `uf_lib`'s invariant refuses to export an internal module, correctly, and this is a small pure function a project composing configs could legitimately want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791050138&installation_model_id=422833&pr_number=90&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F90&signature=2484daab09a986e9bae3b6710831c5d01e6e9d355e8391d7ce86d55faed23bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->