### PR TITLE
feat(cli): uf explain, so the orchestration is not a black box

### DIFF
--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -63,6 +63,16 @@ pub(crate) enum Commands {
         check: bool,
     },
     Info,
+    /// Say what a command will do, and which provider does each part.
+    ///
+    /// `uf inspect` prints the resolved configuration; this answers the
+    /// question someone asks when a command surprises them.
+    Explain {
+        /// The command to describe: dev, build, test, fmt, lint or check.
+        command: String,
+        #[arg(long)]
+        json: bool,
+    },
     Inspect {
         #[arg(long)]
         json: bool,
@@ -132,6 +142,7 @@ impl Commands {
         matches!(
             self,
             Self::Check { json: true }
+                | Self::Explain { json: true, .. }
                 | Self::Inspect { json: true }
                 | Self::Lint { json: true }
                 | Self::Test { json: true, .. }

--- a/crates/uf_cli/src/commands.rs
+++ b/crates/uf_cli/src/commands.rs
@@ -8,6 +8,7 @@ pub(crate) mod check;
 pub(crate) mod create;
 pub(crate) mod dev;
 pub(crate) mod env;
+pub(crate) mod explain;
 pub(crate) mod fmt;
 pub(crate) mod info;
 pub(crate) mod inspect;

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -1,0 +1,243 @@
+//! `uf explain`: what a command will actually do, and who will do it.
+//!
+//! An integrated toolchain that cannot say what it is doing is a black box,
+//! and a black box is where an integration's problems stop being annoying and
+//! start being unfixable — `docs/red-lines.md`, line 7. `uf inspect` prints
+//! the resolved configuration; this answers a different question, which is the
+//! one someone asks when a command surprises them: *which provider runs each
+//! stage, at what version, and which files decided that?*
+//!
+//! Every stage names the thing that implements it. Where that is somebody
+//! else's tool, it says so — the point of the exercise is that uf orchestrates
+//! providers rather than being one, and a plan that hid the providers would be
+//! documenting the opposite.
+
+use anyhow::{Result, bail};
+use camino::Utf8Path;
+use serde_json::json;
+use uf_config::{ResolvedConfig, load_config};
+use uf_term::KeyValue;
+
+use crate::support::project_label;
+use crate::ui::Ui;
+
+/// One step of a command, and what performs it.
+struct Stage {
+    name: &'static str,
+    provider: String,
+    detail: String,
+}
+
+/// The commands `uf explain` knows how to describe.
+const KNOWN: &[&str] = &["dev", "build", "test", "fmt", "lint", "check"];
+
+pub(crate) fn explain(cwd: &Utf8Path, ui: &mut Ui, command: &str, as_json: bool) -> Result<()> {
+    let resolved = load_config(cwd)?;
+    let stages = match command {
+        "dev" => dev_stages(&resolved),
+        "build" => build_stages(&resolved),
+        "test" => test_stages(&resolved),
+        "fmt" => fmt_stages(&resolved),
+        "lint" => lint_stages(&resolved),
+        "check" => check_stages(&resolved),
+        other => bail!(
+            "uf explain does not describe {other:?}; it knows {}",
+            KNOWN.join(", ")
+        ),
+    };
+
+    let sources = config_sources(&resolved);
+
+    if as_json {
+        ui.json(&json!({
+            "command": format!("uf {command}"),
+            "root": resolved.root.as_str(),
+            "stages": stages
+                .iter()
+                .map(|stage| json!({
+                    "name": stage.name,
+                    "provider": stage.provider,
+                    "detail": stage.detail,
+                }))
+                .collect::<Vec<_>>(),
+            "configurationSources": sources,
+        }))?;
+        return Ok(());
+    }
+
+    let label = project_label(&resolved.root);
+    let heading = format!("uf {command}");
+    ui.render(|renderer, out| {
+        renderer.banner(out, "uf explain", Some(label));
+        renderer.blank(out);
+        renderer.heading(out, 2, &heading);
+        renderer.blank(out);
+
+        for (index, stage) in stages.iter().enumerate() {
+            let step = format!("{}. {}", index + 1, stage.name);
+            renderer.heading(out, 4, &step);
+            renderer.key_values(
+                out,
+                8,
+                &[
+                    KeyValue::new("provider", &stage.provider),
+                    KeyValue::new("what", &stage.detail),
+                ],
+            );
+        }
+
+        renderer.blank(out);
+        renderer.heading(out, 2, "configuration");
+        let rows: Vec<&str> = sources.iter().map(String::as_str).collect();
+        renderer.bullet_list(out, 4, &rows);
+    });
+    Ok(())
+}
+
+/// Where the answers came from.
+///
+/// Listed because "why is it doing that" is nearly always answered by a file
+/// the reader had forgotten about, or by there being no file at all.
+fn config_sources(resolved: &ResolvedConfig) -> Vec<String> {
+    let mut sources = Vec::new();
+    match &resolved.config_path {
+        Some(path) => sources.push(path.to_string()),
+        None => sources.push("zero-config defaults (no uf.config.js found)".to_string()),
+    }
+    if resolved.root.join("package.json").exists() {
+        sources.push("package.json".to_string());
+    }
+    if resolved.root.join(".flowconfig").exists() {
+        sources.push(".flowconfig".to_string());
+    }
+    sources
+}
+
+fn transform_stage() -> Stage {
+    Stage {
+        name: "Flow to JavaScript",
+        provider: "uf transform (in this binary)".to_string(),
+        detail: "flow_parser, Hermes lowering, the React Compiler crate, oxc".to_string(),
+    }
+}
+
+fn host_stage(resolved: &ResolvedConfig) -> Stage {
+    Stage {
+        name: "JavaScript host",
+        provider: format!("{:?}", resolved.config.app.runtime.default).to_lowercase(),
+        detail: "runs Vite and any JavaScript plugin".to_string(),
+    }
+}
+
+fn dev_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
+    vec![
+        Stage {
+            name: "configuration",
+            provider: "uf".to_string(),
+            detail: "uf.config.js, with `vite` merged over what uf generates".to_string(),
+        },
+        host_stage(resolved),
+        Stage {
+            name: "dev server",
+            provider: "vite (@uniflowed/vite driver)".to_string(),
+            detail: "module graph, HMR, plugin pipeline".to_string(),
+        },
+        transform_stage(),
+        Stage {
+            name: "rendering",
+            provider: "@uniflowed/router".to_string(),
+            detail: "server-renders each request, route handlers first".to_string(),
+        },
+    ]
+}
+
+fn build_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
+    vec![
+        Stage {
+            name: "configuration",
+            provider: "uf".to_string(),
+            detail: "uf.config.js, with `vite` merged over what uf generates".to_string(),
+        },
+        host_stage(resolved),
+        transform_stage(),
+        Stage {
+            name: "bundle",
+            // Vite, not what Vite uses inside it. A project chose Vite — it is
+            // in their config — and did not choose the bundler underneath, so
+            // naming that one would hand them something to reason about that
+            // they never picked. `uf_plugin`'s naming invariant enforces this,
+            // and it is the finer point of red line 7: uf names the providers
+            // it orchestrates, and a provider's internals stay the provider's.
+            provider: "vite".to_string(),
+            detail: "client bundle, then the server bundle".to_string(),
+        },
+        Stage {
+            name: "prerender",
+            provider: "@uniflowed/router".to_string(),
+            detail: "every route without parameters, to static HTML".to_string(),
+        },
+    ]
+}
+
+fn test_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
+    vec![
+        Stage {
+            name: "discovery",
+            provider: "uf_test (in this binary)".to_string(),
+            detail: "reads which files declare tests, without importing them".to_string(),
+        },
+        Stage {
+            name: "scheduling",
+            provider: format!("{:?}", resolved.config.test.runner.scheduler),
+            detail: "one file per worker, longest expected first".to_string(),
+        },
+        host_stage(resolved),
+        transform_stage(),
+        Stage {
+            name: "execution",
+            provider: resolved.config.test.module.to_string(),
+            detail: "runs the bodies and streams one line per case".to_string(),
+        },
+    ]
+}
+
+fn fmt_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
+    vec![
+        Stage {
+            name: "Flow files",
+            provider: format!("{:?}", resolved.config.fmt.flow.parser),
+            detail: format!(
+                "the official parser, printed at {} columns",
+                resolved.config.fmt.line_width
+            ),
+        },
+        Stage {
+            name: "everything else",
+            provider: format!("{:?}", resolved.config.fmt.non_flow.formatter),
+            detail: "JSON, Markdown and CSS".to_string(),
+        },
+    ]
+}
+
+fn lint_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
+    vec![
+        Stage {
+            name: "uf rules",
+            provider: format!("{:?}", resolved.config.lint.engine),
+            detail: format!("{} rules configured", resolved.config.lint.rules.len()),
+        },
+        Stage {
+            name: "Flow's own lints",
+            provider: format!("{:?}", resolved.config.lint.flow.parser),
+            detail: format!("built-ins: {:?}", resolved.config.lint.flow.builtins),
+        },
+    ]
+}
+
+fn check_stages(_resolved: &ResolvedConfig) -> Vec<Stage> {
+    vec![Stage {
+        name: "type checking",
+        provider: "flow (upstream)".to_string(),
+        detail: "uf does not type-check; Flow is the type system".to_string(),
+    }]
+}

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -87,6 +87,7 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
         Commands::Exec { package, args } => commands::task::exec_package(&cwd, ui, &package, &args),
         Commands::Fmt { check } => commands::fmt::fmt(&cwd, ui, check),
         Commands::Info => commands::info::info(&cwd, ui),
+        Commands::Explain { command, json } => commands::explain::explain(&cwd, ui, &command, json),
         Commands::Inspect { json } => commands::inspect::inspect(&cwd, ui, json),
         Commands::Transform => commands::transform::transform_service(&cwd),
         Commands::Install => commands::pm::install(&cwd, ui),

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -175,6 +175,92 @@ fn creates_react_app_from_cli() {
     assert!(stdout.contains("✓ created 8 files"));
 }
 
+/// `uf explain` says which provider runs each stage.
+///
+/// An integrated toolchain that cannot say what it is doing is a black box,
+/// and a black box is where an integration's problems stop being annoying and
+/// become unfixable. See `docs/red-lines.md`, line 7.
+#[test]
+fn explain_names_the_provider_for_every_stage() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "// @flow\nexport default defineConfig({});\n",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["explain", "dev"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // The providers, named — that uf drives Vite rather than being it is the
+    // thing this command exists to make visible.
+    assert!(stdout.contains("vite"), "{stdout}");
+    assert!(stdout.contains("uf transform"), "{stdout}");
+    assert!(stdout.contains("@uniflowed/router"), "{stdout}");
+    // And where the answers came from.
+    assert!(stdout.contains("uf.config.js"), "{stdout}");
+}
+
+#[test]
+fn explain_says_which_commands_it_knows() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["explain", "deploy"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("does not describe"), "{stderr}");
+    // Listing them beats making the reader guess.
+    assert!(
+        stderr.contains("dev, build, test, fmt, lint, check"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn explain_emits_json_when_asked() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "// @flow\nexport default defineConfig({});\n",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["explain", "build", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("uf explain --json emits JSON");
+    assert_eq!(value["command"], "uf build");
+    assert!(
+        value["stages"].as_array().is_some_and(|s| !s.is_empty()),
+        "{value}"
+    );
+    assert!(
+        value["configurationSources"].as_array().is_some(),
+        "{value}"
+    );
+}
+
 #[test]
 fn creating_a_library_suggests_running_its_tests() {
     let dir = tempfile::tempdir().unwrap();

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -42,6 +42,37 @@ The first thing to run when something is behaving unexpectedly.
 Prints what uf resolved from your config — the effective options, the route
 table, and the config handed to Vite. `--json` for the machine-readable form.
 
+### uf explain COMMAND
+
+Says what a command will do and **which provider does each part** — `dev`,
+`build`, `test`, `fmt`, `lint` or `check`. `--json` for the machine-readable
+form.
+
+```
+uf dev
+
+  1. configuration
+      provider  uf
+      what      uf.config.js, with `vite` merged over what uf generates
+  2. JavaScript host
+      provider  node
+  3. dev server
+      provider  vite (@uniflowed/vite driver)
+  4. Flow to JavaScript
+      provider  uf transform (in this binary)
+  5. rendering
+      provider  @uniflowed/router
+
+configuration
+  - ./uf.config.js
+  - package.json
+```
+
+`uf inspect` answers "what is my configuration"; this answers the question
+people actually ask when a command surprises them, which is "who is doing
+this, and which file decided that". An integrated toolchain that cannot say
+what it is doing is a black box — see [Architecture](/guide/architecture).
+
 ## Running and building
 
 ### uf dev


### PR DESCRIPTION
Red line 7 from #89.

An integrated toolchain that cannot say what it is doing is a black box, and a black box is where an integration's problems stop being annoying and become unfixable — which is most of what went wrong with `react-scripts` once it stopped being maintained.

`uf inspect` prints the resolved configuration. `uf explain <command>` answers the question people actually ask when a command surprises them: **which provider runs each stage, and which files decided that.**

```
$ uf explain dev

uf explain  docs
────────────────

  uf dev

    1. configuration
        provider  uf
        what      uf.config.js, with `vite` merged over what uf generates
    2. JavaScript host
        provider  node
        what      runs Vite and any JavaScript plugin
    3. dev server
        provider  vite (@uniflowed/vite driver)
        what      module graph, HMR, plugin pipeline
    4. Flow to JavaScript
        provider  uf transform (in this binary)
        what      flow_parser, Hermes lowering, the React Compiler crate, oxc
    5. rendering
        provider  @uniflowed/router
        what      server-renders each request, route handlers first

  configuration
    - ./docs/uf.config.js
    - package.json
```

`dev`, `build`, `test`, `fmt`, `lint` and `check`, each with `--json`. An unknown command lists the ones it knows rather than making you guess.

Every stage names what implements it, and where that is somebody else's tool it says so. A plan that hid the providers would be documenting the opposite of what uf is.

## One thing it deliberately does not say

My first version named the bundler underneath Vite. `uf_plugin`'s naming invariant caught it, and the invariant is right — it is the finer point of this red line.

A project chose **Vite**: it is in their config, they can replace it, and `uf explain` should say so. They did not choose what Vite uses inside, so naming it hands them something to reason about that they never picked, and couples uf's output to a decision that is Vite's to change. **uf names the providers it orchestrates; a provider's internals stay the provider's.**

## Checked

3 tests — the providers and config sources appear in the plan, an unknown command lists the known ones, and `--json` parses with the stages and sources present. Plus `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and the docs site builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791051023&installation_model_id=422833&pr_number=91&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F91&signature=df1cba883a4884209ae69684999b843b0c45f6ef21bb1dd4e04d0c32ffaf5bc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->