### PR TITLE
chore(release): 0.0.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,7 +3292,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "brotli",
  "camino",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "compact_str",
  "dupe",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "criterion",
  "memchr",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "criterion",
  "phf",
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "compact_str",
  "serde",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "tempfile",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "compact_str",
  "serde",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "serde",
  "smallvec",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3601,14 +3601,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.1",
-    "@uniflowed/config": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1",
-    "@uniflowed/router": "0.0.0-alpha.1",
-    "@uniflowed/vite": "0.0.0-alpha.1",
-    "@uniflowed/web": "0.0.0-alpha.1",
+    "@uniflowed/brand": "0.0.0-alpha.2",
+    "@uniflowed/config": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2",
+    "@uniflowed/router": "0.0.0-alpha.2",
+    "@uniflowed/vite": "0.0.0-alpha.2",
+    "@uniflowed/web": "0.0.0-alpha.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.1",
-        "@uniflowed/config": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1",
-        "@uniflowed/router": "0.0.0-alpha.1",
-        "@uniflowed/vite": "0.0.0-alpha.1",
-        "@uniflowed/web": "0.0.0-alpha.1",
+        "@uniflowed/brand": "0.0.0-alpha.2",
+        "@uniflowed/config": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2",
+        "@uniflowed/router": "0.0.0-alpha.2",
+        "@uniflowed/vite": "0.0.0-alpha.2",
+        "@uniflowed/web": "0.0.0-alpha.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -3956,183 +3956,187 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT"
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT"
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.1",
-      "license": "MIT",
-      "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
-      }
+      "version": "0.0.0-alpha.2",
+      "license": "MIT"
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/fetch": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/fetch": "0.0.0-alpha.2"
       }
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/react": "0.0.0-alpha.2"
+      },
+      "peerDependencies": {
+        "react": ">=19"
       }
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.1",
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/fetch": "0.0.0-alpha.1"
+        "@uniflowed/cell": "0.0.0-alpha.2",
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/fetch": "0.0.0-alpha.2"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.1",
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/config": "0.0.0-alpha.2",
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/hooks": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
+      },
+      "peerDependencies": {
+        "react": ">=19"
       }
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4140,51 +4144,55 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1",
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2",
         "happy-dom": "^20.13.2"
+      },
+      "peerDependencies": {
+        "react": ">=19",
+        "react-dom": ">=19"
       }
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.1",
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/config": "0.0.0-alpha.2",
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4193,104 +4201,106 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.1"
+        "@uniflowed/cell": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.1",
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/mock": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1"
+        "@uniflowed/browser": "0.0.0-alpha.2",
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/mock": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT"
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.1",
-        "@uniflowed/test": "0.0.0-alpha.1"
+        "@uniflowed/react-testing": "0.0.0-alpha.2",
+        "@uniflowed/test": "0.0.0-alpha.2"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1",
-        "@uniflowed/validator": "0.0.0-alpha.1"
+        "@uniflowed/react": "0.0.0-alpha.2"
+      },
+      "peerDependencies": {
+        "react": ">=19"
       }
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
@@ -4309,20 +4319,20 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.1",
-        "@uniflowed/core": "0.0.0-alpha.1"
+        "@uniflowed/browser": "0.0.0-alpha.2",
+        "@uniflowed/core": "0.0.0-alpha.2"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.1",
+      "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.1",
-        "@uniflowed/react": "0.0.0-alpha.1"
+        "@uniflowed/core": "0.0.0-alpha.2",
+        "@uniflowed/react": "0.0.0-alpha.2"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow implementation for @uniflowed/cell, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/graphql, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/fetch": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/fetch": "0.0.0-alpha.2"
   }
 }

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/react": "0.0.0-alpha.2"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/cell": "0.0.0-alpha.1",
-    "@uniflowed/fetch": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/cell": "0.0.0-alpha.2",
+    "@uniflowed/fetch": "0.0.0-alpha.2"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/mock, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.1",
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/config": "0.0.0-alpha.2",
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "A query cache with de-duplication and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/hooks": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1",
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/relay, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.1",
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/config": "0.0.0-alpha.2",
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/server, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/cell": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/story, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,9 +17,9 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.1",
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/mock": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/browser": "0.0.0-alpha.2",
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/mock": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.1",
-    "@uniflowed/test": "0.0.0-alpha.1"
+    "@uniflowed/react-testing": "0.0.0-alpha.2",
+    "@uniflowed/test": "0.0.0-alpha.2"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/tui, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/react": "0.0.0-alpha.2"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow implementation for @uniflowed/validator, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.1",
-    "@uniflowed/core": "0.0.0-alpha.1"
+    "@uniflowed/browser": "0.0.0-alpha.2",
+    "@uniflowed/core": "0.0.0-alpha.2"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "Flow declarations for @uniflowed/web, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.1",
-    "@uniflowed/react": "0.0.0-alpha.1"
+    "@uniflowed/core": "0.0.0-alpha.2",
+    "@uniflowed/react": "0.0.0-alpha.2"
   }
 }


### PR DESCRIPTION
Everything since `0.0.0-alpha.1`.

## The libraries stopped being declarations that throw

| package | what landed |
| --- | --- |
| `@uniflowed/effect` | typed effects: fibers, scopes, layers, schedules |
| `@uniflowed/validator` | schemas that parse rather than assert |
| `@uniflowed/state`, `cell` | atoms, fine-grained reactivity |
| `@uniflowed/hooks` | 29 hooks, prerender-safe through `useSyncExternalStore` |
| `@uniflowed/ui` | headless accessible components; `Tabs.List` takes `renders* Tabs.Tab` |
| `@uniflowed/fetch`, `query` | typed HTTP; de-duplication and stale-while-revalidate |
| `@uniflowed/react-testing` | a real DOM, so a component can be tested at all |

**Nine defects were found by writing those tests**, each with a regression test: a service that could be *provided and never read* (the whole layers feature was unreachable), a listener called after it unsubscribed inside a batch, `retry` repeating defects on schedule, a `__proto__` key reaching the prototype, `strictObject` stopping at the first error, and four more.

## The framework

Route handlers — `app/api/users/[id]/_uf.route.js` exporting `GET`, on the platform's own `Request` and `Response`, with `HEAD` falling back to `GET` and `405` carrying `Allow`. Syntax highlighting on the docs site that knows `component`, `hook`, `renders` and `match` are keywords, which no highlighter has a grammar for.

## The architecture gained a spine

After the create-react-app post-mortem:

- **`docs/red-lines.md`** — ten things uf will not do, with an audit of where it already does them.
- **`vite` in `uf.config.js`** — Vite's own configuration, merged over uf's. uf had re-declared Vite's options one at a time, so anything it had not enumerated was unreachable until a uf release named it. That is `react-scripts`, structurally.
- **`uf explain <command>`** — which provider runs each stage, and which files decided that.

## And uf builds uf

The repository is a uf project. `uf run ci` is what the pipeline runs, every CI job calls `uf run <task>`, the site is built by `uf build`, and the library suite is run by `uf test`. Two bugs were found that way, including `uf fmt` reformatting the vendored Flow submodule.

## Before tagging

`fetch`, `hooks`, `query`, `react-testing` and `ui` are in the publish list and not yet bound for OIDC. One command, needs 2FA:

```bash
tools/release/trust-npm.sh
```

The preflight added in #85 fails the publish job **before** sending anything if that has not been run, so a tag cannot half-publish.

Verified with `uf run ci` — the whole pipeline — passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057418&installation_model_id=422833&pr_number=93&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F93&signature=4217422c4c120aed80b1e8c6f78428be854cece5a96c0ae1b9fdea48e256f868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->