### PR TITLE
fix(project): never walk into another repository

### DIFF
--- a/crates/uf_project/src/lib.rs
+++ b/crates/uf_project/src/lib.rs
@@ -129,7 +129,17 @@ pub fn collect_source_files(
     config: &UniflowedConfig,
 ) -> Result<Vec<ProjectFile>, ProjectError> {
     let mut files = Vec::new();
-    for entry in WalkDir::new(root) {
+    // A directory holding a `.git` is another repository — a submodule, or a
+    // checkout that happens to live inside this one. Its contents are not this
+    // project's to read, and formatting them writes into somebody else's
+    // history: `uf fmt` reformatted the vendored Flow sources, and the next
+    // submodule sync would have thrown the result away.
+    let walk = WalkDir::new(root).into_iter().filter_entry(|entry| {
+        entry.path() == root.as_std_path()
+            || !entry.file_type().is_dir()
+            || !entry.path().join(".git").exists()
+    });
+    for entry in walk {
         let entry = entry.map_err(|source| ProjectError::Walk {
             path: root.to_path_buf(),
             source,

--- a/crates/uf_project/src/tests.rs
+++ b/crates/uf_project/src/tests.rs
@@ -136,6 +136,24 @@ fn a_build_directory_is_ignored_wherever_it_sits() {
 }
 
 #[test]
+fn a_nested_repository_is_not_this_project() {
+    // `upstream/flow` is Meta's source, vendored as a submodule. `uf fmt`
+    // reformatted it, and the next sync would have discarded the result —
+    // a directory with a `.git` in it belongs to another history.
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::create_dir_all(root.join("vendor/upstream/.git")).unwrap();
+    fs::write(root.join("app/index.js"), "// @flow\n").unwrap();
+    fs::write(root.join("vendor/upstream/lib.js"), "// @flow\n").unwrap();
+
+    let files = collect_source_files(&root, &UniflowedConfig::default()).unwrap();
+
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].relative_path, "app/index.js");
+}
+
+#[test]
 fn an_ignore_entry_with_a_separator_still_means_one_place() {
     // `dist` names a kind of directory; `app/dist` names one directory. A
     // project that ignores the latter has not asked for the former.

--- a/docs/app/guide/format/_uf.page.mdx
+++ b/docs/app/guide/format/_uf.page.mdx
@@ -21,10 +21,13 @@ Formats every Flow, JavaScript, JSON, Markdown and CSS file in the project.
 
 Flow files go through the official Flow parser and a printer written for it, so
 `component`, `hook`, `renders`, `match` and enums are formatted as first-class
-syntax rather than survived. The output follows Prettier's conventions —
-80 columns, double quotes, trailing commas, the same line-breaking decisions —
-because the point of a formatter is that nobody argues about it, and Prettier
-already won that argument.
+syntax rather than survived. The output follows Prettier's conventions — double quotes, trailing commas,
+the same line-breaking decisions — because the point of a formatter is that
+nobody argues about it, and Prettier already won that argument. The default
+width is 100 rather than Prettier's 80; `fmt.lineWidth` changes it.
+
+That claim is checked rather than asserted: every fixture in `uf_fmt`'s suite
+is compared byte for byte against Prettier's own output for the same input.
 
 Files uf has no opinion about are handed to Biome, which is also Rust and also
 fast, so a repository with a `README.md` and a `package.json` in it does not


### PR DESCRIPTION
`uf fmt` reformatted **`upstream/flow`** — Meta's Flow sources, vendored as a submodule. The next `tools/upstream/sync.sh` would have thrown the result away, and in the meantime the working tree carried a diff against somebody else's history.

It also revealed a second symptom: `uf fmt` did not reach a fixed point. A full run left one file still reported by `uf fmt --check`, and that file was in the submodule — uf was rewriting something it should never have opened.

**A directory holding a `.git` is another repository.** Its contents are not this project's to read, whatever the ignore list happens to say, so the walk stops at one. That is stronger than an ignore entry and does not depend on a project remembering to write it.

## Also: the formatter guide claimed the wrong number

The guide said "80 columns, double quotes, trailing commas… Prettier already won that argument". The default is **100**.

I started by changing the default to 80, since the repository's own JavaScript is written that way (95% of its lines are under 78 characters) and 80 is Prettier's default. That broke `uf_fmt`'s golden fixtures, which are byte-for-byte Prettier output at `--print-width 100` — and regenerating them needs `prettier-plugin-hermes-parser`, which is not available here. Hand-editing them was the one thing I would not do: those goldens are what make "Prettier compatible" a claim the suite *checks* rather than a description of intent.

So the number in the prose was the thing that was wrong, and it now says 100 with `fmt.lineWidth` named as the way to change it. Whether the default should become 80 is a real question, and it is a separate change that has to regenerate the goldens with Prettier rather than by hand.

## Checked

A test that a nested repository is skipped, plus `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, the docs site builds, and `git status` on the submodule is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791054945&installation_model_id=422833&pr_number=92&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F92&signature=34f1599489a218d922aa7aada074f5fb15ebbda000921677fc4b6aec93c5d524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project formatting now skips nested repositories, submodules, and checkouts while continuing to process the main project’s source files.

* **Documentation**
  * Updated formatting guidance to reflect the 100-character default line width, configurable through `fmt.lineWidth`.
  * Clarified how formatter compatibility is verified against Prettier output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->