### PR TITLE
ci(publish): drop a preflight that could never pass

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,19 @@ jobs:
       - run: npm ci --no-audit --no-fund
       - run: cargo test --workspace
       # Only the packages in `tools/release/published-packages.txt`, which is
-      # the set that is implemented. Publishing a declaration module whose
+      # the set that is implemented.
+      #
+      # A name that has not been bound by `tools/release/trust-npm.sh` fails
+      # here, and the packages published before it stay published. That is
+      # recoverable — npm is additive, and re-running this job after binding
+      # the name publishes the rest — but it means adding a package to the
+      # list and tagging without running that script leaves a release
+      # half-sent.
+      #
+      # This job cannot check the bindings itself: `npm trust list` reads them
+      # as the *user*, and this job authenticates as a workflow. An earlier
+      # version tried, and reported every package as unbound including the
+      # five that were bound, because an unauthenticated read returns nothing. Publishing a declaration module whose
       # functions throw would squat the name and would need a trusted-publisher
       # configuration of its own, which is a manual step on npmjs.com.
       #
@@ -47,29 +59,6 @@ jobs:
       # the OIDC id-token GitHub mints for it. There is no npm token in this
       # repository, in its secrets, or on anyone's machine.
       # See tools/release/trust-npm.sh.
-      # Check every name is bound to this workflow before publishing any of
-      # them. A package added to the list without `npm trust` being run for it
-      # fails on `npm publish`, and by then the earlier packages are already on
-      # the registry and cannot be taken back — a half-published release. This
-      # turns that into one failure, before anything is sent, naming the fix.
-      - name: Check trusted publishers
-        run: |
-          set -eu
-          missing=""
-          for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.txt); do
-            name="@uniflowed/${package}"
-            if npm view "$name" version >/dev/null 2>&1; then
-              if ! npm trust list "$name" 2>/dev/null | grep -q "file: publish.yml"; then
-                missing="${missing} ${name}"
-              fi
-            fi
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::not bound to this workflow:${missing}"
-            echo "::error::run tools/release/trust-npm.sh once, then re-run this job"
-            exit 1
-          fi
-          echo "every package is bound to publish.yml"
       - name: Publish
         run: |
           set -eu

--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -53,3 +53,7 @@ done
 
 echo
 echo "Done. A 'uf@*' tag now publishes these over OIDC, with no token anywhere."
+echo
+echo "Run this again after adding a name to published-packages.txt. The publish"
+echo "job cannot check the bindings itself — it authenticates as a workflow and"
+echo "'npm trust list' reads them as you — so an unbound name fails mid-release."


### PR DESCRIPTION
The check I added in #85 read the trusted-publisher bindings with `npm trust list` — which reads them **as the user**. The publish job authenticates as a *workflow*, so the read returns nothing and every package is reported unbound, including the five that are bound. The `uf@0.0.0-alpha.2` tag failed on exactly that:

```
##[error]not bound to this workflow: @uniflowed/config @uniflowed/react
          @uniflowed/router @uniflowed/test @uniflowed/vite
```

All five of those *are* bound. The guard was wrong, not the state.

A guard that cannot succeed is worse than no guard: it fails every release for a reason that is not the reason it gives.

## What replaces it

The truth, written where the publish happens. An unbound name fails at `npm publish`; the packages published before it stay published; re-running the job after binding the name publishes the rest. npm is additive, so that is **recoverable** — it is not the unrecoverable half-send the removed check claimed to prevent, and I overstated that when I added it.

`trust-npm.sh` now says the same thing when it finishes, because running it again after adding a name to the list is the thing that actually has to happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791058818&installation_model_id=422833&pr_number=94&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F94&signature=21d3c6dc36c00db8bfd15d76e95a91156028b9312b9a99383fa08e3ceaa6ad9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that trusted-publisher validation occurs during package publishing.
  - Documented that publishing may partially complete if a package is not properly bound.
  - Explained why binding verification cannot be performed before publishing.

- **Chores**
  - Removed the separate pre-publish trust verification step.
  - Updated release guidance to explain when to rerun the release helper after adding packages to the publish list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->