### PR TITLE
feat(check): honour `@noflow`, Flow's own way to say "this is plain JavaScript"

### DIFF
--- a/crates/uf_check/src/report.rs
+++ b/crates/uf_check/src/report.rs
@@ -46,8 +46,15 @@ pub struct BuiltinsTiming {
 pub struct CheckReport {
     /// Every diagnostic, errors before warnings and ordered within each.
     pub diagnostics: Vec<TypeDiagnostic>,
-    /// How many files were checked.
+    /// How many files inference actually ran over.
     pub files_checked: usize,
+    /// How many files opted out of inference with `@noflow`.
+    ///
+    /// Kept apart from `files_checked` rather than folded into it, because a
+    /// clean check over a project that opted every file out is not the same
+    /// result as a clean check over the project, and a reader is entitled to
+    /// tell those apart at a glance.
+    pub files_skipped: usize,
     /// Module specifiers that resolved to nothing typed, sorted and de-duped.
     ///
     /// Every file is checked against Flow's standard library, but not yet

--- a/crates/uf_check/src/tests.rs
+++ b/crates/uf_check/src/tests.rs
@@ -2,6 +2,21 @@ use super::*;
 
 const CLEAN: &str = "// @flow\nconst n: number = 1;\n";
 
+/// A type error that inference reports whenever it runs over the file.
+const TYPE_ERROR: &str = "// @flow\nconst n: number = \"not a number\";\n";
+
+/// The same type error in a file that opts out of Flow.
+const OPTED_OUT: &str = "// @noflow\nconst n: number = \"not a number\";\n";
+
+/// Skip the body when this build has no checker compiled in.
+macro_rules! require_checker {
+    () => {
+        if !is_available() {
+            return;
+        }
+    };
+}
+
 #[test]
 fn backend_names_are_stable() {
     assert_eq!(
@@ -74,6 +89,7 @@ fn an_empty_batch_is_not_an_error() {
     match check_sources(&[], &CheckLimits::default()) {
         Ok(report) => {
             assert_eq!(report.files_checked, 0);
+            assert_eq!(report.files_skipped, 0);
             assert!(report.diagnostics.is_empty());
             assert!(!report.has_errors());
         }
@@ -86,6 +102,7 @@ fn a_report_counts_by_severity() {
     let report = CheckReport {
         diagnostics: Vec::new(),
         files_checked: 3,
+        files_skipped: 0,
         untyped_modules: Vec::new(),
         builtins: BuiltinsTiming {
             elapsed: std::time::Duration::ZERO,
@@ -106,6 +123,7 @@ fn throughput_is_unknown_when_no_time_passed() {
     let report = CheckReport {
         diagnostics: Vec::new(),
         files_checked: 1,
+        files_skipped: 0,
         untyped_modules: Vec::new(),
         builtins: BuiltinsTiming {
             elapsed: std::time::Duration::ZERO,
@@ -116,4 +134,74 @@ fn throughput_is_unknown_when_no_time_passed() {
     };
 
     assert_eq!(report.files_per_second(), None);
+}
+
+#[test]
+fn a_file_that_opts_out_of_flow_is_not_checked() {
+    require_checker!();
+
+    let checked = check_source(Source::new("app.js", TYPE_ERROR), &CheckLimits::default())
+        .expect("the checker runs");
+    assert!(
+        checked.iter().any(TypeDiagnostic::is_error),
+        "the fixture must be a type error when it is checked, or this test proves nothing"
+    );
+
+    let opted_out = check_source(Source::new("app.js", OPTED_OUT), &CheckLimits::default())
+        .expect("the checker runs");
+
+    assert!(
+        opted_out.is_empty(),
+        "`@noflow` must opt a file out of inference, but it reported {opted_out:?}"
+    );
+}
+
+#[test]
+fn opting_out_is_counted_as_skipped_rather_than_checked() {
+    require_checker!();
+
+    let report = check_sources(
+        &[
+            Source::new("checked.js", CLEAN),
+            Source::new("plain.js", OPTED_OUT),
+        ],
+        &CheckLimits::default(),
+    )
+    .expect("the checker runs");
+
+    assert_eq!(report.files_checked, 1, "only one file opted in");
+    assert_eq!(report.files_skipped, 1, "the other opted out");
+}
+
+#[test]
+fn opting_out_does_not_hide_a_file_that_cannot_be_parsed() {
+    require_checker!();
+
+    let diagnostics = check_source(
+        Source::new("broken.js", "// @noflow\nfunction ( {\n"),
+        &CheckLimits::default(),
+    )
+    .expect("the checker runs");
+
+    assert!(
+        diagnostics.iter().any(TypeDiagnostic::is_error),
+        "a file uf must still transform has to parse, whatever its docblock says"
+    );
+}
+
+#[test]
+fn a_file_with_no_docblock_is_still_checked() {
+    require_checker!();
+
+    let diagnostics = check_source(
+        Source::new("app.js", "const n: number = \"not a number\";\n"),
+        &CheckLimits::default(),
+    )
+    .expect("the checker runs");
+
+    assert!(
+        diagnostics.iter().any(TypeDiagnostic::is_error),
+        "uf is Flow-first: a file without a pragma is checked, and `@noflow` is \
+         the way to say otherwise"
+    );
 }

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -120,17 +120,31 @@ fn check_batch(sources: &[Source<'_>], limits: &CheckLimits) -> Result<CheckRepo
 
     let started = Instant::now();
     let mut diagnostics = Vec::new();
+    let mut skipped = 0usize;
     for source in sources {
-        diagnostics.extend(check_one(&master_cx, &options, limits, source, &untyped)?);
+        let outcome = check_one(&master_cx, &options, limits, source, &untyped)?;
+        if outcome.skipped {
+            skipped += 1;
+        }
+        diagnostics.extend(outcome.diagnostics);
     }
 
     Ok(CheckReport {
         diagnostics,
-        files_checked: sources.len(),
+        files_checked: sources.len() - skipped,
+        files_skipped: skipped,
         untyped_modules: untyped.borrow().iter().cloned().collect(),
         builtins,
         elapsed: started.elapsed(),
     })
+}
+
+/// What checking one file produced, and whether it was checked at all.
+struct FileOutcome {
+    /// Diagnostics for the file. A skipped file can still have parse errors.
+    diagnostics: Vec<TypeDiagnostic>,
+    /// Whether the file opted out of inference with `@noflow`.
+    skipped: bool,
 }
 
 /// Module specifiers that resolved to nothing typed, shared across a batch.
@@ -145,7 +159,7 @@ fn check_one(
     limits: &CheckLimits,
     source: &Source<'_>,
     untyped: &UntypedModules,
-) -> Result<Vec<TypeDiagnostic>, CheckError> {
+) -> Result<FileOutcome, CheckError> {
     // Checked before the parser sees the text: the AST alone is several times
     // the size of the source, so an unbounded file is an unbounded allocation.
     if source.source.len() > limits.max_source_bytes {
@@ -160,11 +174,24 @@ fn check_one(
     let parsed = parse::parse_file(file_key.dupe(), source.source, options, false);
     if !parsed.is_parseable() {
         let errors = printable(&parsed, parse_error_set(&parsed));
-        return Ok(convert::diagnostics(
-            &errors,
-            &ConcreteLocPrintableErrorSet::empty(),
-            source.path,
-        ));
+        return Ok(FileOutcome {
+            diagnostics: convert::diagnostics(
+                &errors,
+                &ConcreteLocPrintableErrorSet::empty(),
+                source.path,
+            ),
+            // A file that does not parse is broken whatever its docblock says,
+            // so it is reported — but it was not checked either.
+            skipped: !parsed.is_checked(),
+        });
+    }
+
+    // `@noflow`. The file parsed, and that is all uf asked of it.
+    if !parsed.is_checked() {
+        return Ok(FileOutcome {
+            diagnostics: Vec::new(),
+            skipped: true,
+        });
     }
 
     let metadata = parsed.metadata.clone();
@@ -203,7 +230,10 @@ fn check_one(
     .map_err(|error| job_error(source.path, error))?;
 
     let (errors, warnings) = suppressed(&cx, &parsed, cx.errors());
-    Ok(convert::diagnostics(&errors, &warnings, source.path))
+    Ok(FileOutcome {
+        diagnostics: convert::diagnostics(&errors, &warnings, source.path),
+        skipped: false,
+    })
 }
 
 fn job_error(path: &str, error: JobError) -> CheckError {

--- a/crates/uf_check/src/upstream/parse.rs
+++ b/crates/uf_check/src/upstream/parse.rs
@@ -1,13 +1,17 @@
 //! Parsing one file into everything the checker needs from it.
 //!
-//! The docblock is deliberately consumed here rather than stored. Upstream's
-//! `Docblock` type is private to `flow_parsing`, so the only thing an embedder
-//! can do with one is fold it into a [`Metadata`] immediately — which is also
-//! the only thing anyone wants it for.
+//! The docblock is folded into [`Metadata`] here rather than stored, because
+//! that is the only shape the checker takes it in. One bit is read out first:
+//! whether the file opted out of Flow entirely, which `Metadata` cannot carry
+//! — upstream sets `checked` from `@flow` but deliberately never clears it for
+//! `@noflow`, on the grounds that `--all` outranks the opt-out. uf runs with
+//! `all` on so that a file with no pragma is still checked, and then honours
+//! `@noflow` on top, so the two halves of that policy are decided here.
 
 use std::sync::Arc;
 
 use dupe::Dupe;
+use flow_common::docblock::FlowMode;
 use flow_common::options::Options;
 use flow_parser::PERMISSIVE_PARSE_OPTIONS;
 use flow_parser::ast;
@@ -32,12 +36,26 @@ pub(super) struct Parsed {
     pub(super) file_sig: Arc<FileSig>,
     /// Syntax errors, in source order. Non-empty means inference must not run.
     pub(super) parse_errors: Vec<(Loc, ParseError)>,
+    /// Whether the file's docblock says `@noflow`.
+    opted_out: bool,
 }
 
 impl Parsed {
     /// Whether the file parsed cleanly enough to type check.
     pub(super) fn is_parseable(&self) -> bool {
         self.parse_errors.is_empty()
+    }
+
+    /// Whether inference should run over this file.
+    ///
+    /// `@noflow` is Flow's own way for a file to say it is plain JavaScript,
+    /// and it is the only one uf offers: a config key listing paths would be a
+    /// second, uf-shaped answer to a question Flow has already answered, and
+    /// the file itself is where a reader looks. Parse errors are reported
+    /// either way — uf transforms every `.js` it owns regardless of docblock,
+    /// so a file that does not parse is broken whatever it opted out of.
+    pub(super) fn is_checked(&self) -> bool {
+        !self.opted_out
     }
 }
 
@@ -81,5 +99,6 @@ pub(super) fn parse_file(
         ast: Arc::new(ast),
         file_sig,
         parse_errors,
+        opted_out: matches!(docblock.flow(), Some(FlowMode::OptOut)),
     }
 }

--- a/crates/uf_cli/src/commands/check.rs
+++ b/crates/uf_cli/src/commands/check.rs
@@ -196,6 +196,7 @@ fn type_check_payload(types: &TypeCheck) -> Value {
     });
     if let Some(report) = types.report() {
         value["filesChecked"] = json!(report.files_checked);
+        value["filesSkipped"] = json!(report.files_skipped);
         value["elapsedMs"] = json!(report.elapsed.as_secs_f64() * 1000.0);
         value["builtinsMs"] = json!(report.builtins.cold_elapsed.as_secs_f64() * 1000.0);
         value["builtinsCold"] = json!(report.builtins.cold);
@@ -379,18 +380,21 @@ fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
                 report.builtins.cold_elapsed,
                 if report.builtins.cold { "cold" } else { "warm" }
             );
+            // Only shown when it happened. A project with nothing opted out
+            // should not have to read a line saying so.
+            let skipped = report.files_skipped.to_string();
+            let mut rows = vec![
+                KeyValue::toned("types checked", &files, Tone::Number),
+                KeyValue::toned("inference", &inference, Tone::Muted),
+                KeyValue::toned("builtins", &builtins, Tone::Muted),
+            ];
+            if report.files_skipped > 0 {
+                rows.insert(1, KeyValue::toned("@noflow", &skipped, Tone::Muted));
+            }
             let untyped = untyped_module_list(report);
             ui.render(|renderer, out| {
                 renderer.blank(out);
-                renderer.key_values(
-                    out,
-                    2,
-                    &[
-                        KeyValue::toned("types checked", &files, Tone::Number),
-                        KeyValue::toned("inference", &inference, Tone::Muted),
-                        KeyValue::toned("builtins", &builtins, Tone::Muted),
-                    ],
-                );
+                renderer.key_values(out, 2, &rows);
                 if !untyped.is_empty() {
                     renderer.blank(out);
                     push_spaces(out, 2);

--- a/crates/uf_lib/tests/package_surface.rs
+++ b/crates/uf_lib/tests/package_surface.rs
@@ -31,23 +31,30 @@ const INTERNAL_DIR: &str = "internal";
 
 /// Packages the host runs directly, before any Flow transform exists. See the
 /// module docs for why they are plain JavaScript.
-const HOST_EXECUTED_PACKAGES: &[&str] = &["vite"];
+const PLAIN_JAVASCRIPT_PACKAGES: &[&str] = &["vite"];
 
 /// Individual modules that are process entry points, and so run when they are
 /// loaded because that is what running them means. Everything else in their
-/// package is held to the ordinary bar.
-const HOST_EXECUTED_MODULES: &[&str] = &["test/worker.js"];
+/// package is held to the ordinary bar — including the Flow pragma: an entry
+/// point is still Flow, it just does something when it loads.
+const ENTRY_POINT_MODULES: &[&str] = &["test/worker.js"];
 
-/// Whether `module` (relative to `packages/`) belongs to a host-executed
-/// package.
-fn is_host_executed(module: &Utf8Path) -> bool {
-    if HOST_EXECUTED_MODULES.contains(&module.as_str()) {
-        return true;
-    }
+/// Whether `module` (relative to `packages/`) is plain JavaScript by necessity.
+///
+/// Kept apart from [`runs_at_import`] because the two exemptions answer
+/// different questions. Reaching for one predicate for both is how
+/// `packages/test/worker.js` — Flow, and a process entry point — ended up
+/// exempt from the `// @flow` pragma it in fact carries.
+fn is_plain_javascript(module: &Utf8Path) -> bool {
     module
         .iter()
         .next()
-        .is_some_and(|package| HOST_EXECUTED_PACKAGES.contains(&package))
+        .is_some_and(|package| PLAIN_JAVASCRIPT_PACKAGES.contains(&package))
+}
+
+/// Whether `module` is allowed to run something when it is imported.
+fn runs_at_import(module: &Utf8Path) -> bool {
+    ENTRY_POINT_MODULES.contains(&module.as_str()) || is_plain_javascript(module)
 }
 
 /// Keywords a top-level statement in a shipped module may begin with. Anything
@@ -530,13 +537,38 @@ fn shipped_package_contains_only_modules_and_manifests() {
 #[test]
 fn shipped_modules_start_with_the_flow_pragma() {
     for module in shipped_modules() {
-        if is_host_executed(&module) {
+        if is_plain_javascript(&module) {
             continue;
         }
         let source = read(&module);
         assert!(
             source.starts_with("// @flow\n"),
             "{module} must open with the `// @flow` pragma"
+        );
+    }
+}
+
+/// A module the host runs before any transform exists must say so in its own
+/// docblock, not only in this file's exemption list.
+///
+/// `@noflow` is Flow's declaration that a file is plain JavaScript, and it is
+/// the one uf reads: `uf check` runs inference over every `.js` in a project,
+/// because uf is Flow-first and a file with no pragma is still a file uf owns.
+/// Without this, `@uniflowed/vite` was exempt from the pragma rule here and
+/// nowhere else — so `uf check` type-checked it anyway and reported 258 errors
+/// against source that is plain JavaScript on purpose.
+#[test]
+fn plain_javascript_modules_declare_themselves_plain_javascript() {
+    for module in shipped_modules() {
+        if !is_plain_javascript(&module) {
+            continue;
+        }
+        let source = read(&module);
+        assert!(
+            source.starts_with("// @noflow\n"),
+            "{module} is exempt from the `// @flow` pragma, so it must open with \
+             `// @noflow` — the exemption has to be in the file the checker reads, \
+             not only in this test"
         );
     }
 }
@@ -561,7 +593,7 @@ fn shipped_modules_never_use_star_re_exports() {
 #[test]
 fn shipped_modules_have_no_import_time_side_effects() {
     for module in shipped_modules() {
-        if is_host_executed(&module) {
+        if runs_at_import(&module) {
             continue;
         }
         let code = code_only(&read(&module));

--- a/packages/vite/bun-preload.js
+++ b/packages/vite/bun-preload.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: this file registers the loader, so it cannot need one.
 //
 // `bun --preload @uniflowed/vite/bun-preload app.js` runs a Flow project on

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: the host runs this file directly.
 //
 // The driver `uf dev`, `uf build` and `uf preview` spawn.

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: Vite imports this module directly, before any transform.
 //
 // `@uniflowed/vite` — uf, as Vite plugins.

--- a/packages/vite/internal/config.js
+++ b/packages/vite/internal/config.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // Loading `uf.config.js`.

--- a/packages/vite/internal/events.js
+++ b/packages/vite/internal/events.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // The driver's control channel.

--- a/packages/vite/internal/highlight.js
+++ b/packages/vite/internal/highlight.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Syntax highlighting for fenced code, at build time.
 //
 // uf's claim is that MDX works without a plugin list, and a documentation page

--- a/packages/vite/internal/node-hooks.js
+++ b/packages/vite/internal/node-hooks.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: this *is* the loader, so it cannot be Flow.
 //
 // Node.js module customization hooks that transform Flow on import.

--- a/packages/vite/internal/refresh-runtime.js
+++ b/packages/vite/internal/refresh-runtime.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 /* global window */
 /* eslint-disable eqeqeq, prefer-const, @typescript-eslint/no-empty-function */
 

--- a/packages/vite/internal/refresh.js
+++ b/packages/vite/internal/refresh.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // React Fast Refresh wiring for `uf dev`. The runtime itself is

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // The file-system router, as the build sees it.

--- a/packages/vite/merge.js
+++ b/packages/vite/merge.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // Merging a project's own Vite configuration over the one uf generates.

--- a/packages/vite/register.js
+++ b/packages/vite/register.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: this file registers the loader, so it cannot need one.
 //
 // `node --import @uniflowed/vite/register app.js` runs a Flow project on

--- a/packages/vite/transform.js
+++ b/packages/vite/transform.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform
 // exists — this module is how the transform is reached, so it cannot be Flow.
 //

--- a/uf.config.js
+++ b/uf.config.js
@@ -27,7 +27,15 @@ export default defineConfig({
     // `upstream/` is Meta's and React's source, vendored as submodules. It is
     // not ours to format or lint, and a diff there would be lost on the next
     // sync.
-    ignore: ["upstream", "dist", "target", "node_modules"],
+    //
+    // `crates/` is Rust. The only JavaScript under it is test fixtures — for
+    // the formatter, which needs badly formatted input, and for the checker,
+    // which needs input that fails to check. Both are exercised by the Rust
+    // tests that own them. Checking them again from the repository root would
+    // report every fixture's deliberate defect as this project's defect: 1868
+    // of the 3782 type errors `uf check` used to report here came from
+    // `crates/uf_fmt/tests/fixtures` alone.
+    ignore: ["upstream", "crates", "dist", "target", "node_modules"],
   },
 
   tasks: {


### PR DESCRIPTION
`uf check` ran inference over every `.js` in a project and offered no way out.
That is right by default — uf is Flow-first, so a file with no pragma is still
a file uf owns and transforms — but it left `@noflow`, Flow's own opt-out, with
no effect at all. Upstream sets `metadata.checked` from `@flow` and
deliberately never clears it for `@noflow`, on the grounds that `--all`
outranks the opt-out; uf wants both halves, so the policy is decided in
`parse.rs` now: `all` on, and `@noflow` honoured on top.

The alternative was a config key listing paths, which would be a second,
uf-shaped answer to a question Flow has already answered, and would put the
answer somewhere other than the file a reader is looking at.

`@uniflowed/vite` is the immediate beneficiary. Every one of its modules
already opened with "Plain JavaScript: ..." in prose, because the host runs
them before any transform exists — and `uf check` type-checked them anyway and
reported 258 errors. The prose is now a docblock, and the surface test that
exempted the package from the `// @flow` rule requires the declaration instead
of granting the exemption silently.

Two things fell out of that. `is_host_executed` conflated "is plain
JavaScript" with "runs when imported", so `packages/test/worker.js` — Flow, and
a process entry point — was exempt from a pragma it in fact carries; the two
predicates are now separate. And `crates/` is out of this repository's lint
scope: the only JavaScript under it is fixtures that are deliberately
malformed, and 1868 of the 3782 type errors `uf check` reported here came from
`crates/uf_fmt/tests/fixtures` alone.

`uf check` on this repository: 4324 errors -> 2111. The report now names how
many files opted out, because a clean check over a project that opted every
file out is not the same result as a clean check.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791087468&installation_model_id=422833&pr_number=96&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F96&signature=200c341497202ce9e394fe69bf4faadcf5a4d5b14f2b15be364448a1f1ad5a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->