### PR TITLE
feat(term): draw the real logo, where the terminal can draw a picture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,12 +3299,12 @@ dependencies = [
  "compact_str",
  "criterion",
  "flate2",
- "rayon",
  "serde",
  "serde_json",
  "smallvec",
  "tempfile",
  "thiserror",
+ "uf_infra",
 ]
 
 [[package]]
@@ -3441,7 +3441,6 @@ version = "0.0.0-alpha.2"
 dependencies = [
  "criterion",
  "phf",
- "rayon",
  "serde",
  "thiserror",
  "uf_config",
@@ -3549,7 +3548,6 @@ dependencies = [
  "camino",
  "compact_str",
  "criterion",
- "rayon",
  "serde",
  "serde_json",
  "sha2",
@@ -3613,7 +3611,6 @@ dependencies = [
  "camino",
  "compact_str",
  "criterion",
- "rayon",
  "serde",
  "serde_json",
  "similar-asserts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ json5 = "1.3.1"
 memchr = "2.7.6"
 mimalloc = "0.1.52"
 phf = { version = "0.14.0", features = ["macros"] }
-rayon = "1.11.0"
 react_compiler = "0.1.0"
 react_compiler_ast = "0.1.0"
 rustc-hash = "2.1.1"

--- a/brand/index.js
+++ b/brand/index.js
@@ -1,14 +1,14 @@
 // @flow
 
 export type BrandColorToken = {
-  +name: string,
-  +token: string,
-  +value: string,
+  readonly name: string,
+  readonly token: string,
+  readonly value: string,
 };
 
 export type BrandScaleToken = {
-  +token: string,
-  +value: string,
+  readonly token: string,
+  readonly value: string,
 };
 
 export const ufBrand = {

--- a/crates/uf_bundle/Cargo.toml
+++ b/crates/uf_bundle/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+uf_infra = { path = "../uf_infra" }
 brotli.workspace = true
 camino.workspace = true
 compact_str.workspace = true
 flate2.workspace = true
-rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true

--- a/crates/uf_bundle/src/report.rs
+++ b/crates/uf_bundle/src/report.rs
@@ -5,7 +5,6 @@ use std::fs;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::{CompactString, ToCompactString};
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -278,25 +277,22 @@ pub fn collect_assets(
         }
     }
 
-    let mut assets = files
-        .into_par_iter()
-        .map(|(path, relative)| {
-            let contents = fs::read(&path).map_err(|source| ReportError::Read {
-                path: path.clone(),
-                source,
-            })?;
-            let size = measure(&contents).map_err(|source| ReportError::Measure {
-                path: path.clone(),
-                source,
-            })?;
+    let mut assets = uf_infra::parallel::map(&files, |(path, relative)| {
+        let contents = fs::read(path).map_err(|source| ReportError::Read {
+            path: path.clone(),
+            source,
+        })?;
+        let size = measure(&contents).map_err(|source| ReportError::Measure {
+            path: path.clone(),
+            source,
+        })?;
 
-            Ok(AssetEntry {
-                kind: AssetKind::from_path(&path),
-                path: relative,
-                size,
-            })
+        Ok(AssetEntry {
+            kind: AssetKind::from_path(path),
+            path: relative.clone(),
+            size,
         })
-        .collect::<Result<Vec<_>, ReportError>>()?;
+    })?;
 
     assets.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(assets)

--- a/crates/uf_check/src/report.rs
+++ b/crates/uf_check/src/report.rs
@@ -46,8 +46,15 @@ pub struct BuiltinsTiming {
 pub struct CheckReport {
     /// Every diagnostic, errors before warnings and ordered within each.
     pub diagnostics: Vec<TypeDiagnostic>,
-    /// How many files were checked.
+    /// How many files inference actually ran over.
     pub files_checked: usize,
+    /// How many files opted out of inference with `@noflow`.
+    ///
+    /// Kept apart from `files_checked` rather than folded into it, because a
+    /// clean check over a project that opted every file out is not the same
+    /// result as a clean check over the project, and a reader is entitled to
+    /// tell those apart at a glance.
+    pub files_skipped: usize,
     /// Module specifiers that resolved to nothing typed, sorted and de-duped.
     ///
     /// Every file is checked against Flow's standard library, but not yet

--- a/crates/uf_check/src/tests.rs
+++ b/crates/uf_check/src/tests.rs
@@ -2,6 +2,21 @@ use super::*;
 
 const CLEAN: &str = "// @flow\nconst n: number = 1;\n";
 
+/// A type error that inference reports whenever it runs over the file.
+const TYPE_ERROR: &str = "// @flow\nconst n: number = \"not a number\";\n";
+
+/// The same type error in a file that opts out of Flow.
+const OPTED_OUT: &str = "// @noflow\nconst n: number = \"not a number\";\n";
+
+/// Skip the body when this build has no checker compiled in.
+macro_rules! require_checker {
+    () => {
+        if !is_available() {
+            return;
+        }
+    };
+}
+
 #[test]
 fn backend_names_are_stable() {
     assert_eq!(
@@ -74,6 +89,7 @@ fn an_empty_batch_is_not_an_error() {
     match check_sources(&[], &CheckLimits::default()) {
         Ok(report) => {
             assert_eq!(report.files_checked, 0);
+            assert_eq!(report.files_skipped, 0);
             assert!(report.diagnostics.is_empty());
             assert!(!report.has_errors());
         }
@@ -86,6 +102,7 @@ fn a_report_counts_by_severity() {
     let report = CheckReport {
         diagnostics: Vec::new(),
         files_checked: 3,
+        files_skipped: 0,
         untyped_modules: Vec::new(),
         builtins: BuiltinsTiming {
             elapsed: std::time::Duration::ZERO,
@@ -106,6 +123,7 @@ fn throughput_is_unknown_when_no_time_passed() {
     let report = CheckReport {
         diagnostics: Vec::new(),
         files_checked: 1,
+        files_skipped: 0,
         untyped_modules: Vec::new(),
         builtins: BuiltinsTiming {
             elapsed: std::time::Duration::ZERO,
@@ -116,4 +134,74 @@ fn throughput_is_unknown_when_no_time_passed() {
     };
 
     assert_eq!(report.files_per_second(), None);
+}
+
+#[test]
+fn a_file_that_opts_out_of_flow_is_not_checked() {
+    require_checker!();
+
+    let checked = check_source(Source::new("app.js", TYPE_ERROR), &CheckLimits::default())
+        .expect("the checker runs");
+    assert!(
+        checked.iter().any(TypeDiagnostic::is_error),
+        "the fixture must be a type error when it is checked, or this test proves nothing"
+    );
+
+    let opted_out = check_source(Source::new("app.js", OPTED_OUT), &CheckLimits::default())
+        .expect("the checker runs");
+
+    assert!(
+        opted_out.is_empty(),
+        "`@noflow` must opt a file out of inference, but it reported {opted_out:?}"
+    );
+}
+
+#[test]
+fn opting_out_is_counted_as_skipped_rather_than_checked() {
+    require_checker!();
+
+    let report = check_sources(
+        &[
+            Source::new("checked.js", CLEAN),
+            Source::new("plain.js", OPTED_OUT),
+        ],
+        &CheckLimits::default(),
+    )
+    .expect("the checker runs");
+
+    assert_eq!(report.files_checked, 1, "only one file opted in");
+    assert_eq!(report.files_skipped, 1, "the other opted out");
+}
+
+#[test]
+fn opting_out_does_not_hide_a_file_that_cannot_be_parsed() {
+    require_checker!();
+
+    let diagnostics = check_source(
+        Source::new("broken.js", "// @noflow\nfunction ( {\n"),
+        &CheckLimits::default(),
+    )
+    .expect("the checker runs");
+
+    assert!(
+        diagnostics.iter().any(TypeDiagnostic::is_error),
+        "a file uf must still transform has to parse, whatever its docblock says"
+    );
+}
+
+#[test]
+fn a_file_with_no_docblock_is_still_checked() {
+    require_checker!();
+
+    let diagnostics = check_source(
+        Source::new("app.js", "const n: number = \"not a number\";\n"),
+        &CheckLimits::default(),
+    )
+    .expect("the checker runs");
+
+    assert!(
+        diagnostics.iter().any(TypeDiagnostic::is_error),
+        "uf is Flow-first: a file without a pragma is checked, and `@noflow` is \
+         the way to say otherwise"
+    );
 }

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -120,17 +120,31 @@ fn check_batch(sources: &[Source<'_>], limits: &CheckLimits) -> Result<CheckRepo
 
     let started = Instant::now();
     let mut diagnostics = Vec::new();
+    let mut skipped = 0usize;
     for source in sources {
-        diagnostics.extend(check_one(&master_cx, &options, limits, source, &untyped)?);
+        let outcome = check_one(&master_cx, &options, limits, source, &untyped)?;
+        if outcome.skipped {
+            skipped += 1;
+        }
+        diagnostics.extend(outcome.diagnostics);
     }
 
     Ok(CheckReport {
         diagnostics,
-        files_checked: sources.len(),
+        files_checked: sources.len() - skipped,
+        files_skipped: skipped,
         untyped_modules: untyped.borrow().iter().cloned().collect(),
         builtins,
         elapsed: started.elapsed(),
     })
+}
+
+/// What checking one file produced, and whether it was checked at all.
+struct FileOutcome {
+    /// Diagnostics for the file. A skipped file can still have parse errors.
+    diagnostics: Vec<TypeDiagnostic>,
+    /// Whether the file opted out of inference with `@noflow`.
+    skipped: bool,
 }
 
 /// Module specifiers that resolved to nothing typed, shared across a batch.
@@ -145,7 +159,7 @@ fn check_one(
     limits: &CheckLimits,
     source: &Source<'_>,
     untyped: &UntypedModules,
-) -> Result<Vec<TypeDiagnostic>, CheckError> {
+) -> Result<FileOutcome, CheckError> {
     // Checked before the parser sees the text: the AST alone is several times
     // the size of the source, so an unbounded file is an unbounded allocation.
     if source.source.len() > limits.max_source_bytes {
@@ -160,11 +174,24 @@ fn check_one(
     let parsed = parse::parse_file(file_key.dupe(), source.source, options, false);
     if !parsed.is_parseable() {
         let errors = printable(&parsed, parse_error_set(&parsed));
-        return Ok(convert::diagnostics(
-            &errors,
-            &ConcreteLocPrintableErrorSet::empty(),
-            source.path,
-        ));
+        return Ok(FileOutcome {
+            diagnostics: convert::diagnostics(
+                &errors,
+                &ConcreteLocPrintableErrorSet::empty(),
+                source.path,
+            ),
+            // A file that does not parse is broken whatever its docblock says,
+            // so it is reported — but it was not checked either.
+            skipped: !parsed.is_checked(),
+        });
+    }
+
+    // `@noflow`. The file parsed, and that is all uf asked of it.
+    if !parsed.is_checked() {
+        return Ok(FileOutcome {
+            diagnostics: Vec::new(),
+            skipped: true,
+        });
     }
 
     let metadata = parsed.metadata.clone();
@@ -203,7 +230,10 @@ fn check_one(
     .map_err(|error| job_error(source.path, error))?;
 
     let (errors, warnings) = suppressed(&cx, &parsed, cx.errors());
-    Ok(convert::diagnostics(&errors, &warnings, source.path))
+    Ok(FileOutcome {
+        diagnostics: convert::diagnostics(&errors, &warnings, source.path),
+        skipped: false,
+    })
 }
 
 fn job_error(path: &str, error: JobError) -> CheckError {

--- a/crates/uf_check/src/upstream/parse.rs
+++ b/crates/uf_check/src/upstream/parse.rs
@@ -1,13 +1,17 @@
 //! Parsing one file into everything the checker needs from it.
 //!
-//! The docblock is deliberately consumed here rather than stored. Upstream's
-//! `Docblock` type is private to `flow_parsing`, so the only thing an embedder
-//! can do with one is fold it into a [`Metadata`] immediately — which is also
-//! the only thing anyone wants it for.
+//! The docblock is folded into [`Metadata`] here rather than stored, because
+//! that is the only shape the checker takes it in. One bit is read out first:
+//! whether the file opted out of Flow entirely, which `Metadata` cannot carry
+//! — upstream sets `checked` from `@flow` but deliberately never clears it for
+//! `@noflow`, on the grounds that `--all` outranks the opt-out. uf runs with
+//! `all` on so that a file with no pragma is still checked, and then honours
+//! `@noflow` on top, so the two halves of that policy are decided here.
 
 use std::sync::Arc;
 
 use dupe::Dupe;
+use flow_common::docblock::FlowMode;
 use flow_common::options::Options;
 use flow_parser::PERMISSIVE_PARSE_OPTIONS;
 use flow_parser::ast;
@@ -32,12 +36,26 @@ pub(super) struct Parsed {
     pub(super) file_sig: Arc<FileSig>,
     /// Syntax errors, in source order. Non-empty means inference must not run.
     pub(super) parse_errors: Vec<(Loc, ParseError)>,
+    /// Whether the file's docblock says `@noflow`.
+    opted_out: bool,
 }
 
 impl Parsed {
     /// Whether the file parsed cleanly enough to type check.
     pub(super) fn is_parseable(&self) -> bool {
         self.parse_errors.is_empty()
+    }
+
+    /// Whether inference should run over this file.
+    ///
+    /// `@noflow` is Flow's own way for a file to say it is plain JavaScript,
+    /// and it is the only one uf offers: a config key listing paths would be a
+    /// second, uf-shaped answer to a question Flow has already answered, and
+    /// the file itself is where a reader looks. Parse errors are reported
+    /// either way — uf transforms every `.js` it owns regardless of docblock,
+    /// so a file that does not parse is broken whatever it opted out of.
+    pub(super) fn is_checked(&self) -> bool {
+        !self.opted_out
     }
 }
 
@@ -81,5 +99,6 @@ pub(super) fn parse_file(
         ast: Arc::new(ast),
         file_sig,
         parse_errors,
+        opted_out: matches!(docblock.flow(), Some(FlowMode::OptOut)),
     }
 }

--- a/crates/uf_cli/src/brand.rs
+++ b/crates/uf_cli/src/brand.rs
@@ -1,6 +1,9 @@
 //! Brand-aware terminal snippets shared by human-facing CLI commands.
 
-use uf_term::{Cell, Color, Column, GlyphSet, Renderer, Style, Table, Tone, push_repeat};
+use uf_term::{
+    Cell, Color, Column, GlyphSet, Placement, Renderer, Style, Table, Tone, inline_image,
+    push_repeat,
+};
 
 pub(crate) const HEADLINE: &str = "Unified Toolchain for Flow";
 pub(crate) const TAGLINE: &str = "All-in-one toolchain for Flow and React.";
@@ -55,27 +58,34 @@ const ASCII_MARK: [&str; 5] = [
     " ######    ##",
 ];
 
+/// uf's logo, as the picture it is.
+///
+/// Compiled in rather than read from `brand/`: an installed `uf` is one binary
+/// and has no `brand/` directory to read. 24 KiB, which is nothing beside the
+/// checker.
+const LOGO_PNG: &[u8] = include_bytes!("../../../brand/uniflowed-logo.png");
+
+/// The box the logo is drawn into, in terminal cells.
+///
+/// The same footprint as the block mark it replaces — nineteen columns and five
+/// rows — so the banner is laid out identically whether a terminal can draw a
+/// picture or not, and nothing below it moves.
+const LOGO_PLACEMENT: Placement = Placement::new(19, 5);
+
 /// The mark and the headline, for the moments that deserve it.
 ///
 /// Not on every command. `uf test` printing a five-row logo before a hundred
 /// test results is not beautiful, it is in the way — this is for first contact
 /// (`uf create`) and for the command whose whole job is to say what you have
 /// (`uf info`).
+///
+/// Where the terminal can draw an image, it draws the real logo; everywhere
+/// else it draws the same shape out of block characters. The picture is not a
+/// different banner, it is the same banner rendered properly.
 pub(crate) fn render_mark(renderer: &Renderer, out: &mut String, context: &str) {
-    let stops = [CYAN, BLUE, INDIGO, VIOLET, MAGENTA];
-    let rows = match renderer.glyph_set() {
-        GlyphSet::Ascii => &ASCII_MARK,
-        GlyphSet::Unicode => &MARK,
-    };
-
     out.push('\n');
-    for (row, colour) in rows.iter().zip(stops) {
-        out.push_str("  ");
-        Style::new()
-            .fg(colour)
-            .bold()
-            .paint(renderer.color(), row, out);
-        out.push('\n');
+    if !render_logo_image(renderer, out) {
+        render_logo_blocks(renderer, out);
     }
     out.push('\n');
 
@@ -90,6 +100,43 @@ pub(crate) fn render_mark(renderer: &Renderer, out: &mut String, context: &str) 
         .subtitle
         .paint(renderer.color(), context, out);
     out.push('\n');
+}
+
+/// Draw the logo as a picture, or report that this terminal cannot.
+///
+/// The decision was made once at start-up, with the rest of the terminal's
+/// capability, so this asks the renderer rather than the environment — no write
+/// path in uf re-probes the process it is running in.
+fn render_logo_image(renderer: &Renderer, out: &mut String) -> bool {
+    let Some(protocol) = renderer.image() else {
+        return false;
+    };
+    let Some(escape) = inline_image(LOGO_PNG, protocol, LOGO_PLACEMENT) else {
+        return false;
+    };
+
+    out.push_str("  ");
+    out.push_str(&escape);
+    out.push('\n');
+    true
+}
+
+/// Draw the logo out of block characters, which every terminal can render.
+fn render_logo_blocks(renderer: &Renderer, out: &mut String) {
+    let stops = [CYAN, BLUE, INDIGO, VIOLET, MAGENTA];
+    let rows = match renderer.glyph_set() {
+        GlyphSet::Ascii => &ASCII_MARK,
+        GlyphSet::Unicode => &MARK,
+    };
+
+    for (row, colour) in rows.iter().zip(stops) {
+        out.push_str("  ");
+        Style::new()
+            .fg(colour)
+            .bold()
+            .paint(renderer.color(), row, out);
+        out.push('\n');
+    }
 }
 
 pub(crate) fn render_product_card(renderer: &Renderer, out: &mut String, context: &str) {

--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -28,18 +28,32 @@ impl From<ColorOption> for ColorChoice {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Commands {
+    /// Build the project for production.
+    ///
+    /// Runs Vite through `@uniflowed/vite`, with every module transformed by
+    /// `uf transform`, then writes the build manifest and enforces
+    /// `build.budgets`.
     Build {
+        /// Print the emitted bundle's size, by chunk.
         #[arg(long)]
         size_report: bool,
     },
+    /// Lint the project, then type check it with Flow.
+    ///
+    /// `uf lint` answers whether the source is well formed and idiomatic; this
+    /// answers that and whether the types hold. A file that opts out with
+    /// `@noflow` is parsed but not inferred.
     Check {
+        /// Emit machine-readable JSON on stdout.
         #[arg(long)]
         json: bool,
     },
+    /// Scaffold a new application or library.
     Create {
         #[command(subcommand)]
         command: CreateCommand,
     },
+    /// Start the development server, with hot module replacement.
     Dev {
         /// Bind a routable address instead of loopback. Requires a non-empty
         /// `dev.allowedHosts` in `uf.config.js`; see `docs/security.md`.
@@ -49,20 +63,19 @@ pub(crate) enum Commands {
         #[arg(long, value_name = "PORT")]
         port: Option<u16>,
     },
+    /// Inspect and switch the Capability JS Host uf runs JavaScript on.
     Env {
         #[command(subcommand)]
         command: EnvCommand,
     },
+    /// Run a package's binary without installing it. Also `ufx`.
     Exec {
+        /// The package to fetch and run, for example `@uniflowed/create`.
         package: String,
+        /// Everything after the package name, handed to it untouched.
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
     },
-    Fmt {
-        #[arg(long)]
-        check: bool,
-    },
-    Info,
     /// Say what a command will do, and which provider does each part.
     ///
     /// `uf inspect` prints the resolved configuration; this answers the
@@ -73,10 +86,24 @@ pub(crate) enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Format every file in the project.
+    ///
+    /// Flow source is printed from the official Flow parser's syntax tree.
+    Fmt {
+        /// Report what would change and exit non-zero, writing nothing.
+        #[arg(long)]
+        check: bool,
+    },
+    /// Print the toolchain's version, host, and resolved paths.
+    Info,
+    /// Print the resolved configuration, after defaults and plugins.
     Inspect {
+        /// Emit machine-readable JSON on stdout.
         #[arg(long)]
         json: bool,
     },
+    /// Install the project's dependencies. Also `uf i`.
+    #[command(visible_alias = "i")]
     Install,
     /// Serve uf's module transform over stdin/stdout, for the Vite plugin.
     ///
@@ -85,22 +112,33 @@ pub(crate) enum Commands {
     /// per-file `uf` invocation would have paid startup for thousands of times.
     #[command(hide = true)]
     Transform,
+    /// Lint the project without type checking it.
     Lint {
+        /// Emit machine-readable JSON on stdout.
         #[arg(long)]
         json: bool,
     },
+    /// Serve the language server over stdin/stdout, for an editor.
     Lsp,
+    /// Run the checks and code generation a commit should not go without.
     Prepare,
+    /// Publish the project's packages to the registry.
     Publish,
+    /// Cut a release: calculate the next version and write its metadata.
     Release {
+        /// How far to move the version.
         #[arg(value_enum)]
         bump: ReleaseBump,
     },
+    /// Run a task from `uf.config.js`. Also `ufr`.
     Run {
+        /// The task to run, as named under `tasks` in `uf.config.js`.
         script: String,
+        /// Everything after the task name, handed to it untouched.
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
     },
+    /// Run the project's tests.
     Test {
         /// List what would run instead of running it.
         #[arg(long)]
@@ -130,10 +168,13 @@ pub(crate) enum Commands {
         #[arg(value_name = "PATH")]
         paths: Vec<String>,
     },
+    /// Upgrade the project's dependencies and the toolchain.
+    Upgrade,
+    /// Switch the active uf toolchain, for example `uf use uf@0.1.0`.
     Use {
+        /// The toolchain to activate.
         runtime: String,
     },
-    Upgrade,
 }
 
 impl Commands {

--- a/crates/uf_cli/src/commands/check.rs
+++ b/crates/uf_cli/src/commands/check.rs
@@ -196,6 +196,7 @@ fn type_check_payload(types: &TypeCheck) -> Value {
     });
     if let Some(report) = types.report() {
         value["filesChecked"] = json!(report.files_checked);
+        value["filesSkipped"] = json!(report.files_skipped);
         value["elapsedMs"] = json!(report.elapsed.as_secs_f64() * 1000.0);
         value["builtinsMs"] = json!(report.builtins.cold_elapsed.as_secs_f64() * 1000.0);
         value["builtinsCold"] = json!(report.builtins.cold);
@@ -379,18 +380,21 @@ fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
                 report.builtins.cold_elapsed,
                 if report.builtins.cold { "cold" } else { "warm" }
             );
+            // Only shown when it happened. A project with nothing opted out
+            // should not have to read a line saying so.
+            let skipped = report.files_skipped.to_string();
+            let mut rows = vec![
+                KeyValue::toned("types checked", &files, Tone::Number),
+                KeyValue::toned("inference", &inference, Tone::Muted),
+                KeyValue::toned("builtins", &builtins, Tone::Muted),
+            ];
+            if report.files_skipped > 0 {
+                rows.insert(1, KeyValue::toned("@noflow", &skipped, Tone::Muted));
+            }
             let untyped = untyped_module_list(report);
             ui.render(|renderer, out| {
                 renderer.blank(out);
-                renderer.key_values(
-                    out,
-                    2,
-                    &[
-                        KeyValue::toned("types checked", &files, Tone::Number),
-                        KeyValue::toned("inference", &inference, Tone::Muted),
-                        KeyValue::toned("builtins", &builtins, Tone::Muted),
-                    ],
-                );
+                renderer.key_values(out, 2, &rows);
                 if !untyped.is_empty() {
                     renderer.blank(out);
                     push_spaces(out, 2);

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -24,6 +24,7 @@ use crate::ui::{OutputMode, Ui};
 #[derive(Debug, Parser)]
 #[command(version, about = "Unified Toolchain for Flow (React)")]
 struct Cli {
+    /// Run as if uf had been started in DIR instead of the current directory.
     #[arg(long, global = true, value_name = "DIR")]
     cwd: Option<Utf8PathBuf>,
     /// When to colourise output.

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -17,6 +17,106 @@ fn uf_prints_help() {
     assert!(stdout.contains("--color"));
 }
 
+/// Every command `uf --help` lists must say what it does.
+///
+/// clap prints the first line of a command's doc comment beside its name, and
+/// prints nothing at all when there is no doc comment. Fifteen of the twenty
+/// commands had none, so the front door of the toolchain was a list of bare
+/// verbs — `build`, `check`, `create`, `dev` — with a description beside
+/// exactly one of them.
+#[test]
+fn every_command_in_the_help_says_what_it_does() {
+    let output = uf().arg("--help").output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    let commands = stdout
+        .split_once("Commands:")
+        .expect("help lists commands")
+        .1
+        .split_once("\nOptions:")
+        .expect("commands come before options")
+        .0;
+
+    let undescribed = commands
+        .lines()
+        .filter(|line| line.starts_with("  ") && !line.starts_with("     "))
+        .filter_map(|line| {
+            let mut words = line.split_whitespace();
+            let name = words.next()?;
+            words.next().is_none().then_some(name)
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        undescribed.is_empty(),
+        "these commands have no description in `uf --help`: {}",
+        undescribed.join(", ")
+    );
+}
+
+/// `uf i` is `uf install`.
+///
+/// The one command a person types before anything else works, and every
+/// package manager they have used has a one-letter form of it.
+#[test]
+fn install_has_a_one_letter_alias() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "// @flow\nimport { defineConfig } from \"@uniflowed/config\";\n\
+         export default defineConfig({ app: { router: { enabled: false } } });\n",
+    )
+    .unwrap();
+
+    let long = uf()
+        .current_dir(dir.path())
+        .arg("install")
+        .output()
+        .unwrap();
+    let short = uf().current_dir(dir.path()).arg("i").output().unwrap();
+
+    assert_eq!(
+        short.status.code(),
+        long.status.code(),
+        "`uf i` must be `uf install`, got {}",
+        String::from_utf8_lossy(&short.stderr)
+    );
+
+    // Compared line by line, skipping the one that carries a duration: two
+    // runs of the same command differ by a few milliseconds and that is not a
+    // difference between the alias and the command.
+    let lines = |output: &[u8]| {
+        String::from_utf8_lossy(output)
+            .lines()
+            .filter(|line| !line.contains("ms"))
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(lines(&short.stdout), lines(&long.stdout));
+    assert!(
+        String::from_utf8_lossy(&short.stdout).contains("uf install"),
+        "`uf i` should report itself as `uf install`"
+    );
+}
+
+/// The alias binaries are the longhand commands, and the help says so.
+#[test]
+fn alias_binaries_are_documented_as_the_commands_they_expand_to() {
+    let output = uf().arg("--help").output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    for (command, alias) in [("run", "ufr"), ("exec", "ufx")] {
+        let line = stdout
+            .lines()
+            .find(|line| line.trim_start().starts_with(&format!("{command} ")))
+            .unwrap_or_else(|| panic!("`{command}` is missing from the help"));
+        assert!(
+            line.contains(alias),
+            "`uf {command}` should name its `{alias}` alias in the help, got {line:?}"
+        );
+    }
+}
+
 #[test]
 fn alias_binaries_print_the_root_version() {
     for name in ["ufr", "ufx"] {

--- a/crates/uf_cli/tests/installer.rs
+++ b/crates/uf_cli/tests/installer.rs
@@ -1,0 +1,143 @@
+//! The `curl … | sh` installer, checked against the binary it installs.
+//!
+//! `infra/cloudflare/setup-assets/install.sh` draws the same banner `uf` draws,
+//! and has to decide the same way whether the terminal can take a picture. It
+//! cannot call into `uf_term` — it runs before any of uf exists on the machine
+//! — so the decision is written twice, and these tests are what keeps the two
+//! copies the same. A terminal the binary draws a logo on and the installer
+//! draws blocks on is not a disaster, but it is the kind of drift nobody
+//! notices until someone asks why the installer looks worse than the tool.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use uf_term::{ImageEnv, ImageProtocol};
+
+fn installer() -> String {
+    let path = repository_root().join("infra/cloudflare/setup-assets/install.sh");
+    fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the crate lives inside the repository")
+}
+
+/// Every terminal the binary recognises, and the protocol it picks for it.
+///
+/// The table is written here rather than derived, so a terminal added to one
+/// side and not the other is a failure rather than a silently shorter list.
+const TERMINALS: &[(&str, ImageProtocol)] = &[
+    ("kitty", ImageProtocol::Kitty),
+    ("ghostty", ImageProtocol::Kitty),
+    ("WezTerm", ImageProtocol::Kitty),
+    ("iTerm.app", ImageProtocol::ITerm2),
+    ("vscode", ImageProtocol::ITerm2),
+    ("Hyper", ImageProtocol::ITerm2),
+    ("rio", ImageProtocol::ITerm2),
+];
+
+#[test]
+fn the_installer_knows_every_terminal_the_binary_knows() {
+    let script = installer();
+
+    for (terminal, _) in TERMINALS {
+        assert!(
+            script.contains(terminal),
+            "the installer does not mention {terminal}, which `uf` draws a logo on"
+        );
+    }
+    assert!(
+        script.contains("KITTY_WINDOW_ID") && script.contains("KONSOLE_VERSION"),
+        "the installer must check the same two identifying variables the binary does"
+    );
+}
+
+/// The table above has to be the binary's actual behaviour, not a wish.
+#[test]
+fn the_binary_picks_the_protocol_the_table_claims() {
+    for (terminal, protocol) in TERMINALS {
+        let by_term_program = ImageEnv::default().with_term_program(terminal).protocol();
+        let by_term = ImageEnv::default()
+            .with_term(&format!("xterm-{}", terminal.to_lowercase()))
+            .protocol();
+
+        assert!(
+            by_term_program == Some(*protocol) || by_term == Some(*protocol),
+            "{terminal} should resolve to {protocol:?}, got {by_term_program:?} by TERM_PROGRAM \
+             and {by_term:?} by TERM"
+        );
+    }
+}
+
+#[test]
+fn the_installer_refuses_inline_images_inside_a_multiplexer() {
+    let script = installer();
+
+    assert!(
+        script.contains("TMUX") && script.contains("STY"),
+        "a multiplexer rewrites the stream, and the installer must refuse for the same \
+         reason the binary does"
+    );
+}
+
+#[test]
+fn the_installer_honours_the_same_override_variable() {
+    let script = installer();
+
+    assert!(
+        script.contains("UF_INLINE_IMAGES"),
+        "the one escape hatch has to work in both places or it is not an escape hatch"
+    );
+}
+
+/// The kitty protocol discards a sequence whose payload is over the limit, so
+/// an installer that stopped chunking would silently print nothing.
+#[test]
+fn the_installer_chunks_its_kitty_payload() {
+    let script = installer();
+
+    assert!(
+        script.contains("fold -w 4096"),
+        "the embedded logo is larger than one kitty sequence may carry"
+    );
+    assert!(
+        script.contains("m=1") && script.contains("m=0"),
+        "chunks must say whether more is coming"
+    );
+}
+
+/// The `size` key iTerm2 reads has to be the real decoded length.
+#[test]
+fn the_installers_declared_logo_size_is_the_logo_it_embeds() {
+    let script = installer();
+
+    let declared: usize = script
+        .lines()
+        .find_map(|line| line.strip_prefix("uf_logo_bytes="))
+        .expect("the installer states the logo's decoded size")
+        .trim()
+        .parse()
+        .expect("the size is a number");
+
+    let payload = script
+        .split_once("<<'UF_LOGO_PNG'\n")
+        .expect("the logo is embedded in a heredoc")
+        .1
+        .split_once("\nUF_LOGO_PNG")
+        .expect("the heredoc is terminated")
+        .0
+        .replace('\n', "");
+
+    // Base64 without padding carries 6 bits per character; the padding says how
+    // many of the final three bytes are real.
+    let padding = payload.chars().rev().take_while(|&c| c == '=').count();
+    let decoded = payload.len() / 4 * 3 - padding;
+
+    assert_eq!(
+        decoded, declared,
+        "the installer tells iTerm2 the image is {declared} bytes, but embeds {decoded}"
+    );
+}

--- a/crates/uf_infra/src/lib.rs
+++ b/crates/uf_infra/src/lib.rs
@@ -4,6 +4,8 @@
 //! change as benchmarks teach us more, while downstream crates get one stable
 //! import path for the fast defaults we want everywhere.
 
+pub mod parallel;
+
 pub use bumpalo::{Bump, collections::Vec as ArenaVec};
 pub use compact_str::CompactString;
 pub use memchr::{memchr, memchr_iter};

--- a/crates/uf_infra/src/parallel.rs
+++ b/crates/uf_infra/src/parallel.rs
@@ -1,0 +1,178 @@
+//! Running one function over a slice on every core.
+//!
+//! This is the entire shape of uf's data parallelism. `uf_lint` lints each
+//! file, `uf_rsc` reads and classifies each module, `uf_bundle` measures each
+//! emitted asset: three crates, one operation — map a fallible function over a
+//! slice, keep the input's order, stop at the first error. Nothing needs
+//! nested parallelism, a global pool, futures, or work-stealing deques.
+//!
+//! So it is written here rather than depended on. rayon is an excellent crate
+//! and it is also a general-purpose parallel iterator framework; sixty lines of
+//! scoped threads over an atomic cursor gives uf the one thing it actually
+//! uses, with no global thread pool living in the process and nothing to
+//! configure. `uf_test` already schedules its own work this way.
+//!
+//! There is no `unsafe` here. Each thread collects its own results and they are
+//! placed by index after every thread has been joined, which is both simpler
+//! than sharing the output buffer and, at these sizes, not measurably slower:
+//! the work is reading and parsing files, not moving a `Vec` around.
+//!
+//! # Scheduling
+//!
+//! Threads pull indices off a shared atomic cursor rather than being handed a
+//! contiguous block each. Blocks would be simpler and would be wrong here: lint
+//! cost is proportional to file size, and files are not the same size, so a
+//! thread handed the block containing the four biggest files finishes long
+//! after the rest. Pulling one index at a time costs a single relaxed
+//! fetch-add per item and keeps every core busy to the end.
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+#[cfg(test)]
+mod tests;
+
+/// Below this many items, the threads cost more than they save.
+///
+/// Spawning is on the order of tens of microseconds per thread; a handful of
+/// items is done before a pool would have finished starting.
+const SERIAL_THRESHOLD: usize = 8;
+
+/// How many threads [`map`] will use for `items` items on `cores` cores.
+///
+/// Never more threads than there is work, and never more than the machine has
+/// cores. One means the caller runs the work on its own thread.
+fn threads_for(items: usize, cores: NonZeroUsize) -> usize {
+    if items < SERIAL_THRESHOLD {
+        return 1;
+    }
+    cores.get().min(items)
+}
+
+/// The number of cores to schedule across.
+fn available_cores() -> NonZeroUsize {
+    std::thread::available_parallelism().unwrap_or(NonZeroUsize::MIN)
+}
+
+/// Map `body` over `items` in parallel, in order, stopping at the first error.
+///
+/// The result is exactly `items.iter().map(body).collect::<Result<Vec<_>, _>>()`
+/// — same values, same order, same error — computed on every core. That
+/// equivalence is the contract, and it is what lets a caller reach for this
+/// without thinking about threads at all.
+///
+/// # Errors
+///
+/// Returns the error from the lowest-indexed item that produced one, so a
+/// failing run reports the same error every time however the threads
+/// interleaved. Once any item fails, threads stop claiming new work; items
+/// already in flight run to completion.
+///
+/// # Panics
+///
+/// A panic in `body` propagates once every thread has been joined, as
+/// [`std::thread::scope`] does.
+pub fn map<T, U, E, F>(items: &[T], body: F) -> Result<Vec<U>, E>
+where
+    T: Sync,
+    U: Send,
+    E: Send,
+    F: Fn(&T) -> Result<U, E> + Sync,
+{
+    map_with_cores(items, available_cores(), body)
+}
+
+/// [`map`], with the core count given rather than detected.
+///
+/// Separated so the scheduler can be tested at a fixed width: a test that only
+/// ran on however many cores the machine happens to have would prove something
+/// different on every machine.
+fn map_with_cores<T, U, E, F>(items: &[T], cores: NonZeroUsize, body: F) -> Result<Vec<U>, E>
+where
+    T: Sync,
+    U: Send,
+    E: Send,
+    F: Fn(&T) -> Result<U, E> + Sync,
+{
+    let threads = threads_for(items.len(), cores);
+    if threads == 1 {
+        return items.iter().map(body).collect();
+    }
+
+    let cursor = AtomicUsize::new(0);
+    let failed = AtomicBool::new(false);
+    let body = &body;
+    let cursor = &cursor;
+    let failed = &failed;
+
+    let claimed = std::thread::scope(|scope| {
+        let handles = (0..threads)
+            .map(|_| {
+                scope.spawn(move || {
+                    let mut mine: Vec<(usize, Result<U, E>)> = Vec::new();
+                    loop {
+                        // Relaxed throughout: the cursor only has to hand out
+                        // each index once, and the flag only has to be seen
+                        // eventually. Every result is published by the join,
+                        // which is what orders the writes against the reader.
+                        if failed.load(Ordering::Relaxed) {
+                            return mine;
+                        }
+                        let index = cursor.fetch_add(1, Ordering::Relaxed);
+                        if index >= items.len() {
+                            return mine;
+                        }
+                        let outcome = body(&items[index]);
+                        if outcome.is_err() {
+                            failed.store(true, Ordering::Relaxed);
+                        }
+                        mine.push((index, outcome));
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("a worker thread panicked"))
+            .collect::<Vec<_>>()
+    });
+
+    collect_in_order(claimed, items.len())
+}
+
+/// Put `claimed` results back into input order and unwrap them.
+///
+/// Returns the error belonging to the lowest index, which is exactly the error
+/// the serial equivalent would have returned. Indices are claimed in increasing
+/// order, so every index below a failing one was claimed and will have
+/// finished; the ones that were never started are all *above* it, and are the
+/// same ones a serial run would never have reached.
+///
+/// The error is looked for before the values are unwrapped, rather than while:
+/// unwrapping in order would meet an unclaimed slot first whenever the failure
+/// was far enough along for the other threads to have stopped.
+fn collect_in_order<U, E>(claimed: Vec<(usize, Result<U, E>)>, length: usize) -> Result<Vec<U>, E> {
+    let mut slots: Vec<Option<Result<U, E>>> = (0..length).map(|_| None).collect();
+    for (index, outcome) in claimed {
+        slots[index] = Some(outcome);
+    }
+
+    if let Some(index) = slots.iter().position(|slot| matches!(slot, Some(Err(_)))) {
+        match slots.swap_remove(index) {
+            Some(Err(error)) => return Err(error),
+            _ => unreachable!("the slot at this index was just matched as an error"),
+        }
+    }
+
+    let results = slots
+        .into_iter()
+        .map(|slot| match slot {
+            Some(Ok(value)) => value,
+            // Threads only stop claiming work when something failed, and
+            // nothing did, so every index was claimed and succeeded.
+            _ => unreachable!("an index was skipped without any item failing"),
+        })
+        .collect();
+    Ok(results)
+}

--- a/crates/uf_infra/src/parallel/tests.rs
+++ b/crates/uf_infra/src/parallel/tests.rs
@@ -1,0 +1,190 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::*;
+
+fn cores(count: usize) -> NonZeroUsize {
+    NonZeroUsize::new(count).expect("a positive core count")
+}
+
+/// The contract, stated as a test: the parallel result is the serial result.
+#[test]
+fn a_parallel_map_is_the_serial_map() {
+    let items = (0..500u64).collect::<Vec<_>>();
+    let double = |item: &u64| Ok::<_, ()>(item * 2);
+
+    let serial = items.iter().map(double).collect::<Result<Vec<_>, ()>>();
+    let parallel = map_with_cores(&items, cores(8), double);
+
+    assert_eq!(parallel, serial);
+}
+
+#[test]
+fn results_come_back_in_input_order_however_the_work_interleaved() {
+    // Reversing the cost makes the first items the slowest, so a scheduler
+    // that returned completion order would return something close to reversed.
+    let items = (0..200usize).collect::<Vec<_>>();
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        for _ in 0..(200 - item) * 50 {
+            std::hint::black_box(item);
+        }
+        Ok::<_, ()>(*item)
+    })
+    .expect("nothing fails");
+
+    assert_eq!(out, items);
+}
+
+#[test]
+fn every_item_is_visited_exactly_once() {
+    let items = (0..1000usize).collect::<Vec<_>>();
+    let calls = AtomicUsize::new(0);
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Ok::<_, ()>(*item)
+    })
+    .expect("nothing fails");
+
+    assert_eq!(calls.load(Ordering::Relaxed), items.len());
+    assert_eq!(out.len(), items.len());
+}
+
+#[test]
+fn an_empty_slice_is_an_empty_result() {
+    let items: [u8; 0] = [];
+
+    assert_eq!(map(&items, |item: &u8| Ok::<_, ()>(*item)), Ok(Vec::new()));
+}
+
+#[test]
+fn a_single_item_does_not_start_a_thread() {
+    assert_eq!(threads_for(1, cores(16)), 1);
+    assert_eq!(map(&[7u8], |item| Ok::<_, ()>(*item * 2)), Ok(vec![14]));
+}
+
+/// The reported error must not depend on which thread happened to finish first.
+#[test]
+fn the_lowest_indexed_error_is_the_one_reported() {
+    let items = (0..500usize).collect::<Vec<_>>();
+
+    for _ in 0..32 {
+        let out = map_with_cores(&items, cores(8), |item| {
+            if *item == 100 || *item == 300 {
+                Err(*item)
+            } else {
+                Ok(*item)
+            }
+        });
+
+        assert_eq!(out, Err(100));
+    }
+}
+
+/// An error far enough along that the other threads stop before claiming the
+/// indices after it. Those unclaimed slots must not be mistaken for a bug.
+#[test]
+fn an_error_leaves_later_items_unclaimed_without_panicking() {
+    let items = (0..5000usize).collect::<Vec<_>>();
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        if *item == 10 {
+            Err("failed")
+        } else {
+            Ok(*item)
+        }
+    });
+
+    assert_eq!(out, Err("failed"));
+}
+
+/// Once something fails, the remaining work is abandoned rather than run.
+#[test]
+fn a_failure_stops_the_threads_claiming_more_work() {
+    let items = (0..100_000usize).collect::<Vec<_>>();
+    let calls = AtomicUsize::new(0);
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        if *item == 0 { Err(()) } else { Ok(*item) }
+    });
+
+    assert_eq!(out, Err(()));
+    assert!(
+        calls.load(Ordering::Relaxed) < items.len(),
+        "every one of {} items ran even though the first failed",
+        items.len()
+    );
+}
+
+// --- the scheduler -----------------------------------------------------
+
+#[test]
+fn small_inputs_stay_on_the_calling_thread() {
+    for length in 0..SERIAL_THRESHOLD {
+        assert_eq!(
+            threads_for(length, cores(16)),
+            1,
+            "{length} items is not worth a thread"
+        );
+    }
+    assert!(threads_for(SERIAL_THRESHOLD, cores(16)) > 1);
+}
+
+#[test]
+fn there_are_never_more_threads_than_work_or_cores() {
+    assert_eq!(threads_for(10, cores(16)), 10, "no idle threads");
+    assert_eq!(threads_for(1000, cores(4)), 4, "no oversubscription");
+    assert_eq!(threads_for(1000, cores(1)), 1);
+}
+
+#[test]
+fn one_core_is_the_serial_path() {
+    let items = (0..100u32).collect::<Vec<_>>();
+
+    let out = map_with_cores(&items, cores(1), |item| Ok::<_, ()>(*item + 1));
+
+    assert_eq!(out, Ok((1..101u32).collect::<Vec<_>>()));
+}
+
+// --- ordering of collected results -------------------------------------
+
+#[test]
+fn collecting_places_results_by_index_rather_than_by_arrival() {
+    let claimed = vec![
+        (2usize, Ok::<&str, ()>("third")),
+        (0, Ok("first")),
+        (1, Ok("second")),
+    ];
+
+    assert_eq!(
+        collect_in_order(claimed, 3),
+        Ok(vec!["first", "second", "third"])
+    );
+}
+
+#[test]
+fn collecting_reports_the_lowest_indexed_error_past_an_unclaimed_slot() {
+    // Index 1 was never claimed; index 2 failed. The unclaimed slot must not
+    // shadow the error.
+    let claimed = vec![(0usize, Ok::<u8, &str>(1)), (2, Err("boom"))];
+
+    assert_eq!(collect_in_order(claimed, 4), Err("boom"));
+}
+
+#[test]
+fn a_panicking_body_propagates() {
+    let items = (0..64usize).collect::<Vec<_>>();
+
+    let panicked = std::panic::catch_unwind(|| {
+        map_with_cores(&items, cores(4), |item| {
+            assert_ne!(*item, 32, "deliberate");
+            Ok::<_, ()>(*item)
+        })
+    });
+
+    assert!(
+        panicked.is_err(),
+        "a panic in the body must not be swallowed"
+    );
+}

--- a/crates/uf_infra/tests/dependencies.rs
+++ b/crates/uf_infra/tests/dependencies.rs
@@ -1,0 +1,127 @@
+//! What uf's own crates are allowed to depend on.
+//!
+//! uf schedules its own work. `uf_infra::parallel` is the one data-parallel
+//! primitive the toolchain needs, `uf_test` runs its own worker pool, and
+//! nothing in uf is asynchronous — so neither a parallel iterator framework nor
+//! an async runtime has a place in the dependency graph, and the way to keep
+//! one out is to say so somewhere that fails.
+//!
+//! This is about uf's crates only. `upstream/flow` is Meta's source, vendored
+//! as a submodule, and it uses rayon itself; that is its business and not ours
+//! to rewrite.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Crates uf may not depend on, and what to reach for instead.
+const BANNED: &[(&str, &str)] = &[
+    ("rayon", "uf_infra::parallel::map"),
+    ("tokio", "std::thread, as uf_test does"),
+    ("async-std", "std::thread, as uf_test does"),
+    ("smol", "std::thread, as uf_test does"),
+    ("futures", "std::thread, as uf_test does"),
+];
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the crate lives inside the workspace")
+}
+
+/// Every `crates/*/Cargo.toml`, which is every crate uf owns.
+fn uf_manifests() -> Vec<PathBuf> {
+    let mut manifests = fs::read_dir(workspace_root().join("crates"))
+        .expect("the workspace has a crates directory")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("Cargo.toml"))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    manifests.sort();
+    manifests
+}
+
+/// The dependency names one manifest declares, in any of its three tables.
+fn declared_dependencies(manifest: &str) -> Vec<String> {
+    manifest
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.starts_with('#') && !line.starts_with('['))
+        .filter_map(|line| line.split_once(['=', '.']))
+        .map(|(name, _)| name.trim().trim_matches('"').to_owned())
+        .collect()
+}
+
+#[test]
+fn no_uf_crate_depends_on_a_parallel_or_async_runtime() {
+    let mut offenders = Vec::new();
+
+    for manifest in uf_manifests() {
+        let source = fs::read_to_string(&manifest).expect("a readable manifest");
+        let declared = declared_dependencies(&source);
+        for (banned, instead) in BANNED {
+            if declared.iter().any(|name| name == banned) {
+                let crate_name = manifest
+                    .parent()
+                    .and_then(Path::file_name)
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                offenders.push(format!("{crate_name} depends on {banned}; use {instead}"));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "{}\n\nuf schedules its own work; see crates/uf_infra/src/parallel.rs",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn the_workspace_does_not_offer_one_either() {
+    let root = fs::read_to_string(workspace_root().join("Cargo.toml")).expect("a root manifest");
+    let declared = declared_dependencies(&root);
+
+    for (banned, instead) in BANNED {
+        assert!(
+            !declared.iter().any(|name| name == banned),
+            "the workspace still offers {banned} to any crate that asks; use {instead}"
+        );
+    }
+}
+
+/// The parser reads what a manifest actually declares, in every table shape.
+#[test]
+fn dependencies_are_read_from_every_table_shape() {
+    let manifest = r#"
+[package]
+name = "example"
+
+[dependencies]
+plain = "1"
+detailed = { version = "1", features = ["x"] }
+workspace-style.workspace = true
+
+[dev-dependencies]
+only-for-tests = "1"
+
+[build-dependencies]
+only-for-build = "1"
+"#;
+
+    let declared = declared_dependencies(manifest);
+
+    for expected in [
+        "plain",
+        "detailed",
+        "workspace-style",
+        "only-for-tests",
+        "only-for-build",
+    ] {
+        assert!(
+            declared.iter().any(|name| name == expected),
+            "{expected} was not read out of the manifest, got {declared:?}"
+        );
+    }
+}

--- a/crates/uf_lib/tests/package_surface.rs
+++ b/crates/uf_lib/tests/package_surface.rs
@@ -31,23 +31,30 @@ const INTERNAL_DIR: &str = "internal";
 
 /// Packages the host runs directly, before any Flow transform exists. See the
 /// module docs for why they are plain JavaScript.
-const HOST_EXECUTED_PACKAGES: &[&str] = &["vite"];
+const PLAIN_JAVASCRIPT_PACKAGES: &[&str] = &["vite"];
 
 /// Individual modules that are process entry points, and so run when they are
 /// loaded because that is what running them means. Everything else in their
-/// package is held to the ordinary bar.
-const HOST_EXECUTED_MODULES: &[&str] = &["test/worker.js"];
+/// package is held to the ordinary bar — including the Flow pragma: an entry
+/// point is still Flow, it just does something when it loads.
+const ENTRY_POINT_MODULES: &[&str] = &["test/worker.js"];
 
-/// Whether `module` (relative to `packages/`) belongs to a host-executed
-/// package.
-fn is_host_executed(module: &Utf8Path) -> bool {
-    if HOST_EXECUTED_MODULES.contains(&module.as_str()) {
-        return true;
-    }
+/// Whether `module` (relative to `packages/`) is plain JavaScript by necessity.
+///
+/// Kept apart from [`runs_at_import`] because the two exemptions answer
+/// different questions. Reaching for one predicate for both is how
+/// `packages/test/worker.js` — Flow, and a process entry point — ended up
+/// exempt from the `// @flow` pragma it in fact carries.
+fn is_plain_javascript(module: &Utf8Path) -> bool {
     module
         .iter()
         .next()
-        .is_some_and(|package| HOST_EXECUTED_PACKAGES.contains(&package))
+        .is_some_and(|package| PLAIN_JAVASCRIPT_PACKAGES.contains(&package))
+}
+
+/// Whether `module` is allowed to run something when it is imported.
+fn runs_at_import(module: &Utf8Path) -> bool {
+    ENTRY_POINT_MODULES.contains(&module.as_str()) || is_plain_javascript(module)
 }
 
 /// Keywords a top-level statement in a shipped module may begin with. Anything
@@ -530,13 +537,38 @@ fn shipped_package_contains_only_modules_and_manifests() {
 #[test]
 fn shipped_modules_start_with_the_flow_pragma() {
     for module in shipped_modules() {
-        if is_host_executed(&module) {
+        if is_plain_javascript(&module) {
             continue;
         }
         let source = read(&module);
         assert!(
             source.starts_with("// @flow\n"),
             "{module} must open with the `// @flow` pragma"
+        );
+    }
+}
+
+/// A module the host runs before any transform exists must say so in its own
+/// docblock, not only in this file's exemption list.
+///
+/// `@noflow` is Flow's declaration that a file is plain JavaScript, and it is
+/// the one uf reads: `uf check` runs inference over every `.js` in a project,
+/// because uf is Flow-first and a file with no pragma is still a file uf owns.
+/// Without this, `@uniflowed/vite` was exempt from the pragma rule here and
+/// nowhere else — so `uf check` type-checked it anyway and reported 258 errors
+/// against source that is plain JavaScript on purpose.
+#[test]
+fn plain_javascript_modules_declare_themselves_plain_javascript() {
+    for module in shipped_modules() {
+        if !is_plain_javascript(&module) {
+            continue;
+        }
+        let source = read(&module);
+        assert!(
+            source.starts_with("// @noflow\n"),
+            "{module} is exempt from the `// @flow` pragma, so it must open with \
+             `// @noflow` — the exemption has to be in the file the checker reads, \
+             not only in this test"
         );
     }
 }
@@ -561,7 +593,7 @@ fn shipped_modules_never_use_star_re_exports() {
 #[test]
 fn shipped_modules_have_no_import_time_side_effects() {
     for module in shipped_modules() {
-        if is_host_executed(&module) {
+        if runs_at_import(&module) {
             continue;
         }
         let code = code_only(&read(&module));

--- a/crates/uf_lib/tests/package_surface.rs
+++ b/crates/uf_lib/tests/package_surface.rs
@@ -950,7 +950,7 @@ fn covariant_opaque_types_are_defined_with_a_covariant_carrier() {
             let Some(open) = declaration.find('<') else {
                 continue;
             };
-            if !declaration[open..].starts_with("<+") {
+            if !declaration[open..].starts_with("<out ") {
                 continue;
             }
             assert!(
@@ -960,8 +960,7 @@ fn covariant_opaque_types_are_defined_with_a_covariant_carrier() {
                     || declaration.contains("TagCarrier")
                     || declaration.contains("LayerCarrier"),
                 "{module} declares a covariant opaque type without a covariant \
-                 carrier, so the `+` sigil promises more than the definition \
-                 delivers: {}",
+                 carrier, so `out` promises more than the definition delivers: {}",
                 declaration.trim()
             );
             covariant.push(module.clone());
@@ -971,6 +970,45 @@ fn covariant_opaque_types_are_defined_with_a_covariant_carrier() {
     assert!(
         !covariant.is_empty(),
         "expected at least one covariant opaque type in the shipped surface"
+    );
+}
+
+/// The shipped surface is written in the Flow of today, not the Flow of 2019.
+///
+/// Three spellings the checker itself now reports as deprecated: `+prop` for a
+/// read-only property, `<+T>` for a covariant type parameter, and `<T: Bound>`
+/// for a bound. Modern Flow spells them `readonly prop`, `<out T>` and
+/// `<T extends Bound>`, and `uf check` reported 1015 errors against this
+/// repository's own packages for using the old ones.
+///
+/// A test rather than a one-time cleanup, because the old spellings still parse
+/// and a contributor who learned Flow five years ago will reach for them.
+#[test]
+fn the_shipped_surface_uses_modern_flow_spellings() {
+    let mut legacy = BTreeSet::new();
+
+    for module in shipped_modules() {
+        let code = code_only(&read(&module));
+        for (number, line) in code.lines().enumerate() {
+            let number = number + 1;
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('+') && trimmed.contains(':') {
+                legacy.insert(format!("{module}:{number}: `+prop` is now `readonly prop`"));
+            }
+            if line.contains("<+") {
+                legacy.insert(format!("{module}:{number}: `<+T>` is now `<out T>`"));
+            }
+            if line.contains("<-") {
+                legacy.insert(format!("{module}:{number}: `<-T>` is now `<in T>`"));
+            }
+        }
+    }
+
+    assert!(
+        legacy.is_empty(),
+        "{} deprecated Flow spellings in the shipped surface:\n{}",
+        legacy.len(),
+        legacy.into_iter().collect::<Vec<_>>().join("\n")
     );
 }
 

--- a/crates/uf_lint/Cargo.toml
+++ b/crates/uf_lint/Cargo.toml
@@ -15,7 +15,6 @@ uf_infra = { path = "../uf_infra" }
 uf_react_compiler = { path = "../uf_react_compiler" }
 uf_router = { path = "../uf_router" }
 phf.workspace = true
-rayon.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 

--- a/crates/uf_lint/src/lib.rs
+++ b/crates/uf_lint/src/lib.rs
@@ -27,7 +27,6 @@ mod runner;
 mod scan;
 mod suppression;
 
-use rayon::prelude::*;
 use thiserror::Error;
 use uf_config::{RuleLevel, UniflowedConfig};
 
@@ -147,10 +146,7 @@ pub fn lint_sources(
     files: &[SourceFile],
     config: &UniflowedConfig,
 ) -> Result<LintReport, LintError> {
-    let per_file = files
-        .par_iter()
-        .map(|file| lint_file(file, config))
-        .collect::<Result<Vec<_>, _>>()?;
+    let per_file = uf_infra::parallel::map(files, |file| lint_file(file, config))?;
 
     let mut diagnostics = per_file.into_iter().flatten().collect::<Vec<_>>();
     sort_diagnostics(&mut diagnostics);

--- a/crates/uf_rsc/Cargo.toml
+++ b/crates/uf_rsc/Cargo.toml
@@ -11,7 +11,6 @@ authors.workspace = true
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true
-rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/uf_rsc/src/project.rs
+++ b/crates/uf_rsc/src/project.rs
@@ -14,7 +14,6 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::CompactString;
-use rayon::prelude::*;
 use walkdir::WalkDir;
 
 use crate::RscError;
@@ -97,19 +96,16 @@ pub fn analyze_project(
 ) -> Result<RscAnalysis, RscError> {
     let paths = collect_module_paths(root, options)?;
 
-    let modules = paths
-        .par_iter()
-        .map(|(absolute, relative)| {
-            let bytes = std::fs::read(absolute).map_err(|source| RscError::Read {
-                path: relative.clone(),
-                source,
-            })?;
-            let source = uf_infra::validate_utf8(&bytes).map_err(|_| RscError::NonUtf8Source {
-                path: relative.clone(),
-            })?;
-            Ok(RscModuleInput::from_source(relative.clone(), source))
-        })
-        .collect::<Result<Vec<_>, RscError>>()?;
+    let modules = uf_infra::parallel::map(&paths, |(absolute, relative)| {
+        let bytes = std::fs::read(absolute).map_err(|source| RscError::Read {
+            path: relative.clone(),
+            source,
+        })?;
+        let source = uf_infra::validate_utf8(&bytes).map_err(|_| RscError::NonUtf8Source {
+            path: relative.clone(),
+        })?;
+        Ok(RscModuleInput::from_source(relative.clone(), source))
+    })?;
 
     let mut builder = RscGraphBuilder::new();
     for module in modules {

--- a/crates/uf_term/src/capability.rs
+++ b/crates/uf_term/src/capability.rs
@@ -8,6 +8,8 @@
 
 use std::io::IsTerminal;
 
+use crate::image::{ImageEnv, ImageProtocol};
+
 /// Colour behaviour requested on the command line, i.e. `--color`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ColorChoice {
@@ -238,6 +240,7 @@ pub struct Capabilities {
     color: ColorLevel,
     glyphs: GlyphSet,
     tty: Tty,
+    image: Option<ImageProtocol>,
 }
 
 impl Capabilities {
@@ -254,11 +257,19 @@ impl Capabilities {
     /// 6. `CLICOLOR=0`
     /// 7. whether the stream is a terminal
     /// 8. `COLORTERM` / `TERM`
+    ///
+    /// The inline-image protocol is resolved here too, and gated on the same
+    /// two answers a caller would otherwise have to re-ask: an image is a large
+    /// escape sequence, so a stream that may not carry colour may not carry one
+    /// either, and a stream nobody is looking at gets bytes in a log rather
+    /// than a picture.
     pub fn detect(choice: ColorChoice, tty: Tty, env: &TerminalEnv) -> Self {
+        let color = detect_color(choice, tty, env);
         Self {
-            color: detect_color(choice, tty, env),
+            color,
             glyphs: detect_glyphs(env),
             tty,
+            image: detect_image(color, tty, &ImageEnv::from_process()),
         }
     }
 
@@ -280,13 +291,26 @@ impl Capabilities {
             color: ColorLevel::Never,
             glyphs: GlyphSet::Ascii,
             tty: Tty::Piped,
+            image: None,
         }
     }
 
     /// Build a capability directly, for tests and for callers that already know
     /// what they want.
     pub fn new(color: ColorLevel, glyphs: GlyphSet, tty: Tty) -> Self {
-        Self { color, glyphs, tty }
+        Self {
+            color,
+            glyphs,
+            tty,
+            image: None,
+        }
+    }
+
+    /// The same, with an inline-image protocol.
+    #[must_use]
+    pub fn with_image(mut self, image: Option<ImageProtocol>) -> Self {
+        self.image = image;
+        self
     }
 
     /// How much colour this stream can carry.
@@ -308,6 +332,23 @@ impl Capabilities {
     pub fn is_unicode(self) -> bool {
         matches!(self.glyphs, GlyphSet::Unicode)
     }
+
+    /// The inline-image protocol this stream accepts, if any.
+    pub fn image(self) -> Option<ImageProtocol> {
+        self.image
+    }
+}
+
+/// Which inline-image protocol may be used on a stream.
+///
+/// Separate from [`ImageEnv::protocol`] because that answers what the terminal
+/// *understands* and this answers what uf may *send*: the two differ whenever
+/// colour is off or the stream is not a terminal.
+fn detect_image(color: ColorLevel, tty: Tty, env: &ImageEnv) -> Option<ImageProtocol> {
+    if !color.is_enabled() || !matches!(tty, Tty::Interactive) {
+        return None;
+    }
+    env.protocol()
 }
 
 fn detect_color(choice: ColorChoice, tty: Tty, env: &TerminalEnv) -> ColorLevel {

--- a/crates/uf_term/src/capability/tests.rs
+++ b/crates/uf_term/src/capability/tests.rs
@@ -257,3 +257,58 @@ fn case_insensitive_contains_handles_edges() {
     assert!(!contains_ignore_ascii_case("ab", "abc"));
     assert!(contains_ignore_ascii_case("abc", ""));
 }
+
+// --- inline images -----------------------------------------------------
+
+/// An image is a much larger escape sequence than a colour, so a stream that
+/// may not carry colour may not carry one either.
+#[test]
+fn colour_being_off_turns_inline_images_off() {
+    let kitty = ImageEnv::default().with_term("xterm-kitty");
+
+    assert_eq!(
+        detect_image(ColorLevel::Never, Tty::Interactive, &kitty),
+        None
+    );
+    assert_eq!(
+        detect_image(ColorLevel::TrueColor, Tty::Interactive, &kitty),
+        Some(ImageProtocol::Kitty)
+    );
+}
+
+/// A picture in a pipe is bytes in a log.
+#[test]
+fn a_piped_stream_never_gets_an_inline_image() {
+    let kitty = ImageEnv::default().with_term("xterm-kitty");
+
+    assert_eq!(
+        detect_image(ColorLevel::TrueColor, Tty::Piped, &kitty),
+        None
+    );
+}
+
+#[test]
+fn a_terminal_that_speaks_no_protocol_gets_no_image_however_capable_it_is() {
+    let plain = ImageEnv::default().with_term("xterm-256color");
+
+    assert_eq!(
+        detect_image(ColorLevel::TrueColor, Tty::Interactive, &plain),
+        None
+    );
+}
+
+#[test]
+fn the_conservative_floor_carries_no_image_protocol() {
+    assert_eq!(Capabilities::plain().image(), None);
+    assert_eq!(
+        Capabilities::new(ColorLevel::TrueColor, GlyphSet::Unicode, Tty::Interactive).image(),
+        None,
+        "a directly built capability opts in explicitly"
+    );
+    assert_eq!(
+        Capabilities::new(ColorLevel::TrueColor, GlyphSet::Unicode, Tty::Interactive)
+            .with_image(Some(ImageProtocol::ITerm2))
+            .image(),
+        Some(ImageProtocol::ITerm2)
+    );
+}

--- a/crates/uf_term/src/image.rs
+++ b/crates/uf_term/src/image.rs
@@ -1,0 +1,98 @@
+//! Drawing a real image in a terminal, where the terminal can draw one.
+//!
+//! uf's mark is a picture, and for years the only way to put a picture in a
+//! terminal was to approximate it out of block characters. That is no longer
+//! true: kitty, ghostty, WezTerm, iTerm2, Konsole, VS Code's terminal and Hyper
+//! all accept an image inline, and between them they cover most of the
+//! terminals anyone installs uf from.
+//!
+//! Two protocols cover all of them — [`kitty`] and [`iterm2`] — and this module
+//! is the whole of uf's use of either: encode one PNG, place it in a box
+//! measured in cells, hand back a string. It never queries the terminal, never
+//! writes a temporary file, and never blocks.
+//!
+//! **Nothing here decides whether to draw an image.** [`ImageEnv::protocol`]
+//! says what the terminal understands; whether uf *should* — colour is on, the
+//! stream is a terminal, the user has not asked for quiet — belongs to the
+//! caller, which already knows all three. The fallback is not this module's
+//! business either: uf's block mark renders on everything and is what a caller
+//! prints when this returns [`None`].
+
+mod base64;
+mod iterm2;
+mod kitty;
+mod protocol;
+
+#[cfg(test)]
+mod tests;
+
+pub use protocol::{ImageEnv, ImageProtocol};
+
+/// Base64 characters one kitty escape sequence may carry.
+///
+/// The protocol's own limit. Exceeding it is not a soft failure: the terminal
+/// discards the sequence and prints nothing.
+const MAX_PAYLOAD_CHARS: usize = 4096;
+
+/// Where an inline image goes, measured in terminal cells.
+///
+/// Cells rather than pixels, because the layout around the image is measured in
+/// cells and a terminal's cell size is not knowable from here. Both protocols
+/// scale the image into this box and preserve its aspect ratio, so the box is a
+/// bound and the picture is never stretched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Placement {
+    /// Width in cells.
+    pub columns: u16,
+    /// Height in cells.
+    pub rows: u16,
+}
+
+impl Placement {
+    /// A placement `columns` wide and `rows` tall.
+    #[must_use]
+    pub const fn new(columns: u16, rows: u16) -> Self {
+        Self { columns, rows }
+    }
+}
+
+/// Encode `png` for `protocol`, placed in `placement`.
+///
+/// Returns [`None`] for an empty payload rather than an escape sequence with
+/// nothing in it: a terminal handed one either prints nothing or prints the
+/// sequence, and the caller's block mark is better than both.
+#[must_use]
+pub fn inline_image(png: &[u8], protocol: ImageProtocol, placement: Placement) -> Option<String> {
+    if png.is_empty() {
+        return None;
+    }
+
+    let mut out = String::new();
+    match protocol {
+        ImageProtocol::Kitty => kitty::encode(png, placement, &mut out),
+        ImageProtocol::ITerm2 => iterm2::encode(png, placement, &mut out),
+    }
+    Some(out)
+}
+
+/// Append `value`'s decimal spelling to `out`.
+///
+/// `push_str(&value.to_string())` would allocate a `String` per number, and
+/// this module assembles escape sequences into one buffer on purpose.
+fn push_number(out: &mut String, value: impl Into<u64>) {
+    let mut value = value.into();
+    if value == 0 {
+        out.push('0');
+        return;
+    }
+    let mut digits = [0u8; 20];
+    let mut length = 0;
+    while value > 0 {
+        digits[length] = b'0' + (value % 10) as u8;
+        value /= 10;
+        length += 1;
+    }
+    for index in (0..length).rev() {
+        out.push(digits[index] as char);
+    }
+}

--- a/crates/uf_term/src/image/base64.rs
+++ b/crates/uf_term/src/image/base64.rs
@@ -1,0 +1,112 @@
+//! Standard base64, because both inline-image protocols carry their payload
+//! that way.
+//!
+//! Written here rather than depended on: `uf_term` has no dependencies, and an
+//! encoder with no alphabet options, no streaming, and no decoder is forty
+//! lines. A crate would be more code to audit than this is to read.
+
+/// The standard alphabet, RFC 4648 §4.
+const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Encode `bytes` as standard base64 with padding, appending to `out`.
+///
+/// Appends rather than returns, so a caller assembling an escape sequence
+/// writes the payload straight into the buffer it is already building.
+pub(super) fn encode_into(bytes: &[u8], out: &mut String) {
+    out.reserve(encoded_len(bytes.len()));
+
+    let chunks = bytes.as_chunks::<3>();
+    for chunk in chunks.0 {
+        let triple = u32::from(chunk[0]) << 16 | u32::from(chunk[1]) << 8 | u32::from(chunk[2]);
+        for shift in [18, 12, 6, 0] {
+            out.push(ALPHABET[(triple >> shift & 0x3f) as usize] as char);
+        }
+    }
+
+    match chunks.1 {
+        [] => {}
+        [one] => {
+            let triple = u32::from(*one) << 16;
+            out.push(ALPHABET[(triple >> 18 & 0x3f) as usize] as char);
+            out.push(ALPHABET[(triple >> 12 & 0x3f) as usize] as char);
+            out.push_str("==");
+        }
+        [one, two] => {
+            let triple = u32::from(*one) << 16 | u32::from(*two) << 8;
+            for shift in [18, 12, 6] {
+                out.push(ALPHABET[(triple >> shift & 0x3f) as usize] as char);
+            }
+            out.push('=');
+        }
+        // `as_chunks::<3>` cannot leave three or more bytes over.
+        _ => unreachable!("the remainder of a 3-byte chunking is shorter than 3"),
+    }
+}
+
+/// How many characters `encode_into` will append for `len` bytes.
+pub(super) const fn encoded_len(len: usize) -> usize {
+    len.div_ceil(3) * 4
+}
+
+/// Encode `bytes` into a fresh `String`.
+#[cfg(test)]
+pub(super) fn encode(bytes: &[u8]) -> String {
+    let mut out = String::new();
+    encode_into(bytes, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The vectors from RFC 4648 §10, which is what "standard base64" means.
+    #[test]
+    fn matches_the_rfc_4648_test_vectors() {
+        assert_eq!(encode(b""), "");
+        assert_eq!(encode(b"f"), "Zg==");
+        assert_eq!(encode(b"fo"), "Zm8=");
+        assert_eq!(encode(b"foo"), "Zm9v");
+        assert_eq!(encode(b"foob"), "Zm9vYg==");
+        assert_eq!(encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn encodes_every_byte_value() {
+        let all = (0u8..=255).collect::<Vec<_>>();
+        let encoded = encode(&all);
+
+        assert_eq!(encoded.len(), encoded_len(all.len()));
+        assert!(
+            encoded
+                .bytes()
+                .all(|byte| ALPHABET.contains(&byte) || byte == b'='),
+            "every character must be in the alphabet or be padding"
+        );
+    }
+
+    /// The high bit must survive: a PNG is mostly bytes above 0x7f, and an
+    /// encoder that sign-extended them would corrupt every image it sent.
+    #[test]
+    fn high_bytes_are_not_sign_extended() {
+        assert_eq!(encode(&[0xff, 0xff, 0xff]), "////");
+        assert_eq!(encode(&[0x80, 0x00, 0x00]), "gAAA");
+    }
+
+    #[test]
+    fn the_predicted_length_is_the_real_length() {
+        for len in 0..64 {
+            let bytes = vec![0xa5; len];
+            assert_eq!(encode(&bytes).len(), encoded_len(len), "at length {len}");
+        }
+    }
+
+    #[test]
+    fn encoding_appends_rather_than_replaces() {
+        let mut out = String::from("data:image/png;base64,");
+        encode_into(b"foobar", &mut out);
+
+        assert_eq!(out, "data:image/png;base64,Zm9vYmFy");
+    }
+}

--- a/crates/uf_term/src/image/iterm2.rs
+++ b/crates/uf_term/src/image/iterm2.rs
@@ -1,0 +1,33 @@
+//! iTerm2's inline images.
+//!
+//! One image is one operating system command:
+//!
+//! ```text
+//! ESC ] 1337 ; File = <key>=<value>;... : <base64 payload> BEL
+//! ```
+//!
+//! No chunking: the sequence carries the whole payload, and terminals that
+//! implement this read to the terminator. `size` is the *decoded* byte count,
+//! which iTerm2 uses to show progress while a large image arrives.
+
+use super::Placement;
+use super::base64::encode_into;
+use super::push_number;
+
+/// Write `png` as an iTerm2 inline image escape.
+///
+/// `width` and `height` are given in cells, so the image occupies the same
+/// space in the layout as the block mark it replaces. `preserveAspectRatio=1`
+/// makes that box a bound rather than a stretch, and `inline=1` is what
+/// separates displaying the image from downloading it as a file.
+pub(super) fn encode(png: &[u8], placement: Placement, out: &mut String) {
+    out.push_str("\x1b]1337;File=inline=1;preserveAspectRatio=1;size=");
+    push_number(out, png.len() as u64);
+    out.push_str(";width=");
+    push_number(out, placement.columns);
+    out.push_str(";height=");
+    push_number(out, placement.rows);
+    out.push(':');
+    encode_into(png, out);
+    out.push('\x07');
+}

--- a/crates/uf_term/src/image/kitty.rs
+++ b/crates/uf_term/src/image/kitty.rs
@@ -1,0 +1,54 @@
+//! The kitty graphics protocol.
+//!
+//! One image becomes one or more Application Programming Command sequences:
+//!
+//! ```text
+//! ESC _G <key>=<value>,... ; <base64 payload> ESC \
+//! ```
+//!
+//! The payload is chunked because the protocol caps one escape sequence's
+//! payload at 4096 base64 characters. Every chunk but the last carries `m=1`,
+//! "more is coming"; the last carries `m=0`. Only the first chunk carries the
+//! rest of the keys — repeating them on a continuation is an error, not a
+//! redundancy.
+
+use super::base64::encode_into;
+use super::{MAX_PAYLOAD_CHARS, Placement, push_number};
+
+/// Write `png` as kitty graphics escapes.
+///
+/// - `a=T` transmit and display in one step, so nothing has to be freed later.
+/// - `f=100` the payload is a PNG, which the terminal decodes itself.
+/// - `t=d` the payload is the data, not a path — uf never writes a temporary
+///   file for this, which also means it works over ssh.
+/// - `c` and `r` place the image in a box that many cells wide and tall, so the
+///   surrounding layout is the same whatever the terminal's cell size is.
+pub(super) fn encode(png: &[u8], placement: Placement, out: &mut String) {
+    let mut payload = String::new();
+    encode_into(png, &mut payload);
+
+    let mut rest = payload.as_str();
+    let mut first = true;
+    loop {
+        let take = rest.len().min(MAX_PAYLOAD_CHARS);
+        let (chunk, remainder) = rest.split_at(take);
+        rest = remainder;
+
+        out.push_str("\x1b_G");
+        if first {
+            out.push_str("a=T,f=100,t=d,c=");
+            push_number(out, placement.columns);
+            out.push_str(",r=");
+            push_number(out, placement.rows);
+            out.push(',');
+            first = false;
+        }
+        out.push_str(if rest.is_empty() { "m=0;" } else { "m=1;" });
+        out.push_str(chunk);
+        out.push_str("\x1b\\");
+
+        if rest.is_empty() {
+            break;
+        }
+    }
+}

--- a/crates/uf_term/src/image/protocol.rs
+++ b/crates/uf_term/src/image/protocol.rs
@@ -1,0 +1,172 @@
+//! Which inline-image protocol the attached terminal speaks, if any.
+//!
+//! There is no portable way to *ask*. Both protocols have a query form, but the
+//! answer arrives on stdin — and uf's two callers cannot read it: `curl … | sh`
+//! has the script on stdin, and a CLI that blocked on a reply would hang on
+//! every terminal that does not implement the query. So this is detection from
+//! the environment, which is what every other tool that draws images in a
+//! terminal does, and it is deliberately conservative: an unrecognised terminal
+//! gets the block mark, which always renders.
+
+/// An inline-image protocol a terminal understands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageProtocol {
+    /// The kitty graphics protocol, `ESC _G … ESC \`.
+    ///
+    /// kitty's own, also implemented by ghostty and by WezTerm.
+    Kitty,
+    /// iTerm2's inline images, `ESC ] 1337 ; File= … BEL`.
+    ///
+    /// iTerm2's own, also implemented by WezTerm, Konsole, VS Code's terminal,
+    /// and Hyper.
+    ITerm2,
+}
+
+/// The environment variables that identify a terminal emulator.
+///
+/// Captured into an owned value for the same reason [`crate::TerminalEnv`] is:
+/// detection stays a pure function of its inputs and is unit-testable without
+/// mutating the process environment.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImageEnv {
+    /// `TERM`, which identifies ghostty and kitty by their terminfo names.
+    pub term: Option<String>,
+    /// `TERM_PROGRAM`, which is how iTerm2, WezTerm and VS Code identify
+    /// themselves.
+    pub term_program: Option<String>,
+    /// `KITTY_WINDOW_ID`, set by kitty in every window it owns.
+    pub kitty_window_id: Option<String>,
+    /// `KONSOLE_VERSION`, set by Konsole, which speaks the iTerm2 protocol.
+    pub konsole_version: Option<String>,
+    /// `TMUX`, set inside a tmux session.
+    pub tmux: Option<String>,
+    /// `STY`, set inside a GNU screen session.
+    pub sty: Option<String>,
+    /// `UF_INLINE_IMAGES`; `0`/`never` refuses, `kitty`/`iterm2` force one.
+    pub uf_inline_images: Option<String>,
+}
+
+impl ImageEnv {
+    /// Read the relevant variables from the process environment.
+    pub fn from_process() -> Self {
+        Self {
+            term: var("TERM"),
+            term_program: var("TERM_PROGRAM"),
+            kitty_window_id: var("KITTY_WINDOW_ID"),
+            konsole_version: var("KONSOLE_VERSION"),
+            tmux: var("TMUX"),
+            sty: var("STY"),
+            uf_inline_images: var("UF_INLINE_IMAGES"),
+        }
+    }
+
+    /// Set `TERM`.
+    #[must_use]
+    pub fn with_term(mut self, value: &str) -> Self {
+        self.term = Some(value.to_owned());
+        self
+    }
+
+    /// Set `TERM_PROGRAM`.
+    #[must_use]
+    pub fn with_term_program(mut self, value: &str) -> Self {
+        self.term_program = Some(value.to_owned());
+        self
+    }
+
+    /// Set `KITTY_WINDOW_ID`.
+    #[must_use]
+    pub fn with_kitty_window_id(mut self, value: &str) -> Self {
+        self.kitty_window_id = Some(value.to_owned());
+        self
+    }
+
+    /// Set `KONSOLE_VERSION`.
+    #[must_use]
+    pub fn with_konsole_version(mut self, value: &str) -> Self {
+        self.konsole_version = Some(value.to_owned());
+        self
+    }
+
+    /// Set `TMUX`.
+    #[must_use]
+    pub fn with_tmux(mut self, value: &str) -> Self {
+        self.tmux = Some(value.to_owned());
+        self
+    }
+
+    /// Set `STY`.
+    #[must_use]
+    pub fn with_sty(mut self, value: &str) -> Self {
+        self.sty = Some(value.to_owned());
+        self
+    }
+
+    /// Set `UF_INLINE_IMAGES`.
+    #[must_use]
+    pub fn with_uf_inline_images(mut self, value: &str) -> Self {
+        self.uf_inline_images = Some(value.to_owned());
+        self
+    }
+
+    /// Which protocol to use, or [`None`] to draw the block mark instead.
+    ///
+    /// `UF_INLINE_IMAGES` wins over everything, in both directions: a terminal
+    /// this does not recognise can be told to try, and one it recognises
+    /// wrongly can be told to stop. That is the whole escape hatch, and it is
+    /// an environment variable rather than a config key because the answer
+    /// belongs to the terminal a person is sitting at, not to the project they
+    /// happen to be in.
+    #[must_use]
+    pub fn protocol(&self) -> Option<ImageProtocol> {
+        match non_empty(self.uf_inline_images.as_deref()) {
+            Some("0" | "never" | "no" | "off" | "false") => return None,
+            Some("kitty") => return Some(ImageProtocol::Kitty),
+            Some("iterm2" | "iterm") => return Some(ImageProtocol::ITerm2),
+            // `1`/`yes` asks for the best available, which is what detection
+            // already answers, so it falls through rather than forcing one.
+            _ => {}
+        }
+
+        // A multiplexer rewrites the stream it forwards, and neither protocol
+        // survives that intact without passthrough that is off by default. The
+        // failure mode is not a missing image, it is escape-sequence garbage
+        // across the pane, so this refuses rather than guesses.
+        if non_empty(self.tmux.as_deref()).is_some() || non_empty(self.sty.as_deref()).is_some() {
+            return None;
+        }
+
+        if non_empty(self.kitty_window_id.as_deref()).is_some() {
+            return Some(ImageProtocol::Kitty);
+        }
+
+        if let Some(term) = non_empty(self.term.as_deref()) {
+            // Both are terminfo names, matched on a substring because a
+            // terminal is commonly reached through `xterm-kitty`, `xterm-ghostty`
+            // or a `-direct` variant of either.
+            if term.contains("kitty") || term.contains("ghostty") {
+                return Some(ImageProtocol::Kitty);
+            }
+        }
+
+        match non_empty(self.term_program.as_deref()) {
+            // WezTerm implements both; kitty's is the one it implements more
+            // completely, and the one that places an image in cells rather than
+            // at the cursor.
+            Some("WezTerm" | "ghostty") => Some(ImageProtocol::Kitty),
+            Some("iTerm.app" | "vscode" | "Hyper" | "rio") => Some(ImageProtocol::ITerm2),
+            _ if non_empty(self.konsole_version.as_deref()).is_some() => {
+                Some(ImageProtocol::ITerm2)
+            }
+            _ => None,
+        }
+    }
+}
+
+fn var(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}

--- a/crates/uf_term/src/image/tests.rs
+++ b/crates/uf_term/src/image/tests.rs
@@ -1,0 +1,266 @@
+use super::*;
+
+/// A payload long enough to force kitty's chunking, and short enough to read.
+fn long_png() -> Vec<u8> {
+    // 4096 base64 characters carry 3072 bytes, so this is just over two chunks.
+    (0..7000u32).map(|byte| byte as u8).collect()
+}
+
+const PNG: &[u8] = b"\x89PNG\r\n\x1a\n-not-really-a-png";
+const PLACEMENT: Placement = Placement::new(20, 5);
+
+#[test]
+fn an_empty_payload_produces_no_escape_at_all() {
+    for protocol in [ImageProtocol::Kitty, ImageProtocol::ITerm2] {
+        assert_eq!(
+            inline_image(&[], protocol, PLACEMENT),
+            None,
+            "{protocol:?} should refuse an empty image"
+        );
+    }
+}
+
+#[test]
+fn the_kitty_escape_transmits_a_png_and_displays_it_in_cells() {
+    let escape = inline_image(PNG, ImageProtocol::Kitty, PLACEMENT).expect("a payload");
+
+    assert!(escape.starts_with("\x1b_Ga=T,f=100,t=d,c=20,r=5,m=0;"));
+    assert!(escape.ends_with("\x1b\\"));
+}
+
+#[test]
+fn a_long_kitty_payload_is_chunked_and_only_the_last_chunk_says_so() {
+    let png = long_png();
+    let escape = inline_image(&png, ImageProtocol::Kitty, PLACEMENT).expect("a payload");
+
+    let chunks = escape.split("\x1b_G").skip(1).collect::<Vec<_>>();
+    assert!(chunks.len() > 1, "7000 bytes must not fit in one chunk");
+
+    for (index, chunk) in chunks.iter().enumerate() {
+        let last = index + 1 == chunks.len();
+        let payload = chunk.split_once(';').expect("keys then payload").1;
+        let payload = payload.strip_suffix("\x1b\\").expect("chunk terminator");
+
+        assert!(
+            payload.len() <= MAX_PAYLOAD_CHARS,
+            "chunk {index} carries {} characters, over the protocol's limit",
+            payload.len()
+        );
+        assert_eq!(
+            chunk.contains("m=0;"),
+            last,
+            "only the last chunk may say the transmission is complete"
+        );
+        assert_eq!(
+            chunk.contains("a=T"),
+            index == 0,
+            "only the first chunk carries the keys"
+        );
+    }
+}
+
+/// Reassembling every chunk's payload must give back the original image.
+#[test]
+fn the_chunks_of_a_kitty_escape_reassemble_into_the_whole_payload() {
+    let png = long_png();
+    let escape = inline_image(&png, ImageProtocol::Kitty, PLACEMENT).expect("a payload");
+
+    let reassembled = escape
+        .split("\x1b_G")
+        .skip(1)
+        .map(|chunk| {
+            chunk
+                .split_once(';')
+                .expect("keys then payload")
+                .1
+                .strip_suffix("\x1b\\")
+                .expect("chunk terminator")
+        })
+        .collect::<String>();
+
+    let mut expected = String::new();
+    base64::encode_into(&png, &mut expected);
+    assert_eq!(reassembled, expected);
+}
+
+#[test]
+fn the_iterm2_escape_is_one_sequence_carrying_the_decoded_size() {
+    let escape = inline_image(PNG, ImageProtocol::ITerm2, PLACEMENT).expect("a payload");
+
+    assert!(escape.starts_with("\x1b]1337;File=inline=1;preserveAspectRatio=1;size="));
+    assert!(escape.contains(&format!("size={};", PNG.len())));
+    assert!(escape.contains("width=20;height=5:"));
+    assert!(escape.ends_with('\x07'));
+    assert_eq!(escape.matches("\x1b]1337").count(), 1);
+}
+
+#[test]
+fn the_iterm2_payload_is_the_base64_of_the_image() {
+    let escape = inline_image(PNG, ImageProtocol::ITerm2, PLACEMENT).expect("a payload");
+
+    let payload = escape
+        .rsplit_once(':')
+        .expect("keys then payload")
+        .1
+        .strip_suffix('\x07')
+        .expect("bell terminator");
+
+    let mut expected = String::new();
+    base64::encode_into(PNG, &mut expected);
+    assert_eq!(payload, expected);
+}
+
+#[test]
+fn a_placement_is_reported_in_the_escape_it_produces() {
+    let escape =
+        inline_image(PNG, ImageProtocol::Kitty, Placement::new(120, 40)).expect("a payload");
+    assert!(escape.contains("c=120,r=40"), "{escape:?}");
+
+    let escape =
+        inline_image(PNG, ImageProtocol::ITerm2, Placement::new(120, 40)).expect("a payload");
+    assert!(escape.contains("width=120;height=40"), "{escape:?}");
+}
+
+#[test]
+fn numbers_are_written_without_allocating_a_string_per_number() {
+    let mut out = String::new();
+    for value in [0u32, 1, 9, 10, 99, 100, 4096, 65535, 1_000_000] {
+        out.clear();
+        push_number(&mut out, value);
+        assert_eq!(out, value.to_string(), "for {value}");
+    }
+}
+
+// --- protocol detection ------------------------------------------------
+
+#[test]
+fn an_unrecognised_terminal_gets_no_protocol() {
+    assert_eq!(ImageEnv::default().protocol(), None);
+    assert_eq!(
+        ImageEnv::default().with_term("xterm-256color").protocol(),
+        None
+    );
+    assert_eq!(ImageEnv::default().with_term("dumb").protocol(), None);
+}
+
+#[test]
+fn kitty_is_recognised_by_its_window_id_and_by_terminfo() {
+    assert_eq!(
+        ImageEnv::default().with_kitty_window_id("1").protocol(),
+        Some(ImageProtocol::Kitty)
+    );
+    assert_eq!(
+        ImageEnv::default().with_term("xterm-kitty").protocol(),
+        Some(ImageProtocol::Kitty)
+    );
+}
+
+#[test]
+fn ghostty_and_wezterm_speak_the_kitty_protocol() {
+    assert_eq!(
+        ImageEnv::default().with_term("xterm-ghostty").protocol(),
+        Some(ImageProtocol::Kitty)
+    );
+    assert_eq!(
+        ImageEnv::default().with_term_program("WezTerm").protocol(),
+        Some(ImageProtocol::Kitty)
+    );
+}
+
+#[test]
+fn iterm2_konsole_and_vscode_speak_the_iterm2_protocol() {
+    assert_eq!(
+        ImageEnv::default()
+            .with_term_program("iTerm.app")
+            .protocol(),
+        Some(ImageProtocol::ITerm2)
+    );
+    assert_eq!(
+        ImageEnv::default().with_term_program("vscode").protocol(),
+        Some(ImageProtocol::ITerm2)
+    );
+    assert_eq!(
+        ImageEnv::default()
+            .with_konsole_version("220803")
+            .protocol(),
+        Some(ImageProtocol::ITerm2)
+    );
+}
+
+/// A multiplexer rewrites the stream, and the failure mode is escape-sequence
+/// garbage across the pane rather than a missing picture.
+#[test]
+fn a_multiplexer_turns_inline_images_off() {
+    assert_eq!(
+        ImageEnv::default()
+            .with_kitty_window_id("1")
+            .with_tmux("/tmp/tmux-501/default,1,0")
+            .protocol(),
+        None
+    );
+    assert_eq!(
+        ImageEnv::default()
+            .with_term_program("iTerm.app")
+            .with_sty("4242.pts-0.host")
+            .protocol(),
+        None
+    );
+}
+
+#[test]
+fn the_environment_override_wins_in_both_directions() {
+    assert_eq!(
+        ImageEnv::default()
+            .with_kitty_window_id("1")
+            .with_uf_inline_images("0")
+            .protocol(),
+        None,
+        "a recognised terminal can be told to stop"
+    );
+    assert_eq!(
+        ImageEnv::default()
+            .with_uf_inline_images("kitty")
+            .protocol(),
+        Some(ImageProtocol::Kitty),
+        "an unrecognised terminal can be told to try"
+    );
+    assert_eq!(
+        ImageEnv::default()
+            .with_uf_inline_images("iterm2")
+            .protocol(),
+        Some(ImageProtocol::ITerm2)
+    );
+}
+
+/// `UF_INLINE_IMAGES=1` asks for the best available rather than forcing one,
+/// so it must not override the multiplexer refusal or invent a protocol.
+#[test]
+fn asking_for_images_in_general_falls_through_to_detection() {
+    assert_eq!(
+        ImageEnv::default().with_uf_inline_images("1").protocol(),
+        None
+    );
+    assert_eq!(
+        ImageEnv::default()
+            .with_uf_inline_images("1")
+            .with_term("xterm-kitty")
+            .protocol(),
+        Some(ImageProtocol::Kitty)
+    );
+}
+
+#[test]
+fn an_empty_variable_is_the_same_as_an_unset_one() {
+    assert_eq!(
+        ImageEnv::default()
+            .with_term("xterm-kitty")
+            .with_tmux("")
+            .protocol(),
+        Some(ImageProtocol::Kitty),
+        "an empty TMUX is not a tmux session"
+    );
+    assert_eq!(
+        ImageEnv::default().with_kitty_window_id("").protocol(),
+        None
+    );
+}

--- a/crates/uf_term/src/lib.rs
+++ b/crates/uf_term/src/lib.rs
@@ -55,6 +55,7 @@
 mod capability;
 mod diagnostic;
 mod glyph;
+mod image;
 mod progress;
 mod render;
 mod style;
@@ -67,6 +68,7 @@ mod tree;
 pub use crate::capability::{Capabilities, ColorChoice, ColorLevel, GlyphSet, TerminalEnv, Tty};
 pub use crate::diagnostic::{CodeFrame, DiagnosticLevel};
 pub use crate::glyph::{ASCII_GLYPHS, Glyphs, Status, UNICODE_GLYPHS};
+pub use crate::image::{ImageEnv, ImageProtocol, Placement, inline_image};
 pub use crate::progress::{DEFAULT_TICK, Progress};
 pub use crate::render::{KeyValue, Renderer};
 pub use crate::style::{Attributes, Color, Style};

--- a/crates/uf_term/src/render.rs
+++ b/crates/uf_term/src/render.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use crate::capability::{Capabilities, ColorLevel, GlyphSet};
 use crate::diagnostic::{CodeFrame, render_frame};
 use crate::glyph::{Glyphs, Status};
+use crate::image::ImageProtocol;
 use crate::style::Style;
 use crate::text::{display_width, push_repeat, push_spaces, push_usize};
 use crate::theme::{Theme, Tone};
@@ -91,6 +92,11 @@ impl Renderer {
     /// The glyph set in use.
     pub fn glyph_set(&self) -> GlyphSet {
         self.capabilities.glyphs()
+    }
+
+    /// The inline-image protocol this stream accepts, if any.
+    pub fn image(&self) -> Option<ImageProtocol> {
+        self.capabilities.image()
     }
 
     /// The palette in use.

--- a/crates/uf_test/Cargo.toml
+++ b/crates/uf_test/Cargo.toml
@@ -13,7 +13,6 @@ uf_infra = { path = "../uf_infra" }
 uf_rsc = { path = "../uf_rsc" }
 camino.workspace = true
 compact_str.workspace = true
-rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -9,16 +9,16 @@
 
 /** A page in the manual. `href` is the route, not a file path. */
 export type Entry = {|
-  +href: string,
-  +title: string,
+  readonly href: string,
+  readonly title: string,
   /** One line, shown when a reader is deciding whether to open the page. */
-  +blurb: string,
+  readonly blurb: string,
 |};
 
 /** A run of pages under one heading. */
 export type Section = {|
-  +title: string,
-  +pages: $ReadOnlyArray<Entry>,
+  readonly title: string,
+  readonly pages: $ReadOnlyArray<Entry>,
 |};
 
 export const sections: $ReadOnlyArray<Section> = [
@@ -120,9 +120,7 @@ export const sections: $ReadOnlyArray<Section> = [
 ];
 
 /** Every page, flattened into reading order. */
-export const pages: $ReadOnlyArray<Entry> = sections.flatMap(
-  (section) => section.pages,
-);
+export const pages: $ReadOnlyArray<Entry> = sections.flatMap((section) => section.pages);
 
 /**
  * The entry for a pathname, or `null` for a page outside the manual (the home

--- a/docs/app/_design/parts.js
+++ b/docs/app/_design/parts.js
@@ -38,8 +38,8 @@ export component Command(children: string) {
 
 /** A line of terminal output, and how it should read. */
 export type OutputLine = {|
-  +text: string,
-  +tone?: "plain" | "ok" | "bad" | "muted",
+  readonly text: string,
+  readonly tone?: "plain" | "ok" | "bad" | "muted",
 |};
 
 /**
@@ -111,8 +111,8 @@ export component ManualNav() {
 
 /** A claim the project makes, and the page that backs it up. */
 export type Claim = {|
-  +title: string,
-  +body: React.Node,
+  readonly title: string,
+  readonly body: React.Node,
 |};
 
 /**

--- a/docs/app/_uf.layout.js
+++ b/docs/app/_uf.layout.js
@@ -23,7 +23,7 @@ const VERSION = "0.0.0-alpha";
  * result as a hoistable `<title>` — which is why there is no `<title>` in the
  * head below. Two of them is what you get if you write one here as well.
  */
-export const metadata: {| +title: string, +description: string |} = {
+export const metadata: {| readonly title: string, readonly description: string |} = {
   title: "uf — Unified Toolchain for Flow",
   description:
     "One binary that runs, builds, tests, formats and lints Flow and React. No Babel, no plugin list, no second config file.",
@@ -85,11 +85,7 @@ component ThemeToggle() {
   const [theme, setTheme] = useTheme();
 
   return (
-    <button
-      className="theme-toggle"
-      type="button"
-      onClick={() => setTheme(nextTheme(theme))}
-    >
+    <button className="theme-toggle" type="button" onClick={() => setTheme(nextTheme(theme))}>
       {themeLabel(theme)}
     </button>
   );
@@ -98,9 +94,7 @@ component ThemeToggle() {
 component Colophon() {
   return (
     <footer className="colophon">
-      <span>
-        uf is MIT licensed and pre-release. Nothing here is stable yet.
-      </span>
+      <span>uf is MIT licensed and pre-release. Nothing here is stable yet.</span>
       <span>
         Built with uf — this site is a uf project, in Flow, in{" "}
         <a href="https://github.com/ubugeeei-prod/uf/tree/main/docs">docs/</a>.

--- a/docs/app/_uf.not-found.js
+++ b/docs/app/_uf.not-found.js
@@ -11,7 +11,7 @@ import { Link } from "@uniflowed/router";
 import { Eyebrow, Lede } from "./_design/parts.js";
 import { pages } from "./_design/nav.js";
 
-export const metadata: {| +title: string |} = { title: "Not found · uf" };
+export const metadata: {| readonly title: string |} = { title: "Not found · uf" };
 
 export default component NotFound() {
   return (
@@ -19,8 +19,8 @@ export default component NotFound() {
       <Eyebrow>Not found</Eyebrow>
       <h1>There is no page here.</h1>
       <Lede>
-        The link may be from an older version of the site — uf is pre-release
-        and pages still move. Everything that does exist is below.
+        The link may be from an older version of the site — uf is pre-release and pages still move.
+        Everything that does exist is below.
       </Lede>
       <ul>
         {pages.map((page) => (

--- a/docs/app/_uf.page.js
+++ b/docs/app/_uf.page.js
@@ -50,9 +50,8 @@ export default component Home() {
             your code and the web.
           </h1>
           <Lede>
-            uf runs, builds, tests, formats and lints Flow and React from a
-            single command. No Babel in the pipeline, no plugin list to
-            assemble, and one config file for all of it.
+            uf runs, builds, tests, formats and lints Flow and React from a single command. No Babel
+            in the pipeline, no plugin list to assemble, and one config file for all of it.
           </Lede>
         </div>
 
@@ -90,31 +89,25 @@ export default component Home() {
         </div>
 
         <div className="notice">
-          <strong>Pre-release.</strong> uf is at{" "}
-          <code>0.0.0-alpha</code>. Interfaces move without warning and the
-          packages are not on npm yet. The guide says what works today and{" "}
-          <Link to="/guide/testing">where it loses</Link> to the tools it means
-          to replace.
+          <strong>Pre-release.</strong> uf is at <code>0.0.0-alpha</code>. Interfaces move without
+          warning and the packages are not on npm yet. The guide says what works today and{" "}
+          <Link to="/guide/testing">where it loses</Link> to the tools it means to replace.
         </div>
       </section>
 
       <section className="home-section">
         <h2 className="seam-mark">Install it</h2>
         <p>
-          One binary. It reads the checksum from the release manifest before it
-          writes anything, and it is short enough to read first.
+          One binary. It reads the checksum from the release manifest before it writes anything, and
+          it is short enough to read first.
         </p>
         <Command>curl -fsSL https://setup.uniflowed.dev | sh</Command>
-        <p>
-          Then a project, and a dev server, with nothing to configure in
-          between:
-        </p>
+        <p>Then a project, and a dev server, with nothing to configure in between:</p>
         <Command>uf create app my-site</Command>
         <Command>cd my-site &amp;&amp; uf dev</Command>
         <p>
-          That is the whole setup. No <code>npm install</code> of a toolchain,
-          no config to copy from somewhere. If you would rather build from
-          source, or pin the project to Bun or Deno,{" "}
+          That is the whole setup. No <code>npm install</code> of a toolchain, no config to copy
+          from somewhere. If you would rather build from source, or pin the project to Bun or Deno,{" "}
           <Link to="/guide/install">the install page</Link> covers both.
         </p>
       </section>
@@ -124,10 +117,9 @@ export default component Home() {
         <Command>uf build</Command>
         <Terminal lines={BUILD_OUTPUT} label="Output of uf build" />
         <p>
-          There is no <code>vite.config.ts</code> next to that, no{" "}
-          <code>babel.config.js</code>, and no <code>@babel/preset-flow</code>{" "}
-          in the dependency tree. Flow reaches JavaScript through Meta's own
-          Rust parser and React's own compiler, both linked into the binary.
+          There is no <code>vite.config.ts</code> next to that, no <code>babel.config.js</code>, and
+          no <code>@babel/preset-flow</code> in the dependency tree. Flow reaches JavaScript through
+          Meta's own Rust parser and React's own compiler, both linked into the binary.
         </p>
       </section>
 
@@ -139,10 +131,9 @@ export default component Home() {
               title: "Flow without Babel",
               body: (
                 <>
-                  The official Flow parser, the official React Compiler and oxc,
-                  in one Rust pipeline. <code>component</code>, <code>hook</code>,{" "}
-                  <code>match</code> and enums are lowered where they are parsed.{" "}
-                  <Link to="/guide/flow">How it works</Link>
+                  The official Flow parser, the official React Compiler and oxc, in one Rust
+                  pipeline. <code>component</code>, <code>hook</code>, <code>match</code> and enums
+                  are lowered where they are parsed. <Link to="/guide/flow">How it works</Link>
                 </>
               ),
             },
@@ -150,9 +141,8 @@ export default component Home() {
               title: "Vite, not a fork of it",
               body: (
                 <>
-                  The dev server and the production build are Vite 8. uf decides
-                  what Vite is handed and drives it over a JSON protocol, so
-                  Vite's plugin ecosystem keeps working.{" "}
+                  The dev server and the production build are Vite 8. uf decides what Vite is handed
+                  and drives it over a JSON protocol, so Vite's plugin ecosystem keeps working.{" "}
                   <Link to="/guide/dev">Dev and build</Link>
                 </>
               ),
@@ -161,10 +151,9 @@ export default component Home() {
               title: "Tests that actually run",
               body: (
                 <>
-                  Rust owns discovery, ordering, the worker pool and the report;
-                  the host runs the bodies. About nine times faster than Vitest
-                  on 1,000 tests — and about three times slower than Bun, which
-                  the guide explains rather than hides.{" "}
+                  Rust owns discovery, ordering, the worker pool and the report; the host runs the
+                  bodies. About nine times faster than Vitest on 1,000 tests — and about three times
+                  slower than Bun, which the guide explains rather than hides.{" "}
                   <Link to="/guide/testing">Testing</Link>
                 </>
               ),
@@ -173,10 +162,9 @@ export default component Home() {
               title: "One config file",
               body: (
                 <>
-                  <code>uf.config.js</code> configures the runtime, the router,
-                  the build, the test runner and the formatter. It is Flow, so
-                  it is type-checked like the rest of your code.{" "}
-                  <Link to="/reference/config">Every option</Link>
+                  <code>uf.config.js</code> configures the runtime, the router, the build, the test
+                  runner and the formatter. It is Flow, so it is type-checked like the rest of your
+                  code. <Link to="/reference/config">Every option</Link>
                 </>
               ),
             },
@@ -184,9 +172,8 @@ export default component Home() {
               title: "Any JavaScript host",
               body: (
                 <>
-                  Node.js, Bun and Deno are capabilities, not targets: uf asks
-                  the host what it can do and picks one. The same project builds
-                  and tests on all three.{" "}
+                  Node.js, Bun and Deno are capabilities, not targets: uf asks the host what it can
+                  do and picks one. The same project builds and tests on all three.{" "}
                   <Link to="/guide/install">Install</Link>
                 </>
               ),

--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -10,6 +10,9 @@ requested_version="${UF_VERSION:-latest}"
 install_root="${UF_INSTALL_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/uf}"
 bin_dir="${UF_BIN_DIR:-$HOME/.local/bin}"
 
+# Decoded size of the embedded logo, which the iTerm2 protocol asks for.
+uf_logo_bytes=8177
+
 # Colour, unless the terminal or the reader has said not to.
 #
 # `NO_COLOR` is the convention, and a redirected stream is not a terminal — an
@@ -29,18 +32,251 @@ uf_paint() {
   fi
 }
 
+# Which inline-image protocol this terminal speaks, if any.
+#
+# There is no way to ask it. Both protocols have a query form, but the answer
+# arrives on stdin — and stdin here is the script itself, coming down a pipe
+# from curl. So this is detection from the environment, and it is deliberately
+# conservative: anything unrecognised gets the block mark, which always renders.
+#
+# Mirrors `ImageProtocol` in `crates/uf_term/src/image/protocol.rs`. The two
+# have to agree: the installer and the binary it installs should not disagree
+# about what the terminal they are both printing to can draw.
+uf_image_protocol() {
+  case "${UF_INLINE_IMAGES:-}" in
+    0 | never | no | off | false) return 1 ;;
+    kitty) printf kitty; return 0 ;;
+    iterm2 | iterm) printf iterm2; return 0 ;;
+  esac
+
+  # A multiplexer rewrites the stream it forwards, and the failure mode is not
+  # a missing picture — it is escape-sequence garbage across the pane.
+  [ -z "${TMUX:-}" ] || return 1
+  [ -z "${STY:-}" ] || return 1
+
+  if [ -n "${KITTY_WINDOW_ID:-}" ]; then
+    printf kitty
+    return 0
+  fi
+  case "${TERM:-}" in
+    *kitty* | *ghostty*) printf kitty; return 0 ;;
+  esac
+  case "${TERM_PROGRAM:-}" in
+    WezTerm | ghostty) printf kitty; return 0 ;;
+    iTerm.app | vscode | Hyper | rio) printf iterm2; return 0 ;;
+  esac
+  if [ -n "${KONSOLE_VERSION:-}" ]; then
+    printf iterm2
+    return 0
+  fi
+  return 1
+}
+
+# The logo, as a 240x65 PNG. Embedded rather than fetched: the installer must
+# work before anything of uf's exists on the machine, and one more network
+# round trip is one more thing that can fail between `curl` and a working `uf`.
+uf_logo_png_base64() {
+  tr -d '\n' <<'UF_LOGO_PNG'
+iVBORw0KGgoAAAANSUhEUgAAAPAAAABBCAYAAADvwylCAAAAAXNSR0IArs4c6QAAAERlWElmTU0A
+KgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAA8KADAAQAAAAB
+AAAAQQAAAAD4TwtvAAAfW0lEQVR4Ae19CZwXxZ3vr6q6/8f854ThPuRGGEEJR+KRJ3yWBTWQNRsH
+Eldz7PpM1Bh1s8ln8178SNQ8X95L1myi4PFccV2jMkE0JiLgfaOACM4AwwzMwMww9/mf/9FH1ftW
+z+EMDDDgDM5AF/R0/7urq6t+Xd/6nVVN5CefAj4FfAr4FPAp4FPAp4BPAZ8CPgV8CvgU8ClwblCA
+nRvN9Ft5higgeniOwjnZw3n/VB9QwAdwHxDxXC4iM3NCpjQj2Uy5GSRERndaSI7zNY3VhZ90P+//
+6isKGH1VkF/OuUWBrKxJGZYhJkoeWMQZu0yRmKqkGg4qdDIFzgWTxLbg3D+cW9Q5c631AXzmaH3W
+PCkle/po1zC+YRJ9Tyk1V6k20DLWid32tjJ9IfOsafgAbIgP4AH4UgZylVKyZ4wKmfRTqdgPAN5w
+W121mttT0sgGE/ZTv1HAB3C/kfYsLHhYTqrJ6HZX0m2wSx3Nbj3h2eO5XtPbQK1I8bOQEgOmST6A
+B8yrGPgVyWRsCeB4CynVHbz6l2Iu/jZjH2trCaCMhKyNA79lg7eGPoAH77s7szWH0Qoo/QkpimDf
++Wyt9kJQrmdM7mIkPlKCDgO6UIsVB8wFU1Tcmdk/6HMK+ADuc5KenQVmBUOXAKgLSH2m0raDtwEY
+XhtU5gNVVbsOnp2tH7it8gE8cN/NgKqZS2wxI9Wtv0A8lsTpTyksdGdFxfZ20XlAVfusr0y3F3LW
+t9Zv4OlSgHOlZrd7i9rKANvF/wbB+L/54D1dsn7++3wAfy4aKrZqIXnhg3e9Qa7W/T5XcQP15tGj
+QyT5cBivOmvIwHolU3sbK4YWdZ70D844BXwAnyLJl6+qSBljjMoKt1iZqVEnPWJRJBx32dqVwZZ1
+tao5WE+NZgvVXVXEkqdY9KlnHzE7ElEylbF4J7J4POQ0N+c3oLDOcycqWIdCOkER6MgD1y4LOol4
+fX1Rc8e5YXYWtwXMU0clJlUF0RvOUaf9n2eQAj6Ae0nsnAdV6iiicWaLO8d25MUhHphFhhpjx9y0
+YJwz2Sqb3aQqI4vtNJR6683z4jv/W2moFFz5M6tPL5/V22xDlHuZEuyrrgxp6RaA5aQispGaJ6wm
+Kkn0phwVSFnJOR8H7iq1OVkIEg4L7sa9Tx91PyTm7gk6cLz7Gf/XmaaAD+CTURy9dMYfaXx6wl3M
+4vxa4upiRTzsOorsRthwyqEL1hKJpBpuOnwKpEwtVH/XFKG/bJ9qP7htv9oxj5h9ssecznWH5FJO
+xh0edj1+i8hjxsrSxoSeaCmn3gCY44abcP+FHfwa7h8MA+x51OdoAHfj6IjC0jpwSsaIaZM6667a
+gzsYRzEBjF2WaqoqPITrPpfuJFLfHvgAPhE9X1fGxPU0E0z0NkQpfEtylQLvJjmWI5Ol6KP7iNwW
+ogCHvMrBwLBppLqMZaF7Xy+UcX5kJt1KBbT1RI853WtAiNuml3bBFqp3CuWhCOT3bm8vA85bGJd7
+GnCO5cBMLWBk3qM5v0Y9yU4xG1IHLNbKtCPDL7ijtfrTqlOok5/1FCjgA/h4xFq3TgyppAXSUL9i
+ki0kB/0cPVvCWZLciZv2gOuiz2vtUcAh6pmv0MWBby3NAgHAkTDm267zy7opasXQItapUx7vkQPn
+PAB5bGpHeMcFzYHZePy61pvue7Si0AZ3yR12N/L4AO4gWx/ve3xTffyMQVlcZuvfLzddtZYn1OUs
+ZoP5wmSDbph4hcguAEhBORFE0wQODWwmYxzz6hA8iAMAGZtNrhScL44adPngIsJRoZLHrbzG9Ik2
+SjIuT0UiOO6T/As9U8DnwD3QJbhaTWeu+6/gt1OZI6XQqh1EZfdDALcSM18xj05obisEMzAJljhr
+AcATOCeE4OkmMcT8o2PjkgELEenJ7udmwjDWw6SHc5MW/dLqwQ9gBV2rnCYBJFMAnyGeV9ZKfkDj
+QkWnRbGHlWkknRuhws0H85Dahqz5kZsPSJZAbAR4wWj1xsBdC/GMD8CE92HRmGbOKAhFcJyhjAvg
+Jb3QJDddMbXfJaGtuoMo9ejPbhOKu7dC68qtMIRpNuwlPXuh7YeXHRzY1ZMc/NRPFBjcAC5MTKIi
+WkpcfpWZfDI5aqhnRpHiUdDr16dDs0AzzVBMfIsxl4G5KgkeojCfRhUAvOiTDCiFfIwdfwPrTTwS
+NMXWVJeqsqZSMvVjMiiNp7uWM90kPj9AYrgr5Q6LCWjMgz51glS3BOMXiCL3KMGfxuClr2nzNQK2
+oBp7GTDuOcqmlJR677f/p18oMHgBvMuay23zZoz3S9GRxpAD85EGGKClHHbhaVMr5vw9N8VoqK9S
+67J6U0Uw17S2ic4My8RAVP5EkfvL33xsvIUcbR17u/dEzW1q9PbSFPXRyFQKT9hJzbj7aBPPaVdv
+4NwIWYP4nnSe/u/aCN2RpLQ8AHMeUAQDX1nJ+71xZ3Xc7u9PkQKDE8DvQEe16BeYgroMiEWEEIIQ
+LGDHixUCbwRHOC3ErFIpwnKXkt3GRrTorFAsK8VvDWS4SsCALZifH3h0m/nmiWjdHonV/9FYJ6pE
+v19TTlnZ+34wR7/T+fgPGHwAfl2lcte+XVliOUkXQhs4YJvvRiun2NDY09S6gq00Bp7V8zVq9ToS
+WhxXmCwno+C3KBo2Zb0vVFy8cHySnjtXQPxzp7EDtKWDD8DKvRw66kqKa36owQvKan3M2+tjTel2
+sVYfnkpqdSZDv03HeCD1GGDDYJVSrygd7qIRqURDwtD8bFldXkqTvj9TTU5HnnRQMB2OEu8Yv8P6
+XPs+A4zbcKl6WiE7gFODJ+lwrF4kZPOo3YusfpZ+osDgAnC+ClC1+h66VxYlsTKT7j4auF3B63Wp
+XvW/Y0gqXDZG2Zg5J12ZDf1tCqgzZaSiSaOJRg3Blumo3cU09UipWKWdI1p4h48IfmA9NwfHeKyh
+vUresY5owj/hFL0+4fV/WVSy6AzpgqjE5w4Z6Z0C0kucH0Nn/0TfUWBwAfgITWBCXk4uOqkOD9BO
+DK336s0DcztwHc2STz3ZMRbJBEVmhRXNARvNwTYWLHU4uG869kMylCqr4uNcJcdhKh2M3qgGniTR
+3yUeqaulu77eYMOGG1g7nMTwKc7C06rPqbfAe4zk3OwdAtse0E60rk/rUYLpqQ093Nu1HP+4vykw
+uAAcoC9BOR2qtVE4bDxOo3VVzw3pRVagj3nAPvV+pcXBr0ScUePBTecBsJPTFGVCdA7pkAwU5wAS
+NuRqxHWArbbxHn0eniao3G3g1Y/u2FwEZAHA2NGfx95ASVrVL6/yWFAhdkSm2pyaevU8PfQFeicw
+H5vL14F7ReN+zTS4ACyd2WQYHKxOUgoMTFUALyzGHgf25FbQSnPlNr9krwm3cJUyrg/QsjmtfOkY
+x1UZKMsB8myANqh5GYxjHF1d4Dx2OorDY/htGiCO9XgBKGkR2rOj6Sox3oqBZQts4k+yVf3jRsJj
+ot0R7FUkQ1h8PGpUdzICZGdPnwjyjTw2n4wee+7YMxjGNNX99AVSYFABGFarsbqLegkiLU+FhfgQ
+LEUwNmnF0+PGGsCaDfYy5a5Toq7K/YYdEz/nQl7kOFJZeIjmuNqZZIHZVzc4VF7pEMKdWX2DKBAU
+2qExrHuvJ71r8OJYg1drvvivJeiDiNB6YWo+K+5lVU4jm0LZWg7wxpOO+xH9xb6dk5OTj2R1nDx6
+v3DhQmPnnprrcD5bt7RrgureU+BJ97Gi6w3+8RdGgUEFYNiH0rxeBLRo9PAx6HhlAHEz9rolGkUw
+PpHdow7XI5F3NLpLRjP+C4u7syy4j+w2CFISRR6sTlJVRSvV11jU2gybmR3Ct7roXSVT/o+Bn3rc
+0GOFtljrx+u9TqZDOn6wNmcfQwR1/yWDB3a4yoHJiuklX70HgetjaGHfPlzDPxk9eu6GntarGjv2
+4vDH+TVfw+hzPUYbHT3VmXAYQ4DG+50n/IMBTYFBBWAA1PVACpJ64iuMTMEJmN73EaRmzf0AYAVU
+9VZgTXlKzZVx906b5CzHBRTAQuFZpnpw8YLSVirf30wNVUlSCU4hQDSVmxRQsnFjZX9y1d73l/pQ
+U3FGPOVdtPiqjrva+fFYzuX/aJXxUUNGzH4HUysOuwZrNaLJsGXwcVG7+VLQ8Tsg2XldwYtyQDu1
+o8VJftpRXpd9F5h3nu3pXOdF/6D/KTCoAIwQ5EZP60K36bAzm9OZ4keIxTDFTwdeaLaop9aflHRP
+qfPgLvo5QjYudiE2a06q76+BUnh4fytVYVkp3iQ90GZg3mCEByidpQDAvSj7pA/vowwlJQk26vzH
+SBpYs1l/RKwdT0AlBriZEEl+5jJ3MSLLSrA12gbL8EBLbC5MbMOPAS/DVxUYPUZd1sPqo5r6xfQT
+BQYVgEGDEk/bQy/09F3dYUNw8XwZwIXJJlqMjgvLMTouvh5wgvRfKp07zo/gwV0GH5COllQavPXw
+1Jbtj1HLJ02UFgV4jRClYcZ+Gg8iOENQBgtSSGmr2cBJjbbakmHIZ0CBG0COz96nV0s5DGr7UhxC
+nccie4hOxsCnpza3ac7dm4FVctTz0nBf7H6645dWSwZU0zsqdk7vT86pBhB5sDrGLkQ5Y3YeeqGu
+ubYaQXY2hjM1YjFTWeMgAkJXpRZ3Iv2jSuux6r9XQZ6U31VSfB8rVZmYbq5tVdSSILan1FZNlS4N
+jQRpSGYqgBugVApC8Qb3hXI9BL0/S+iHDqBUu68Fsx7vB4Cfwwbhv3v19NpVSFB19VAH8Orf3XDo
+5ceCBbQZyP51S/nek1qvB1Drz/mqDCoAkxSfoCtWai4C8CIkGZvujbBuhSdhycjliJaa7aqAEpOo
+1L38mLeLub6IZr4GU1bv4FIO4XAZoW+rRJLTwRIZi9aJHaOyUmnohCwaOjGNhmanUBqAm4YYaHzY
+CwAmcOFOW9UxxX9RJ1pq9xZiAsevIDY/BfpgNpQGZXcgH1u39jycGpB3nUPs7obqT3cdm6/jjGd1
+6Pjh7wcIBT4TuQZIhU5YDYvKWYrCUnPiOsYczAxCpCKGIB3DARsUpU1hKi2DVPpoFWktpNv4Jaq8
+9B7CClYQ//5NhUUTXS1D/F8RBzIBbEjqkCnXUqy6lHhDudz0pUDo4wxB89OEKzNSYbQKSxLgaakt
+XAMXOjAszMR75SM9YTv64aIGX8bwC+7F0JYP6WQxXOWzYJAehkdpY/nRCXilesgreyDQbJGOu76l
+rnDv0Zk6fivMz1SYcN2Vc0M012K49qL56QukwOAC8CIscPNR4mkeDHwdnS9NoAshcMqTpLX9yoV6
+Gh5BNOEqKRMzaGGQuXddcSc9V7bbrtr8gn2+nWL+dyyTMxMGHUQ+epybRQ9xFitTJS4FfjPe5DM0
+QVKZoz/BRxlwWoUQB20WEUXwnBT04ADTi5kPzNRU/WkxjR37YJqV+i7nxkUI5pyBgBJEc6sUCC1Y
+g0/pSVUxLFNQBSNCEUD8SZPk26huzwkHpdrapJ01wngb/uUDaDmGPQx/EGNw//aBSYlzp1aDC8D6
+vaQF3wZSNzLTWMmZzbDmlAdiRDxi/SmgGPYZE9pexmwlRIwtr9gnZhVsoyrHlucx2x2FpV+1LKiF
+cGWVI+LiIMVlgq2hTcbW0Aq6MACLFoK8AGLsgfEIAjcDZdhbxMJMxQNSwN49gFNZWRzOZ+3H/TB1
+xOShkkLZWDUzRUoXcSUYvkjFMHzVtdYEoetu12EvvUglls1m/h7kTWEOIlu0RGMaGANtX1/uBfX6
+M8vgA/D5WEBuv/od1g6fZZjGDFNICppKBQ0GGVkx/Y0C3sKoqZpUfbHLjhTTxMojNNFz/phQlmGl
+BoMltwohzQeA0oTcgEXI12roG7YrwpDJEeQFa3PbFkZgSBDsONUSLMhpT4ak44qa/fmiTqNsN1pV
+XI379PZ5k4xWFuR/3kL8+/ueAoMPwKCBPYW2hkvhNjmgHnJtMduCzqpNS62NxJLlmONwSKnWeqI4
+IrIcANxjqRAivWgPzO+VFQ6C/dF0lx4n0/o5bQx6nVxzXkxEatuQXYM4rNkO5gGHG8nCOPF/55T4
+X5zv+27ol3i6FBiUAIYoqOLb1Dbxprw9VibuYUlxqRe8aJNy4Mt1EAGMtSo9HzGFgURtbE5gawCY
+WyE8x71pB0+QI+6mlwOYEtGWID4zLCtJIWza8qOPA5hSFLYFAbxPCC5e6sj7Re+/du1NWSkI7czL
+ux9DFbG/+fYNw1OiY1tefHFVrIe6saXX3T5SMaN585O/aV2ae8cQFYobpovlCWzD2Jj3B1iuj5+u
+/Idb00MxaW7Y8KAnMufmrgo0itpsLam0pRTM1IrbJyunI7fe6/qbgaB6fu3vsGRg93T1976XGW8V
+fFPeY7ptx025N96YEbWDgY2Pn7j+ugCdt9UywpHWmpq8vDwM9ydPubm54aSYmAWzgZe5lQnXnZ5V
+J/aVDR0XdJrWrl2L3vbFJvCXQZrmMTt6l/FO4hD7cbxWPRav503xFoPZCaBbYi1J7e/UMRcJvKtG
+BEjW4FwTLKkJ4wjcUfeQK1bRy6yka+sDOIkv+njh1Jhjx0Pc4EFpWsJR/xGX1n1fGUBfV3BsurVZ
+JX6i63/jjQ8bhhN80Akc+Zuu7ek4zl23jrNE8p8Nu/mCJdf/aCK+WfQ4Br1/dmyFNcWcf+zId7y9
+TDorYoZ7Z8f1JlkxCULPs0lH5iVd91mbYusxO/reVatW9bo/2Zb6cTyavLmjzK77eDR0I2PBH3c9
+19NxS71YoqLuP/V0reu5Zbl3jGluEI+5UXl3zMxO73rtRMcNzrC5Nmt91nKd9ZaS603Hfji8q26k
+pnVFS+T0F0480UNP8drg5MCdjUTgwib1MS3nd8PAugWnv44Ij4uxHwl5OeyFa+lZCSSxuBw/jGtv
+EnfXUyKxnTanHaMbBoRIhmHORtwzD3LZanK+S3dURE8+v7Q0XNr52AFxgIX9mKeuU0PDERzKeRAg
+XvrGN24ZGjPlHLh5mmCBHiVd9n7eihW1V15zc5UtAwaPuzfA8ncpLNGvS1eBo3Id4EFXXXsLQkv5
+fCxoX/RS3mq43oiW5t66APLMMLR/Nvbn63NekhyckeXh64xzoIZcgwWI7sO86AMAsFyee9t4hG/O
+B6Arvzxz5Pv6XG7uHeFWw7oMa5WEOHPe+esf12ClMTUd0SMeB1uS+6OJQsi5QH9FiluztYXxSVjS
+d9jSFTcvQj3ZJTkj30I5ztKVt16I+6Yheu5IGtW83yBFM/z6tYtzb8QMUHMBFtWvVXARGhT48C95
+90OZAueFtNDMqq6D1XIxrPAPVO5zonoQEwk5F5JZ2cbn1nyw5Pp/iQgrdiksJDZWWbFffnr1O/pe
+w5DDlMsvdBm/F5NXYq5kMZbS4FIi9cuYkI7QVdAt9+aLsILCVHxOKn9j3sMFV+bedDkijQ5NH8kq
+9lW5S4Qp3kS4QSpzVc4lOcNe1fTQ9/VVAr85S1KuCuN7fCOJO2MhSE+CKWsU5Gh4fhyAV5YTNwrJ
+dsqp9MARys/pcZrdL76ppmYZ8oYI54mIcPemKffTDDNweNHagaf3Ls296SlIGZFNf3roaq+TUtV+
++NPutKSVH+LBJ+EXfwuBLtOU6xSks/rbmij7VdiOn4D9/ev4BswiKeXPYPNLx8r1cwIkf26TeAAD
+XBWklzHw7t6nXGUi3//C5IZP4T76Mu499HLe6q/p3gLRUtTYkbSICC+zOfudSvLZdlA2h0mMd8n9
+LfzzVehYozGobhgRSTxeGQ//Co5kvBNKSkdZwYy0WxLN0dWIxUni+zT3KtdaA6d+Dbx0Y8l1fgM3
+wd9iVZHleHcbsarYxa50VgWZ3IU6/k+IVu9goPoO9vcBOLPgzppnMH6PK9ULAPt7wjBGIX/9hMw5
+33/kkR/YWgxupuz/h69o/J1rO/fCa/EyBptf47OsFWjTWChb/4XPwb6CWWibMejtA91e3bJ+zYO6
+nUtW3Hg13HFY91puYMLAzFK5hRpSnucZrfswOfy7cKjBJCp/gvdwCKgcj3OQUtgyBAhZWK3lhVA4
+5Rk7bt+CwW86aLpg07o139Xl9mUa5By4CynyvG/VHsQLKaUlxg50liA6hEEuNFsBaG8mLH964qVm
+jDo66A7j9ysrKoNGasvVeQbuGcAJ2kJb7fKhJ2Tr1UGkqaBYSjVWCnzXSbFFWCf7ukQiKwhqjJEQ
+pJkrXweNclRS/EUGFDoXy0gycxHmWs9DR/098s/G5I5rsTcBXgCa349ljO6C+8njOPp57Tpk4xXX
+3BrDxw1Vk90Q3frnp6JLr/khFsSnDES3/pQ7/G+xotAPq2ORfMTMrETc+T85jlONCSnPW9GGS7DU
+kAWOl2QyeQWKHI2omp+aip1nBYP7uWVfhYGgBhNN1hgkZ6Nul8ezst4Wjc27AOghAMx0DECzwdW0
+t2+4I9wAFk4Yh2evAwceC2676kDDdm2TbMrLy0kuXln1CgaGRZLLPwJYt2OAMZQlf8sD/O/AVX+M
+cJ0dWFdlPAbA/204AvTpSBDHdMSAggNCL3UGW2kwuA+r1Y8lx3YNQ/Cbca2AJH8IToxfgBQ34Ya/
+4pYfwplhSdcehmYuxsySHATbv9VRal/ue62z9OVD+7cseII3s1baxOqxr6ZXMc1B/9Ye4pOkVW8w
+52d5rPKmDWnVK9oGhJPc8cVdRseBzZ1PX/bNH0xtksPnoX1DMDm5WQCl4ErRWaNDWHyeivX0jpaQ
+oRfnktzlFhamR+iksrb8+YEKuHO1pQAh5g7AiXhRBZsAo2fh4X0Vv7MBjujFs4btQa6EdpwfnfD1
+Cu9kOAjbgk6M4R7mbn52TT4JtxInsrEEUQTgz+AsedDhfD8iycOYMhbBc/EoXQE3E2Ixu2TGyIKY
+dEoCyaieMiqEUuWvQiTFpRpIACbVNX0FA/LV8CHsAfetRlR3AK5B7dQHliFHKJkIJKzd8P4XomgD
+ojXQp9MqiWAfqArMuSxndBlAOhT32Js3PJSPu2vgGs/GdFL9gckYVK5dG5/7Q1nbfVAu9NL+TLYw
+Gfgl3Oh3CWZurnYmGPBUIgJQf+2ORsAZ2bhp/YP5kHZakXskPO1vgm7ZaNi3pO2uxQBwJQbDaeS4
+GzvK7cv9sW+lL0v3y+o3CmC+75/R/dNsIZ7Gcj+PAg0lSrg7KegE0RlFGbohuJ1O7R2ZTFc4Ajou
+sOHZ6XCLjkJloQRXb4OrNUIn/SZ4+mUuyXqheB7MfvPf31MD0VrMb8N69+ag8wNLn4VqAlwbNKe+
+YuWPHkKU5Q85k08HzZSPwB3fgk3/PijAq9HpC6FTfoB6wUsHtYfEFhj6zQ/2VD8SNMzfORSYAwkC
+rnq0Agn8D61ABs7TMPBMQxzJRHDm4WgdVi5T0AKwafwhMl6LS+D+erASjmN793s1dhi+VUxGRcUo
+RM/TOhyPuWLlTQ9BKvgOBr0nEM0SxY0BVya7DfLKxHAD9sxCsuTlvH/fp63s4SDiajEoYgByEU//
+JOh35RUrbn4IUsY8DAD/uWn26Co8HxEG7DyEFK3F3RmQjGrLjTo9sPR56ni5fV6wX2D/UmDszAVV
+IcZ2o8uC0/FtiOx+JJPV7WlKpkjoeRXNtUM/CgdjNjxohypZzY50lQqDT+BDaQi4zZyS4oLtH0+e
++RULeup+Mxp4m8LObnyQvAkMdGcgHnkvaSb2ChLl4FJ1kF1eQQzmtgMF2wq6tmrGzEsdR9ChQCy4
+tajoQ3fm5LmV0uQFkA5siJDvJZV6ZtOzf6ieOvNLHwN0cYOLMnDTxzY/+2DR5AsWWMxgu0Wz8SEP
+K3B5ZiFQdntS8Nfxzak6TJsqQB33TTp/XhJGt10J4WxF/fREllp8r/ldfN9mNwJDCyHa7g9Z7m4n
+qGptEdiKeJ4ERNlKO93dWrJzp57mTRMv+pIDJltWffi17W6ElRsU2seZgG1EvZ1kLG8YOU34tGR9
+KK7eLyzc3uYzwn1TZ1yAsUUcSgRjH3WUNWPiVzFkqWYREB9YNt9uCl4G1MfAlZ+X5Gw+sPq3ick5
+CyoxOO0sY9VbMlS4DsF/W97703/u6Uq7vjr2AdxXlDzD5ZQUfGSZMyeUcuiY3HR2bmF1Bwvg35ww
+clmUIk17X3vpt3HzgvOaIyxYuDXvydjEnDnFdVlOdUO8pj4rkFFYtPvD5PCc82psyzjw2l8fjmUE
+55aFs6yiloS755UXVzcdKNiemDFpzoEYJfc1OKzAMEWxfmbXZqZedmGz0Rzf88pfHvE6PTq/PW7Y
+skNGpL5INsbzX3nxPzy/cVHB9pppF11cHItHC15d/2gJylCTx5xfTnHr0KZNj8YzQnMOpWTZhUlu
+7n4jb3W9HgicWPxgcfEue/K8hYcDLfHDm9c/0jRt/LRiKM2lIpLxqaqtL7OGuhWOHTiw2ahrGWfx
+vW8892jLuOxIK0sdsve1Pz7WCcSswNyWUJYETdbHSwoKrMzw3NJwpr0/kKB8iNINBQXL7XFTa/dt
+DjY3UQG+YteeMi6b3yyak3vfeGYtVLC2hIFKTsiZU1hbJOvffe2h6Jj5Mw8altwnosG9m19Y4+Ub
+NyynMpAVLnjvmcdjI6bMLo6baUVlBR94g0lHOf7ep4BPAZ8CPgV8CvgU8CngU8CngE8BnwI+BXwK
++BTwKeBTwKeATwGfAj4FfAr4FPAp4FPAp4BPAZ8CPgV8CvgU8CngU8CngE8BnwI+BXwK+BTwKeBT
+4HNT4P8Dj9AIO6tNCf4AAAAASUVORK5CYII=
+UF_LOGO_PNG
+}
+
+# Draw the real logo, or report that this terminal cannot.
+uf_logo_image() {
+  [ -n "$uf_colour" ] || return 1
+  protocol="$(uf_image_protocol)" || return 1
+
+  case "$protocol" in
+    kitty)
+      # `a=T` transmit and display, `f=100` the payload is a PNG, `t=d` the
+      # payload is the data itself, `c`/`r` place it in a box of cells.
+      #
+      # The protocol caps one sequence's payload at 4096 base64 characters, so
+      # the payload is split: every chunk but the last carries `m=1`, "more is
+      # coming", and only the first carries the rest of the keys — repeating
+      # them on a continuation is an error rather than a redundancy. awk holds
+      # one line back so it knows which chunk is the last one.
+      printf '  ' >&2
+      uf_logo_png_base64 | fold -w 4096 | awk '
+        NR > 1 {
+          if (NR == 2) printf "\033_Ga=T,f=100,t=d,c=19,r=5,m=1;%s\033\\", previous
+          else printf "\033_Gm=1;%s\033\\", previous
+        }
+        { previous = $0 }
+        END {
+          if (NR == 0) exit 1
+          if (NR == 1) printf "\033_Ga=T,f=100,t=d,c=19,r=5,m=0;%s\033\\\n", previous
+          else printf "\033_Gm=0;%s\033\\\n", previous
+        }
+      ' >&2
+      ;;
+    iterm2)
+      printf '  \033]1337;File=inline=1;preserveAspectRatio=1;size=%s;width=19;height=5:%s\a\n' \
+        "$uf_logo_bytes" "$(uf_logo_png_base64)" >&2
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 # The mark, in the brand's five stops from top to bottom.
 #
 # One colour per row rather than per character: a per-character gradient means
 # slicing a string that is full of multi-byte block characters, and `cut -c`
 # counts bytes — it cuts them in half and prints replacement characters.
-uf_brand() {
-  printf '\n' >&2
+uf_logo_blocks() {
   uf_paint '53;214;246'  "  ██    ██   ████████"
   uf_paint '38;119;255'  "  ██    ██   ██"
   uf_paint '92;73;255'   "  ██    ██   ██████"
   uf_paint '143;75;255'  "  ██    ██   ██"
   uf_paint '216;75;255'  "   ██████    ██"
+}
+
+uf_brand() {
+  printf '\n' >&2
+  uf_logo_image || uf_logo_blocks
   printf '\n' >&2
   if [ -z "$uf_colour" ]; then
     printf '  %s\n\n' "Unified Toolchain for Flow" >&2

--- a/infra/cloudflare/workers/setup.js
+++ b/infra/cloudflare/workers/setup.js
@@ -1,8 +1,7 @@
 // GitHub Releases is where the release workflow publishes, and it is what
 // install.sh downloads from by default. Point metadata at the same place so the
 // two cannot disagree about what "latest" is.
-const RELEASE_BASE_URL =
-  "https://github.com/ubugeeei-prod/uf/releases/latest/download";
+const RELEASE_BASE_URL = "https://github.com/ubugeeei-prod/uf/releases/latest/download";
 const DOCS_INSTALL_URL = "https://docs.uniflowed.dev/install";
 
 function responseWithHeaders(response, headers) {

--- a/packages/brand/index.js
+++ b/packages/brand/index.js
@@ -3,14 +3,14 @@
 // `@uniflowed/brand`.
 
 export type BrandColorToken = {
-  +name: string,
-  +token: string,
-  +value: string,
+  readonly name: string,
+  readonly token: string,
+  readonly value: string,
 };
 
 export type BrandScaleToken = {
-  +token: string,
-  +value: string,
+  readonly token: string,
+  readonly value: string,
 };
 
 export const ufBrand = {

--- a/packages/browser/index.js
+++ b/packages/browser/index.js
@@ -8,16 +8,16 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 const MODULE = "@uniflowed/core/browser";
 
 export type Viewport = {
-  +name: string,
-  +width: number,
-  +height: number,
-  +deviceScaleFactor?: number,
+  readonly name: string,
+  readonly width: number,
+  readonly height: number,
+  readonly deviceScaleFactor?: number,
 };
 
 export type VisualSnapshot = {
-  +storyId: string,
-  +viewport: string,
-  +baseline: string,
+  readonly storyId: string,
+  readonly viewport: string,
+  readonly baseline: string,
 };
 
 export opaque type BrowserPlan = NativeHandle<"@uniflowed/core/browser#BrowserPlan">;

--- a/packages/cell/internal/reactive.js
+++ b/packages/cell/internal/reactive.js
@@ -41,18 +41,18 @@ type Listener = () => void;
 /** How far along a [`resource`]'s load is. */
 export type ResourceStatus = "idle" | "pending" | "success" | "failure";
 
-export type CellSnapshot<+T> = {
-  +scope: CellScope,
-  +value: T,
+export type CellSnapshot<out T> = {
+  readonly scope: CellScope,
+  readonly value: T,
 };
 
 type CellCarrier<T> = {
-  +__kind: "Cell",
-  +scope: CellScope,
-  +get: () => T,
-  +set: (T) => void,
-  +subscribe: (Listener) => Unsubscribe,
-  +observe: (Listener) => Unsubscribe,
+  readonly __kind: "Cell",
+  readonly scope: CellScope,
+  readonly get: () => T,
+  readonly set: (T) => void,
+  readonly subscribe: (Listener) => Unsubscribe,
+  readonly observe: (Listener) => Unsubscribe,
 };
 
 export opaque type Cell<T> = CellCarrier<T>;

--- a/packages/config/internal/schema.js
+++ b/packages/config/internal/schema.js
@@ -8,197 +8,197 @@ export type RuleLevel = "off" | "warn" | "error" | 0 | 1 | 2 | boolean;
 export type TaskDefinition =
   | string
   | {
-      +command: string,
-      +cwd?: string,
-      +dependsOn?: $ReadOnlyArray<string>,
-      +env?: { +[string]: string },
+      readonly command: string,
+      readonly cwd?: string,
+      readonly dependsOn?: $ReadOnlyArray<string>,
+      readonly env?: { readonly [string]: string },
     };
 
 export type CapabilityJsHost = "node" | "deno" | "bun";
 
 export type UniflowedConfig = {
-  +app?: {
-    +orm?: {
-      +enabled?: boolean,
-      +module?: "@uniflowed/orm",
-      +native?: true,
-      +generatedFlowTypes?: true,
-      +preparedByDefault?: true,
+  readonly app?: {
+    readonly orm?: {
+      readonly enabled?: boolean,
+      readonly module?: "@uniflowed/orm",
+      readonly native?: true,
+      readonly generatedFlowTypes?: true,
+      readonly preparedByDefault?: true,
     },
-    +builtins?: {
-      +fetch?: {
-        +module?: "@uniflowed/fetch",
-        +overrideGlobalFetch?: false,
+    readonly builtins?: {
+      readonly fetch?: {
+        readonly module?: "@uniflowed/fetch",
+        readonly overrideGlobalFetch?: false,
       },
-      +cell?: boolean,
-      +reactCompiler?: {
-        +enabled?: boolean,
-        +implementation?: "official-rust",
-        +mode?: "syntax",
+      readonly cell?: boolean,
+      readonly reactCompiler?: {
+        readonly enabled?: boolean,
+        readonly implementation?: "official-rust",
+        readonly mode?: "syntax",
       },
-      +graphql?: {
-        +module?: "@uniflowed/graphql",
-        +relayBase?: true,
+      readonly graphql?: {
+        readonly module?: "@uniflowed/graphql",
+        readonly relayBase?: true,
       },
-      +loader?: {
-        +module?: "@uniflowed/loader",
-        +stateModule?: "@uniflowed/state",
-        +cache?: "opt-in",
+      readonly loader?: {
+        readonly module?: "@uniflowed/loader",
+        readonly stateModule?: "@uniflowed/state",
+        readonly cache?: "opt-in",
       },
-      +markdown?: {
-        +module?: "@uniflowed/markdown",
-        +engine?: "ox-content-wasm",
-        +mdx?: {
-          +enabled?: boolean,
-          +extensions?: $ReadOnlyArray<".mdx">,
-          +jsxImportSource?: "@uniflowed/jsx-runtime",
-          +pipelinePlugin?: "built-in",
+      readonly markdown?: {
+        readonly module?: "@uniflowed/markdown",
+        readonly engine?: "ox-content-wasm",
+        readonly mdx?: {
+          readonly enabled?: boolean,
+          readonly extensions?: $ReadOnlyArray<".mdx">,
+          readonly jsxImportSource?: "@uniflowed/jsx-runtime",
+          readonly pipelinePlugin?: "built-in",
         },
-        +cache?: "opt-in",
+        readonly cache?: "opt-in",
       },
-      +motion?: {
-        +module?: "@uniflowed/motion",
-        +engine?: "uf-native",
-        +compilerSafe?: true,
-        +serverComponentSafe?: true,
-        +reducedMotionDefault?: true,
+      readonly motion?: {
+        readonly module?: "@uniflowed/motion",
+        readonly engine?: "uf-native",
+        readonly compilerSafe?: true,
+        readonly serverComponentSafe?: true,
+        readonly reducedMotionDefault?: true,
       },
-      +tui?: {
-        +module?: "@uniflowed/tui",
-        +stdModule?: "@uniflowed/std/tui",
-        +standard?: "open-tui",
-        +nativeRenderer?: true,
-        +beatReactInk?: true,
-        +richMedia?: true,
-        +inMemoryTests?: true,
+      readonly tui?: {
+        readonly module?: "@uniflowed/tui",
+        readonly stdModule?: "@uniflowed/std/tui",
+        readonly standard?: "open-tui",
+        readonly nativeRenderer?: true,
+        readonly beatReactInk?: true,
+        readonly richMedia?: true,
+        readonly inMemoryTests?: true,
       },
-      +pwa?: {
-        +module?: "@uniflowed/pwa",
-        +enabledByDefault?: false,
-        +cache?: "opt-in",
+      readonly pwa?: {
+        readonly module?: "@uniflowed/pwa",
+        readonly enabledByDefault?: false,
+        readonly cache?: "opt-in",
       },
-      +temporal?: {
-        +module?: "@uniflowed/temporal",
-        +lite?: true,
+      readonly temporal?: {
+        readonly module?: "@uniflowed/temporal",
+        readonly lite?: true,
       },
-      +web?: {
-        +module?: "@uniflowed/web",
-        +typedRoutes?: true,
-        +linkPrefetch?: "off" | "intent" | "render",
-        +cache?: "opt-in",
+      readonly web?: {
+        readonly module?: "@uniflowed/web",
+        readonly typedRoutes?: true,
+        readonly linkPrefetch?: "off" | "intent" | "render",
+        readonly cache?: "opt-in",
       },
     },
-    +runtime?: {
-      +default?: "node" | "deno" | "bun" | "uf",
-      +compatibility?: $ReadOnlyArray<
+    readonly runtime?: {
+      readonly default?: "node" | "deno" | "bun" | "uf",
+      readonly compatibility?: $ReadOnlyArray<
         "node" | "bun" | "deno" | "edge" | "serverless" | "container",
       >,
-      +capabilityJsHost?: {
-        +default?: CapabilityJsHost,
-        +hosts?: $ReadOnlyArray<CapabilityJsHost>,
-        +autoDetect?: boolean,
+      readonly capabilityJsHost?: {
+        readonly default?: CapabilityJsHost,
+        readonly hosts?: $ReadOnlyArray<CapabilityJsHost>,
+        readonly autoDetect?: boolean,
       },
-      +deploy?: {
-        +enabled?: boolean,
-        +adapters?: $ReadOnlyArray<
+      readonly deploy?: {
+        readonly enabled?: boolean,
+        readonly adapters?: $ReadOnlyArray<
           "node" | "bun" | "deno" | "edge" | "serverless" | "static" | "container",
         >,
       },
     },
-    +router?: {
-      +entry?: string,
-      +root?: string,
-      +manifest?: string,
+    readonly router?: {
+      readonly entry?: string,
+      readonly root?: string,
+      readonly manifest?: string,
     },
-    +rendering?: {
-      +modes?: $ReadOnlyArray<"ppr" | "ssr" | "ssg" | "isr">,
-      +cache?: {
-        +actions?: boolean,
-        +data?: boolean,
-        +fetch?: boolean,
-        +route?: boolean,
+    readonly rendering?: {
+      readonly modes?: $ReadOnlyArray<"ppr" | "ssr" | "ssg" | "isr">,
+      readonly cache?: {
+        readonly actions?: boolean,
+        readonly data?: boolean,
+        readonly fetch?: boolean,
+        readonly route?: boolean,
       },
     },
   },
-  +build?: {
-    +entries?: $ReadOnlyArray<string>,
-    +outDir?: string,
-    +staticBuild?: boolean,
-    +sourcemap?: boolean,
+  readonly build?: {
+    readonly entries?: $ReadOnlyArray<string>,
+    readonly outDir?: string,
+    readonly staticBuild?: boolean,
+    readonly sourcemap?: boolean,
   },
-  +dev?: {
-    +host?: string,
-    +port?: number,
-    +strictPort?: boolean,
+  readonly dev?: {
+    readonly host?: string,
+    readonly port?: number,
+    readonly strictPort?: boolean,
   },
-  +docs?: {
-    +enabled?: boolean,
-    +app?: string,
-    +source?: string,
-    +outDir?: string,
-    +staticBuild?: boolean,
-    +deploy?: "void",
+  readonly docs?: {
+    readonly enabled?: boolean,
+    readonly app?: string,
+    readonly source?: string,
+    readonly outDir?: string,
+    readonly staticBuild?: boolean,
+    readonly deploy?: "void",
   },
-  +lint?: {
-    +engine?: "rust",
-    +flow?: {
-      +builtins?: "mixed",
-      +parser?: "official-flow-rust",
+  readonly lint?: {
+    readonly engine?: "rust",
+    readonly flow?: {
+      readonly builtins?: "mixed",
+      readonly parser?: "official-flow-rust",
     },
-    +rules?: { +[string]: RuleLevel },
+    readonly rules?: { readonly [string]: RuleLevel },
   },
-  +fmt?: {
-    +indentWidth?: number,
-    +lineWidth?: number,
-    +maxBlankLines?: number,
-    +flow?: {
-      +parser?: "official-flow-rust",
-      +printer?: "uf-rust",
+  readonly fmt?: {
+    readonly indentWidth?: number,
+    readonly lineWidth?: number,
+    readonly maxBlankLines?: number,
+    readonly flow?: {
+      readonly parser?: "official-flow-rust",
+      readonly printer?: "uf-rust",
     },
-    +nonFlow?: {
-      +formatter?: "biome",
+    readonly nonFlow?: {
+      readonly formatter?: "biome",
     },
-    +quotes?: "single" | "double",
-    +semicolons?: boolean,
+    readonly quotes?: "single" | "double",
+    readonly semicolons?: boolean,
   },
-  +package?: {
-    +generator?: "napi-rs",
-    +targets?: $ReadOnlyArray<
+  readonly package?: {
+    readonly generator?: "napi-rs",
+    readonly targets?: $ReadOnlyArray<
       "node-napi" | "bun-napi" | "deno-napi" | "edge-wasm" | "serverless-napi",
     >,
-    +typescriptDeclarationsToFlow?: true,
+    readonly typescriptDeclarationsToFlow?: true,
   },
-  +pm?: {
-    +module?: "@uniflowed/pm",
-    +resolver?: "uf-native",
-    +lockfile?: "uf.lock",
-    +storeDir?: string,
-    +allowLifecycleScripts?: false,
+  readonly pm?: {
+    readonly module?: "@uniflowed/pm",
+    readonly resolver?: "uf-native",
+    readonly lockfile?: "uf.lock",
+    readonly storeDir?: string,
+    readonly allowLifecycleScripts?: false,
   },
-  +rm?: {
-    +module?: "@uniflowed/rm",
-    +inferFromConfig?: true,
-    +version?: "node@system" | string,
-    +autoSwitch?: boolean,
-    +acquisition?: "auto",
-    +apply?: "config-and-host",
-    +doctor?: boolean,
+  readonly rm?: {
+    readonly module?: "@uniflowed/rm",
+    readonly inferFromConfig?: true,
+    readonly version?: "node@system" | string,
+    readonly autoSwitch?: boolean,
+    readonly acquisition?: "auto",
+    readonly apply?: "config-and-host",
+    readonly doctor?: boolean,
   },
-  +server?: {
-    +engine?: "native-rust",
-    +native?: {
-      +streaming?: boolean,
-      +zeroCopyHttp?: boolean,
-      +adapters?: $ReadOnlyArray<
+  readonly server?: {
+    readonly engine?: "native-rust",
+    readonly native?: {
+      readonly streaming?: boolean,
+      readonly zeroCopyHttp?: boolean,
+      readonly adapters?: $ReadOnlyArray<
         "uf" | "node" | "bun" | "deno" | "edge" | "serverless" | "container",
       >,
     },
   },
-  +std?: {
-    +module?: "@uniflowed/std",
-    +wintertcAligned?: true,
-    +nativeBindings?: boolean,
-    +modules?: $ReadOnlyArray<
+  readonly std?: {
+    readonly module?: "@uniflowed/std",
+    readonly wintertcAligned?: true,
+    readonly nativeBindings?: boolean,
+    readonly modules?: $ReadOnlyArray<
       | "vfs"
       | "fs"
       | "types"
@@ -245,58 +245,58 @@ export type UniflowedConfig = {
       | "defer",
     >,
   },
-  +publish?: {
-    +registry?: string,
-    +dryRun?: boolean,
-    +firstPublish?: {
-      +mode?: "local",
-      +localBootstrap?: true,
+  readonly publish?: {
+    readonly registry?: string,
+    readonly dryRun?: boolean,
+    readonly firstPublish?: {
+      readonly mode?: "local",
+      readonly localBootstrap?: true,
     },
-    +trustedPublish?: {
-      +enabled?: true,
-      +provider?: "github-actions-oidc",
-      +tokenless?: true,
-      +trigger?: "tag-push",
-    },
-  },
-  +release?: {
-    +tagPrefix?: "uf@",
-    +command?: "uf release alpha" | string,
-    +publish?: true,
-  },
-  +story?: {
-    +enabled?: boolean,
-    +module?: "@uniflowed/story",
-    +mocks?: {
-      +module?: "@uniflowed/mock",
-      +mswCompatible?: boolean,
-    },
-    +browser?: {
-      +module?: "@uniflowed/browser",
-      +playwrightCompatible?: boolean,
+    readonly trustedPublish?: {
+      readonly enabled?: true,
+      readonly provider?: "github-actions-oidc",
+      readonly tokenless?: true,
+      readonly trigger?: "tag-push",
     },
   },
-  +taskRunner?: {
-    +engine?: "vite-task",
-    +allowPackageScripts?: false,
+  readonly release?: {
+    readonly tagPrefix?: "uf@",
+    readonly command?: "uf release alpha" | string,
+    readonly publish?: true,
   },
-  +test?: {
-    +module?: "@uniflowed/test",
-    +runner?: {
-      +runtime?: "capability-js-host" | "uf-self-hosted",
-      +jsHosts?: $ReadOnlyArray<CapabilityJsHost>,
-      +scheduler?: "native-work-stealing",
-      +performanceTarget?: "faster-than-bun",
-      +officialFlowParser?: true,
+  readonly story?: {
+    readonly enabled?: boolean,
+    readonly module?: "@uniflowed/story",
+    readonly mocks?: {
+      readonly module?: "@uniflowed/mock",
+      readonly mswCompatible?: boolean,
     },
-    +reactTestingLibraryNative?: true,
+    readonly browser?: {
+      readonly module?: "@uniflowed/browser",
+      readonly playwrightCompatible?: boolean,
+    },
   },
-  +tasks?: { +[string]: TaskDefinition },
-  +vrt?: {
-    +enabled?: boolean,
-    +module?: "@uniflowed/vrt",
-    +baselines?: string,
-    +threshold?: number,
+  readonly taskRunner?: {
+    readonly engine?: "vite-task",
+    readonly allowPackageScripts?: false,
+  },
+  readonly test?: {
+    readonly module?: "@uniflowed/test",
+    readonly runner?: {
+      readonly runtime?: "capability-js-host" | "uf-self-hosted",
+      readonly jsHosts?: $ReadOnlyArray<CapabilityJsHost>,
+      readonly scheduler?: "native-work-stealing",
+      readonly performanceTarget?: "faster-than-bun",
+      readonly officialFlowParser?: true,
+    },
+    readonly reactTestingLibraryNative?: true,
+  },
+  readonly tasks?: { readonly [string]: TaskDefinition },
+  readonly vrt?: {
+    readonly enabled?: boolean,
+    readonly module?: "@uniflowed/vrt",
+    readonly baselines?: string,
+    readonly threshold?: number,
   },
 };
 

--- a/packages/core/internal/native-runtime.js
+++ b/packages/core/internal/native-runtime.js
@@ -23,7 +23,7 @@ export type ModuleSpecifier = string;
  * `Name` is a distinct string literal per handle, which keeps two unrelated
  * handles from unifying even inside the module that defines them.
  */
-export type NativeHandle<Name: string> = { +__ufNative: Name };
+export type NativeHandle<Name extends string> = { readonly __ufNative: Name };
 
 /**
  * Phantom carrier for an opaque handle with an invariant type parameter.
@@ -31,8 +31,8 @@ export type NativeHandle<Name: string> = { +__ufNative: Name };
  * `T` sits behind a writable property, which is precisely what invariance
  * means: `Handle<Dog>` is neither a subtype nor a supertype of `Handle<Animal>`.
  */
-export type NativeHandleInvariant<Name: string, T> = {
-  +__ufNative: Name,
+export type NativeHandleInvariant<Name extends string, T> = {
+  readonly __ufNative: Name,
   __ufValue: T,
 };
 
@@ -42,9 +42,9 @@ export type NativeHandleInvariant<Name: string, T> = {
  * `T` only ever appears in a return position, so `Handle<Dog>` stays assignable
  * to `Handle<Animal>` — the guarantee a `+T` sigil makes to callers.
  */
-export type NativeHandleCovariant<Name: string, +T> = {
-  +__ufNative: Name,
-  +__ufValue: () => T,
+export type NativeHandleCovariant<Name extends string, out T> = {
+  readonly __ufNative: Name,
+  readonly __ufValue: () => T,
 };
 
 /**
@@ -53,10 +53,10 @@ export type NativeHandleCovariant<Name: string, +T> = {
  * Same guarantee as `NativeHandleCovariant`, for a handle that tracks two
  * things at once — a fiber's success and failure types, say.
  */
-export type NativeHandleCovariant2<Name: string, +A, +B> = {
-  +__ufNative: Name,
-  +__ufFirst: () => A,
-  +__ufSecond: () => B,
+export type NativeHandleCovariant2<Name extends string, out A, out B> = {
+  readonly __ufNative: Name,
+  readonly __ufFirst: () => A,
+  readonly __ufSecond: () => B,
 };
 
 /**
@@ -66,11 +66,11 @@ export type NativeHandleCovariant2<Name: string, +A, +B> = {
  * behind a function that returns it, which is what makes all three covariant
  * rather than merely declared so.
  */
-export type NativeHandleCovariant3<Name: string, +A, +B, +C> = {
-  +__ufNative: Name,
-  +__ufFirst: () => A,
-  +__ufSecond: () => B,
-  +__ufThird: () => C,
+export type NativeHandleCovariant3<Name extends string, out A, out B, out C> = {
+  readonly __ufNative: Name,
+  readonly __ufFirst: () => A,
+  readonly __ufSecond: () => B,
+  readonly __ufThird: () => C,
 };
 
 /**
@@ -103,9 +103,6 @@ export class NativeRuntimeRequiredError extends Error {
  * free of side effects so bundlers can drop the modules an application never
  * touches.
  */
-export function nativeRuntimeRequired(
-  moduleSpecifier: ModuleSpecifier,
-  binding: string,
-): empty {
+export function nativeRuntimeRequired(moduleSpecifier: ModuleSpecifier, binding: string): empty {
   throw new NativeRuntimeRequiredError(moduleSpecifier, binding);
 }

--- a/packages/effect/internal/runtime.js
+++ b/packages/effect/internal/runtime.js
@@ -7,40 +7,40 @@
 // native binding to construct or run these effects on Node.js, Deno, or Bun.
 
 type EffectKernel = {
-  +run: (Context) => Promise<Exit<mixed, mixed>>,
-  +runSync?: (Context) => Exit<mixed, mixed>,
+  readonly run: (Context) => Promise<Exit<mixed, mixed>>,
+  readonly runSync?: (Context) => Exit<mixed, mixed>,
 };
 
-type FiberCarrier<+A, +E> = {
-  +__kind: "Fiber",
-  +__value: () => A,
-  +__error: () => E,
-  +__promise: Promise<Exit<mixed, mixed>>,
-  +__fiber: FiberState,
+type FiberCarrier<out A, out E> = {
+  readonly __kind: "Fiber",
+  readonly __value: () => A,
+  readonly __error: () => E,
+  readonly __promise: Promise<Exit<mixed, mixed>>,
+  readonly __fiber: FiberState,
 };
 
-type EffectCarrier<+A, +E, +R> = {
-  +__kind: "Effect",
-  +__value: () => A,
-  +__error: () => E,
-  +__requires: () => R,
-  +__kernel: EffectKernel,
+type EffectCarrier<out A, out E, out R> = {
+  readonly __kind: "Effect",
+  readonly __value: () => A,
+  readonly __error: () => E,
+  readonly __requires: () => R,
+  readonly __kernel: EffectKernel,
 };
 
-type TagCarrier<+Service> = {
-  +__kind: "Tag",
-  +__service: () => Service,
-  +identifier: string,
+type TagCarrier<out Service> = {
+  readonly __kind: "Tag",
+  readonly __service: () => Service,
+  readonly identifier: string,
 };
 
 type LayerKernel = (Context) => Promise<Exit<{ [string]: mixed }, mixed>>;
 
-type LayerCarrier<+Out, +E, +In> = {
-  +__kind: "Layer",
-  +__out: () => Out,
-  +__error: () => E,
-  +__in: () => In,
-  +__layer: LayerKernel,
+type LayerCarrier<out Out, out E, out In> = {
+  readonly __kind: "Layer",
+  readonly __out: () => Out,
+  readonly __error: () => E,
+  readonly __in: () => In,
+  readonly __layer: LayerKernel,
 };
 
 type ScopeState = {
@@ -72,41 +72,41 @@ type Context = {
  * `E` defaults to `empty`, Flow's bottom type, so `Effect<number>` reads as
  * cannot fail. `R` defaults to `empty` for an effect that needs no services.
  */
-export opaque type Effect<+A, +E = empty, +R = empty> = EffectCarrier<A, E, R>;
+export opaque type Effect<out A, out E = empty, out R = empty> = EffectCarrier<A, E, R>;
 
 /** A running effect, addressable so it can be awaited. */
-export opaque type Fiber<+A, +E = empty> = FiberCarrier<A, E>;
+export opaque type Fiber<out A, out E = empty> = FiberCarrier<A, E>;
 
 /** Identifies one service inside a context. */
-export opaque type Tag<+Service> = TagCarrier<Service>;
+export opaque type Tag<out Service> = TagCarrier<Service>;
 
 /** A recipe for building services, itself possibly failing. */
-export opaque type Layer<+Out, +E = empty, +In = empty> = LayerCarrier<Out, E, In>;
+export opaque type Layer<out Out, out E = empty, out In = empty> = LayerCarrier<Out, E, In>;
 
 /** The lifetime a resource is released at. */
-export opaque type Scope = { +__kind: "Scope" };
+export opaque type Scope = { readonly __kind: "Scope" };
 
-export type Cause<+E> =
-  | { +kind: "empty" }
-  | { +kind: "fail", +error: E }
-  | { +kind: "die", +defect: string }
-  | { +kind: "interrupt" }
-  | { +kind: "sequential", +causes: $ReadOnlyArray<Cause<E>> }
-  | { +kind: "parallel", +causes: $ReadOnlyArray<Cause<E>> };
+export type Cause<out E> =
+  | { readonly kind: "empty" }
+  | { readonly kind: "fail", readonly error: E }
+  | { readonly kind: "die", readonly defect: string }
+  | { readonly kind: "interrupt" }
+  | { readonly kind: "sequential", readonly causes: $ReadOnlyArray<Cause<E>> }
+  | { readonly kind: "parallel", readonly causes: $ReadOnlyArray<Cause<E>> };
 
-export type Exit<+A, +E> =
-  | { +kind: "success", +value: A }
-  | { +kind: "failure", +cause: Cause<E> };
+export type Exit<out A, out E> =
+  | { readonly kind: "success", readonly value: A }
+  | { readonly kind: "failure", readonly cause: Cause<E> };
 
 export type Schedule =
-  | { +kind: "recurs", +times: number }
-  | { +kind: "spaced", +millis: number }
-  | { +kind: "exponential", +baseMillis: number, +factorPercent?: number }
-  | { +kind: "fibonacci", +baseMillis: number }
-  | { +kind: "upTo", +millis: number }
-  | { +kind: "intersect", +left: Schedule, +right: Schedule }
-  | { +kind: "union", +left: Schedule, +right: Schedule }
-  | { +kind: "maxDelay", +schedule: Schedule, +millis: number };
+  | { readonly kind: "recurs", readonly times: number }
+  | { readonly kind: "spaced", readonly millis: number }
+  | { readonly kind: "exponential", readonly baseMillis: number, readonly factorPercent?: number }
+  | { readonly kind: "fibonacci", readonly baseMillis: number }
+  | { readonly kind: "upTo", readonly millis: number }
+  | { readonly kind: "intersect", readonly left: Schedule, readonly right: Schedule }
+  | { readonly kind: "union", readonly left: Schedule, readonly right: Schedule }
+  | { readonly kind: "maxDelay", readonly schedule: Schedule, readonly millis: number };
 
 export type Concurrency = number | "unbounded" | "inherit";
 
@@ -290,17 +290,11 @@ function defect<A>(defectValue: mixed): Exit<A, empty> {
   return failure(dieCause(defectValue));
 }
 
-async function runKernel<A, E, R>(
-  self: Effect<A, E, R>,
-  runContext: Context,
-): Promise<Exit<A, E>> {
-  return ((await readKernel(self).run(runContext)): any);
+async function runKernel<A, E, R>(self: Effect<A, E, R>, runContext: Context): Promise<Exit<A, E>> {
+  return (await readKernel(self).run(runContext): any);
 }
 
-function runSyncKernel<A, E, R>(
-  self: Effect<A, E, R>,
-  runContext: Context,
-): Exit<A, E> {
+function runSyncKernel<A, E, R>(self: Effect<A, E, R>, runContext: Context): Exit<A, E> {
   const runSync = readKernel(self).runSync;
   if (runSync == null) {
     return failure(dieCause("effect is asynchronous"));
@@ -319,17 +313,19 @@ function isPromiseLike(value: mixed): boolean {
 function mapCause<E, F>(cause: Cause<E>, transform: (E) => F): Cause<F> {
   return match (cause) {
     {kind: "fail", error: const error} => failCause(transform(error)),
-    {kind: "sequential", causes: const causes} => ({
-      kind: "sequential",
-      causes: causes.map((entry) => mapCause(entry, transform)),
-    }),
-    {kind: "parallel", causes: const causes} => ({
-      kind: "parallel",
-      causes: causes.map((entry) => mapCause(entry, transform)),
-    }),
-    {kind: "die", defect: const defect} => ({ kind: "die", defect }),
-    {kind: "interrupt"} => ({ kind: "interrupt" }),
-    _ => ({ kind: "empty" }),
+    {kind: "sequential", causes: const causes} =>
+      {
+        kind: "sequential",
+        causes: causes.map((entry) => mapCause(entry, transform)),
+      },
+    {kind: "parallel", causes: const causes} =>
+      {
+        kind: "parallel",
+        causes: causes.map((entry) => mapCause(entry, transform)),
+      },
+    {kind: "die", defect: const defect} => { kind: "die", defect },
+    {kind: "interrupt"} => { kind: "interrupt" },
+    _ => { kind: "empty" },
   };
 }
 
@@ -414,12 +410,12 @@ function fibonacci(index: number): number {
 
 function scheduleDelay(schedule: Schedule, attempt: number): ?number {
   return match (schedule) {
-    {kind: "recurs", times: const times} => (attempt < times ? 0 : null),
+    {kind: "recurs", times: const times} => attempt < times ? 0 : null,
     {kind: "spaced", millis: const millis} => millis,
     {kind: "exponential", baseMillis: const baseMillis, factorPercent: const factorPercent} =>
       exponentialDelay(baseMillis, factorPercent, attempt),
     {kind: "fibonacci", baseMillis: const baseMillis} => baseMillis * fibonacci(attempt),
-    {kind: "upTo", millis: const millis} => (attempt === 0 ? Math.max(0, millis) : null),
+    {kind: "upTo", millis: const millis} => attempt === 0 ? Math.max(0, millis) : null,
     {kind: "intersect", left: const left, right: const right} =>
       intersectDelay(left, right, attempt),
     {kind: "union", left: const left, right: const right} => unionDelay(left, right, attempt),
@@ -456,7 +452,10 @@ function capDelay(schedule: Schedule, millis: number, attempt: number): ?number 
   return delayed == null ? null : Math.min(delayed, millis);
 }
 
-function concurrencyLimit(length: number, options?: { +concurrency?: Concurrency }): number {
+function concurrencyLimit(
+  length: number,
+  options?: { readonly concurrency?: Concurrency },
+): number {
   const requested = options == null ? "unbounded" : options.concurrency;
   if (requested == null || requested === "unbounded" || requested === "inherit") {
     return Math.max(1, length);
@@ -542,8 +541,8 @@ export function promise<A>(body: () => Promise<A>): Effect<A> {
 }
 
 export function tryPromise<A, E>(options: {
-  +try: () => Promise<A>,
-  +catch: (error: mixed) => E,
+  readonly try: () => Promise<A>,
+  readonly catch: (error: mixed) => E,
 }): Effect<A, E> {
   return makeEffect({
     run: async () => {
@@ -711,7 +710,7 @@ export function zip<A, B, E1, E2, R1, R2>(
 
 export function all<A, E, R>(
   effects: $ReadOnlyArray<Effect<A, E, R>>,
-  options?: { +concurrency?: Concurrency },
+  options?: { readonly concurrency?: Concurrency },
 ): Effect<$ReadOnlyArray<A>, E, R> {
   return makeEffect({
     run: async (runContext) => {
@@ -746,14 +745,15 @@ export function all<A, E, R>(
 export function forEach<A, B, E, R>(
   items: $ReadOnlyArray<A>,
   body: (item: A, index: number) => Effect<B, E, R>,
-  options?: { +concurrency?: Concurrency },
+  options?: { readonly concurrency?: Concurrency },
 ): Effect<$ReadOnlyArray<B>, E, R> {
-  return all(items.map((item, index) => body(item, index)), options);
+  return all(
+    items.map((item, index) => body(item, index)),
+    options,
+  );
 }
 
-export function race<A, E, R>(
-  effects: $ReadOnlyArray<Effect<A, E, R>>,
-): Effect<A, E, R> {
+export function race<A, E, R>(effects: $ReadOnlyArray<Effect<A, E, R>>): Effect<A, E, R> {
   return makeEffect({
     run: (runContext) => {
       if (effects.length === 0) {
@@ -808,7 +808,11 @@ export function orElse<A, B, E, F, R1, R2>(
 
 export function either<A, E, R>(
   self: Effect<A, E, R>,
-): Effect<{ +ok: true, +value: A } | { +ok: false, +error: E }, empty, R> {
+): Effect<
+  { readonly ok: true, readonly value: A } | { readonly ok: false, readonly error: E },
+  empty,
+  R,
+> {
   return makeEffect({
     run: async (runContext) => {
       const exit = await runKernel(self, runContext);
@@ -827,10 +831,7 @@ export function either<A, E, R>(
   });
 }
 
-export function retry<A, E, R>(
-  self: Effect<A, E, R>,
-  schedule: Schedule,
-): Effect<A, E, R> {
+export function retry<A, E, R>(self: Effect<A, E, R>, schedule: Schedule): Effect<A, E, R> {
   return makeEffect({
     run: async (runContext) => {
       let attempt = 0;
@@ -860,7 +861,7 @@ export function retry<A, E, R>(
 export function timeout<A, E, R>(
   self: Effect<A, E, R>,
   millis: number,
-): Effect<A, E | { +kind: "timeout", +millis: number }, R> {
+): Effect<A, E | { readonly kind: "timeout", readonly millis: number }, R> {
   return makeEffect({
     run: (runContext) =>
       Promise.race([
@@ -894,9 +895,7 @@ export function acquireRelease<A, E, R>(
   });
 }
 
-export function scoped<A, E, R>(
-  self: Effect<A, E, R | Scope>,
-): Effect<A, E, R> {
+export function scoped<A, E, R>(self: Effect<A, E, R | Scope>): Effect<A, E, R> {
   return makeEffect({
     run: async (runContext) => {
       const scopedContext = withScope(runContext);
@@ -957,10 +956,7 @@ export function provide<A, E, R, Out, LayerError, In>(
   });
 }
 
-export function layerSucceed<Service>(
-  serviceTag: Tag<Service>,
-  service: Service,
-): Layer<Service> {
+export function layerSucceed<Service>(serviceTag: Tag<Service>, service: Service): Layer<Service> {
   return makeLayer(() => Promise.resolve(success({ [readTag(serviceTag)]: service })));
 }
 
@@ -970,9 +966,7 @@ export function layerEffect<Service, E, R>(
 ): Layer<Service, E, R> {
   return makeLayer(async (runContext) => {
     const exit = await runKernel(build, runContext);
-    return exit.kind === "failure"
-      ? (exit: any)
-      : success({ [readTag(serviceTag)]: exit.value });
+    return exit.kind === "failure" ? (exit: any) : success({ [readTag(serviceTag)]: exit.value });
   });
 }
 
@@ -1035,11 +1029,10 @@ export function interrupt<A, E>(fiber: Fiber<A, E>): Effect<Exit<A, E>> {
       for (const wake of Array.from(carrier.__fiber.wakers)) {
         wake();
       }
-      return success(((await carrier.__promise): any));
+      return success((await carrier.__promise: any));
     },
   });
 }
-
 
 /**
  * Wait, doing nothing.
@@ -1086,9 +1079,7 @@ export function tapError<A, E, R1, R2>(
 /** Turn any failure of `self` into a defect, so its error type is `empty`. */
 function orDie<A, E, R>(self: Effect<A, E, R>): Effect<A, empty, R> {
   const convert = (settled) =>
-    settled.kind === "success"
-      ? (settled: any)
-      : failure(dieCause(causeMessage(settled.cause)));
+    settled.kind === "success" ? (settled: any) : failure(dieCause(causeMessage(settled.cause)));
 
   return makeEffect({
     run: async (runContext) => convert(await runKernel(self, runContext)),
@@ -1115,9 +1106,7 @@ export function ensuring<A, E, R>(
   // that is itself cancelled is not a cleanup. A finalizer that fails replaces
   // a success and is swallowed by a failure, which is already worse news.
   const combine = (settled, released) =>
-    released.kind === "failure" && settled.kind === "success"
-      ? (released: any)
-      : (settled: any);
+    released.kind === "failure" && settled.kind === "success" ? (released: any) : (settled: any);
 
   return makeEffect({
     run: async (runContext) => {
@@ -1142,7 +1131,7 @@ export function ensuring<A, E, R>(
  */
 export function exit<A, E, R>(self: Effect<A, E, R>): Effect<Exit<A, E>, empty, R> {
   return makeEffect({
-    run: async (runContext) => success(((await runKernel(self, runContext)): any)),
+    run: async (runContext) => success((await runKernel(self, runContext): any)),
     runSync: (runContext) => success((runSyncKernel(self, runContext): any)),
   });
 }

--- a/packages/fetch/internal/client.js
+++ b/packages/fetch/internal/client.js
@@ -20,11 +20,16 @@
 
 /** What went wrong, as a value rather than a string. */
 export type FetchFailure =
-  | {| +kind: "http", +status: number, +statusText: string, +response: Response |}
-  | {| +kind: "network", +cause: mixed |}
-  | {| +kind: "timeout", +millis: number |}
-  | {| +kind: "parse", +cause: mixed |}
-  | {| +kind: "invalid", +issues: $ReadOnlyArray<mixed> |};
+  | {|
+      readonly kind: "http",
+      readonly status: number,
+      readonly statusText: string,
+      readonly response: Response,
+    |}
+  | {| readonly kind: "network", readonly cause: mixed |}
+  | {| readonly kind: "timeout", readonly millis: number |}
+  | {| readonly kind: "parse", readonly cause: mixed |}
+  | {| readonly kind: "invalid", readonly issues: $ReadOnlyArray<mixed> |};
 
 /**
  * A request that failed, carrying why.
@@ -34,8 +39,8 @@ export type FetchFailure =
  * a message that already says what happened.
  */
 export class FetchError extends Error {
-  +failure: FetchFailure;
-  +url: string;
+  readonly failure: FetchFailure;
+  readonly url: string;
 
   constructor(url: string, failure: FetchFailure) {
     super(describe(url, failure));
@@ -53,9 +58,7 @@ export class FetchError extends Error {
       // the server's problem rather than the request's. Nothing else is worth
       // sending again: a 400 will be a 400 next time too.
       "http" =>
-        this.failure.status === 408 ||
-        this.failure.status === 429 ||
-        this.failure.status >= 500,
+        this.failure.status === 408 || this.failure.status === 429 || this.failure.status >= 500,
       _ => false,
     };
   }
@@ -80,42 +83,44 @@ function describe(url: string, failure: FetchFailure): string {
  */
 export type Parse<T> = (
   value: mixed,
-) => {| +ok: true, +value: T |} | {| +ok: false, +issues: $ReadOnlyArray<mixed> |};
+) =>
+  | {| readonly ok: true, readonly value: T |}
+  | {| readonly ok: false, readonly issues: $ReadOnlyArray<mixed> |};
 
 /** How a client behaves for every request it makes. */
 export type FetchConfig = {|
-  +baseURL?: string,
-  +headers?: { +[string]: string },
+  readonly baseURL?: string,
+  readonly headers?: { readonly [string]: string },
   /** Abort a request that has not answered. Defaults to 30 seconds. */
-  +timeout?: number,
+  readonly timeout?: number,
   /** How many further attempts a retriable failure gets. Defaults to none. */
-  +retries?: number,
+  readonly retries?: number,
   /** Milliseconds before the first retry; doubles each time. Defaults to 200. */
-  +retryDelay?: number,
+  readonly retryDelay?: number,
   /** Swap in a different `fetch`, which is how a test avoids the network. */
-  +fetch?: typeof fetch,
+  readonly fetch?: typeof fetch,
 |};
 
 /** One request. */
 export type RequestOptions<T> = {|
-  +method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE",
+  readonly method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE",
   /** Sent as JSON unless it is already a `BodyInit`. */
-  +body?: mixed,
-  +headers?: { +[string]: string },
-  +searchParams?: { +[string]: string | number | boolean },
-  +signal?: AbortSignal,
-  +timeout?: number,
-  +retries?: number,
+  readonly body?: mixed,
+  readonly headers?: { readonly [string]: string },
+  readonly searchParams?: { readonly [string]: string | number | boolean },
+  readonly signal?: AbortSignal,
+  readonly timeout?: number,
+  readonly retries?: number,
   /** Checked against the parsed body; its failure is the request's failure. */
-  +parse?: Parse<T>,
+  readonly parse?: Parse<T>,
 |};
 
 /** A configured client. */
 export type FetchClient = {|
-  +request: <T>(path: string, options?: RequestOptions<T>) => Promise<T>,
-  +raw: (path: string, options?: RequestOptions<mixed>) => Promise<Response>,
+  readonly request: <T>(path: string, options?: RequestOptions<T>) => Promise<T>,
+  readonly raw: (path: string, options?: RequestOptions<mixed>) => Promise<Response>,
   /** A client with more defaults applied on top of this one's. */
-  +extend: (config: FetchConfig) => FetchClient,
+  readonly extend: (config: FetchConfig) => FetchClient,
 |};
 
 const DEFAULTS = { timeout: 30_000, retries: 0, retryDelay: 200 };
@@ -131,7 +136,7 @@ const IDEMPOTENT = new Set(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"]);
  * application talks to more than one.
  */
 export function createFetch(config?: FetchConfig): FetchClient {
-  const settings = { ...DEFAULTS, ...(config ?? {}) };
+  const settings = { ...DEFAULTS, ...config ?? {} };
 
   const raw = async (path: string, options?: RequestOptions<mixed>): Promise<Response> =>
     send(settings, path, options ?? {});
@@ -147,7 +152,7 @@ export function createFetch(config?: FetchConfig): FetchClient {
       createFetch({
         ...settings,
         ...extra,
-        headers: { ...(settings.headers ?? {}), ...(extra.headers ?? {}) },
+        headers: { ...settings.headers ?? {}, ...extra.headers ?? {} },
       }),
   };
 }
@@ -209,8 +214,8 @@ function requestInit(
   signal: AbortSignal,
 ): RequestOptions<mixed> {
   const headers: { [string]: string } = {
-    ...(settings.headers ?? {}),
-    ...(options.headers ?? {}),
+    ...settings.headers ?? {},
+    ...options.headers ?? {},
   };
 
   let body = options.body;
@@ -304,11 +309,7 @@ async function parse<T>(
   return checked.value;
 }
 
-function resolveUrl(
-  settings: $FlowFixMe,
-  path: string,
-  options: RequestOptions<mixed>,
-): string {
+function resolveUrl(settings: $FlowFixMe, path: string, options: RequestOptions<mixed>): string {
   const base = settings.baseURL;
   const joined =
     base == null || /^[a-z][a-z0-9+.-]*:/i.test(path)

--- a/packages/graphql/index.js
+++ b/packages/graphql/index.js
@@ -9,29 +9,27 @@ const MODULE = "@uniflowed/core/graphql";
 
 /** A compiled operation, keyed by both its data and its variables. */
 export opaque type GraphQlOperation<TData, TVariables> = {
-  +__ufNative: "@uniflowed/core/graphql#GraphQlOperation",
+  readonly __ufNative: "@uniflowed/core/graphql#GraphQlOperation",
   __ufData: TData,
   __ufVariables: TVariables,
 };
 
 export type GraphQlClient = {
-  +fetch: FetchClient,
-  +relayBase: true,
+  readonly fetch: FetchClient,
+  readonly relayBase: true,
 };
 
-export function graphql<TData, TVariables: {...}>(
+export function graphql<TData, TVariables extends { ... }>(
   text: string,
 ): GraphQlOperation<TData, TVariables> {
   return nativeRuntimeRequired(MODULE, "graphql");
 }
 
-export function createGraphQlClient(config: {
-  +fetch: FetchClient,
-}): GraphQlClient {
+export function createGraphQlClient(config: { readonly fetch: FetchClient }): GraphQlClient {
   return nativeRuntimeRequired(MODULE, "createGraphQlClient");
 }
 
-export function useLazyLoadQuery<TData, TVariables: {...}>(
+export function useLazyLoadQuery<TData, TVariables extends { ... }>(
   operation: GraphQlOperation<TData, TVariables>,
   variables: TVariables,
 ): Promise<TData> {

--- a/packages/hmr/internal/client.js
+++ b/packages/hmr/internal/client.js
@@ -30,12 +30,7 @@ export const LOG_PREFIX: string = "[uf hmr]";
 export type ChangeKind = "created" | "modified" | "deleted";
 
 /** What the browser and the server have to do about it. */
-export type UpdateKind =
-  | "inert"
-  | "hot"
-  | "route"
-  | "hot-and-route"
-  | "full-reload";
+export type UpdateKind = "inert" | "hot" | "route" | "hot-and-route" | "full-reload";
 
 /** Why an update could not be applied in place. */
 export type ReloadReason =
@@ -50,21 +45,21 @@ export type UpdateRole = "boundary" | "dependency";
 
 /** One module to re-fetch. */
 export type UpdateModule = {
-  +path: string,
-  +url: string,
-  +role: UpdateRole,
+  readonly path: string,
+  readonly url: string,
+  readonly role: UpdateRole,
 };
 
 /** One update, exactly as `uf_devserver::hmr::HmrUpdate` serializes it. */
 export type HmrUpdate = {
-  +id: number,
-  +path: string,
-  +change: ChangeKind,
-  +kind: UpdateKind,
-  +reason?: ReloadReason,
-  +modules: $ReadOnlyArray<UpdateModule>,
-  +routes: $ReadOnlyArray<string>,
-  +elapsedMicros: number,
+  readonly id: number,
+  readonly path: string,
+  readonly change: ChangeKind,
+  readonly kind: UpdateKind,
+  readonly reason?: ReloadReason,
+  readonly modules: $ReadOnlyArray<UpdateModule>,
+  readonly routes: $ReadOnlyArray<string>,
+  readonly elapsedMicros: number,
 };
 
 /**
@@ -78,17 +73,17 @@ export type RefreshHandler = (next: mixed) => void;
 
 /** What `connect` hands back. */
 export type HmrClient = {
-  +accept: (modulePath: string, handler: RefreshHandler) => void,
-  +apply: (update: HmrUpdate) => Promise<UpdateKind>,
-  +close: () => void,
-  +applied: () => number,
+  readonly accept: (modulePath: string, handler: RefreshHandler) => void,
+  readonly apply: (update: HmrUpdate) => Promise<UpdateKind>,
+  readonly close: () => void,
+  readonly applied: () => number,
 };
 
 /** How to open the channel. */
 export type ConnectOptions = {
-  +endpoint?: string,
-  +onUpdate?: (update: HmrUpdate) => void,
-  +onReload?: (reason: string) => void,
+  readonly endpoint?: string,
+  readonly onUpdate?: (update: HmrUpdate) => void,
+  readonly onReload?: (reason: string) => void,
 };
 
 /**
@@ -109,7 +104,7 @@ export function parseUpdate(data: string): HmrUpdate | null {
   if (parsed == null || typeof parsed !== "object") {
     return null;
   }
-  const candidate: { +[string]: mixed } = (parsed: $FlowFixMe);
+  const candidate: { readonly [string]: mixed } = (parsed: $FlowFixMe);
   if (typeof candidate.kind !== "string" || typeof candidate.path !== "string") {
     return null;
   }
@@ -135,8 +130,7 @@ export function isFullReload(update: HmrUpdate): boolean {
  */
 export function connect(options?: ConnectOptions): HmrClient {
   const settings: ConnectOptions = options == null ? {} : options;
-  const endpoint: string =
-    typeof settings.endpoint === "string" ? settings.endpoint : HMR_ENDPOINT;
+  const endpoint: string = typeof settings.endpoint === "string" ? settings.endpoint : HMR_ENDPOINT;
   const handlers: Map<string, RefreshHandler> = new Map();
   const global = getGlobal();
   const source = openStream(global, endpoint);
@@ -228,11 +222,7 @@ function applyModules(
         }
         const handler = handlers.get(module.path);
         if (handler == null) {
-          report(
-            global,
-            "warn",
-            module.path + " has no refresh handler registered",
-          );
+          report(global, "warn", module.path + " has no refresh handler registered");
           return false;
         }
         handler(next);

--- a/packages/hooks/internal/async.js
+++ b/packages/hooks/internal/async.js
@@ -17,11 +17,11 @@ import { useCallback, useEffect, useState } from "@uniflowed/react";
 
 /** What an in-flight, settled or failed call looks like. */
 export type Async<T> = {|
-  +value: T | null,
-  +error: Error | null,
-  +pending: boolean,
+  readonly value: T | null,
+  readonly error: Error | null,
+  readonly pending: boolean,
   /** Run it again, keeping whatever is on screen until the new value lands. */
-  +reload: () => void,
+  readonly reload: () => void,
 |};
 
 /**
@@ -31,10 +31,7 @@ export type Async<T> = {|
  * blanking the page to show a spinner every time a filter changes is worse
  * than showing slightly stale data for a moment. `pending` says which it is.
  */
-export function useAsync<T>(
-  body: () => Promise<T>,
-  deps: $ReadOnlyArray<mixed>,
-): Async<T> {
+export function useAsync<T>(body: () => Promise<T>, deps: $ReadOnlyArray<mixed>): Async<T> {
   const [state, setState] = useState<{|
     value: T | null,
     error: Error | null,

--- a/packages/hooks/internal/browser.js
+++ b/packages/hooks/internal/browser.js
@@ -61,12 +61,8 @@ export function useMediaQuery(query: string, serverValue: boolean = false): bool
 }
 
 /** The reader's colour-scheme preference. */
-export function usePreferredColorScheme(
-  serverValue: "light" | "dark" = "light",
-): "light" | "dark" {
-  return useMediaQuery("(prefers-color-scheme: dark)", serverValue === "dark")
-    ? "dark"
-    : "light";
+export function usePreferredColorScheme(serverValue: "light" | "dark" = "light"): "light" | "dark" {
+  return useMediaQuery("(prefers-color-scheme: dark)", serverValue === "dark") ? "dark" : "light";
 }
 
 /** Whether the reader has asked for less motion. */
@@ -91,7 +87,7 @@ export function useOnline(serverValue: boolean = true): boolean {
 
   return useSyncExternalStore(
     subscribe,
-    () => (inBrowser() ? (windowOf().navigator?.onLine ?? true) : serverValue),
+    () => (inBrowser() ? windowOf().navigator?.onLine ?? true : serverValue),
     () => serverValue,
   );
 }
@@ -114,9 +110,12 @@ export function useDocumentVisible(serverValue: boolean = true): boolean {
 }
 
 /** The size of the viewport. */
-export function useWindowSize(serverValue?: {| +width: number, +height: number |}): {|
-  +width: number,
-  +height: number,
+export function useWindowSize(serverValue?: {|
+  readonly width: number,
+  readonly height: number,
+|}): {|
+  readonly width: number,
+  readonly height: number,
 |} {
   const fallback = serverValue ?? { width: 0, height: 0 };
 

--- a/packages/hooks/internal/element.js
+++ b/packages/hooks/internal/element.js
@@ -32,7 +32,7 @@ function windowOf(): any {
  * covers the window, the document, and a node that does not exist yet at the
  * time the hook is called.
  */
-export function useEventListener<TEvent: Event>(
+export function useEventListener<TEvent extends Event>(
   target: Ref<EventTarget> | EventTarget | (() => EventTarget | null) | null,
   name: string,
   handler: (event: TEvent) => mixed,
@@ -61,10 +61,7 @@ export function useEventListener<TEvent: Event>(
  * open for the whole press — and because a click whose press started inside
  * the menu and ended outside it should not close it.
  */
-export function useClickOutside(
-  ref: Ref<HTMLElement>,
-  handler: (event: Event) => mixed,
-): void {
+export function useClickOutside(ref: Ref<HTMLElement>, handler: (event: Event) => mixed): void {
   const stable = useStableCallback(handler);
 
   useEffect(() => {
@@ -107,8 +104,8 @@ export function useFocusWithin(ref: Ref<HTMLElement>): boolean {
  * container query fires — none of which resizes the window.
  */
 export function useElementSize(ref: Ref<HTMLElement>): {|
-  +width: number,
-  +height: number,
+  readonly width: number,
+  readonly height: number,
 |} {
   const [size, setSize] = useState({ width: 0, height: 0 });
 
@@ -141,7 +138,7 @@ export function useElementSize(ref: Ref<HTMLElement>): {|
 /** Whether the element is in the viewport. */
 export function useIntersecting(
   ref: Ref<HTMLElement>,
-  options?: {| +rootMargin?: string, +threshold?: number |},
+  options?: {| readonly rootMargin?: string, readonly threshold?: number |},
 ): boolean {
   const [intersecting, setIntersecting] = useState(false);
   const rootMargin = options?.rootMargin;
@@ -184,6 +181,6 @@ function resolve(
 }
 
 /** A ref for one of the hooks above, typed for the element you will attach it to. */
-export function useElementRef<T: HTMLElement>(): Ref<T> {
+export function useElementRef<T extends HTMLElement>(): Ref<T> {
   return useRef<T | null>(null);
 }

--- a/packages/hooks/internal/lifecycle.js
+++ b/packages/hooks/internal/lifecycle.js
@@ -38,7 +38,7 @@ export const useIsomorphicLayoutEffect: typeof useLayoutEffect =
  * — and it is written before any layout effect runs, so a subscription set up
  * in one already sees the current body.
  */
-export function useStableCallback<TArgs: $ReadOnlyArray<mixed>, TReturn>(
+export function useStableCallback<TArgs extends $ReadOnlyArray<mixed>, TReturn>(
   callback: (...args: TArgs) => TReturn,
 ): (...args: TArgs) => TReturn {
   const latest = useRef(callback);

--- a/packages/hooks/internal/state.js
+++ b/packages/hooks/internal/state.js
@@ -14,9 +14,9 @@ import { useStableCallback } from "./lifecycle.js";
 
 /** A boolean with the three things a caller ever does to one. */
 export function useToggle(initial: boolean = false): {|
-  +on: boolean,
-  +toggle: () => void,
-  +set: (value: boolean) => void,
+  readonly on: boolean,
+  readonly toggle: () => void,
+  readonly set: (value: boolean) => void,
 |} {
   const [on, setOn] = useState(initial);
   const toggle = useCallback(() => setOn((value) => !value), []);
@@ -26,13 +26,13 @@ export function useToggle(initial: boolean = false): {|
 /** A number, optionally clamped. */
 export function useCounter(
   initial: number = 0,
-  bounds?: {| +min?: number, +max?: number |},
+  bounds?: {| readonly min?: number, readonly max?: number |},
 ): {|
-  +count: number,
-  +increment: (by?: number) => void,
-  +decrement: (by?: number) => void,
-  +set: (value: number) => void,
-  +reset: () => void,
+  readonly count: number,
+  readonly increment: (by?: number) => void,
+  readonly decrement: (by?: number) => void,
+  readonly set: (value: number) => void,
+  readonly reset: () => void,
 |} {
   const min = bounds?.min;
   const max = bounds?.max;
@@ -46,10 +46,7 @@ export function useCounter(
   );
 
   const [count, setCount] = useState(() => clamp(initial));
-  const move = useCallback(
-    (delta: number) => setCount((value) => clamp(value + delta)),
-    [clamp],
-  );
+  const move = useCallback((delta: number) => setCount((value) => clamp(value + delta)), [clamp]);
 
   return useMemo(
     () => ({
@@ -99,7 +96,7 @@ function area(session: boolean): mixed {
 export function useStorage<T>(
   key: string,
   initial: T,
-  options?: {| +session?: boolean |},
+  options?: {| readonly session?: boolean |},
 ): [T, (value: T) => void] {
   const session = options?.session ?? false;
 

--- a/packages/hooks/internal/timing.js
+++ b/packages/hooks/internal/timing.js
@@ -66,7 +66,7 @@ export function useDebouncedValue<T>(value: T, millis: number): T {
  * the window are dropped, which is what a scroll or resize handler wants —
  * the trailing-edge version would make the first paint late.
  */
-export function useThrottledCallback<TArgs: $ReadOnlyArray<mixed>>(
+export function useThrottledCallback<TArgs extends $ReadOnlyArray<mixed>>(
   body: (...args: TArgs) => mixed,
   millis: number,
 ): (...args: TArgs) => void {
@@ -88,7 +88,7 @@ export function useThrottledCallback<TArgs: $ReadOnlyArray<mixed>>(
  * Trailing edge, and it cancels itself at unmount — the version people write
  * calls `setState` on a component that is gone.
  */
-export function useDebouncedCallback<TArgs: $ReadOnlyArray<mixed>>(
+export function useDebouncedCallback<TArgs extends $ReadOnlyArray<mixed>>(
   body: (...args: TArgs) => mixed,
   millis: number,
 ): (...args: TArgs) => void {

--- a/packages/jsx-runtime/index.js
+++ b/packages/jsx-runtime/index.js
@@ -16,7 +16,7 @@ const MODULE = "@uniflowed/core/jsx-runtime";
  * Props an element carries, with its children under the reserved name the
  * runtime reads them from.
  */
-export type JsxProps = { +children?: Node, ... };
+export type JsxProps = { readonly children?: Node, ... };
 
 /**
  * Create an element with zero or one child.

--- a/packages/lib/index.js
+++ b/packages/lib/index.js
@@ -19,10 +19,10 @@ export type NativeModuleKind =
   | "ui";
 
 export type NativeModule = {
-  +specifier: string,
-  +kind: NativeModuleKind,
-  +stability: "experimental" | "planned" | "stable",
-  +flowExports: $ReadOnlyArray<string>,
+  readonly specifier: string,
+  readonly kind: NativeModuleKind,
+  readonly stability: "experimental" | "planned" | "stable",
+  readonly flowExports: $ReadOnlyArray<string>,
 };
 
 /**

--- a/packages/lint/index.js
+++ b/packages/lint/index.js
@@ -9,20 +9,18 @@ const MODULE = "@uniflowed/core/lint";
 export type RuleSeverity = "off" | "warn" | "error";
 
 export type RuleContext = {
-  +filename: string,
-  +source: string,
+  readonly filename: string,
+  readonly source: string,
 };
 
 export type RuleDiagnostic = {
-  +rule: string,
-  +message: string,
-  +line: number,
-  +column: number,
+  readonly rule: string,
+  readonly message: string,
+  readonly line: number,
+  readonly column: number,
 };
 
-export type NativeRule = (
-  context: RuleContext,
-) => $ReadOnlyArray<RuleDiagnostic>;
+export type NativeRule = (context: RuleContext) => $ReadOnlyArray<RuleDiagnostic>;
 
 export function defineRule(name: string, rule: NativeRule): NativeRule {
   return nativeRuntimeRequired(MODULE, "defineRule");

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -14,20 +14,14 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 const MODULE = "@uniflowed/core/loader";
 
 export type LoaderState<T> =
-  | { +status: "idle" }
-  | { +status: "pending" }
-  | { +status: "ready", +value: T }
-  | { +status: "failed", +error: Error };
+  | { readonly status: "idle" }
+  | { readonly status: "pending" }
+  | { readonly status: "ready", readonly value: T }
+  | { readonly status: "failed", readonly error: Error };
 
-export opaque type Loader<T> = NativeHandleInvariant<
-  "@uniflowed/core/loader#Loader",
-  T,
->;
+export opaque type Loader<T> = NativeHandleInvariant<"@uniflowed/core/loader#Loader", T>;
 
-export function createLoader<T>(
-  key: string,
-  load: (client: FetchClient) => Promise<T>,
-): Loader<T> {
+export function createLoader<T>(key: string, load: (client: FetchClient) => Promise<T>): Loader<T> {
   return nativeRuntimeRequired(MODULE, "createLoader");
 }
 

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -8,33 +8,24 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 const MODULE = "@uniflowed/core/markdown";
 
 export type MarkdownOptions = {
-  +cache?: "opt-in",
-  +rsc?: true,
+  readonly cache?: "opt-in",
+  readonly rsc?: true,
 };
 
 export type MdxOptions = MarkdownOptions & {
-  +components?: { +[string]: mixed },
-  +jsxImportSource?: "@uniflowed/jsx-runtime",
+  readonly components?: { readonly [string]: mixed },
+  readonly jsxImportSource?: "@uniflowed/jsx-runtime",
 };
 
-export component Markdown(
-  source: string,
-  options?: MarkdownOptions,
-) renders React.Node {
+export component Markdown(source: string, options?: MarkdownOptions) renders React.Node {
   return nativeRuntimeRequired(MODULE, "Markdown");
 }
 
-export function renderMarkdown(
-  source: string,
-  options?: MarkdownOptions,
-): Promise<string> {
+export function renderMarkdown(source: string, options?: MarkdownOptions): Promise<string> {
   return nativeRuntimeRequired(MODULE, "renderMarkdown");
 }
 
-export function compileMarkdown(
-  source: string,
-  options?: MarkdownOptions,
-): Promise<React.Node> {
+export function compileMarkdown(source: string, options?: MarkdownOptions): Promise<React.Node> {
   return nativeRuntimeRequired(MODULE, "compileMarkdown");
 }
 
@@ -46,9 +37,6 @@ export function renderMdx(source: string, options?: MdxOptions): Promise<string>
   return nativeRuntimeRequired(MODULE, "renderMdx");
 }
 
-export function compileMdx(
-  source: string,
-  options?: MdxOptions,
-): Promise<React.Node> {
+export function compileMdx(source: string, options?: MdxOptions): Promise<React.Node> {
   return nativeRuntimeRequired(MODULE, "compileMdx");
 }

--- a/packages/motion/index.js
+++ b/packages/motion/index.js
@@ -12,18 +12,18 @@ export type MotionProperty = "transform" | "opacity" | "color";
 export type MotionEasing = "linear" | "out" | "spring";
 
 export type MotionTrack = {
-  +id: string,
-  +property: MotionProperty,
-  +durationMs: number,
-  +easing?: MotionEasing,
+  readonly id: string,
+  readonly property: MotionProperty,
+  readonly durationMs: number,
+  readonly easing?: MotionEasing,
 };
 
 export type MotionContract = {
-  +engine: MotionEngine,
-  +tracks: $ReadOnlyArray<MotionTrack>,
-  +compilerSafe: true,
-  +serverComponentSafe: true,
-  +reducedMotionDefault: true,
+  readonly engine: MotionEngine,
+  readonly tracks: $ReadOnlyArray<MotionTrack>,
+  readonly compilerSafe: true,
+  readonly serverComponentSafe: true,
+  readonly reducedMotionDefault: true,
 };
 
 export function motion(contract?: MotionContract): MotionContract {
@@ -34,17 +34,11 @@ export function animate(track: MotionTrack): MotionContract {
   return nativeRuntimeRequired(MODULE, "animate");
 }
 
-export function timeline(
-  tracks: $ReadOnlyArray<MotionTrack>,
-): MotionContract {
+export function timeline(tracks: $ReadOnlyArray<MotionTrack>): MotionContract {
   return nativeRuntimeRequired(MODULE, "timeline");
 }
 
-export function spring(
-  id: string,
-  property: MotionProperty,
-  durationMs: number,
-): MotionTrack {
+export function spring(id: string, property: MotionProperty, durationMs: number): MotionTrack {
   return nativeRuntimeRequired(MODULE, "spring");
 }
 

--- a/packages/orm/index.js
+++ b/packages/orm/index.js
@@ -2,41 +2,29 @@
 //
 // `@uniflowed/orm`.
 
-import type {
-  NativeHandle,
-  NativeHandleInvariant,
-} from "@uniflowed/core/native";
+import type { NativeHandle, NativeHandleInvariant } from "@uniflowed/core/native";
 import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
 const MODULE = "@uniflowed/core/orm";
 
-export opaque type Table<Row: { +[string]: mixed }> = NativeHandleInvariant<
+export opaque type Table<Row extends { readonly [string]: mixed }> = NativeHandleInvariant<
   "@uniflowed/core/orm#Table",
   Row,
 >;
-export opaque type Column<T> = NativeHandleInvariant<
-  "@uniflowed/core/orm#Column",
-  T,
->;
-export opaque type Query<Row: { +[string]: mixed }> = NativeHandleInvariant<
+export opaque type Column<T> = NativeHandleInvariant<"@uniflowed/core/orm#Column", T>;
+export opaque type Query<Row extends { readonly [string]: mixed }> = NativeHandleInvariant<
   "@uniflowed/core/orm#Query",
   Row,
 >;
 export opaque type Migration = NativeHandle<"@uniflowed/core/orm#Migration">;
 
-export type ColumnType =
-  | "text"
-  | "int64"
-  | "boolean"
-  | "json"
-  | "timestamp"
-  | "uuid";
+export type ColumnType = "text" | "int64" | "boolean" | "json" | "timestamp" | "uuid";
 
 export type OrmContract = {
-  +driver: "sqlite" | "postgres" | "mysql",
-  +preparedByDefault: true,
-  +generatedFlowTypes: true,
-  +parameterizedQueriesOnly: true,
+  readonly driver: "sqlite" | "postgres" | "mysql",
+  readonly preparedByDefault: true,
+  readonly generatedFlowTypes: true,
+  readonly parameterizedQueriesOnly: true,
 };
 
 export function column<T>(name: string, ty: ColumnType): Column<T> {
@@ -51,27 +39,25 @@ export function nullable<T>(column: Column<T>): Column<?T> {
   return nativeRuntimeRequired(MODULE, "nullable");
 }
 
-export function defineTable<Row: { +[string]: mixed }>(
+export function defineTable<Row extends { readonly [string]: mixed }>(
   name: string,
-  columns: { +[string]: Column<mixed> },
+  columns: { readonly [string]: Column<mixed> },
 ): Table<Row> {
   return nativeRuntimeRequired(MODULE, "defineTable");
 }
 
 export function relation<
-  From: { +[string]: mixed },
-  To: { +[string]: mixed },
+  From extends { readonly [string]: mixed },
+  To extends { readonly [string]: mixed },
 >(from: Table<From>, to: Table<To>): void {
   return nativeRuntimeRequired(MODULE, "relation");
 }
 
-export function query<Row: { +[string]: mixed }>(
-  table: Table<Row>,
-): Query<Row> {
+export function query<Row extends { readonly [string]: mixed }>(table: Table<Row>): Query<Row> {
   return nativeRuntimeRequired(MODULE, "query");
 }
 
-export function whereEq<Row: { +[string]: mixed }, Value>(
+export function whereEq<Row extends { readonly [string]: mixed }, Value>(
   query: Query<Row>,
   column: Column<Value>,
   value: Value,
@@ -79,7 +65,7 @@ export function whereEq<Row: { +[string]: mixed }, Value>(
   return nativeRuntimeRequired(MODULE, "whereEq");
 }
 
-export function limit<Row: { +[string]: mixed }>(
+export function limit<Row extends { readonly [string]: mixed }>(
   query: Query<Row>,
   count: number,
 ): Query<Row> {
@@ -91,13 +77,9 @@ export function migration(name: string): Migration {
 }
 
 export const db: {
-  query<Row: { +[string]: mixed }>(
-    query: Query<Row>,
-  ): Promise<$ReadOnlyArray<Row>>,
+  query<Row extends { readonly [string]: mixed }>(query: Query<Row>): Promise<$ReadOnlyArray<Row>>,
 } = {
-  query<Row: { +[string]: mixed }>(
-    query: Query<Row>,
-  ): Promise<$ReadOnlyArray<Row>> {
+  query<Row extends { readonly [string]: mixed }>(query: Query<Row>): Promise<$ReadOnlyArray<Row>> {
     return nativeRuntimeRequired(MODULE, "db.query");
   },
 };

--- a/packages/pm/index.js
+++ b/packages/pm/index.js
@@ -13,24 +13,24 @@ export type PackageStoreStrategy = "content-addressed";
 export type PackageLinkMode = "hardlink-then-copy";
 
 export type WorkspacePackage = {
-  +name: string,
-  +path: string,
+  readonly name: string,
+  readonly path: string,
 };
 
 export type PackageStore = {
-  +strategy: PackageStoreStrategy,
-  +directory: string,
+  readonly strategy: PackageStoreStrategy,
+  readonly directory: string,
 };
 
 export type PackageManagerPlan = {
-  +resolver: PackageResolver,
-  +lockfile: "uf.lock" | string,
-  +registry: string,
-  +scripts: PackageScriptPolicy,
-  +store: PackageStore,
-  +linkMode: PackageLinkMode,
-  +workspacePackages: $ReadOnlyArray<WorkspacePackage>,
-  +steps: $ReadOnlyArray<
+  readonly resolver: PackageResolver,
+  readonly lockfile: "uf.lock" | string,
+  readonly registry: string,
+  readonly scripts: PackageScriptPolicy,
+  readonly store: PackageStore,
+  readonly linkMode: PackageLinkMode,
+  readonly workspacePackages: $ReadOnlyArray<WorkspacePackage>,
+  readonly steps: $ReadOnlyArray<
     | "read-config"
     | "resolve-graph"
     | "verify-integrity"
@@ -40,9 +40,7 @@ export type PackageManagerPlan = {
   >,
 };
 
-export function inferFromConfig(
-  config: UniflowedConfig,
-): PackageManagerPlan {
+export function inferFromConfig(config: UniflowedConfig): PackageManagerPlan {
   return nativeRuntimeRequired(MODULE, "inferFromConfig");
 }
 

--- a/packages/prepare/index.js
+++ b/packages/prepare/index.js
@@ -15,10 +15,10 @@ export type PrepareStep =
   | "run-format-check";
 
 export type PreparePlan = {
-  +lintStagedCompatible: boolean,
-  +codeGenerator: boolean,
-  +cache: "opt-in",
-  +steps: $ReadOnlyArray<PrepareStep>,
+  readonly lintStagedCompatible: boolean,
+  readonly codeGenerator: boolean,
+  readonly cache: "opt-in",
+  readonly steps: $ReadOnlyArray<PrepareStep>,
 };
 
 export function prepare(): PreparePlan {

--- a/packages/pwa/index.js
+++ b/packages/pwa/index.js
@@ -7,9 +7,9 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 const MODULE = "@uniflowed/core/pwa";
 
 export type PwaConfig = {
-  +name: string,
-  +shortName?: string,
-  +cache?: "opt-in",
+  readonly name: string,
+  readonly shortName?: string,
+  readonly cache?: "opt-in",
 };
 
 export function definePwa(config: PwaConfig): PwaConfig {

--- a/packages/query/index.js
+++ b/packages/query/index.js
@@ -19,16 +19,7 @@
 // the cache is testable without rendering anything.
 
 export type { Entry, QueryKey } from "./internal/cache.js";
-export type {
-  MutationResult,
-  QueryOptions,
-  QueryResult,
-} from "./internal/react.js";
+export type { MutationResult, QueryOptions, QueryResult } from "./internal/react.js";
 
 export { QueryCache, hash } from "./internal/cache.js";
-export {
-  QueryProvider,
-  useMutation,
-  useQuery,
-  useQueryCache,
-} from "./internal/react.js";
+export { QueryProvider, useMutation, useQuery, useQueryCache } from "./internal/react.js";

--- a/packages/query/internal/cache.js
+++ b/packages/query/internal/cache.js
@@ -25,13 +25,13 @@ export type QueryKey = $ReadOnlyArray<mixed>;
 
 /** What the cache holds for one key. */
 export type Entry<T> = {|
-  +value: T | void,
-  +error: Error | null,
+  readonly value: T | void,
+  readonly error: Error | null,
   /** When the value arrived, so staleness is a question the reader can ask. */
-  +updatedAt: number,
-  +pending: boolean,
+  readonly updatedAt: number,
+  readonly pending: boolean,
   /** Bumped on every change, so a snapshot can be compared by identity. */
-  +version: number,
+  readonly version: number,
 |};
 
 type Slot = {
@@ -70,10 +70,10 @@ const EMPTY: Entry<mixed> = {
  * decides another's result.
  */
 export class QueryCache {
-  +slots: Map<string, Slot> = new Map();
-  +garbageMillis: number;
+  readonly slots: Map<string, Slot> = new Map();
+  readonly garbageMillis: number;
 
-  constructor(options?: {| +garbageMillis?: number |}) {
+  constructor(options?: {| readonly garbageMillis?: number |}) {
     this.garbageMillis = options?.garbageMillis ?? DEFAULT_GARBAGE_MILLIS;
   }
 
@@ -114,7 +114,7 @@ export class QueryCache {
   watch<T>(
     key: QueryKey,
     query: () => Promise<T>,
-    options: {| +listener: () => void, +staleTime: number |},
+    options: {| readonly listener: () => void, readonly staleTime: number |},
   ): () => void {
     const id = hash(key);
     const slot = this.slot(id);
@@ -229,7 +229,7 @@ export class QueryCache {
     return slot;
   }
 
-  write(id: string, patch: { +[string]: mixed }): void {
+  write(id: string, patch: { readonly [string]: mixed }): void {
     const slot = this.slot(id);
     slot.entry = ({
       ...slot.entry,

--- a/packages/query/internal/react.js
+++ b/packages/query/internal/react.js
@@ -55,21 +55,21 @@ export function useQueryCache(): QueryCache {
 
 /** What a query looks like to a component. */
 export type QueryResult<T> = {|
-  +value: T | void,
-  +error: Error | null,
+  readonly value: T | void,
+  readonly error: Error | null,
   /** A request is in flight. True on the first load and on a refresh. */
-  +pending: boolean,
+  readonly pending: boolean,
   /** There has never been a value, so there is nothing to show yet. */
-  +loading: boolean,
+  readonly loading: boolean,
   /** The value is older than `staleTime`. */
-  +stale: boolean,
-  +refetch: () => Promise<T>,
+  readonly stale: boolean,
+  readonly refetch: () => Promise<T>,
 |};
 
 /** How a query behaves. */
 export type QueryOptions = {|
   /** How long a value is fresh. Defaults to none, so a mount refetches. */
-  +staleTime?: number,
+  readonly staleTime?: number,
 |};
 
 /**
@@ -127,10 +127,10 @@ export function useQuery<T>(
 
 /** What a mutation looks like to a component. */
 export type MutationResult<TInput, TOutput> = {|
-  +run: (input: TInput) => Promise<TOutput>,
-  +value: TOutput | void,
-  +error: Error | null,
-  +pending: boolean,
+  readonly run: (input: TInput) => Promise<TOutput>,
+  readonly value: TOutput | void,
+  readonly error: Error | null,
+  readonly pending: boolean,
 |};
 
 /**
@@ -148,7 +148,7 @@ export type MutationResult<TInput, TOutput> = {|
  */
 export function useMutation<TInput, TOutput>(
   mutation: (input: TInput) => Promise<TOutput>,
-  options?: {| +invalidates?: $ReadOnlyArray<QueryKey> |},
+  options?: {| readonly invalidates?: $ReadOnlyArray<QueryKey> |},
 ): MutationResult<TInput, TOutput> {
   const cache = useQueryCache();
   const [state, setState] = useState<{|

--- a/packages/react-compiler/index.js
+++ b/packages/react-compiler/index.js
@@ -10,9 +10,9 @@ export type ReactCompilerMode = "syntax";
 export type ReactCompilerImplementation = "official-rust";
 
 export interface ReactCompilerConfig {
-  readonly enabled: boolean,
-  readonly implementation: ReactCompilerImplementation,
-  readonly mode: ReactCompilerMode,
+  readonly enabled: boolean;
+  readonly implementation: ReactCompilerImplementation;
+  readonly mode: ReactCompilerMode;
 }
 
 /** Default configuration: syntax mode, enabled. */
@@ -22,8 +22,6 @@ export const syntaxMode: ReactCompilerConfig = {
   mode: "syntax",
 };
 
-export function compiler(
-  config?: Partial<ReactCompilerConfig>,
-): ReactCompilerConfig {
+export function compiler(config?: Partial<ReactCompilerConfig>): ReactCompilerConfig {
   return nativeRuntimeRequired(MODULE, "compiler");
 }

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -7,11 +7,11 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
 const MODULE = "@uniflowed/core/react-native";
 
-export component View(...props: $ReadOnly<{ +children?: React.Node }>) {
+export component View(...props: $ReadOnly<{ readonly children?: React.Node }>) {
   return nativeRuntimeRequired(MODULE, "View");
 }
 
-export component Text(...props: $ReadOnly<{ +children?: React.Node }>) {
+export component Text(...props: $ReadOnly<{ readonly children?: React.Node }>) {
   return nativeRuntimeRequired(MODULE, "Text");
 }
 
@@ -21,13 +21,23 @@ export component Text(...props: $ReadOnly<{ +children?: React.Node }>) {
  * `select` raises rather than silently picking a branch.
  */
 export const Platform: {
-  +OS: "ios" | "android" | "web" | "native",
-  +select: <T>(
-    options: $ReadOnly<{ +ios?: T, +android?: T, +web?: T, +native?: T }>,
+  readonly OS: "ios" | "android" | "web" | "native",
+  readonly select: <T>(
+    options: $ReadOnly<{
+      readonly ios?: T,
+      readonly android?: T,
+      readonly web?: T,
+      readonly native?: T,
+    }>,
   ) => T | void,
 } = {
   OS: "native",
   select: <T>(
-    options: $ReadOnly<{ +ios?: T, +android?: T, +web?: T, +native?: T }>,
+    options: $ReadOnly<{
+      readonly ios?: T,
+      readonly android?: T,
+      readonly web?: T,
+      readonly native?: T,
+    }>,
   ): T | void => nativeRuntimeRequired(MODULE, "Platform.select"),
 };

--- a/packages/react-testing/internal/events.js
+++ b/packages/react-testing/internal/events.js
@@ -18,7 +18,7 @@
 import { actively } from "./render.js";
 
 /** Event constructors by DOM event name, with the right interface for each. */
-const EVENT_TYPES: { +[string]: string } = {
+const EVENT_TYPES: { readonly [string]: string } = {
   click: "MouseEvent",
   dblclick: "MouseEvent",
   mousedown: "MouseEvent",
@@ -45,7 +45,7 @@ const EVENT_TYPES: { +[string]: string } = {
 /** Events that do not bubble, whatever else is said about them. */
 const NON_BUBBLING = new Set(["focus", "blur", "mouseenter", "mouseleave"]);
 
-function construct(name: string, init: { +[string]: mixed }): Event {
+function construct(name: string, init: { readonly [string]: mixed }): Event {
   const interfaceName = EVENT_TYPES[name] ?? "Event";
   const Constructor = (globalThis: any)[interfaceName] ?? globalThis.Event;
   const options = {
@@ -71,7 +71,7 @@ function construct(name: string, init: { +[string]: mixed }): Event {
 export function dispatch(
   target: EventTarget,
   name: string,
-  init?: { +[string]: mixed },
+  init?: { readonly [string]: mixed },
 ): boolean {
   const event = construct(name, init ?? {});
   let ran = true;
@@ -89,7 +89,7 @@ export function dispatch(
  * also works, for an event whose name is computed.
  */
 export const fireEvent: any = new Proxy(
-  (target: EventTarget, name: string, init?: { +[string]: mixed }) =>
+  (target: EventTarget, name: string, init?: { readonly [string]: mixed }) =>
     dispatch(target, name, init),
   {
     get(base, property) {
@@ -99,7 +99,7 @@ export const fireEvent: any = new Proxy(
       if (property in base) {
         return (base: any)[property];
       }
-      return (target: EventTarget, init?: { +[string]: mixed }) =>
+      return (target: EventTarget, init?: { readonly [string]: mixed }) =>
         dispatch(target, property.toLowerCase(), init);
     },
   },
@@ -122,7 +122,7 @@ function setValue(element: HTMLElement, value: string): void {
 
 /** A key's `key`, `code` and printable text. */
 function describeKey(key: string): {| key: string, code: string, text: string | null |} {
-  const named: { +[string]: {| code: string, text: string | null |} } = {
+  const named: { readonly [string]: {| code: string, text: string | null |} } = {
     Enter: { code: "Enter", text: "\n" },
     Tab: { code: "Tab", text: null },
     Escape: { code: "Escape", text: null },
@@ -163,7 +163,7 @@ function tabbable(): Array<HTMLElement> {
  */
 export const userEvent = {
   /** Press and release, with the events a real click produces, in order. */
-  async click(element: HTMLElement, init?: { +[string]: mixed }): Promise<void> {
+  async click(element: HTMLElement, init?: { readonly [string]: mixed }): Promise<void> {
     if ((element: any).disabled === true) {
       return;
     }
@@ -230,7 +230,7 @@ export const userEvent = {
   },
 
   /** Move focus the way the Tab key does. */
-  async tab(options?: {| +shift?: boolean |}): Promise<void> {
+  async tab(options?: {| readonly shift?: boolean |}): Promise<void> {
     const order = tabbable();
     if (order.length === 0) {
       return;

--- a/packages/react-testing/internal/queries.js
+++ b/packages/react-testing/internal/queries.js
@@ -21,7 +21,7 @@ export type Matcher = string | RegExp | ((content: string, element: Element) => 
 /** How exactly a string matcher has to match. */
 export type MatcherOptions = {|
   /** `false` matches a substring, case-insensitively. Defaults to `true`. */
-  +exact?: boolean,
+  readonly exact?: boolean,
 |};
 
 /**
@@ -35,7 +35,12 @@ export function normalize(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
-function matches(content: string, element: Element, matcher: Matcher, options?: MatcherOptions): boolean {
+function matches(
+  content: string,
+  element: Element,
+  matcher: Matcher,
+  options?: MatcherOptions,
+): boolean {
   if (typeof matcher === "function") {
     return matcher(content, element);
   }
@@ -80,7 +85,7 @@ export function allByText(
 export function allByRole(
   root: ParentNode,
   role: string,
-  options?: {| +name?: Matcher, +exact?: boolean |},
+  options?: {| readonly name?: Matcher, readonly exact?: boolean |},
 ): Array<Element> {
   const found = candidates(root, "*").filter((element) => roleOf(element) === role);
   const name = options?.name;
@@ -174,7 +179,7 @@ function cssEscape(value: string): string {
 }
 
 /** Roles a tag has without being told. */
-const IMPLICIT_ROLES: { +[string]: string } = {
+const IMPLICIT_ROLES: { readonly [string]: string } = {
   a: "link",
   article: "article",
   aside: "complementary",
@@ -209,7 +214,7 @@ const IMPLICIT_ROLES: { +[string]: string } = {
 };
 
 /** The input types that are not a textbox. */
-const INPUT_ROLES: { +[string]: string } = {
+const INPUT_ROLES: { readonly [string]: string } = {
   button: "button",
   checkbox: "checkbox",
   email: "textbox",
@@ -301,7 +306,6 @@ export function queryFailure(
         : JSON.stringify(matcher);
   const html = (root: any).innerHTML ?? "";
   const shown = html.length > 2000 ? `${html.slice(0, 2000)}\n…` : html;
-  const count =
-    found === 0 ? "found nothing" : `found ${found} elements and needed exactly one`;
+  const count = found === 0 ? "found nothing" : `found ${found} elements and needed exactly one`;
   return new Error(`${kind} ${description}: ${count}\n\n${shown}`);
 }

--- a/packages/react-testing/internal/render.js
+++ b/packages/react-testing/internal/render.js
@@ -21,15 +21,15 @@ import { installDom } from "./dom.js";
 /** What `render` hands back. */
 export type RenderResult = {|
   /** The element the tree was mounted into. */
-  +container: Element,
+  readonly container: Element,
   /** The document body, which is where a portal ends up. */
-  +baseElement: Element,
+  readonly baseElement: Element,
   /** Render different elements into the same container. */
-  +rerender: (ui: React.Node) => void,
+  readonly rerender: (ui: React.Node) => void,
   /** Take the tree down and remove the container. */
-  +unmount: () => void,
+  readonly unmount: () => void,
   /** The container's markup, for a failure message. */
-  +asFragment: () => string,
+  readonly asFragment: () => string,
 |};
 
 type Mounted = {|
@@ -47,7 +47,7 @@ const mounted: Array<Mounted> = [];
  * make "there is exactly one Save button" false for reasons that have nothing
  * to do with the test being read.
  */
-export function render(ui: React.Node, options?: {| +container?: Element |}): RenderResult {
+export function render(ui: React.Node, options?: {| readonly container?: Element |}): RenderResult {
   installDom();
   cleanup();
 
@@ -147,7 +147,7 @@ export function actively<T>(body: () => T): T {
  */
 export async function waitFor<T>(
   body: () => T | Promise<T>,
-  options?: {| +timeout?: number, +interval?: number |},
+  options?: {| readonly timeout?: number, readonly interval?: number |},
 ): Promise<T> {
   const timeout = options?.timeout ?? 1000;
   const interval = options?.interval ?? 20;

--- a/packages/react-testing/internal/screen.js
+++ b/packages/react-testing/internal/screen.js
@@ -24,7 +24,7 @@ import { waitFor } from "./render.js";
 
 /** The queries available on `screen` and on `within(element)`. */
 export type Queries = {
-  +[string]: (matcher: mixed, options?: mixed) => any,
+  readonly [string]: (matcher: mixed, options?: mixed) => any,
 };
 
 /** Every query, as the one function each needs. */

--- a/packages/relay/index.js
+++ b/packages/relay/index.js
@@ -7,30 +7,26 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
 const MODULE = "@uniflowed/core/relay";
 
-export opaque type GraphQLTaggedNode =
-  NativeHandle<"@uniflowed/core/relay#GraphQLTaggedNode">;
+export opaque type GraphQLTaggedNode = NativeHandle<"@uniflowed/core/relay#GraphQLTaggedNode">;
 
 export function graphql(source: string): GraphQLTaggedNode {
   return nativeRuntimeRequired(MODULE, "graphql");
 }
 
-export function useFragment<T>(
-  fragment: GraphQLTaggedNode,
-  key: mixed,
-): T {
+export function useFragment<T>(fragment: GraphQLTaggedNode, key: mixed): T {
   return nativeRuntimeRequired(MODULE, "useFragment");
 }
 
 export function useLazyLoadQuery<T>(
   query: GraphQLTaggedNode,
-  variables: { +[string]: mixed },
+  variables: { readonly [string]: mixed },
 ): T {
   return nativeRuntimeRequired(MODULE, "useLazyLoadQuery");
 }
 
 export function commitMutation<T>(config: {
-  +mutation: GraphQLTaggedNode,
-  +variables: { +[string]: mixed },
+  readonly mutation: GraphQLTaggedNode,
+  readonly variables: { readonly [string]: mixed },
 }): Promise<T> {
   return nativeRuntimeRequired(MODULE, "commitMutation");
 }

--- a/packages/rm/index.js
+++ b/packages/rm/index.js
@@ -7,37 +7,30 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
 const MODULE = "@uniflowed/core/rm";
 
-export type RuntimeEngine =
-  | "uf"
-  | "node"
-  | "deno"
-  | "bun"
-  | "edge"
-  | "serverless"
-  | "container";
+export type RuntimeEngine = "uf" | "node" | "deno" | "bun" | "edge" | "serverless" | "container";
 
 export type RuntimeHost = RuntimeEngine;
 export type RuntimeAcquisition = "auto";
 export type RuntimeApplication = "config-and-host";
-export type RuntimeReference = { +name: "uf" | string, +version: string };
+export type RuntimeReference = { readonly name: "uf" | string, readonly version: string };
 
 export type XdgLayout = {
-  +configDir: string,
-  +dataDir: string,
-  +cacheDir: string,
-  +stateDir: string,
-  +runtimeDir?: string,
-  +binDir: string,
-  +shimPath: string,
-  +versionsDir: string,
+  readonly configDir: string,
+  readonly dataDir: string,
+  readonly cacheDir: string,
+  readonly stateDir: string,
+  readonly runtimeDir?: string,
+  readonly binDir: string,
+  readonly shimPath: string,
+  readonly versionsDir: string,
 };
 
 export type RuntimeManagerPlan = {
-  +engine: RuntimeEngine,
-  +hosts: $ReadOnlyArray<RuntimeHost>,
-  +acquisition: RuntimeAcquisition,
-  +application: RuntimeApplication,
-  +steps: $ReadOnlyArray<
+  readonly engine: RuntimeEngine,
+  readonly hosts: $ReadOnlyArray<RuntimeHost>,
+  readonly acquisition: RuntimeAcquisition,
+  readonly application: RuntimeApplication,
+  readonly steps: $ReadOnlyArray<
     | "read-config"
     | "infer-runtime"
     | "detect-capability-host"
@@ -48,10 +41,10 @@ export type RuntimeManagerPlan = {
 };
 
 export type RuntimeUsePlan = {
-  +requested: RuntimeReference,
-  +layout: XdgLayout,
-  +autoSwitch: boolean,
-  +steps: $ReadOnlyArray<
+  readonly requested: RuntimeReference,
+  readonly layout: XdgLayout,
+  readonly autoSwitch: boolean,
+  readonly steps: $ReadOnlyArray<
     | "resolve-version"
     | "download-runtime"
     | "verify-checksum"
@@ -61,9 +54,7 @@ export type RuntimeUsePlan = {
   >,
 };
 
-export function inferRuntime(
-  config: UniflowedConfig,
-): RuntimeManagerPlan {
+export function inferRuntime(config: UniflowedConfig): RuntimeManagerPlan {
   return nativeRuntimeRequired(MODULE, "inferRuntime");
 }
 
@@ -71,9 +62,7 @@ export function useRuntime(specifier: string): RuntimeUsePlan {
   return nativeRuntimeRequired(MODULE, "useRuntime");
 }
 
-export function acquireRuntime(
-  plan: RuntimeManagerPlan,
-): Promise<RuntimeManagerPlan> {
+export function acquireRuntime(plan: RuntimeManagerPlan): Promise<RuntimeManagerPlan> {
   return nativeRuntimeRequired(MODULE, "acquireRuntime");
 }
 

--- a/packages/router/client.js
+++ b/packages/router/client.js
@@ -18,9 +18,9 @@ import { DATA_ID, ROOT_ID } from "./server.js";
  * Hydrate the current document.
  */
 export async function hydrate(options: {|
-  +App: React.ComponentType<AppProps>,
-  +routes: RouteTable["routes"],
-  +notFound: RouteTable["notFound"],
+  readonly App: React.ComponentType<AppProps>,
+  readonly routes: RouteTable["routes"],
+  readonly notFound: RouteTable["notFound"],
 |}): Promise<void> {
   const table: RouteTable = { routes: options.routes, notFound: options.notFound };
   installRoutes(table);

--- a/packages/router/handler.js
+++ b/packages/router/handler.js
@@ -31,26 +31,23 @@ import type { RouteParams } from "./internal/runtime.js";
 /** What a handler is given besides the request. */
 export type HandlerContext = {|
   /** The `[param]` and `[...rest]` segments of the matched path. */
-  +params: RouteParams,
+  readonly params: RouteParams,
   /** The parsed query string, for the common case of reading one value. */
-  +searchParams: URLSearchParams,
+  readonly searchParams: URLSearchParams,
 |};
 
 /** One exported method of a handler module. */
-export type Handler = (
-  request: Request,
-  context: HandlerContext,
-) => Response | Promise<Response>;
+export type Handler = (request: Request, context: HandlerContext) => Response | Promise<Response>;
 
 /** A handler module, as the generated table loads it. */
-export type HandlerModule = { +[method: string]: mixed };
+export type HandlerModule = { readonly [method: string]: mixed };
 
 /** One entry of the generated handler table. */
 export type HandlerRecord = {|
-  +path: string,
-  +params: $ReadOnlyArray<{| +name: string, +catchAll: boolean |}>,
-  +file: string,
-  +load: () => Promise<HandlerModule>,
+  readonly path: string,
+  readonly params: $ReadOnlyArray<{| readonly name: string, readonly catchAll: boolean |}>,
+  readonly file: string,
+  readonly load: () => Promise<HandlerModule>,
 |};
 
 /**
@@ -71,13 +68,11 @@ const METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
  * it says so.
  */
 export function createDispatcher(options: {|
-  +handlers: $ReadOnlyArray<HandlerRecord>,
+  readonly handlers: $ReadOnlyArray<HandlerRecord>,
 |}): (request: Request) => Promise<Response | null> {
   // Longest path first, so `/api/users/new` wins over `/api/users/[id]` and a
   // catch-all is the last thing tried.
-  const table = [...options.handlers].sort(
-    (a, b) => specificity(b.path) - specificity(a.path),
-  );
+  const table = [...options.handlers].sort((a, b) => specificity(b.path) - specificity(a.path));
 
   return async function dispatch(request: Request): Promise<Response | null> {
     const url = new URL(request.url);

--- a/packages/router/index.js
+++ b/packages/router/index.js
@@ -49,16 +49,18 @@ export {
 
 /** Props a page receives. */
 export type PageProps<
-  TParams: { +[string]: string | $ReadOnlyArray<string> } = {},
+  TParams extends { readonly [string]: string | $ReadOnlyArray<string> } = {},
   TData = void,
 > = {|
-  +params: TParams,
-  +searchParams: { +[string]: string },
-  +data: TData,
+  readonly params: TParams,
+  readonly searchParams: { readonly [string]: string },
+  readonly data: TData,
 |};
 
 /** Props a layout receives. */
-export type LayoutProps<TParams: { +[string]: string | $ReadOnlyArray<string> } = {}> = {|
-  +params: TParams,
-  +children: React$Node,
+export type LayoutProps<
+  TParams extends { readonly [string]: string | $ReadOnlyArray<string> } = {},
+> = {|
+  readonly params: TParams,
+  readonly children: React$Node,
 |};

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -22,101 +22,103 @@ import {
 } from "react";
 
 /** One parameter a route path captures. */
-export type RouteParamSpec = {| +name: string, +catchAll: boolean |};
+export type RouteParamSpec = {| readonly name: string, readonly catchAll: boolean |};
 
 /** The parameters captured from a URL. A catch-all captures the rest as a list. */
-export type RouteParams = { +[string]: string | $ReadOnlyArray<string> };
+export type RouteParams = { readonly [string]: string | $ReadOnlyArray<string> };
 
 /** The query string, as a read-only map. */
-export type SearchParams = { +[string]: string };
+export type SearchParams = { readonly [string]: string };
 
 /** What a page module may export. The component is `default` or `Page`. */
 export type PageModule = {
-  +default?: React.ComponentType<any>,
-  +Page?: React.ComponentType<any>,
-  +loader?: (args: LoaderArgs) => mixed | Promise<mixed>,
-  +metadata?: Metadata,
-  +generateMetadata?: (args: MetadataArgs) => Metadata | Promise<Metadata>,
-  +generateStaticParams?: () => $ReadOnlyArray<RouteParams> | Promise<$ReadOnlyArray<RouteParams>>,
-  +frontmatter?: { +title?: string, +description?: string, ... },
+  readonly default?: React.ComponentType<any>,
+  readonly Page?: React.ComponentType<any>,
+  readonly loader?: (args: LoaderArgs) => mixed | Promise<mixed>,
+  readonly metadata?: Metadata,
+  readonly generateMetadata?: (args: MetadataArgs) => Metadata | Promise<Metadata>,
+  readonly generateStaticParams?: () =>
+    | $ReadOnlyArray<RouteParams>
+    | Promise<$ReadOnlyArray<RouteParams>>,
+  readonly frontmatter?: { readonly title?: string, readonly description?: string, ... },
   ...
 };
 
 /** What a layout module may export. The component is `default` or `Layout`. */
 export type LayoutModule = {
-  +default?: React.ComponentType<any>,
-  +Layout?: React.ComponentType<any>,
-  +metadata?: Metadata,
+  readonly default?: React.ComponentType<any>,
+  readonly Layout?: React.ComponentType<any>,
+  readonly metadata?: Metadata,
   ...
 };
 
 /** Document metadata a page or layout declares. */
 export type Metadata = {
-  +title?: string,
-  +description?: string,
-  +openGraph?: {
-    +title?: string,
-    +description?: string,
-    +images?: $ReadOnlyArray<string>,
+  readonly title?: string,
+  readonly description?: string,
+  readonly openGraph?: {
+    readonly title?: string,
+    readonly description?: string,
+    readonly images?: $ReadOnlyArray<string>,
   },
 };
 
 /** Arguments a loader receives. */
 export type LoaderArgs = {|
-  +params: RouteParams,
-  +searchParams: SearchParams,
-  +pathname: string,
+  readonly params: RouteParams,
+  readonly searchParams: SearchParams,
+  readonly pathname: string,
 |};
 
 /** Arguments `generateMetadata` receives. */
 export type MetadataArgs = {|
-  +params: RouteParams,
-  +searchParams: SearchParams,
-  +data: mixed,
+  readonly params: RouteParams,
+  readonly searchParams: SearchParams,
+  readonly data: mixed,
 |};
 
 /** One entry of the generated route table. */
 export type RouteRecord = {|
-  +path: string,
-  +params: $ReadOnlyArray<RouteParamSpec>,
-  +mdx: boolean,
-  +file: string,
-  +page: () => Promise<PageModule>,
-  +layouts: $ReadOnlyArray<() => Promise<LayoutModule>>,
+  readonly path: string,
+  readonly params: $ReadOnlyArray<RouteParamSpec>,
+  readonly mdx: boolean,
+  readonly file: string,
+  readonly page: () => Promise<PageModule>,
+  readonly layouts: $ReadOnlyArray<() => Promise<LayoutModule>>,
 |};
 
 /** The not-found page, when the app declares one. */
 export type NotFoundRecord = {|
-  +mdx: boolean,
-  +file: string,
-  +page: () => Promise<PageModule>,
-  +layouts: $ReadOnlyArray<() => Promise<LayoutModule>>,
+  readonly mdx: boolean,
+  readonly file: string,
+  readonly page: () => Promise<PageModule>,
+  readonly layouts: $ReadOnlyArray<() => Promise<LayoutModule>>,
 |};
 
 /** A route table plus the not-found page. */
 export type RouteTable = {|
-  +routes: $ReadOnlyArray<RouteRecord>,
-  +notFound: ?NotFoundRecord,
+  readonly routes: $ReadOnlyArray<RouteRecord>,
+  readonly notFound: ?NotFoundRecord,
 |};
 
 /** A URL matched against the table. */
 export type RouteMatch = {|
-  +route: RouteRecord,
-  +params: RouteParams,
+  readonly route: RouteRecord,
+  readonly params: RouteParams,
 |};
 
 /** A match whose modules are loaded and whose loader has run. */
 export type ResolvedRoute = {|
-  +pathname: string,
-  +search: string,
-  +path: string,
-  +params: RouteParams,
-  +searchParams: SearchParams,
-  +page: PageModule,
-  +layouts: $ReadOnlyArray<LayoutModule>,
-  +data: mixed,
-  +metadata: Metadata,
-  +status: 200 | 404,
+  readonly pathname: string,
+  readonly search: string,
+  readonly path: string,
+  readonly params: RouteParams,
+  readonly searchParams: SearchParams,
+  readonly page: PageModule,
+  readonly layouts: $ReadOnlyArray<LayoutModule>,
+  readonly data: mixed,
+  readonly metadata: Metadata,
+  readonly status: 200 | 404,
 |};
 
 /** Thrown by `notFound()`; the renderer answers with the not-found page. */
@@ -145,9 +147,9 @@ export class RedirectError extends Error {
 // ---------------------------------------------------------------------------
 
 type Segment =
-  | {| +kind: "static", +value: string |}
-  | {| +kind: "param", +name: string |}
-  | {| +kind: "catchAll", +name: string |};
+  | {| readonly kind: "static", readonly value: string |}
+  | {| readonly kind: "param", readonly name: string |}
+  | {| readonly kind: "catchAll", readonly name: string |};
 
 function compile(routePath: string): $ReadOnlyArray<Segment> {
   return routePath
@@ -171,35 +173,37 @@ function compile(routePath: string): $ReadOnlyArray<Segment> {
 function specificity(segments: $ReadOnlyArray<Segment>): number {
   let score = 0;
   for (const segment of segments) {
-    score +=
-      match (segment) {
-        { kind: "static" } => 3,
-        { kind: "param" } => 2,
-        { kind: "catchAll" } => 1,
-      };
+    score += match (segment) {
+      {kind: "static"} => 3,
+      {kind: "param"} => 2,
+      {kind: "catchAll"} => 1,
+    };
   }
   return score;
 }
 
-function matchSegments(segments: $ReadOnlyArray<Segment>, parts: $ReadOnlyArray<string>): ?RouteParams {
+function matchSegments(
+  segments: $ReadOnlyArray<Segment>,
+  parts: $ReadOnlyArray<string>,
+): ?RouteParams {
   const params: { [string]: string | $ReadOnlyArray<string> } = {};
   let index = 0;
   for (const segment of segments) {
     match (segment) {
-      { kind: "static", value: const value } => {
+      {kind: "static", value: const value} => {
         if (parts[index] !== value) {
           return null;
         }
         index += 1;
       }
-      { kind: "param", name: const name } => {
+      {kind: "param", name: const name} => {
         if (index >= parts.length) {
           return null;
         }
         params[name] = decodeSegment(parts[index]);
         index += 1;
       }
-      { kind: "catchAll", name: const name } => {
+      {kind: "catchAll", name: const name} => {
         params[name] = parts.slice(index).map(decodeSegment);
         index = parts.length;
       }
@@ -239,7 +243,7 @@ export function matchRoute(routes: $ReadOnlyArray<RouteRecord>, pathname: string
 }
 
 /** Split a URL into its pathname and search string. */
-export function splitUrl(url: string): {| +pathname: string, +search: string |} {
+export function splitUrl(url: string): {| readonly pathname: string, readonly search: string |} {
   const hash = url.indexOf("#");
   const withoutHash = hash === -1 ? url : url.slice(0, hash);
   const question = withoutHash.indexOf("?");
@@ -295,7 +299,7 @@ function loadOnce<T>(load: () => Promise<T>): Promise<T> {
 export async function resolveMatch(
   table: RouteTable,
   url: string,
-  options?: {| +data?: mixed, +skipLoader?: boolean |},
+  options?: {| readonly data?: mixed, readonly skipLoader?: boolean |},
 ): Promise<ResolvedRoute> {
   const { pathname, search } = splitUrl(url);
   const searchParams = parseSearch(search);
@@ -322,7 +326,11 @@ export async function resolveMatch(
     }
   }
 
-  const metadata = await resolveMetadata(page, layouts, { params: matched.params, searchParams, data });
+  const metadata = await resolveMetadata(page, layouts, {
+    params: matched.params,
+    searchParams,
+    data,
+  });
   return {
     pathname,
     search,
@@ -362,7 +370,11 @@ async function resolveNotFound(
     loadOnce(record.page),
     ...record.layouts.map((layout) => loadOnce(layout)),
   ]);
-  const metadata = await resolveMetadata(page, layouts, { params: {}, searchParams, data: undefined });
+  const metadata = await resolveMetadata(page, layouts, {
+    params: {},
+    searchParams,
+    data: undefined,
+  });
   return {
     pathname,
     search,
@@ -390,13 +402,17 @@ async function resolveMetadata(
   }
   if (page.frontmatter != null) {
     const { title, description } = page.frontmatter;
-    merged = { ...merged, ...(title != null ? { title } : {}), ...(description != null ? { description } : {}) };
+    merged = {
+      ...merged,
+      ...title != null ? { title } : {},
+      ...description != null ? { description } : {},
+    };
   }
   if (page.metadata != null) {
     merged = { ...merged, ...page.metadata };
   }
   if (typeof page.generateMetadata === "function") {
-    merged = { ...merged, ...(await page.generateMetadata(args)) };
+    merged = { ...merged, ...await page.generateMetadata(args) };
   }
   return merged;
 }
@@ -416,32 +432,32 @@ component DefaultNotFound() {
 // ---------------------------------------------------------------------------
 
 /** How a navigation is performed. */
-export type NavigateOptions = {| +replace?: boolean, +scroll?: boolean |};
+export type NavigateOptions = {| readonly replace?: boolean, readonly scroll?: boolean |};
 
 /** What `useRouter()` returns. */
 export type Router = {|
-  +push: (to: string, options?: NavigateOptions) => Promise<void>,
-  +replace: (to: string) => Promise<void>,
-  +prefetch: (to: string) => Promise<void>,
-  +refresh: () => Promise<void>,
-  +back: () => void,
-  +forward: () => void,
+  readonly push: (to: string, options?: NavigateOptions) => Promise<void>,
+  readonly replace: (to: string) => Promise<void>,
+  readonly prefetch: (to: string) => Promise<void>,
+  readonly refresh: () => Promise<void>,
+  readonly back: () => void,
+  readonly forward: () => void,
 |};
 
 /** What `useRoute()` returns. */
 export type RouteInfo = {|
-  +path: string,
-  +pathname: string,
-  +params: RouteParams,
-  +searchParams: SearchParams,
-  +data: mixed,
-  +pending: boolean,
+  readonly path: string,
+  readonly pathname: string,
+  readonly params: RouteParams,
+  readonly searchParams: SearchParams,
+  readonly data: mixed,
+  readonly pending: boolean,
 |};
 
 type RouterState = {|
-  +resolved: ResolvedRoute,
-  +router: Router,
-  +pending: boolean,
+  readonly resolved: ResolvedRoute,
+  readonly router: Router,
+  readonly pending: boolean,
 |};
 
 const RouterContext: React.Context<?RouterState> = createContext(null);
@@ -457,15 +473,17 @@ export function installRoutes(table: RouteTable): void {
 /** The registered table, or a clear error when the entry forgot to install it. */
 export function routeTable(): RouteTable {
   if (installedTable == null) {
-    throw new Error("@uniflowed/router: no route table is installed; start the app through `uf dev` or `uf build`");
+    throw new Error(
+      "@uniflowed/router: no route table is installed; start the app through `uf dev` or `uf build`",
+    );
   }
   return installedTable;
 }
 
 /** Props the app root receives from the client and server entries. */
 export type AppProps = {|
-  +url: string,
-  +initial: ResolvedRoute,
+  readonly url: string,
+  readonly initial: ResolvedRoute,
 |};
 
 const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
@@ -547,13 +565,19 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
         if (matched == null) {
           return;
         }
-        await Promise.all([loadOnce(matched.route.page), ...matched.route.layouts.map((layout) => loadOnce(layout))]);
+        await Promise.all([
+          loadOnce(matched.route.page),
+          ...matched.route.layouts.map((layout) => loadOnce(layout)),
+        ]);
       },
       refresh: async () => {
         if (!isBrowser) {
           return;
         }
-        const nextResolved = await resolveMatch(routeTable(), window.location.pathname + window.location.search);
+        const nextResolved = await resolveMatch(
+          routeTable(),
+          window.location.pathname + window.location.search,
+        );
         startTransition(() => {
           setResolved(nextResolved);
         });
@@ -572,14 +596,19 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
     [navigate],
   );
 
-  const value = useMemo<RouterState>(() => ({ resolved, router, pending }), [resolved, router, pending]);
+  const value = useMemo<RouterState>(
+    () => ({ resolved, router, pending }),
+    [resolved, router, pending],
+  );
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
 }
 
 hook useRouterState(): RouterState {
   const state = useContext(RouterContext);
   if (state == null) {
-    throw new Error("@uniflowed/router: this hook must be used inside the app started by `routerView`");
+    throw new Error(
+      "@uniflowed/router: this hook must be used inside the app started by `routerView`",
+    );
   }
   return state;
 }
@@ -637,7 +666,9 @@ export component RouteView() {
 function pageComponent(module: PageModule): React.ComponentType<any> {
   const component = module.default ?? module.Page;
   if (component == null) {
-    throw new Error("@uniflowed/router: a page module must export a component as `default` or `Page`");
+    throw new Error(
+      "@uniflowed/router: a page module must export a component as `default` or `Page`",
+    );
   }
   return component;
 }
@@ -646,7 +677,9 @@ function pageComponent(module: PageModule): React.ComponentType<any> {
 function layoutComponent(module: LayoutModule): React.ComponentType<any> {
   const component = module.default ?? module.Layout;
   if (component == null) {
-    throw new Error("@uniflowed/router: a layout module must export a component as `default` or `Layout`");
+    throw new Error(
+      "@uniflowed/router: a layout module must export a component as `default` or `Layout`",
+    );
   }
   return component;
 }
@@ -658,9 +691,13 @@ component Head(metadata: Metadata) {
       {title != null ? <title>{title}</title> : null}
       {description != null ? <meta name="description" content={description} /> : null}
       {openGraph?.title != null ? <meta property="og:title" content={openGraph.title} /> : null}
-      {openGraph?.description != null ? <meta property="og:description" content={openGraph.description} /> : null}
+      {openGraph?.description != null ? (
+        <meta property="og:description" content={openGraph.description} />
+      ) : null}
       {openGraph?.images != null
-        ? openGraph.images.map((image) => <meta key={image} property="og:image" content={image} />)
+        ? openGraph.images.map((image) => (
+            <meta key={image} property="og:image" content={image} />
+          ))
         : null}
     </>
   );
@@ -683,7 +720,7 @@ export component Link(
   children?: React.Node,
   className?: string,
   onClick?: (event: SyntheticMouseEvent<HTMLAnchorElement>) => mixed,
-  ...rest: { +[string]: mixed }
+  ...rest: { readonly [string]: mixed }
 ) {
   const router = useRouter();
   const prefetched = React.useRef(false);

--- a/packages/router/server.js
+++ b/packages/router/server.js
@@ -21,16 +21,16 @@ import {
 
 /** Asset URLs to reference from the document. */
 export type RenderAssets = {|
-  +scripts: $ReadOnlyArray<string>,
-  +styles: $ReadOnlyArray<string>,
-  +preloads: $ReadOnlyArray<string>,
+  readonly scripts: $ReadOnlyArray<string>,
+  readonly styles: $ReadOnlyArray<string>,
+  readonly preloads: $ReadOnlyArray<string>,
 |};
 
 /** A rendered document. */
 export type RenderResult = {|
-  +status: number,
-  +html: string,
-  +headers?: { +[string]: string },
+  readonly status: number,
+  readonly html: string,
+  readonly headers?: { readonly [string]: string },
 |};
 
 /** The id of the element the client hydrates when the app does not render `<html>`. */
@@ -46,9 +46,9 @@ export type { Handler, HandlerContext, HandlerModule, HandlerRecord } from "./ha
 export { createDispatcher } from "./handler.js";
 
 export function createRenderer(options: {|
-  +App: React.ComponentType<AppProps>,
-  +routes: RouteTable["routes"],
-  +notFound: RouteTable["notFound"],
+  readonly App: React.ComponentType<AppProps>,
+  readonly routes: RouteTable["routes"],
+  readonly notFound: RouteTable["notFound"],
 |}): (url: string, assets: RenderAssets) => Promise<RenderResult> {
   const table: RouteTable = { routes: options.routes, notFound: options.notFound };
   installRoutes(table);
@@ -96,7 +96,8 @@ function assemble(markup: string, resolved: ResolvedRoute, assets: RenderAssets)
       : markup.replace(/<html([^>]*)>/i, `<html$1><head>${head}</head>`);
     return `<!doctype html>\n${document}\n`;
   }
-  const title = resolved.metadata.title != null ? `<title>${escapeText(resolved.metadata.title)}</title>` : "";
+  const title =
+    resolved.metadata.title != null ? `<title>${escapeText(resolved.metadata.title)}</title>` : "";
   return `<!doctype html>\n<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">${title}${head}</head><body><div id="${ROOT_ID}">${markup}</div></body></html>\n`;
 }
 

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -6,14 +6,7 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
 const MODULE = "@uniflowed/core/runtime";
 
-export type RuntimeEngine =
-  | "uf"
-  | "node"
-  | "deno"
-  | "bun"
-  | "edge"
-  | "serverless"
-  | "container";
+export type RuntimeEngine = "uf" | "node" | "deno" | "bun" | "edge" | "serverless" | "container";
 
 export type CapabilityJsHost = "node" | "deno" | "bun";
 export type JavaScriptEngine = "capability-js-host" | "hermes";
@@ -52,11 +45,11 @@ export type RuntimeCapability =
   | "terminal-ui";
 
 export type RuntimeContract = {
-  +standard: "winter-tc",
-  +language: "flow",
-  +javascriptEngine: JavaScriptEngine,
-  +hosts: $ReadOnlyArray<RuntimeEngine>,
-  +capabilities: $ReadOnlyArray<RuntimeCapability>,
+  readonly standard: "winter-tc",
+  readonly language: "flow",
+  readonly javascriptEngine: JavaScriptEngine,
+  readonly hosts: $ReadOnlyArray<RuntimeEngine>,
+  readonly capabilities: $ReadOnlyArray<RuntimeCapability>,
 };
 
 export function run(entry: string): Promise<void> {
@@ -70,8 +63,8 @@ export function resolve(specifier: string, from?: string): Promise<string> {
 export function spawn(
   entry: string,
   options?: $ReadOnly<{
-    +runtime?: RuntimeEngine,
-    +adapter?: DeployAdapter,
+    readonly runtime?: RuntimeEngine,
+    readonly adapter?: DeployAdapter,
   }>,
 ): Promise<void> {
   return nativeRuntimeRequired(MODULE, "spawn");

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -6,13 +6,13 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
 const MODULE = "@uniflowed/core/server";
 
-export opaque type ServerAction<TArgs: $ReadOnlyArray<mixed>, TReturn> = {
-  +__ufNative: "@uniflowed/core/server#ServerAction",
+export opaque type ServerAction<TArgs extends $ReadOnlyArray<mixed>, TReturn> = {
+  readonly __ufNative: "@uniflowed/core/server#ServerAction",
   __ufArgs: TArgs,
   __ufReturn: TReturn,
 };
 
-export function serverAction<TArgs: $ReadOnlyArray<mixed>, TReturn>(
+export function serverAction<TArgs extends $ReadOnlyArray<mixed>, TReturn>(
   action: (...TArgs) => Promise<TReturn> | TReturn,
 ): (...TArgs) => Promise<TReturn> {
   return nativeRuntimeRequired(MODULE, "serverAction");
@@ -31,9 +31,9 @@ export function cache<T>(key: string, body: () => T | Promise<T>): Promise<T> {
 }
 
 export function draftMode(): {
-  +isEnabled: boolean,
-  +enable: () => void,
-  +disable: () => void,
+  readonly isEnabled: boolean,
+  readonly enable: () => void,
+  readonly disable: () => void,
 } {
   return nativeRuntimeRequired(MODULE, "draftMode");
 }

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -19,16 +19,16 @@ export type StdCategory =
   | "cloud";
 
 export type StdModule = {
-  +specifier: string,
-  +category: StdCategory,
-  +wintertcAligned: true,
-  +nativeBinding: true,
-  +exports: $ReadOnlyArray<string>,
+  readonly specifier: string,
+  readonly category: StdCategory,
+  readonly wintertcAligned: true,
+  readonly nativeBinding: true,
+  readonly exports: $ReadOnlyArray<string>,
 };
 
 export type Result<Ok, Err> =
-  | { +ok: true, +value: Ok }
-  | { +ok: false, +error: Err };
+  | { readonly ok: true, readonly value: Ok }
+  | { readonly ok: false, readonly error: Err };
 
 /**
  * Nominal wrapper around `T`.
@@ -37,7 +37,7 @@ export type Result<Ok, Err> =
  * `string` is expected while blocking the reverse, so branding never costs a
  * conversion.
  */
-export opaque type Brand<Name: string, T>: T = T;
+export opaque type Brand<Name extends string, T>: T = T;
 
 export type JsonValue =
   | null
@@ -45,74 +45,78 @@ export type JsonValue =
   | number
   | string
   | $ReadOnlyArray<JsonValue>
-  | { +[string]: JsonValue };
+  | { readonly [string]: JsonValue };
 
-export type VirtualPath = { +path: string };
-export type QueryPair = { +key: string, +value: string };
-export type ByteBuffer = { +bytes: Uint8Array };
+export type VirtualPath = { readonly path: string };
+export type QueryPair = { readonly key: string, readonly value: string };
+export type ByteBuffer = { readonly bytes: Uint8Array };
 export type ImportMeta = {
-  +url: string,
-  +dirname?: string,
-  +filename?: string,
+  readonly url: string,
+  readonly dirname?: string,
+  readonly filename?: string,
 };
 export type DeferPhase = "microtask" | "idle" | "post-response";
-export type DeferredTask = { +id: string, +phase: DeferPhase };
+export type DeferredTask = { readonly id: string, readonly phase: DeferPhase };
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-export type HttpRoute = { +method: HttpMethod, +path: string };
+export type HttpRoute = { readonly method: HttpMethod, readonly path: string };
 export type WebSocketMode = "web-socket" | "web-socket-stream";
 export type SqlDriverKind = "sqlite" | "postgres" | "mysql";
-export type SqlDriver = { +kind: SqlDriverKind, +preparedByDefault: true };
+export type SqlDriver = { readonly kind: SqlDriverKind, readonly preparedByDefault: true };
 export type DigestAlgorithm = "fast-hash" | "sha256";
 export type OsFamily = "mac-os" | "linux" | "windows" | "unknown";
 export type OsInfo = {
-  +family: OsFamily,
-  +arch: string,
-  +availableParallelism: number,
+  readonly family: OsFamily,
+  readonly arch: string,
+  readonly availableParallelism: number,
 };
 export type DnsRecordType = "A" | "AAAA" | "CNAME" | "MX" | "TXT";
-export type DnsQuery = { +name: string, +recordType: DnsRecordType };
+export type DnsQuery = { readonly name: string, readonly recordType: DnsRecordType };
 export type StreamKind = "readable" | "writable" | "transform";
-export type StreamDescriptor = { +kind: StreamKind, +backpressure: true };
-export type UrlParts = { +scheme: string, +host: string, +path: string };
-export type WasmModulePlan = { +name: string, +aheadOfTime: true };
-export type GlobPattern = { +pattern: string, +dotfiles: boolean };
+export type StreamDescriptor = { readonly kind: StreamKind, readonly backpressure: true };
+export type UrlParts = { readonly scheme: string, readonly host: string, readonly path: string };
+export type WasmModulePlan = { readonly name: string, readonly aheadOfTime: true };
+export type GlobPattern = { readonly pattern: string, readonly dotfiles: boolean };
 export type MotionEase = "linear" | "out" | "spring";
 export type MotionTransition = {
-  +durationMs: number,
-  +ease: MotionEase,
-  +respectsReducedMotion: true,
+  readonly durationMs: number,
+  readonly ease: MotionEase,
+  readonly respectsReducedMotion: true,
 };
 export type TerminalColorDepth = "ansi16" | "ansi256" | "true-color";
 export type TerminalCapabilities = {
-  +columns: number,
-  +rows: number,
-  +colorDepth: TerminalColorDepth,
-  +unicode: boolean,
-  +mouse: boolean,
-  +inlineImages: boolean,
-  +sixel: boolean,
+  readonly columns: number,
+  readonly rows: number,
+  readonly colorDepth: TerminalColorDepth,
+  readonly unicode: boolean,
+  readonly mouse: boolean,
+  readonly inlineImages: boolean,
+  readonly sixel: boolean,
 };
 export type CronSchedule = {
-  +minute: string,
-  +hour: string,
-  +dayOfMonth: string,
-  +month: string,
-  +dayOfWeek: string,
+  readonly minute: string,
+  readonly hour: string,
+  readonly dayOfMonth: string,
+  readonly month: string,
+  readonly dayOfWeek: string,
 };
-export type S3ObjectRequest = { +bucket: string, +key: string, +sigv4: true };
-export type SigV4Scope = { +region: string, +service: string };
+export type S3ObjectRequest = {
+  readonly bucket: string,
+  readonly key: string,
+  readonly sigv4: true,
+};
+export type SigV4Scope = { readonly region: string, readonly service: string };
 export type FunctionRuntime = "worker" | "lambda";
 export type FunctionDescriptor = {
-  +name: string,
-  +runtime: FunctionRuntime,
-  +entry: string,
+  readonly name: string,
+  readonly runtime: FunctionRuntime,
+  readonly entry: string,
 };
 export type UuidVersion = "v4" | "v7";
 export type ZipCompression = "store" | "deflate";
 export type ZipEntry = {
-  +path: string,
-  +compression: ZipCompression,
-  +size: number,
+  readonly path: string,
+  readonly compression: ZipCompression,
+  readonly size: number,
 };
 
 export function modules(): $ReadOnlyArray<StdModule> {
@@ -137,7 +141,7 @@ export function defer(id: string, phase?: DeferPhase): DeferredTask {
 
 export function parseDotEnv(
   source: string,
-): $ReadOnlyArray<{ +key: string, +value: string }> {
+): $ReadOnlyArray<{ readonly key: string, readonly value: string }> {
   return nativeRuntimeRequired(MODULE, "parseDotEnv");
 }
 
@@ -185,9 +189,7 @@ export function parseToml(source: string): mixed {
   return nativeRuntimeRequired(MODULE, "parseToml");
 }
 
-export function detectYaml(
-  source: string,
-): "mapping" | "sequence" | "scalar" | "empty" {
+export function detectYaml(source: string): "mapping" | "sequence" | "scalar" | "empty" {
   return nativeRuntimeRequired(MODULE, "detectYaml");
 }
 
@@ -199,11 +201,7 @@ export function lerp(start: number, end: number, amount: number): number {
   return nativeRuntimeRequired(MODULE, "lerp");
 }
 
-export function osInfo(
-  family: OsFamily,
-  arch: string,
-  availableParallelism: number,
-): OsInfo {
+export function osInfo(family: OsFamily, arch: string, availableParallelism: number): OsInfo {
   return nativeRuntimeRequired(MODULE, "osInfo");
 }
 
@@ -239,10 +237,7 @@ export function motion(durationMs: number, ease: MotionEase): MotionTransition {
   return nativeRuntimeRequired(MODULE, "motion");
 }
 
-export function terminalCapabilities(
-  columns: number,
-  rows: number,
-): TerminalCapabilities {
+export function terminalCapabilities(columns: number, rows: number): TerminalCapabilities {
   return nativeRuntimeRequired(MODULE, "terminalCapabilities");
 }
 
@@ -266,16 +261,11 @@ export function defineFunction(
   return nativeRuntimeRequired(MODULE, "defineFunction");
 }
 
-export function digest(
-  algorithm: DigestAlgorithm,
-  bytes: Uint8Array,
-): string {
+export function digest(algorithm: DigestAlgorithm, bytes: Uint8Array): string {
   return nativeRuntimeRequired(MODULE, "digest");
 }
 
-export function parseUuid(
-  value: string,
-): ?{ +value: string, +version?: number } {
+export function parseUuid(value: string): ?{ readonly value: string, readonly version?: number } {
   return nativeRuntimeRequired(MODULE, "parseUuid");
 }
 

--- a/packages/story/index.js
+++ b/packages/story/index.js
@@ -12,35 +12,29 @@ const MODULE = "@uniflowed/core/story";
 
 export opaque type Storybook = NativeHandle<"@uniflowed/core/story#Storybook">;
 
-export type StoryVariant<Props: {...}> = {
-  +name: string,
-  +props: Props,
+export type StoryVariant<Props extends { ... }> = {
+  readonly name: string,
+  readonly props: Props,
 };
 
-export function story<Props: {...}>(
+export function story<Props extends { ... }>(
   id: string,
   render: component(...Props) renders React.Node,
 ): Storybook {
   return nativeRuntimeRequired(MODULE, "story");
 }
 
-export function variant<Props: {...}>(
+export function variant<Props extends { ... }>(
   storybook: Storybook,
   variant: StoryVariant<Props>,
 ): Storybook {
   return nativeRuntimeRequired(MODULE, "variant");
 }
 
-export function withMocks(
-  storybook: Storybook,
-  mocks: MockRegistry,
-): Storybook {
+export function withMocks(storybook: Storybook, mocks: MockRegistry): Storybook {
   return nativeRuntimeRequired(MODULE, "withMocks");
 }
 
-export function withBrowser(
-  storybook: Storybook,
-  browser: BrowserPlan,
-): Storybook {
+export function withBrowser(storybook: Storybook, browser: BrowserPlan): Storybook {
   return nativeRuntimeRequired(MODULE, "withBrowser");
 }

--- a/packages/stylex/index.js
+++ b/packages/stylex/index.js
@@ -7,29 +7,29 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 const MODULE = "@uniflowed/core/stylex";
 
 export interface StyleXSheet {
-  +[string]: mixed,
+  readonly [string]: mixed;
 }
 
 export interface StyleX {
-  create<T: { +[string]: mixed }>(styles: T): T,
-  props(...styles: $ReadOnlyArray<mixed>): { +[string]: mixed },
-  defineVars<T: { +[string]: string | number }>(tokens: T): T,
-  createTheme<T: { +[string]: string | number }>(tokens: T): T,
+  create<T extends { readonly [string]: mixed }>(styles: T): T;
+  props(...styles: $ReadOnlyArray<mixed>): { readonly [string]: mixed };
+  defineVars<T extends { readonly [string]: string | number }>(tokens: T): T;
+  createTheme<T extends { readonly [string]: string | number }>(tokens: T): T;
 }
 
-export function defineVars<T: { +[string]: string | number }>(tokens: T): T {
+export function defineVars<T extends { readonly [string]: string | number }>(tokens: T): T {
   return nativeRuntimeRequired(MODULE, "defineVars");
 }
 
-export function createTheme<T: { +[string]: string | number }>(tokens: T): T {
+export function createTheme<T extends { readonly [string]: string | number }>(tokens: T): T {
   return nativeRuntimeRequired(MODULE, "createTheme");
 }
 
 export const stylex: StyleX = {
-  create<T: { +[string]: mixed }>(styles: T): T {
+  create<T extends { readonly [string]: mixed }>(styles: T): T {
     return nativeRuntimeRequired(MODULE, "stylex.create");
   },
-  props(...styles: $ReadOnlyArray<mixed>): { +[string]: mixed } {
+  props(...styles: $ReadOnlyArray<mixed>): { readonly [string]: mixed } {
     return nativeRuntimeRequired(MODULE, "stylex.props");
   },
   defineVars,

--- a/packages/temporal/index.js
+++ b/packages/temporal/index.js
@@ -8,39 +8,32 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 const MODULE = "@uniflowed/core/temporal";
 
 export opaque type Instant = NativeHandle<"@uniflowed/core/temporal#Instant">;
-export opaque type PlainDate =
-  NativeHandle<"@uniflowed/core/temporal#PlainDate">;
-export opaque type PlainTime =
-  NativeHandle<"@uniflowed/core/temporal#PlainTime">;
-export opaque type ZonedDateTime =
-  NativeHandle<"@uniflowed/core/temporal#ZonedDateTime">;
+export opaque type PlainDate = NativeHandle<"@uniflowed/core/temporal#PlainDate">;
+export opaque type PlainTime = NativeHandle<"@uniflowed/core/temporal#PlainTime">;
+export opaque type ZonedDateTime = NativeHandle<"@uniflowed/core/temporal#ZonedDateTime">;
 export opaque type Duration = NativeHandle<"@uniflowed/core/temporal#Duration">;
 
 export const Temporal: {
-  +Instant: { +from: (value: string) => Instant },
-  +PlainDate: { +from: (value: string) => PlainDate },
-  +PlainTime: { +from: (value: string) => PlainTime },
-  +ZonedDateTime: { +from: (value: string) => ZonedDateTime },
-  +Duration: { +from: (value: string) => Duration },
+  readonly Instant: { readonly from: (value: string) => Instant },
+  readonly PlainDate: { readonly from: (value: string) => PlainDate },
+  readonly PlainTime: { readonly from: (value: string) => PlainTime },
+  readonly ZonedDateTime: { readonly from: (value: string) => ZonedDateTime },
+  readonly Duration: { readonly from: (value: string) => Duration },
 } = {
   Instant: {
-    from: (value: string): Instant =>
-      nativeRuntimeRequired(MODULE, "Temporal.Instant.from"),
+    from: (value: string): Instant => nativeRuntimeRequired(MODULE, "Temporal.Instant.from"),
   },
   PlainDate: {
-    from: (value: string): PlainDate =>
-      nativeRuntimeRequired(MODULE, "Temporal.PlainDate.from"),
+    from: (value: string): PlainDate => nativeRuntimeRequired(MODULE, "Temporal.PlainDate.from"),
   },
   PlainTime: {
-    from: (value: string): PlainTime =>
-      nativeRuntimeRequired(MODULE, "Temporal.PlainTime.from"),
+    from: (value: string): PlainTime => nativeRuntimeRequired(MODULE, "Temporal.PlainTime.from"),
   },
   ZonedDateTime: {
     from: (value: string): ZonedDateTime =>
       nativeRuntimeRequired(MODULE, "Temporal.ZonedDateTime.from"),
   },
   Duration: {
-    from: (value: string): Duration =>
-      nativeRuntimeRequired(MODULE, "Temporal.Duration.from"),
+    from: (value: string): Duration => nativeRuntimeRequired(MODULE, "Temporal.Duration.from"),
   },
 };

--- a/packages/test/internal/equality.js
+++ b/packages/test/internal/equality.js
@@ -21,7 +21,7 @@
 /** How strictly two values are compared. */
 export type Strictness = "loose" | "strict";
 
-type Pair = {| +left: mixed, +right: mixed |};
+type Pair = {| readonly left: mixed, readonly right: mixed |};
 
 /** Longest rendering of one value inside a failure message. */
 export const MAX_RENDER_BYTES: number = 4096;
@@ -61,7 +61,12 @@ function ownKeys(value: interface {}, strictness: Strictness): Array<string | sy
   return keys.filter((key) => (value: $FlowFixMe)[key] !== undefined);
 }
 
-function sameSet(left: Set<mixed>, right: Set<mixed>, seen: Array<Pair>, strictness: Strictness): boolean {
+function sameSet(
+  left: Set<mixed>,
+  right: Set<mixed>,
+  seen: Array<Pair>,
+  strictness: Strictness,
+): boolean {
   if (left.size !== right.size) {
     return false;
   }
@@ -262,9 +267,7 @@ function elementTag(value: mixed): string | null {
     .join("");
   const text = (node.textContent ?? "").replace(/\s+/g, " ").trim();
   const shown = text.length > 40 ? `${text.slice(0, 40)}…` : text;
-  return shown === ""
-    ? `<${name}${attributes} />`
-    : `<${name}${attributes}>${shown}</${name}>`;
+  return shown === "" ? `<${name}${attributes} />` : `<${name}${attributes}>${shown}</${name}>`;
 }
 
 export function render(value: mixed, depth: number = 0, seen: Array<mixed> = []): string {
@@ -326,19 +329,22 @@ function renderInner(value: mixed, depth: number, seen: Array<mixed>): string {
   }
   if (value instanceof Set) {
     const items = [...value].slice(0, MAX_RENDER_ENTRIES).map(inner);
-    const more = value.size > MAX_RENDER_ENTRIES ? `, …${value.size - MAX_RENDER_ENTRIES} more` : "";
+    const more =
+      value.size > MAX_RENDER_ENTRIES ? `, …${value.size - MAX_RENDER_ENTRIES} more` : "";
     return `Set { ${items.join(", ")}${more} }`;
   }
   if (value instanceof Map) {
     const items = [...value]
       .slice(0, MAX_RENDER_ENTRIES)
       .map(([key, item]) => `${inner(key)} => ${inner(item)}`);
-    const more = value.size > MAX_RENDER_ENTRIES ? `, …${value.size - MAX_RENDER_ENTRIES} more` : "";
+    const more =
+      value.size > MAX_RENDER_ENTRIES ? `, …${value.size - MAX_RENDER_ENTRIES} more` : "";
     return `Map { ${items.join(", ")}${more} }`;
   }
   if (Array.isArray(value)) {
     const items = value.slice(0, MAX_RENDER_ENTRIES).map(inner);
-    const more = value.length > MAX_RENDER_ENTRIES ? `, …${value.length - MAX_RENDER_ENTRIES} more` : "";
+    const more =
+      value.length > MAX_RENDER_ENTRIES ? `, …${value.length - MAX_RENDER_ENTRIES} more` : "";
     return `[${items.join(", ")}${more}]`;
   }
 
@@ -355,5 +361,7 @@ function renderInner(value: mixed, depth: number, seen: Array<mixed>): string {
     prototype != null && prototype.constructor != null && prototype.constructor.name !== "Object"
       ? `${prototype.constructor.name} `
       : "";
-  return entries.length === 0 ? `${constructorName}{}` : `${constructorName}{ ${entries.join(", ")}${more} }`;
+  return entries.length === 0
+    ? `${constructorName}{}`
+    : `${constructorName}{ ${entries.join(", ")}${more} }`;
 }

--- a/packages/test/internal/expect.js
+++ b/packages/test/internal/expect.js
@@ -34,18 +34,18 @@ export class AssertionError extends Error {
 
 /** What a matcher decided, and how to say it either way. */
 type Verdict = {|
-  +pass: boolean,
-  +failure: () => string,
-  +negatedFailure: () => string,
-  +expected?: string,
-  +received?: string,
+  readonly pass: boolean,
+  readonly failure: () => string,
+  readonly negatedFailure: () => string,
+  readonly expected?: string,
+  readonly received?: string,
 |};
 
 /** One recorded call to a spy. */
 export type SpyCall = {|
-  +args: $ReadOnlyArray<mixed>,
-  +returned?: mixed,
-  +threw?: mixed,
+  readonly args: $ReadOnlyArray<mixed>,
+  readonly returned?: mixed,
+  readonly threw?: mixed,
 |};
 
 /**
@@ -96,7 +96,10 @@ function isSpy(value: mixed): boolean {
   return typeof value === "function" && (value: $FlowFixMe).mock != null;
 }
 
-function propertyAt(value: mixed, path: string): {| +found: boolean, +value: mixed |} {
+function propertyAt(
+  value: mixed,
+  path: string,
+): {| readonly found: boolean, readonly value: mixed |} {
   let current = value;
   for (const key of path.split(".")) {
     if (current == null) {
@@ -137,7 +140,9 @@ function matchesThrown(thrown: mixed, expected: mixed): boolean {
  * Every entry returns a [`Verdict`] rather than throwing, which is what lets
  * `.not` reuse all of them.
  */
-function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) => Verdict } {
+function verdicts(received: mixed): {
+  readonly [string]: (...args: $ReadOnlyArray<any>) => Verdict,
+} {
   const shown = () => render(received);
   const simple = (pass: boolean, what: string, expected?: mixed): Verdict => ({
     pass,
@@ -187,13 +192,29 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
     toBeDefined: () => simple(received !== undefined, "to be defined"),
     toBeNaN: () => simple(typeof received === "number" && Number.isNaN(received), "to be NaN"),
     toBeGreaterThan: (expected: mixed) =>
-      simple((received: $FlowFixMe) > (expected: $FlowFixMe), `to be greater than ${render(expected)}`, expected),
+      simple(
+        (received: $FlowFixMe) > (expected: $FlowFixMe),
+        `to be greater than ${render(expected)}`,
+        expected,
+      ),
     toBeGreaterThanOrEqual: (expected: mixed) =>
-      simple((received: $FlowFixMe) >= (expected: $FlowFixMe), `to be at least ${render(expected)}`, expected),
+      simple(
+        (received: $FlowFixMe) >= (expected: $FlowFixMe),
+        `to be at least ${render(expected)}`,
+        expected,
+      ),
     toBeLessThan: (expected: mixed) =>
-      simple((received: $FlowFixMe) < (expected: $FlowFixMe), `to be less than ${render(expected)}`, expected),
+      simple(
+        (received: $FlowFixMe) < (expected: $FlowFixMe),
+        `to be less than ${render(expected)}`,
+        expected,
+      ),
     toBeLessThanOrEqual: (expected: mixed) =>
-      simple((received: $FlowFixMe) <= (expected: $FlowFixMe), `to be at most ${render(expected)}`, expected),
+      simple(
+        (received: $FlowFixMe) <= (expected: $FlowFixMe),
+        `to be at most ${render(expected)}`,
+        expected,
+      ),
     toBeCloseTo: (expected: number, digits?: number) => {
       const places = digits ?? 2;
       const tolerance = 10 ** -places / 2;
@@ -216,7 +237,11 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
       return simple(pass, `to contain ${render(expected)}`, expected);
     },
     toContainEqual: (expected: mixed) => {
-      const items = Array.isArray(received) ? received : received instanceof Set ? [...received] : [];
+      const items = Array.isArray(received)
+        ? received
+        : received instanceof Set
+          ? [...received]
+          : [];
       return simple(
         items.some((item) => equals(item, expected)),
         `to contain something equal to ${render(expected)}`,
@@ -225,7 +250,11 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
     },
     toHaveLength: (expected: number) => {
       const length = received == null ? undefined : (received: $FlowFixMe).length;
-      return simple(length === expected, `to have length ${expected}, not ${render(length)}`, expected);
+      return simple(
+        length === expected,
+        `to have length ${expected}, not ${render(length)}`,
+        expected,
+      );
     },
     toHaveProperty: (path: string, ...rest: $ReadOnlyArray<mixed>) => {
       const found = propertyAt(received, path);
@@ -240,7 +269,8 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
     },
     toMatch: (expected: mixed) => {
       const text = typeof received === "string" ? received : String(received);
-      const pass = typeof expected === "string" ? text.includes(expected) : (expected: $FlowFixMe).test(text);
+      const pass =
+        typeof expected === "string" ? text.includes(expected) : (expected: $FlowFixMe).test(text);
       return simple(pass, `to match ${render(expected)}`, expected);
     },
     toMatchObject: (expected: mixed) =>
@@ -252,7 +282,11 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
         expected,
       ),
     toBeTypeOf: (expected: string) =>
-      simple(typeof received === expected, `to be of type ${expected}, not ${typeof received}`, expected),
+      simple(
+        typeof received === expected,
+        `to be of type ${expected}, not ${typeof received}`,
+        expected,
+      ),
     toSatisfy: (predicate: (value: mixed) => boolean) =>
       simple(predicate(received) === true, "to satisfy the predicate"),
     toThrow: (...rest: $ReadOnlyArray<mixed>) => {
@@ -327,10 +361,7 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
     toBeInTheDocument: () => {
       const node = element("toBeInTheDocument");
       const root = node.ownerDocument;
-      return simple(
-        root != null && root.contains(node),
-        "to be in the document",
-      );
+      return simple(root != null && root.contains(node), "to be in the document");
     },
     toBeVisible: () => {
       const node = element("toBeVisible");
@@ -371,8 +402,7 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
         pass: actual === String(value),
         expected: render(value),
         received: render(actual),
-        failure: () =>
-          `expected ${render(name)} to be ${render(value)}, not ${render(actual)}`,
+        failure: () => `expected ${render(name)} to be ${render(value)}, not ${render(actual)}`,
       };
     },
     toHaveClass: (...names: $ReadOnlyArray<mixed>) => {
@@ -383,8 +413,7 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
         pass: wanted.every((name) => classes.includes(name)),
         expected: render(wanted),
         received: render(classes),
-        failure: () =>
-          `expected the class list ${render(classes)} to include ${render(wanted)}`,
+        failure: () => `expected the class list ${render(classes)} to include ${render(wanted)}`,
       };
     },
     toHaveTextContent: (expected: mixed) => {
@@ -421,9 +450,7 @@ function verdicts(received: mixed): { +[string]: (...args: $ReadOnlyArray<any>) 
   function element(matcher: string): Element {
     const node: $FlowFixMe = received;
     if (node == null || typeof node.getAttribute !== "function") {
-      throw new AssertionError(
-        `${matcher} needs an element, and received ${render(received)}`,
-      );
+      throw new AssertionError(`${matcher} needs an element, and received ${render(received)}`);
     }
     return node;
   }
@@ -442,11 +469,7 @@ function isVisible(node: Element): boolean {
     if (current.hasAttribute("hidden") || current.getAttribute("aria-hidden") === "true") {
       return false;
     }
-    if (
-      current.tagName === "DETAILS" &&
-      !current.hasAttribute("open") &&
-      current !== node
-    ) {
+    if (current.tagName === "DETAILS" && !current.hasAttribute("open") && current !== node) {
       return false;
     }
     const style = current.ownerDocument?.defaultView?.getComputedStyle?.(current);
@@ -494,7 +517,12 @@ function bind(received: mixed, negated: boolean): $FlowFixMe {
         return undefined;
       }
       const message = negated ? verdict.negatedFailure() : verdict.failure();
-      throw new AssertionError(message, name, verdict.expected ?? "", verdict.received ?? render(received));
+      throw new AssertionError(
+        message,
+        name,
+        verdict.expected ?? "",
+        verdict.received ?? render(received),
+      );
     };
   }
   Object.defineProperty(bound, "not", { get: () => bind(received, !negated) });
@@ -562,7 +590,9 @@ function settled(promise: mixed, wanted: "resolve" | "reject", negated: boolean)
  */
 export function expect(received: mixed): $FlowFixMe {
   const expectation: $FlowFixMe = bind(received, false);
-  Object.defineProperty(expectation, "resolves", { get: () => settled(received, "resolve", false) });
+  Object.defineProperty(expectation, "resolves", {
+    get: () => settled(received, "resolve", false),
+  });
   Object.defineProperty(expectation, "rejects", { get: () => settled(received, "reject", false) });
   return expectation;
 }

--- a/packages/test/internal/frames.js
+++ b/packages/test/internal/frames.js
@@ -14,7 +14,7 @@
 // regex-shaped.
 
 /** A position in a source file, one-based line and column. */
-export type Site = {| +line: number, +column: number |};
+export type Site = {| readonly line: number, readonly column: number |};
 
 /** Frames belonging to the runner itself, which no test author wrote. */
 const INTERNAL_MARKERS = [
@@ -54,7 +54,10 @@ export function frameSite(frame: string): Site | null {
 }
 
 /** The run of digits ending at `end`, with where it starts. */
-function digitsBefore(text: string, end: number): {| +value: number, +start: number |} | null {
+function digitsBefore(
+  text: string,
+  end: number,
+): {| readonly value: number, readonly start: number |} | null {
   let start = end;
   while (start > 0 && text[start - 1] >= "0" && text[start - 1] <= "9") {
     start -= 1;
@@ -71,7 +74,10 @@ function digitsBefore(text: string, end: number): {| +value: number, +start: num
  * `skipInternal` is false when the caller has already trimmed the runner's own
  * frames and wants the first frame whatever it is.
  */
-export function firstUserSite(stack: string | null | void, skipInternal: boolean = true): Site | null {
+export function firstUserSite(
+  stack: string | null | void,
+  skipInternal: boolean = true,
+): Site | null {
   if (stack == null) {
     return null;
   }

--- a/packages/test/internal/registry.js
+++ b/packages/test/internal/registry.js
@@ -32,27 +32,27 @@ export type Modifier = "none" | "only" | "skip" | "todo";
 
 /** One registered test case. */
 export type Case = {|
-  +kind: "test",
-  +name: string,
-  +body: Body | null,
-  +modifier: Modifier,
-  +timeoutMs: number | null,
-  +line: number,
-  +column: number,
+  readonly kind: "test",
+  readonly name: string,
+  readonly body: Body | null,
+  readonly modifier: Modifier,
+  readonly timeoutMs: number | null,
+  readonly line: number,
+  readonly column: number,
 |};
 
 /** One `describe` and everything inside it. */
 export type Suite = {|
-  +kind: "suite",
-  +name: string,
-  +modifier: Modifier,
-  +children: Array<Suite | Case>,
-  +beforeAll: Array<Body>,
-  +afterAll: Array<Body>,
-  +beforeEach: Array<Body>,
-  +afterEach: Array<Body>,
-  +line: number,
-  +column: number,
+  readonly kind: "suite",
+  readonly name: string,
+  readonly modifier: Modifier,
+  readonly children: Array<Suite | Case>,
+  readonly beforeAll: Array<Body>,
+  readonly afterAll: Array<Body>,
+  readonly beforeEach: Array<Body>,
+  readonly afterEach: Array<Body>,
+  readonly line: number,
+  readonly column: number,
 |};
 
 function suite(name: string, modifier: Modifier, line: number, column: number): Suite {
@@ -101,7 +101,7 @@ export function collected(): Suite {
  * not in a shape we understand, the position is `0`, which every consumer
  * treats as "unknown" rather than as line one.
  */
-function callSite(): {| +line: number, +column: number |} {
+function callSite(): {| readonly line: number, readonly column: number |} {
   return firstUserSite(new Error("position").stack) ?? { line: 0, column: 0 };
 }
 
@@ -118,7 +118,12 @@ function addSuite(name: string, body: Body, modifier: Modifier): void {
   }
 }
 
-function addCase(name: string, body: Body | null, modifier: Modifier, timeoutMs: number | null): void {
+function addCase(
+  name: string,
+  body: Body | null,
+  modifier: Modifier,
+  timeoutMs: number | null,
+): void {
   const position = callSite();
   current.children.push({
     kind: "test",
@@ -132,7 +137,7 @@ function addCase(name: string, body: Body | null, modifier: Modifier, timeoutMs:
 }
 
 /** Options a single test may carry. */
-export type TestOptions = {| +timeout?: number |};
+export type TestOptions = {| readonly timeout?: number |};
 
 /**
  * The `describe` API, and its modifiers.
@@ -155,13 +160,11 @@ function suiteApi(): $FlowFixMe {
   api.todo = (name: string, body?: Body) => {
     addSuite(name, body ?? (() => {}), "todo");
   };
-  api.each =
-    (table: $ReadOnlyArray<mixed>) =>
-    (name: string, body: (row: mixed) => mixed) => {
-      for (const row of table) {
-        addSuite(formatRow(name, row), () => body(row), "none");
-      }
-    };
+  api.each = (table: $ReadOnlyArray<mixed>) => (name: string, body: (row: mixed) => mixed) => {
+    for (const row of table) {
+      addSuite(formatRow(name, row), () => body(row), "none");
+    }
+  };
   return api;
 }
 
@@ -218,7 +221,7 @@ function formatRow(name: string, row: mixed): string {
   return name.replace(ROW_TOKEN, (token) => {
     const value = values[index];
     index += 1;
-    return token === "%j" ? (JSON.stringify(value) ?? "undefined") : String(value);
+    return token === "%j" ? JSON.stringify(value) ?? "undefined" : String(value);
   });
 }
 

--- a/packages/test/internal/run.js
+++ b/packages/test/internal/run.js
@@ -15,34 +15,34 @@ import { type Body, type Case, type Suite, collected } from "./registry.js";
 
 /** How one case ended. */
 export type Outcome =
-  | {| +status: "passed" |}
+  | {| readonly status: "passed" |}
   | {|
-      +status: "failed",
-      +message: string,
-      +stack: string | null,
-      +expected: string | null,
-      +received: string | null,
+      readonly status: "failed",
+      readonly message: string,
+      readonly stack: string | null,
+      readonly expected: string | null,
+      readonly received: string | null,
       /** Where the failing assertion was written, when the stack says. */
-      +site: {| +line: number, +column: number |} | null,
+      readonly site: {| readonly line: number, readonly column: number |} | null,
     |}
-  | {| +status: "skipped", +reason: "explicit" | "not-only" | "filtered" |}
-  | {| +status: "todo" |};
+  | {| readonly status: "skipped", readonly reason: "explicit" | "not-only" | "filtered" |}
+  | {| readonly status: "todo" |};
 
 /** One finished case, as the runner reports it. */
 export type Result = {|
-  +name: string,
-  +line: number,
-  +column: number,
-  +durationMicros: number,
-  +outcome: Outcome,
+  readonly name: string,
+  readonly line: number,
+  readonly column: number,
+  readonly durationMicros: number,
+  readonly outcome: Outcome,
 |};
 
 /** How a run is configured. */
 export type RunOptions = {|
   /** Keep only cases whose full name contains this, reporting the rest skipped. */
-  +filter?: string | null,
+  readonly filter?: string | null,
   /** Wall-clock budget for one case, in milliseconds. */
-  +timeoutMs?: number,
+  readonly timeoutMs?: number,
 |};
 
 /** Default budget for one case, matching what most runners use. */
@@ -128,11 +128,11 @@ function failure(thrown: mixed): Outcome {
 
 /** Everything one case needs from the suites above it. */
 type Context = {|
-  +path: $ReadOnlyArray<string>,
-  +beforeEach: $ReadOnlyArray<Body>,
-  +afterEach: $ReadOnlyArray<Body>,
-  +skipped: boolean,
-  +onlyPath: boolean,
+  readonly path: $ReadOnlyArray<string>,
+  readonly beforeEach: $ReadOnlyArray<Body>,
+  readonly afterEach: $ReadOnlyArray<Body>,
+  readonly skipped: boolean,
+  readonly onlyPath: boolean,
 |};
 
 /**

--- a/packages/test/worker.js
+++ b/packages/test/worker.js
@@ -28,12 +28,12 @@ import { run } from "./internal/run.js";
 
 /** What `uf` sends for one file. */
 type Request = {|
-  +file: string,
-  +filter?: string | null,
-  +timeoutMs?: number,
+  readonly file: string,
+  readonly filter?: string | null,
+  readonly timeoutMs?: number,
 |};
 
-function write(event: { +[string]: mixed }): void {
+function write(event: { readonly [string]: mixed }): void {
   process.stdout.write(`${JSON.stringify(event)}\n`);
 }
 
@@ -64,7 +64,14 @@ async function runFile(request: Request, generation: number): Promise<void> {
 
   try {
     await run({ filter: request.filter ?? null, timeoutMs: request.timeoutMs }, (result) => {
-      write({ event: "test", ...result.outcome, name: result.name, line: result.line, column: result.column, durationMicros: result.durationMicros });
+      write({
+        event: "test",
+        ...result.outcome,
+        name: result.name,
+        line: result.line,
+        column: result.column,
+        durationMicros: result.durationMicros,
+      });
     });
     write({
       event: "file",
@@ -103,7 +110,11 @@ function serve(): void {
     try {
       request = JSON.parse(line);
     } catch (error) {
-      write({ event: "file", status: "run-failed", message: `malformed request: ${String(error)}` });
+      write({
+        event: "file",
+        status: "run-failed",
+        message: `malformed request: ${String(error)}`,
+      });
       return;
     }
     generation += 1;

--- a/packages/tui/index.js
+++ b/packages/tui/index.js
@@ -52,43 +52,43 @@ export type TuiComponentKind =
   | "integration";
 
 export type TuiComponent = {
-  +name: string,
-  +parts: $ReadOnlyArray<string>,
-  +kind: TuiComponentKind,
-  +serverComponentSafe: boolean,
-  +interactive: boolean,
-  +feature: TuiFeature,
+  readonly name: string,
+  readonly parts: $ReadOnlyArray<string>,
+  readonly kind: TuiComponentKind,
+  readonly serverComponentSafe: boolean,
+  readonly interactive: boolean,
+  readonly feature: TuiFeature,
 };
 
 export type ReactInkTarget = {
-  +replacementReady: true,
-  +nativeRenderer: true,
-  +typedComponents: true,
-  +richMedia: true,
-  +inMemoryTests: true,
-  +performanceTarget: TuiPerformanceTarget,
+  readonly replacementReady: true,
+  readonly nativeRenderer: true,
+  readonly typedComponents: true,
+  readonly richMedia: true,
+  readonly inMemoryTests: true,
+  readonly performanceTarget: TuiPerformanceTarget,
 };
 
 export type TuiFrameworkContract = {
-  +engine: TuiEngine,
-  +standard: TuiStandard,
-  +renderer: TuiRenderer,
-  +layout: TuiLayoutEngine,
-  +input: TuiInputModel,
-  +runtimeBinding: TuiRuntimeBinding,
-  +features: $ReadOnlyArray<TuiFeature>,
-  +components: $ReadOnlyArray<TuiComponent>,
-  +reactInkTarget: ReactInkTarget,
+  readonly engine: TuiEngine,
+  readonly standard: TuiStandard,
+  readonly renderer: TuiRenderer,
+  readonly layout: TuiLayoutEngine,
+  readonly input: TuiInputModel,
+  readonly runtimeBinding: TuiRuntimeBinding,
+  readonly features: $ReadOnlyArray<TuiFeature>,
+  readonly components: $ReadOnlyArray<TuiComponent>,
+  readonly reactInkTarget: ReactInkTarget,
 };
 
 export type TuiProps = {
-  +children?: React.Node,
-  +id?: string,
-  +width?: number | string,
-  +height?: number | string,
-  +grow?: number,
-  +shrink?: number,
-  +focusable?: boolean,
+  readonly children?: React.Node,
+  readonly id?: string,
+  readonly width?: number | string,
+  readonly height?: number | string,
+  readonly grow?: number,
+  readonly shrink?: number,
+  readonly focusable?: boolean,
 };
 
 export type TuiComponentFn = component(
@@ -102,32 +102,32 @@ export type TuiComponentFn = component(
 ) renders React.Node;
 
 export type SelectComponent = {
-  +Root: TuiComponentFn,
-  +Item: TuiComponentFn,
-  +Group: TuiComponentFn,
-  +Empty: TuiComponentFn,
+  readonly Root: TuiComponentFn,
+  readonly Item: TuiComponentFn,
+  readonly Group: TuiComponentFn,
+  readonly Empty: TuiComponentFn,
 };
 
 export type ScrollBoxComponent = {
-  +Root: TuiComponentFn,
-  +Viewport: TuiComponentFn,
-  +Content: TuiComponentFn,
+  readonly Root: TuiComponentFn,
+  readonly Viewport: TuiComponentFn,
+  readonly Content: TuiComponentFn,
 };
 
 export type FrameBufferComponent = {
-  +Root: TuiComponentFn,
-  +Layer: TuiComponentFn,
+  readonly Root: TuiComponentFn,
+  readonly Layer: TuiComponentFn,
 };
 
 export type RenderTuiHandle = {
-  +stop: () => void,
-  +snapshot: () => string,
+  readonly stop: () => void,
+  readonly snapshot: () => string,
 };
 
 export type RenderTuiOptions = {
-  +stdin?: mixed,
-  +stdout?: mixed,
-  +testing?: boolean,
+  readonly stdin?: mixed,
+  readonly stdout?: mixed,
+  readonly testing?: boolean,
 };
 
 /**
@@ -149,10 +149,7 @@ export function contract(): TuiFrameworkContract {
   return nativeRuntimeRequired(MODULE, "contract");
 }
 
-export function renderTui(
-  node: React.Node,
-  options?: RenderTuiOptions,
-): RenderTuiHandle {
+export function renderTui(node: React.Node, options?: RenderTuiOptions): RenderTuiHandle {
   return nativeRuntimeRequired(MODULE, "renderTui");
 }
 
@@ -166,42 +163,32 @@ export const Select: SelectComponent = {
   Group: /*#__PURE__*/ tuiComponent("Select.Group"),
   Empty: /*#__PURE__*/ tuiComponent("Select.Empty"),
 };
-export const TabSelect: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("TabSelect");
+export const TabSelect: TuiComponentFn = /*#__PURE__*/ tuiComponent("TabSelect");
 export const Slider: TuiComponentFn = /*#__PURE__*/ tuiComponent("Slider");
 export const ScrollBox: ScrollBoxComponent = {
   Root: /*#__PURE__*/ tuiComponent("ScrollBox.Root"),
   Viewport: /*#__PURE__*/ tuiComponent("ScrollBox.Viewport"),
   Content: /*#__PURE__*/ tuiComponent("ScrollBox.Content"),
 };
-export const ScrollBar: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("ScrollBar");
+export const ScrollBar: TuiComponentFn = /*#__PURE__*/ tuiComponent("ScrollBar");
 export const Code: TuiComponentFn = /*#__PURE__*/ tuiComponent("Code");
 export const Markdown: TuiComponentFn = /*#__PURE__*/ tuiComponent("Markdown");
-export const LineNumbers: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("LineNumbers");
+export const LineNumbers: TuiComponentFn = /*#__PURE__*/ tuiComponent("LineNumbers");
 export const Diff: TuiComponentFn = /*#__PURE__*/ tuiComponent("Diff");
-export const TextTable: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("TextTable");
-export const AsciiFont: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("AsciiFont");
+export const TextTable: TuiComponentFn = /*#__PURE__*/ tuiComponent("TextTable");
+export const AsciiFont: TuiComponentFn = /*#__PURE__*/ tuiComponent("AsciiFont");
 export const FrameBuffer: FrameBufferComponent = {
   Root: /*#__PURE__*/ tuiComponent("FrameBuffer.Root"),
   Layer: /*#__PURE__*/ tuiComponent("FrameBuffer.Layer"),
 };
 export const Image: TuiComponentFn = /*#__PURE__*/ tuiComponent("Image");
 export const QrCode: TuiComponentFn = /*#__PURE__*/ tuiComponent("QrCode");
-export const EmbeddedTerminal: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("EmbeddedTerminal");
-export const Clipboard: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("Clipboard");
-export const Notification: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("Notification");
+export const EmbeddedTerminal: TuiComponentFn = /*#__PURE__*/ tuiComponent("EmbeddedTerminal");
+export const Clipboard: TuiComponentFn = /*#__PURE__*/ tuiComponent("Clipboard");
+export const Notification: TuiComponentFn = /*#__PURE__*/ tuiComponent("Notification");
 export const Audio: TuiComponentFn = /*#__PURE__*/ tuiComponent("Audio");
 export const Timeline: TuiComponentFn = /*#__PURE__*/ tuiComponent("Timeline");
 export const Keymap: TuiComponentFn = /*#__PURE__*/ tuiComponent("Keymap");
 export const SshHost: TuiComponentFn = /*#__PURE__*/ tuiComponent("SshHost");
-export const ThreeCanvas: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("ThreeCanvas");
-export const TestRenderer: TuiComponentFn =
-  /*#__PURE__*/ tuiComponent("TestRenderer");
+export const ThreeCanvas: TuiComponentFn = /*#__PURE__*/ tuiComponent("ThreeCanvas");
+export const TestRenderer: TuiComponentFn = /*#__PURE__*/ tuiComponent("TestRenderer");

--- a/packages/ui/dialog/types.js
+++ b/packages/ui/dialog/types.js
@@ -2,13 +2,13 @@
 import type { HeadlessComponent } from "../types/renders.js";
 
 export type DialogParts = {
-  +Root: HeadlessComponent,
-  +Trigger: HeadlessComponent,
-  +Overlay: HeadlessComponent,
-  +Body: HeadlessComponent,
-  +Header: HeadlessComponent,
-  +Footer: HeadlessComponent,
-  +Title: HeadlessComponent,
-  +Description: HeadlessComponent,
-  +Close: HeadlessComponent,
+  readonly Root: HeadlessComponent,
+  readonly Trigger: HeadlessComponent,
+  readonly Overlay: HeadlessComponent,
+  readonly Body: HeadlessComponent,
+  readonly Header: HeadlessComponent,
+  readonly Footer: HeadlessComponent,
+  readonly Title: HeadlessComponent,
+  readonly Description: HeadlessComponent,
+  readonly Close: HeadlessComponent,
 };

--- a/packages/ui/form/types.js
+++ b/packages/ui/form/types.js
@@ -3,20 +3,20 @@ import type * as React from "@uniflowed/react";
 import type { Schema } from "@uniflowed/validator";
 import type { HeadlessComponent } from "../types/renders.js";
 
-export type FormState<T: {...}> = {
-  +value: T,
-  +errors: { +[string]: $ReadOnlyArray<string> },
-  +valid: boolean,
+export type FormState<T extends { ... }> = {
+  readonly value: T,
+  readonly errors: { readonly [string]: $ReadOnlyArray<string> },
+  readonly valid: boolean,
 };
 
-export type FormRootProps<T: {...}> = {
-  +schema: Schema<T>,
-  +defaultValue?: T,
-  +children?: React.Node,
-  +onSubmit?: (value: T) => mixed | Promise<mixed>,
+export type FormRootProps<T extends { ... }> = {
+  readonly schema: Schema<T>,
+  readonly defaultValue?: T,
+  readonly children?: React.Node,
+  readonly onSubmit?: (value: T) => mixed | Promise<mixed>,
 };
 
-export type FormRoot = component<T: {...}>(
+export type FormRoot = component<T extends { ... }>(
   schema: Schema<T>,
   defaultValue?: T,
   children?: React.Node,
@@ -24,10 +24,10 @@ export type FormRoot = component<T: {...}>(
 ) renders React.Node;
 
 export type FormParts = {
-  +Root: FormRoot,
-  +Field: HeadlessComponent,
-  +Label: HeadlessComponent,
-  +Control: HeadlessComponent,
-  +Message: HeadlessComponent,
-  +Submit: HeadlessComponent,
+  readonly Root: FormRoot,
+  readonly Field: HeadlessComponent,
+  readonly Label: HeadlessComponent,
+  readonly Control: HeadlessComponent,
+  readonly Message: HeadlessComponent,
+  readonly Submit: HeadlessComponent,
 };

--- a/packages/ui/internal/dialog.js
+++ b/packages/ui/internal/dialog.js
@@ -33,10 +33,10 @@ import {
 } from "@uniflowed/react";
 
 type DialogState = {|
-  +base: string,
-  +open: boolean,
-  +setOpen: (open: boolean) => void,
-  +triggerRef: { current: HTMLElement | null },
+  readonly base: string,
+  readonly open: boolean,
+  readonly setOpen: (open: boolean) => void,
+  readonly triggerRef: { current: HTMLElement | null },
 |};
 
 const DialogContext: React.Context<DialogState | null> = createContext(null);
@@ -80,7 +80,7 @@ export component DialogRoot(
 }
 
 /** What opens the dialog, and what focus comes back to when it closes. */
-export component DialogTrigger(children: React.Node, ...rest: { +[string]: mixed }) {
+export component DialogTrigger(children: React.Node, ...rest: { readonly [string]: mixed }) {
   const dialog = useDialog("Dialog.Trigger");
   const passed = withoutComposed(rest, ["onClick", "ref"]);
 
@@ -106,7 +106,7 @@ export component DialogTrigger(children: React.Node, ...rest: { +[string]: mixed
  * `aria-modal` tells a screen reader that the rest of the page is not
  * available, which is the half of "modal" that CSS cannot express.
  */
-export component DialogContent(children: React.Node, ...rest: { +[string]: mixed }) {
+export component DialogContent(children: React.Node, ...rest: { readonly [string]: mixed }) {
   const dialog = useDialog("Dialog.Content");
   const contentRef = useRef<HTMLElement | null>(null);
 
@@ -119,7 +119,7 @@ export component DialogContent(children: React.Node, ...rest: { +[string]: mixed
     // The first thing worth acting on, not the first thing in the document —
     // and the dialog itself if it contains nothing focusable, so focus is
     // inside it either way.
-    const target = content == null ? null : (focusable(content)[0] ?? content);
+    const target = content == null ? null : focusable(content)[0] ?? content;
     target?.focus();
 
     return () => {
@@ -190,7 +190,7 @@ export component DialogContent(children: React.Node, ...rest: { +[string]: mixed
 }
 
 /** The dialog's accessible name, which `aria-labelledby` points at. */
-export component DialogTitle(children: React.Node, ...rest: { +[string]: mixed }) {
+export component DialogTitle(children: React.Node, ...rest: { readonly [string]: mixed }) {
   const dialog = useDialog("Dialog.Title");
   return (
     <h2 {...rest} id={`${dialog.base}-title`}>
@@ -200,7 +200,7 @@ export component DialogTitle(children: React.Node, ...rest: { +[string]: mixed }
 }
 
 /** A button that closes the dialog. */
-export component DialogClose(children: React.Node, ...rest: { +[string]: mixed }) {
+export component DialogClose(children: React.Node, ...rest: { readonly [string]: mixed }) {
   const dialog = useDialog("Dialog.Close");
   const passed = withoutComposed(rest, ["onClick"]);
 
@@ -231,7 +231,6 @@ function focusable(root: HTMLElement): Array<HTMLElement> {
       // ancestors. Reading `aria-hidden` off the element alone returned a
       // button inside `<div aria-hidden="true">` as a focus stop, and the trap
       // then moved focus to a control no screen reader exposes.
-      element.closest("[hidden]") == null &&
-      element.closest('[aria-hidden="true"]') == null,
+      element.closest("[hidden]") == null && element.closest('[aria-hidden="true"]') == null,
   );
 }

--- a/packages/ui/internal/field.js
+++ b/packages/ui/internal/field.js
@@ -21,14 +21,14 @@ import * as React from "@uniflowed/react";
 import { createContext, useContext, useId, useMemo, useState } from "@uniflowed/react";
 
 type FieldState = {|
-  +controlId: string,
-  +labelId: string,
-  +descriptionId: string,
-  +errorId: string,
-  +invalid: boolean,
-  +describedBy: string | void,
-  +registerDescription: (present: boolean) => void,
-  +registerError: (present: boolean) => void,
+  readonly controlId: string,
+  readonly labelId: string,
+  readonly descriptionId: string,
+  readonly errorId: string,
+  readonly invalid: boolean,
+  readonly describedBy: string | void,
+  readonly registerDescription: (present: boolean) => void,
+  readonly registerError: (present: boolean) => void,
 |};
 
 const FieldContext: React.Context<FieldState | null> = createContext(null);
@@ -58,7 +58,7 @@ function useField(part: string): FieldState {
 export component FieldRoot(
   children: React.Node,
   invalid?: boolean = false,
-  ...rest: { +[string]: mixed }
+  ...rest: { readonly [string]: mixed }
 ) {
   const base = useId();
   const [hasDescription, setHasDescription] = useState(false);
@@ -94,7 +94,7 @@ export component FieldRoot(
 }
 
 /** The label, pointing at the control by id rather than by nesting. */
-export component FieldLabel(children: React.Node, ...rest: { +[string]: mixed }) {
+export component FieldLabel(children: React.Node, ...rest: { readonly [string]: mixed }) {
   const field = useField("Field.Label");
   // `rest` first: a caller `id` here would break the relationship the control
   // points at, and it would break it silently.
@@ -112,9 +112,7 @@ export component FieldLabel(children: React.Node, ...rest: { +[string]: mixed })
  * field wraps a select, a textarea, a combobox or somebody else's component
  * just as often, and each of those needs the same six attributes.
  */
-export component FieldControl(
-  render: (props: { +[string]: mixed }) => React.Node,
-) {
+export component FieldControl(render: (props: { readonly [string]: mixed }) => React.Node) {
   const field = useField("Field.Control");
   return render({
     id: field.controlId,
@@ -125,7 +123,7 @@ export component FieldControl(
 }
 
 /** Help text, which the control points at while it is rendered. */
-export component FieldDescription(children: React.Node, ...rest: { +[string]: mixed }) {
+export component FieldDescription(children: React.Node, ...rest: { readonly [string]: mixed }) {
   const field = useField("Field.Description");
   React.useEffect(() => {
     field.registerDescription(true);
@@ -145,7 +143,7 @@ export component FieldDescription(children: React.Node, ...rest: { +[string]: mi
  * `role="alert"` so it is announced when it appears, which is the point of an
  * error that arrives after a blur or a submit.
  */
-export component FieldError(children: React.Node, ...rest: { +[string]: mixed }) {
+export component FieldError(children: React.Node, ...rest: { readonly [string]: mixed }) {
   const field = useField("Field.Error");
   React.useEffect(() => {
     field.registerError(true);

--- a/packages/ui/internal/props.js
+++ b/packages/ui/internal/props.js
@@ -21,7 +21,7 @@
 // they are composed rather than one replacing the other.
 
 /** Anything a caller can spread onto an element. */
-export type Rest = { +[string]: mixed };
+export type Rest = { readonly [string]: mixed };
 
 /**
  * Call the caller's handler and then the component's.
@@ -31,7 +31,7 @@ export type Rest = { +[string]: mixed };
  * `defaultPrevented` is the caller's way of saying "I handled this", which is
  * the same contract the DOM uses.
  */
-export function composeHandlers<TEvent: { +defaultPrevented?: boolean }>(
+export function composeHandlers<TEvent extends { readonly defaultPrevented?: boolean }>(
   theirs: mixed,
   ours: (event: TEvent) => mixed,
 ): (event: TEvent) => mixed {

--- a/packages/ui/internal/switch.js
+++ b/packages/ui/internal/switch.js
@@ -18,10 +18,7 @@ import { useCallback, useState } from "@uniflowed/react";
 import { composeHandlers, withoutComposed } from "./props.js";
 
 /** Space toggles, and so does Enter, because both do on a native control. */
-function toggleKeys(
-  event: SyntheticKeyboardEvent<HTMLElement>,
-  toggle: () => void,
-): void {
+function toggleKeys(event: SyntheticKeyboardEvent<HTMLElement>, toggle: () => void): void {
   if (event.key !== " " && event.key !== "Enter") {
     return;
   }
@@ -58,7 +55,7 @@ export component Switch(
   onCheckedChange?: (checked: boolean) => void,
   disabled?: boolean = false,
   children?: React.Node,
-  ...rest: { +[string]: mixed }
+  ...rest: { readonly [string]: mixed }
 ) {
   const [on, toggle] = useToggle(checked, defaultChecked, onCheckedChange);
   const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);
@@ -94,7 +91,7 @@ export component Checkbox(
   onCheckedChange?: (checked: boolean) => void,
   disabled?: boolean = false,
   children?: React.Node,
-  ...rest: { +[string]: mixed }
+  ...rest: { readonly [string]: mixed }
 ) {
   const [on, toggle] = useToggle(checked, defaultChecked, onCheckedChange);
   const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);

--- a/packages/ui/internal/tabs.js
+++ b/packages/ui/internal/tabs.js
@@ -28,10 +28,10 @@ import {
 } from "@uniflowed/react";
 
 type TabsState = {|
-  +base: string,
-  +selected: string,
-  +select: (value: string) => void,
-  +register: (value: string, element: HTMLElement | null, disabled: boolean) => void,
+  readonly base: string,
+  readonly selected: string,
+  readonly select: (value: string) => void,
+  readonly register: (value: string, element: HTMLElement | null, disabled: boolean) => void,
   /**
    * Focus the tab `pick` chooses, given where we are and how many there are.
    *
@@ -41,10 +41,7 @@ type TabsState = {|
    * *backwards* to the last enabled one — inferring "forwards" from the target
    * being ahead of us wrapped around to the first tab instead.
    */
-  +focusBy: (
-    from: string,
-    pick: (at: number, count: number) => [number, 1 | -1],
-  ) => void,
+  readonly focusBy: (from: string, pick: (at: number, count: number) => [number, 1 | -1]) => void,
 |};
 
 const TabsContext: React.Context<TabsState | null> = createContext(null);
@@ -69,7 +66,7 @@ export component TabsRoot(
   defaultValue: string,
   value?: string,
   onValueChange?: (value: string) => void,
-  ...rest: { +[string]: mixed }
+  ...rest: { readonly [string]: mixed }
 ) {
   const base = useId();
   const [internal, setInternal] = useState(defaultValue);
@@ -91,22 +88,19 @@ export component TabsRoot(
 
   const disabledTabs = useRef<{ [string]: boolean }>({});
 
-  const register = useCallback(
-    (tab: string, element: HTMLElement | null, disabled: boolean) => {
-      if (element == null) {
-        order.current = order.current.filter((entry) => entry !== tab);
-        delete elements.current[tab];
-        delete disabledTabs.current[tab];
-        return;
-      }
-      if (!order.current.includes(tab)) {
-        order.current.push(tab);
-      }
-      elements.current[tab] = element;
-      disabledTabs.current[tab] = disabled;
-    },
-    [],
-  );
+  const register = useCallback((tab: string, element: HTMLElement | null, disabled: boolean) => {
+    if (element == null) {
+      order.current = order.current.filter((entry) => entry !== tab);
+      delete elements.current[tab];
+      delete disabledTabs.current[tab];
+      return;
+    }
+    if (!order.current.includes(tab)) {
+      order.current.push(tab);
+    }
+    elements.current[tab] = element;
+    disabledTabs.current[tab] = disabled;
+  }, []);
 
   /**
    * Focus and select the first enabled tab at or after `index`.
@@ -148,14 +142,8 @@ export component TabsRoot(
       selected,
       select,
       register,
-      focusBy: (
-        from: string,
-        pick: (at: number, count: number) => [number, 1 | -1],
-      ) => {
-        const [target, direction] = pick(
-          order.current.indexOf(from),
-          order.current.length,
-        );
+      focusBy: (from: string, pick: (at: number, count: number) => [number, 1 | -1]) => {
+        const [target, direction] = pick(order.current.indexOf(from), order.current.length);
         focusAt(target, direction);
       },
     }),
@@ -176,7 +164,7 @@ export component TabsRoot(
  * `<button>` here would be announced as a button inside a tablist, which is
  * how a keyboard user ends up unable to tell where they are.
  */
-export component TabsList(children: renders* TabsTab, ...rest: { +[string]: mixed }) {
+export component TabsList(children: renders* TabsTab, ...rest: { readonly [string]: mixed }) {
   return (
     <div {...rest} role="tablist">
       {children}
@@ -189,7 +177,7 @@ export component TabsTab(
   value: string,
   children: React.Node,
   disabled?: boolean = false,
-  ...rest: { +[string]: mixed }
+  ...rest: { readonly [string]: mixed }
 ) {
   const tabs = useTabs("Tabs.Tab");
   const active = tabs.selected === value;
@@ -222,13 +210,15 @@ export component TabsTab(
         // `match` is an expression, so it computes the index to move to rather
         // than performing the four movements — which also means adding a key
         // to `arrowKey` stops compiling here until it is handled.
-        tabs.focusBy(value, (at, count) =>
-          match (intent) {
-            "previous" => [at - 1, -1],
-            "next" => [at + 1, 1],
-            "first" => [0, 1],
-            "last" => [count - 1, -1],
-          },
+        tabs.focusBy(
+          value,
+          (at, count) =>
+            match (intent) {
+              "previous" => [at - 1, -1],
+              "next" => [at + 1, 1],
+              "first" => [0, 1],
+              "last" => [count - 1, -1],
+            },
         );
       })}
       ref={composeRefs(rest.ref, (element) => tabs.register(value, element, disabled))}
@@ -247,7 +237,7 @@ export component TabsTab(
 export component TabsPanel(
   value: string,
   children: React.Node,
-  ...rest: { +[string]: mixed }
+  ...rest: { readonly [string]: mixed }
 ) {
   const tabs = useTabs("Tabs.Panel");
   if (tabs.selected !== value) {

--- a/packages/ui/types/renders.js
+++ b/packages/ui/types/renders.js
@@ -2,14 +2,14 @@
 import type * as React from "@uniflowed/react";
 
 export type RendersNode = renders React.Node;
-export type RendersElement<Element: React.Node> = renders Element;
+export type RendersElement<Element extends React.Node> = renders Element;
 
 export type HeadlessProps = {
-  +className?: string,
-  +children?: React.Node,
-  +variant?: string,
-  +size?: string,
-  +disabled?: boolean,
+  readonly className?: string,
+  readonly children?: React.Node,
+  readonly variant?: string,
+  readonly size?: string,
+  readonly disabled?: boolean,
 };
 
 export type HeadlessComponent = component(

--- a/packages/validator/internal/schema.js
+++ b/packages/validator/internal/schema.js
@@ -69,7 +69,7 @@ export type Infer<TSchema> = TSchema extends Schema<infer T> ? T : empty;
  * a field-by-field response without parsing the message back apart.
  */
 export class ValidationError extends Error {
-  +issues: $ReadOnlyArray<Issue>;
+  readonly issues: $ReadOnlyArray<Issue>;
 
   constructor(issues: $ReadOnlyArray<Issue>) {
     super(issues.map(describeIssue).join("; "));
@@ -216,7 +216,9 @@ export function unknown(): Schema<mixed> {
 export function literal<T extends string | number | boolean | null>(expected: T): Schema<T> {
   return makeSchema({
     parse: (value, path) =>
-      value === expected ? ok(expected) : failIssue("literal", `expected ${String(expected)}`, path),
+      value === expected
+        ? ok(expected)
+        : failIssue("literal", `expected ${String(expected)}`, path),
   });
 }
 
@@ -290,9 +292,7 @@ export function tuple<TItems extends $ReadOnlyArray<Schema<mixed>>>(
  * Only own enumerable keys are read, so a payload carrying `__proto__` or
  * `constructor` cannot smuggle an inherited value into the parsed result.
  */
-export function record<Value>(
-  value: Schema<Value>,
-): Schema<{ readonly [string]: Value, ... }> {
+export function record<Value>(value: Schema<Value>): Schema<{ readonly [string]: Value, ... }> {
   return makeSchema({
     parse: (input, path) => {
       if (!isPlainObject(input)) {
@@ -348,7 +348,10 @@ export function union<T>(schemas: $ReadOnlyArray<Schema<T>>): Schema<T> {
  * at radius` rather than every reason it is not a square, a triangle and a
  * line as well. Unmatched discriminants name the ones that exist.
  */
-export function variant<T>(key: string, branches: { readonly [string]: Schema<T>, ... }): Schema<T> {
+export function variant<T>(
+  key: string,
+  branches: { readonly [string]: Schema<T>, ... },
+): Schema<T> {
   const known = Object.keys(branches);
   return makeSchema({
     parse: (value, path) => {
@@ -358,11 +361,7 @@ export function variant<T>(key: string, branches: { readonly [string]: Schema<T>
       const discriminant = plainRecord(value)[key];
       if (typeof discriminant !== "string" || !Object.hasOwn(branches, discriminant)) {
         path.push(key);
-        const failed = failIssue(
-          "variant",
-          `expected one of ${known.join(", ")}`,
-          path,
-        );
+        const failed = failIssue("variant", `expected one of ${known.join(", ")}`, path);
         path.pop();
         return failed;
       }

--- a/packages/vite/bun-preload.js
+++ b/packages/vite/bun-preload.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: this file registers the loader, so it cannot need one.
 //
 // `bun --preload @uniflowed/vite/bun-preload app.js` runs a Flow project on

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: the host runs this file directly.
 //
 // The driver `uf dev`, `uf build` and `uf preview` spawn.

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -81,7 +81,8 @@ async function viteConfig(config, mode) {
   const userPlugins = Array.isArray(config.plugins) ? config.plugins : [];
   const host = argument("--host") ?? dev.host ?? "127.0.0.1";
   const port = Number(argument("--port") ?? dev.port ?? 5173);
-  const allowedHosts = Array.isArray(dev.allowedHosts) && dev.allowedHosts.length > 0 ? dev.allowedHosts : undefined;
+  const allowedHosts =
+    Array.isArray(dev.allowedHosts) && dev.allowedHosts.length > 0 ? dev.allowedHosts : undefined;
 
   // What uf generates from the semantics it owns: where the project is, which
   // plugins make Flow compile, and the few settings uf enforces rather than
@@ -118,7 +119,7 @@ async function viteConfig(config, mode) {
   // read this and does not need to: an option added to Vite tomorrow works in
   // a uf project tomorrow, rather than after a uf release that names it.
   return withProjectConfig(generated, {
-    ...(config.vite ?? {}),
+    ...config.vite ?? {},
     plugins: [...(config.vite?.plugins ?? []), ...userPlugins],
   });
 }
@@ -191,7 +192,9 @@ async function dev() {
   emit("listening", {
     local: urls.local,
     network: urls.network,
-    routes: scanRoutes(path.resolve(root, config.app?.router?.root ?? "app")).routes.map((route) => route.path),
+    routes: scanRoutes(path.resolve(root, config.app?.router?.root ?? "app")).routes.map(
+      (route) => route.path,
+    ),
   });
 
   const shutdown = async () => {
@@ -321,13 +324,23 @@ async function build() {
     const file = htmlPathFor(outDir, url);
     mkdirSync(path.dirname(file), { recursive: true });
     writeFileSync(file, result.html);
-    emit("page", { url, file: path.relative(root, file), status: result.status, bytes: Buffer.byteLength(result.html) });
+    emit("page", {
+      url,
+      file: path.relative(root, file),
+      status: result.status,
+      bytes: Buffer.byteLength(result.html),
+    });
   }
   if (server.notFound != null) {
     const result = await server.render("/__uf_not_found__", assets);
     const file = path.join(outDir, "404.html");
     writeFileSync(file, result.html);
-    emit("page", { url: "/404", file: path.relative(root, file), status: 404, bytes: Buffer.byteLength(result.html) });
+    emit("page", {
+      url: "/404",
+      file: path.relative(root, file),
+      status: 404,
+      bytes: Buffer.byteLength(result.html),
+    });
   }
 
   emit("done", { outDir: path.relative(root, outDir), pages: pages.length });
@@ -431,9 +444,12 @@ function fillParams(routePath, params) {
     .map((segment) => {
       if (segment.endsWith("*")) {
         const value = params[segment.slice(1, -1)];
-        return Array.isArray(value) ? value.map(encodeURIComponent).join("/") : encodeURIComponent(String(value ?? ""));
+        return Array.isArray(value)
+          ? value.map(encodeURIComponent).join("/")
+          : encodeURIComponent(String(value ?? ""));
       }
-      if (segment.startsWith(":")) return encodeURIComponent(String(params[segment.slice(1)] ?? ""));
+      if (segment.startsWith(":"))
+        return encodeURIComponent(String(params[segment.slice(1)] ?? ""));
       return segment;
     })
     .join("/");
@@ -441,5 +457,7 @@ function fillParams(routePath, params) {
 
 function htmlPathFor(outDir, url) {
   const pathname = url.split("?")[0].replace(/^\/+/, "");
-  return pathname === "" ? path.join(outDir, "index.html") : path.join(outDir, pathname, "index.html");
+  return pathname === ""
+    ? path.join(outDir, "index.html")
+    : path.join(outDir, pathname, "index.html");
 }

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: Vite imports this module directly, before any transform.
 //
 // `@uniflowed/vite` — uf, as Vite plugins.

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -264,7 +264,11 @@ function mdxPlugin(markdown) {
     enforce: "pre",
     ...mdx({
       jsxImportSource: "react",
-      remarkPlugins: [remarkGfm, remarkFrontmatter, [remarkMdxFrontmatter, { name: "frontmatter" }]],
+      remarkPlugins: [
+        remarkGfm,
+        remarkFrontmatter,
+        [remarkMdxFrontmatter, { name: "frontmatter" }],
+      ],
       rehypePlugins,
     }),
     name: "uf:mdx",

--- a/packages/vite/internal/config.js
+++ b/packages/vite/internal/config.js
@@ -65,14 +65,18 @@ export async function loadUfConfig(root) {
 
   const source = readFileSync(file, "utf8");
   if (source.length > MAX_CONFIG_BYTES) {
-    throw new Error(`uf: ${file} is ${source.length} bytes, over the ${MAX_CONFIG_BYTES} byte ceiling`);
+    throw new Error(
+      `uf: ${file} is ${source.length} bytes, over the ${MAX_CONFIG_BYTES} byte ceiling`,
+    );
   }
 
   const compiled = await compileConfig(source, file, root);
   const module = await import(pathToFileURL(compiled).href);
   const config = module.default;
   if (config == null || typeof config !== "object") {
-    throw new Error(`uf: ${path.relative(root, file)} must \`export default defineConfig({ ... })\``);
+    throw new Error(
+      `uf: ${path.relative(root, file)} must \`export default defineConfig({ ... })\``,
+    );
   }
   return { config, file };
 }
@@ -128,7 +132,10 @@ export function projectConfig(config) {
     JSON.stringify(config, (key, value) => {
       if (typeof value === "function") return undefined;
       if (key === "plugins" && Array.isArray(value)) {
-        return value.flat(Infinity).map(pluginName).filter((name) => name != null);
+        return value
+          .flat(Infinity)
+          .map(pluginName)
+          .filter((name) => name != null);
       }
       return value;
     }),

--- a/packages/vite/internal/config.js
+++ b/packages/vite/internal/config.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // Loading `uf.config.js`.

--- a/packages/vite/internal/events.js
+++ b/packages/vite/internal/events.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // The driver's control channel.

--- a/packages/vite/internal/highlight.js
+++ b/packages/vite/internal/highlight.js
@@ -38,8 +38,6 @@ import rehypeShiki from "@shikijs/rehype";
 const FLOW_KEYWORD_PATTERN =
   /(?<![.\w$])(?:component|hook|renders|match|opaque|mixed|empty)(?![\w$])/g;
 
-
-
 /**
  * The languages a documentation page actually uses.
  *
@@ -100,8 +98,7 @@ function flowKeywords() {
         return;
       }
       const existing = node.properties.class;
-      node.properties.class =
-        existing == null ? KEYWORD_CLASS : `${existing} ${KEYWORD_CLASS}`;
+      node.properties.class = existing == null ? KEYWORD_CLASS : `${existing} ${KEYWORD_CLASS}`;
     },
   };
 }

--- a/packages/vite/internal/highlight.js
+++ b/packages/vite/internal/highlight.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Syntax highlighting for fenced code, at build time.
 //
 // uf's claim is that MDX works without a plugin list, and a documentation page

--- a/packages/vite/internal/node-hooks.js
+++ b/packages/vite/internal/node-hooks.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: this *is* the loader, so it cannot be Flow.
 //
 // Node.js module customization hooks that transform Flow on import.

--- a/packages/vite/internal/refresh-runtime.js
+++ b/packages/vite/internal/refresh-runtime.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 /* global window */
 /* eslint-disable eqeqeq, prefer-const, @typescript-eslint/no-empty-function */
 

--- a/packages/vite/internal/refresh-runtime.js
+++ b/packages/vite/internal/refresh-runtime.js
@@ -10,276 +10,272 @@
  * Some utils are appended at the bottom for HMR integration.
  */
 
-const REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref')
-const REACT_MEMO_TYPE = Symbol.for('react.memo')
+const REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref");
+const REACT_MEMO_TYPE = Symbol.for("react.memo");
 
 // We never remove these associations.
 // It's OK to reference families, but use WeakMap/Set for types.
-let allFamiliesByID = new Map()
-let allFamiliesByType = new WeakMap()
-let allSignaturesByType = new WeakMap()
+let allFamiliesByID = new Map();
+let allFamiliesByType = new WeakMap();
+let allSignaturesByType = new WeakMap();
 
 // This WeakMap is read by React, so we only put families
 // that have actually been edited here. This keeps checks fast.
-const updatedFamiliesByType = new WeakMap()
+const updatedFamiliesByType = new WeakMap();
 
 // This is cleared on every performReactRefresh() call.
 // It is an array of [Family, NextType] tuples.
-let pendingUpdates = []
+let pendingUpdates = [];
 
 // This is injected by the renderer via DevTools global hook.
-const helpersByRendererID = new Map()
+const helpersByRendererID = new Map();
 
-const helpersByRoot = new Map()
+const helpersByRoot = new Map();
 
 // We keep track of mounted roots so we can schedule updates.
-const mountedRoots = new Set()
+const mountedRoots = new Set();
 // If a root captures an error, we remember it so we can retry on edit.
-const failedRoots = new Set()
+const failedRoots = new Set();
 
 // We also remember the last element for every root.
 // It needs to be weak because we do this even for roots that failed to mount.
 // If there is no WeakMap, we won't attempt to do retrying.
-let rootElements = new WeakMap()
-let isPerformingRefresh = false
+let rootElements = new WeakMap();
+let isPerformingRefresh = false;
 
 function computeFullKey(signature) {
   if (signature.fullKey !== null) {
-    return signature.fullKey
+    return signature.fullKey;
   }
 
-  let fullKey = signature.ownKey
-  let hooks
+  let fullKey = signature.ownKey;
+  let hooks;
   try {
-    hooks = signature.getCustomHooks()
+    hooks = signature.getCustomHooks();
   } catch (err) {
     // This can happen in an edge case, e.g. if expression like Foo.useSomething
     // depends on Foo which is lazily initialized during rendering.
     // In that case just assume we'll have to remount.
-    signature.forceReset = true
-    signature.fullKey = fullKey
-    return fullKey
+    signature.forceReset = true;
+    signature.fullKey = fullKey;
+    return fullKey;
   }
 
   for (let i = 0; i < hooks.length; i++) {
-    const hook = hooks[i]
-    if (typeof hook !== 'function') {
+    const hook = hooks[i];
+    if (typeof hook !== "function") {
       // Something's wrong. Assume we need to remount.
-      signature.forceReset = true
-      signature.fullKey = fullKey
-      return fullKey
+      signature.forceReset = true;
+      signature.fullKey = fullKey;
+      return fullKey;
     }
-    const nestedHookSignature = allSignaturesByType.get(hook)
+    const nestedHookSignature = allSignaturesByType.get(hook);
     if (nestedHookSignature === undefined) {
       // No signature means Hook wasn't in the source code, e.g. in a library.
       // We'll skip it because we can assume it won't change during this session.
-      continue
+      continue;
     }
-    const nestedHookKey = computeFullKey(nestedHookSignature)
+    const nestedHookKey = computeFullKey(nestedHookSignature);
     if (nestedHookSignature.forceReset) {
-      signature.forceReset = true
+      signature.forceReset = true;
     }
-    fullKey += '\n---\n' + nestedHookKey
+    fullKey += "\n---\n" + nestedHookKey;
   }
 
-  signature.fullKey = fullKey
-  return fullKey
+  signature.fullKey = fullKey;
+  return fullKey;
 }
 
 function haveEqualSignatures(prevType, nextType) {
-  const prevSignature = allSignaturesByType.get(prevType)
-  const nextSignature = allSignaturesByType.get(nextType)
+  const prevSignature = allSignaturesByType.get(prevType);
+  const nextSignature = allSignaturesByType.get(nextType);
 
   if (prevSignature === undefined && nextSignature === undefined) {
-    return true
+    return true;
   }
   if (prevSignature === undefined || nextSignature === undefined) {
-    return false
+    return false;
   }
   if (computeFullKey(prevSignature) !== computeFullKey(nextSignature)) {
-    return false
+    return false;
   }
   if (nextSignature.forceReset) {
-    return false
+    return false;
   }
 
-  return true
+  return true;
 }
 
 function isReactClass(type) {
-  return type.prototype && type.prototype.isReactComponent
+  return type.prototype && type.prototype.isReactComponent;
 }
 
 function canPreserveStateBetween(prevType, nextType) {
   if (isReactClass(prevType) || isReactClass(nextType)) {
-    return false
+    return false;
   }
   if (haveEqualSignatures(prevType, nextType)) {
-    return true
+    return true;
   }
-  return false
+  return false;
 }
 
 function resolveFamily(type) {
   // Only check updated types to keep lookups fast.
-  return updatedFamiliesByType.get(type)
+  return updatedFamiliesByType.get(type);
 }
 
 // This is a safety mechanism to protect against rogue getters and Proxies.
 function getProperty(object, property) {
   try {
-    return object[property]
+    return object[property];
   } catch (err) {
     // Intentionally ignore.
-    return undefined
+    return undefined;
   }
 }
 
 function performReactRefresh() {
   if (pendingUpdates.length === 0) {
-    return null
+    return null;
   }
   if (isPerformingRefresh) {
-    return null
+    return null;
   }
 
-  isPerformingRefresh = true
+  isPerformingRefresh = true;
   try {
-    const staleFamilies = new Set()
-    const updatedFamilies = new Set()
+    const staleFamilies = new Set();
+    const updatedFamilies = new Set();
 
-    const updates = pendingUpdates
-    pendingUpdates = []
+    const updates = pendingUpdates;
+    pendingUpdates = [];
     updates.forEach(([family, nextType]) => {
       // Now that we got a real edit, we can create associations
       // that will be read by the React reconciler.
-      const prevType = family.current
-      updatedFamiliesByType.set(prevType, family)
-      updatedFamiliesByType.set(nextType, family)
-      family.current = nextType
+      const prevType = family.current;
+      updatedFamiliesByType.set(prevType, family);
+      updatedFamiliesByType.set(nextType, family);
+      family.current = nextType;
 
       // Determine whether this should be a re-render or a re-mount.
       if (canPreserveStateBetween(prevType, nextType)) {
-        updatedFamilies.add(family)
+        updatedFamilies.add(family);
       } else {
-        staleFamilies.add(family)
+        staleFamilies.add(family);
       }
-    })
+    });
 
     // TODO: rename these fields to something more meaningful.
     const update = {
       updatedFamilies, // Families that will re-render preserving state
       staleFamilies, // Families that will be remounted
-    }
+    };
 
     helpersByRendererID.forEach((helpers) => {
       // Even if there are no roots, set the handler on first update.
       // This ensures that if *new* roots are mounted, they'll use the resolve handler.
-      helpers.setRefreshHandler(resolveFamily)
-    })
+      helpers.setRefreshHandler(resolveFamily);
+    });
 
-    let didError = false
-    let firstError = null
+    let didError = false;
+    let firstError = null;
 
     // We snapshot maps and sets that are mutated during commits.
     // If we don't do this, there is a risk they will be mutated while
     // we iterate over them. For example, trying to recover a failed root
     // may cause another root to be added to the failed list -- an infinite loop.
-    const failedRootsSnapshot = new Set(failedRoots)
-    const mountedRootsSnapshot = new Set(mountedRoots)
-    const helpersByRootSnapshot = new Map(helpersByRoot)
+    const failedRootsSnapshot = new Set(failedRoots);
+    const mountedRootsSnapshot = new Set(mountedRoots);
+    const helpersByRootSnapshot = new Map(helpersByRoot);
 
     failedRootsSnapshot.forEach((root) => {
-      const helpers = helpersByRootSnapshot.get(root)
+      const helpers = helpersByRootSnapshot.get(root);
       if (helpers === undefined) {
-        throw new Error(
-          'Could not find helpers for a root. This is a bug in React Refresh.',
-        )
+        throw new Error("Could not find helpers for a root. This is a bug in React Refresh.");
       }
       if (!failedRoots.has(root)) {
         // No longer failed.
       }
       if (rootElements === null) {
-        return
+        return;
       }
       if (!rootElements.has(root)) {
-        return
+        return;
       }
-      const element = rootElements.get(root)
+      const element = rootElements.get(root);
       try {
-        helpers.scheduleRoot(root, element)
+        helpers.scheduleRoot(root, element);
       } catch (err) {
         if (!didError) {
-          didError = true
-          firstError = err
+          didError = true;
+          firstError = err;
         }
         // Keep trying other roots.
       }
-    })
+    });
     mountedRootsSnapshot.forEach((root) => {
-      const helpers = helpersByRootSnapshot.get(root)
+      const helpers = helpersByRootSnapshot.get(root);
       if (helpers === undefined) {
-        throw new Error(
-          'Could not find helpers for a root. This is a bug in React Refresh.',
-        )
+        throw new Error("Could not find helpers for a root. This is a bug in React Refresh.");
       }
       if (!mountedRoots.has(root)) {
         // No longer mounted.
       }
       try {
-        helpers.scheduleRefresh(root, update)
+        helpers.scheduleRefresh(root, update);
       } catch (err) {
         if (!didError) {
-          didError = true
-          firstError = err
+          didError = true;
+          firstError = err;
         }
         // Keep trying other roots.
       }
-    })
+    });
     if (didError) {
-      throw firstError
+      throw firstError;
     }
-    return update
+    return update;
   } finally {
-    isPerformingRefresh = false
+    isPerformingRefresh = false;
   }
 }
 
 function register(type, id) {
   if (type === null) {
-    return
+    return;
   }
-  if (typeof type !== 'function' && typeof type !== 'object') {
-    return
+  if (typeof type !== "function" && typeof type !== "object") {
+    return;
   }
 
   // This can happen in an edge case, e.g. if we register
   // return value of a HOC but it returns a cached component.
   // Ignore anything but the first registration for each type.
   if (allFamiliesByType.has(type)) {
-    return
+    return;
   }
   // Create family or remember to update it.
   // None of this bookkeeping affects reconciliation
   // until the first performReactRefresh() call above.
-  let family = allFamiliesByID.get(id)
+  let family = allFamiliesByID.get(id);
   if (family === undefined) {
-    family = { current: type }
-    allFamiliesByID.set(id, family)
+    family = { current: type };
+    allFamiliesByID.set(id, family);
   } else {
-    pendingUpdates.push([family, type])
+    pendingUpdates.push([family, type]);
   }
-  allFamiliesByType.set(type, family)
+  allFamiliesByType.set(type, family);
 
   // Visit inner types because we might not have registered them.
-  if (typeof type === 'object' && type !== null) {
-    switch (getProperty(type, '$$typeof')) {
+  if (typeof type === "object" && type !== null) {
+    switch (getProperty(type, "$$typeof")) {
       case REACT_FORWARD_REF_TYPE:
-        register(type.render, id + '$render')
-        break
+        register(type.render, id + "$render");
+        break;
       case REACT_MEMO_TYPE:
-        register(type.type, id + '$type')
-        break
+        register(type.type, id + "$type");
+        break;
     }
   }
 }
@@ -291,17 +287,17 @@ function setSignature(type, key, forceReset, getCustomHooks) {
       ownKey: key,
       fullKey: null,
       getCustomHooks: getCustomHooks || (() => []),
-    })
+    });
   }
   // Visit inner types because we might not have signed them.
-  if (typeof type === 'object' && type !== null) {
-    switch (getProperty(type, '$$typeof')) {
+  if (typeof type === "object" && type !== null) {
+    switch (getProperty(type, "$$typeof")) {
       case REACT_FORWARD_REF_TYPE:
-        setSignature(type.render, key, forceReset, getCustomHooks)
-        break
+        setSignature(type.render, key, forceReset, getCustomHooks);
+        break;
       case REACT_MEMO_TYPE:
-        setSignature(type.type, key, forceReset, getCustomHooks)
-        break
+        setSignature(type.type, key, forceReset, getCustomHooks);
+        break;
     }
   }
 }
@@ -309,9 +305,9 @@ function setSignature(type, key, forceReset, getCustomHooks) {
 // This is lazily called during first render for a type.
 // It captures Hook list at that time so inline requires don't break comparisons.
 function collectCustomHooksForSignature(type) {
-  const signature = allSignaturesByType.get(type)
+  const signature = allSignaturesByType.get(type);
   if (signature !== undefined) {
-    computeFullKey(signature)
+    computeFullKey(signature);
   }
 }
 
@@ -321,12 +317,12 @@ export function injectIntoGlobalHook(globalObject) {
 
   // For React Web, the global hook will be set up by the extension.
   // This will also run before us.
-  let hook = globalObject.__REACT_DEVTOOLS_GLOBAL_HOOK__
+  let hook = globalObject.__REACT_DEVTOOLS_GLOBAL_HOOK__;
   if (hook === undefined) {
     // However, if there is no DevTools extension, we'll need to set up the global hook ourselves.
     // Note that in this case it's important that renderer code runs *after* this method call.
     // Otherwise, the renderer will think that there is no global hook, and won't do the injection.
-    let nextID = 0
+    let nextID = 0;
     globalObject.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook = {
       renderers: new Map(),
       supportsFiber: true,
@@ -334,68 +330,68 @@ export function injectIntoGlobalHook(globalObject) {
       onScheduleFiberRoot: (id, root, children) => {},
       onCommitFiberRoot: (id, root, maybePriorityLevel, didError) => {},
       onCommitFiberUnmount() {},
-    }
+    };
   }
 
   if (hook.isDisabled) {
     // This isn't a real property on the hook, but it can be set to opt out
     // of DevTools integration and associated warnings and logs.
     // Using console['warn'] to evade Babel and ESLint
-    console['warn'](
-      'Something has shimmed the React DevTools global hook (__REACT_DEVTOOLS_GLOBAL_HOOK__). ' +
-        'Fast Refresh is not compatible with this shim and will be disabled.',
-    )
-    return
+    console["warn"](
+      "Something has shimmed the React DevTools global hook (__REACT_DEVTOOLS_GLOBAL_HOOK__). " +
+        "Fast Refresh is not compatible with this shim and will be disabled.",
+    );
+    return;
   }
 
   // Here, we just want to get a reference to scheduleRefresh.
-  const oldInject = hook.inject
+  const oldInject = hook.inject;
   hook.inject = function (injected) {
-    const id = oldInject.apply(this, arguments)
+    const id = oldInject.apply(this, arguments);
     if (
-      typeof injected.scheduleRefresh === 'function' &&
-      typeof injected.setRefreshHandler === 'function'
+      typeof injected.scheduleRefresh === "function" &&
+      typeof injected.setRefreshHandler === "function"
     ) {
       // This version supports React Refresh.
-      helpersByRendererID.set(id, injected)
+      helpersByRendererID.set(id, injected);
     }
-    return id
-  }
+    return id;
+  };
 
   // Do the same for any already injected roots.
   // This is useful if ReactDOM has already been initialized.
   // https://github.com/facebook/react/issues/17626
   hook.renderers.forEach((injected, id) => {
     if (
-      typeof injected.scheduleRefresh === 'function' &&
-      typeof injected.setRefreshHandler === 'function'
+      typeof injected.scheduleRefresh === "function" &&
+      typeof injected.setRefreshHandler === "function"
     ) {
       // This version supports React Refresh.
-      helpersByRendererID.set(id, injected)
+      helpersByRendererID.set(id, injected);
     }
-  })
+  });
 
   // We also want to track currently mounted roots.
-  const oldOnCommitFiberRoot = hook.onCommitFiberRoot
-  const oldOnScheduleFiberRoot = hook.onScheduleFiberRoot || (() => {})
+  const oldOnCommitFiberRoot = hook.onCommitFiberRoot;
+  const oldOnScheduleFiberRoot = hook.onScheduleFiberRoot || (() => {});
   hook.onScheduleFiberRoot = function (id, root, children) {
     if (!isPerformingRefresh) {
       // If it was intentionally scheduled, don't attempt to restore.
       // This includes intentionally scheduled unmounts.
-      failedRoots.delete(root)
+      failedRoots.delete(root);
       if (rootElements !== null) {
-        rootElements.set(root, children)
+        rootElements.set(root, children);
       }
     }
-    return oldOnScheduleFiberRoot.apply(this, arguments)
-  }
+    return oldOnScheduleFiberRoot.apply(this, arguments);
+  };
   hook.onCommitFiberRoot = function (id, root, maybePriorityLevel, didError) {
-    const helpers = helpersByRendererID.get(id)
+    const helpers = helpersByRendererID.get(id);
     if (helpers !== undefined) {
-      helpersByRoot.set(root, helpers)
+      helpersByRoot.set(root, helpers);
 
-      const current = root.current
-      const alternate = current.alternate
+      const current = root.current;
+      const alternate = current.alternate;
 
       // We need to determine whether this root has just (un)mounted.
       // This logic is copy-pasted from similar logic in the DevTools backend.
@@ -405,42 +401,41 @@ export function injectIntoGlobalHook(globalObject) {
         const wasMounted =
           alternate.memoizedState != null &&
           alternate.memoizedState.element != null &&
-          mountedRoots.has(root)
+          mountedRoots.has(root);
 
-        const isMounted =
-          current.memoizedState != null && current.memoizedState.element != null
+        const isMounted = current.memoizedState != null && current.memoizedState.element != null;
 
         if (!wasMounted && isMounted) {
           // Mount a new root.
-          mountedRoots.add(root)
-          failedRoots.delete(root)
+          mountedRoots.add(root);
+          failedRoots.delete(root);
         } else if (wasMounted && isMounted) {
           // Update an existing root.
           // This doesn't affect our mounted root Set.
         } else if (wasMounted && !isMounted) {
           // Unmount an existing root.
-          mountedRoots.delete(root)
+          mountedRoots.delete(root);
           if (didError) {
             // We'll remount it on future edits.
-            failedRoots.add(root)
+            failedRoots.add(root);
           } else {
-            helpersByRoot.delete(root)
+            helpersByRoot.delete(root);
           }
         } else if (!wasMounted && !isMounted) {
           if (didError) {
             // We'll remount it on future edits.
-            failedRoots.add(root)
+            failedRoots.add(root);
           }
         }
       } else {
         // Mount a new root.
-        mountedRoots.add(root)
+        mountedRoots.add(root);
       }
     }
 
     // Always call the decorated DevTools hook.
-    return oldOnCommitFiberRoot.apply(this, arguments)
-  }
+    return oldOnCommitFiberRoot.apply(this, arguments);
+  };
 }
 
 // This is a wrapper over more primitive functions for setting signature.
@@ -466,100 +461,97 @@ export function injectIntoGlobalHook(globalObject) {
 //   () => [useCustomHook], /* Lazy to avoid triggering inline requires */
 // );
 export function createSignatureFunctionForTransform() {
-  let savedType
-  let hasCustomHooks
-  let didCollectHooks = false
+  let savedType;
+  let hasCustomHooks;
+  let didCollectHooks = false;
   return function (type, key, forceReset, getCustomHooks) {
-    if (typeof key === 'string') {
+    if (typeof key === "string") {
       // We're in the initial phase that associates signatures
       // with the functions. Note this may be called multiple times
       // in HOC chains like _s(hoc1(_s(hoc2(_s(actualFunction))))).
       if (!savedType) {
         // We're in the innermost call, so this is the actual type.
         // $FlowFixMe[escaped-generic] discovered when updating Flow
-        savedType = type
-        hasCustomHooks = typeof getCustomHooks === 'function'
+        savedType = type;
+        hasCustomHooks = typeof getCustomHooks === "function";
       }
       // Set the signature for all types (even wrappers!) in case
       // they have no signatures of their own. This is to prevent
       // problems like https://github.com/facebook/react/issues/20417.
-      if (
-        type != null &&
-        (typeof type === 'function' || typeof type === 'object')
-      ) {
-        setSignature(type, key, forceReset, getCustomHooks)
+      if (type != null && (typeof type === "function" || typeof type === "object")) {
+        setSignature(type, key, forceReset, getCustomHooks);
       }
-      return type
+      return type;
     } else {
       // We're in the _s() call without arguments, which means
       // this is the time to collect custom Hook signatures.
       // Only do this once. This path is hot and runs *inside* every render!
       if (!didCollectHooks && hasCustomHooks) {
-        didCollectHooks = true
-        collectCustomHooksForSignature(savedType)
+        didCollectHooks = true;
+        collectCustomHooksForSignature(savedType);
       }
     }
-  }
+  };
 }
 
 function isLikelyComponentType(type) {
   switch (typeof type) {
-    case 'function': {
+    case "function": {
       // First, deal with classes.
       if (type.prototype != null) {
         if (type.prototype.isReactComponent) {
           // React class.
-          return true
+          return true;
         }
-        const ownNames = Object.getOwnPropertyNames(type.prototype)
-        if (ownNames.length > 1 || ownNames[0] !== 'constructor') {
+        const ownNames = Object.getOwnPropertyNames(type.prototype);
+        if (ownNames.length > 1 || ownNames[0] !== "constructor") {
           // This looks like a class.
-          return false
+          return false;
         }
 
         if (type.prototype.__proto__ !== Object.prototype) {
           // It has a superclass.
-          return false
+          return false;
         }
         // Pass through.
         // This looks like a regular function with empty prototype.
       }
       // For plain functions and arrows, use name as a heuristic.
-      const name = type.name || type.displayName
-      return typeof name === 'string' && /^[A-Z]/.test(name)
+      const name = type.name || type.displayName;
+      return typeof name === "string" && /^[A-Z]/.test(name);
     }
-    case 'object': {
+    case "object": {
       if (type != null) {
-        switch (getProperty(type, '$$typeof')) {
+        switch (getProperty(type, "$$typeof")) {
           case REACT_FORWARD_REF_TYPE:
           case REACT_MEMO_TYPE:
             // Definitely React components.
-            return true
+            return true;
           default:
-            return false
+            return false;
         }
       }
-      return false
+      return false;
     }
     default: {
-      return false
+      return false;
     }
   }
 }
 
 function isCompoundComponent(type) {
-  if (!isPlainObject(type)) return false
+  if (!isPlainObject(type)) return false;
   for (const key in type) {
-    if (!isLikelyComponentType(type[key])) return false
+    if (!isLikelyComponentType(type[key])) return false;
   }
-  return true
+  return true;
 }
 
 function isPlainObject(obj) {
   return (
-    Object.prototype.toString.call(obj) === '[object Object]' &&
+    Object.prototype.toString.call(obj) === "[object Object]" &&
     (obj.constructor === Object || obj.constructor === undefined)
-  )
+  );
 }
 
 /**
@@ -567,106 +559,87 @@ function isPlainObject(obj) {
  */
 
 export function getRefreshReg(filename) {
-  return (type, id) => register(type, filename + ' ' + id)
+  return (type, id) => register(type, filename + " " + id);
 }
 
 // Taken from https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/lib/runtime/RefreshUtils.js#L141
 // This allows to resister components not detected by SWC like styled component
 export function registerExportsForReactRefresh(filename, moduleExports) {
   for (const key in moduleExports) {
-    if (key === '__esModule') continue
-    const exportValue = moduleExports[key]
+    if (key === "__esModule") continue;
+    const exportValue = moduleExports[key];
     if (isLikelyComponentType(exportValue)) {
       // 'export' is required to avoid key collision when renamed exports that
       // shadow a local component name: https://github.com/vitejs/vite-plugin-react/issues/116
       // The register function has an identity check to not register twice the same component,
       // so this is safe to not used the same key here.
-      register(exportValue, filename + ' export ' + key)
+      register(exportValue, filename + " export " + key);
     } else if (isCompoundComponent(exportValue)) {
       for (const subKey in exportValue) {
-        register(
-          exportValue[subKey],
-          filename + ' export ' + key + '-' + subKey,
-        )
+        register(exportValue[subKey], filename + " export " + key + "-" + subKey);
       }
     }
   }
 }
 
 function debounce(fn, delay) {
-  let handle
+  let handle;
   return () => {
-    clearTimeout(handle)
-    handle = setTimeout(fn, delay)
-  }
+    clearTimeout(handle);
+    handle = setTimeout(fn, delay);
+  };
 }
 
-const hooks = []
+const hooks = [];
 window.__registerBeforePerformReactRefresh = (cb) => {
-  hooks.push(cb)
-}
+  hooks.push(cb);
+};
 const enqueueUpdate = debounce(async () => {
-  if (hooks.length) await Promise.all(hooks.map((cb) => cb()))
-  performReactRefresh()
-}, 16)
+  if (hooks.length) await Promise.all(hooks.map((cb) => cb()));
+  performReactRefresh();
+}, 16);
 
-export function validateRefreshBoundaryAndEnqueueUpdate(
-  id,
-  prevExports,
-  nextExports,
-) {
-  const ignoredExports = window.__getReactRefreshIgnoredExports?.({ id }) ?? []
-  if (
-    predicateOnExport(
-      ignoredExports,
-      prevExports,
-      (key) => key in nextExports,
-    ) !== true
-  ) {
-    return 'Could not Fast Refresh (export removed)'
+export function validateRefreshBoundaryAndEnqueueUpdate(id, prevExports, nextExports) {
+  const ignoredExports = window.__getReactRefreshIgnoredExports?.({ id }) ?? [];
+  if (predicateOnExport(ignoredExports, prevExports, (key) => key in nextExports) !== true) {
+    return "Could not Fast Refresh (export removed)";
   }
-  if (
-    predicateOnExport(
-      ignoredExports,
-      nextExports,
-      (key) => key in prevExports,
-    ) !== true
-  ) {
-    return 'Could not Fast Refresh (new export)'
+  if (predicateOnExport(ignoredExports, nextExports, (key) => key in prevExports) !== true) {
+    return "Could not Fast Refresh (new export)";
   }
 
-  let hasExports = false
+  let hasExports = false;
   const allExportsAreComponentsOrUnchanged = predicateOnExport(
     ignoredExports,
     nextExports,
     (key, value) => {
-      hasExports = true
-      if (isLikelyComponentType(value)) return true
-      if (isCompoundComponent(value)) return true
-      return prevExports[key] === nextExports[key]
+      hasExports = true;
+      if (isLikelyComponentType(value)) return true;
+      if (isCompoundComponent(value)) return true;
+      return prevExports[key] === nextExports[key];
     },
-  )
+  );
   if (hasExports && allExportsAreComponentsOrUnchanged === true) {
-    enqueueUpdate()
+    enqueueUpdate();
   } else {
-    return `Could not Fast Refresh ("${allExportsAreComponentsOrUnchanged}" export is incompatible). Learn more at __README_URL__#consistent-components-exports`
+    return `Could not Fast Refresh ("${allExportsAreComponentsOrUnchanged}" export is incompatible). Learn more at __README_URL__#consistent-components-exports`;
   }
 }
 
 function predicateOnExport(ignoredExports, moduleExports, predicate) {
   for (const key in moduleExports) {
-    if (key === '__esModule') continue
-    if (ignoredExports.includes(key)) continue
-    const desc = Object.getOwnPropertyDescriptor(moduleExports, key)
-    if (desc && desc.get) return key
-    if (!predicate(key, moduleExports[key])) return key
+    if (key === "__esModule") continue;
+    if (ignoredExports.includes(key)) continue;
+    const desc = Object.getOwnPropertyDescriptor(moduleExports, key);
+    if (desc && desc.get) return key;
+    if (!predicate(key, moduleExports[key])) return key;
   }
-  return true
+  return true;
 }
 
 // Hides vite-ignored dynamic import so that Vite can skip analysis if no other
 // dynamic import is present (https://github.com/vitejs/vite/pull/12732)
-export const __hmr_import = (module) => import(/* @vite-ignore */ module)
+export const __hmr_import = (module) => import(/* @vite-ignore */ module);
 
 // For backwards compatibility with @vitejs/plugin-react.
-export default { injectIntoGlobalHook }
+export default { injectIntoGlobalHook };

--- a/packages/vite/internal/refresh.js
+++ b/packages/vite/internal/refresh.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // React Fast Refresh wiring for `uf dev`. The runtime itself is

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // The file-system router, as the build sees it.

--- a/packages/vite/merge.js
+++ b/packages/vite/merge.js
@@ -47,9 +47,8 @@ export function mergeConfig(base, overrides) {
   for (const key of Object.keys(overrides)) {
     const value = overrides[key];
     if (value === undefined) continue;
-    merged[key] = isPlainObject(value) && isPlainObject(base[key])
-      ? mergeConfig(base[key], value)
-      : value;
+    merged[key] =
+      isPlainObject(value) && isPlainObject(base[key]) ? mergeConfig(base[key], value) : value;
   }
   return merged;
 }
@@ -83,7 +82,6 @@ function isPlainObject(value) {
     value !== null &&
     !Array.isArray(value) &&
     // A plugin, a logger or a URL is a value to replace, not a shape to merge.
-    (Object.getPrototypeOf(value) === Object.prototype ||
-      Object.getPrototypeOf(value) === null)
+    (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
   );
 }

--- a/packages/vite/merge.js
+++ b/packages/vite/merge.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform.
 //
 // Merging a project's own Vite configuration over the one uf generates.

--- a/packages/vite/register.js
+++ b/packages/vite/register.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: this file registers the loader, so it cannot need one.
 //
 // `node --import @uniflowed/vite/register app.js` runs a Flow project on

--- a/packages/vite/transform.js
+++ b/packages/vite/transform.js
@@ -1,3 +1,5 @@
+// @noflow
+//
 // Plain JavaScript: executed by the host that runs Vite, before any transform
 // exists — this module is how the transform is reached, so it cannot be Flow.
 //

--- a/packages/vite/transform.js
+++ b/packages/vite/transform.js
@@ -151,7 +151,11 @@ export class TransformService {
             resolve(null);
             return;
           }
-          resolve({ code: reply.code, map: reply.map ?? null, diagnostics: reply.diagnostics ?? [] });
+          resolve({
+            code: reply.code,
+            map: reply.map ?? null,
+            diagnostics: reply.diagnostics ?? [],
+          });
         },
       });
       this.#child.stdin.write(`${JSON.stringify({ id, code, options })}\n`);

--- a/packages/vrt/index.js
+++ b/packages/vrt/index.js
@@ -12,17 +12,15 @@ export type DiffAlgorithm = "pixelmatch-compatible";
 export type BaselinePolicy = "fail-on-missing" | "explicit-update-only";
 
 export type VisualRegressionPlan = {
-  +engine: VrtEngine,
-  +baselines: string,
-  +threshold: number,
-  +diff: DiffAlgorithm,
-  +baselinePolicy: BaselinePolicy,
-  +snapshots: $ReadOnlyArray<VisualSnapshot>,
+  readonly engine: VrtEngine,
+  readonly baselines: string,
+  readonly threshold: number,
+  readonly diff: DiffAlgorithm,
+  readonly baselinePolicy: BaselinePolicy,
+  readonly snapshots: $ReadOnlyArray<VisualSnapshot>,
 };
 
-export function plan(
-  snapshots?: $ReadOnlyArray<VisualSnapshot>,
-): VisualRegressionPlan {
+export function plan(snapshots?: $ReadOnlyArray<VisualSnapshot>): VisualRegressionPlan {
   return nativeRuntimeRequired(MODULE, "plan");
 }
 

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -9,24 +9,19 @@ const MODULE = "@uniflowed/core/web";
 
 export type LinkPrefetch = "off" | "intent" | "render";
 export type RoutePath = string;
-export type RouteParams = { +[string]: string };
+export type RouteParams = { readonly [string]: string };
 
-export type LinkProps<TRoute: RoutePath> = {
-  +to: TRoute,
-  +prefetch?: LinkPrefetch,
-  +children?: React.Node,
+export type LinkProps<TRoute extends RoutePath> = {
+  readonly to: TRoute,
+  readonly prefetch?: LinkPrefetch,
+  readonly children?: React.Node,
 };
 
 export component Font(src: string, family: string, preload?: boolean) {
   return nativeRuntimeRequired(MODULE, "Font");
 }
 
-export component Image(
-  src: string,
-  alt: string,
-  width?: number,
-  height?: number,
-) {
+export component Image(src: string, alt: string, width?: number, height?: number) {
   return nativeRuntimeRequired(MODULE, "Image");
 }
 
@@ -34,7 +29,7 @@ export component OgImage(title: string, description?: string) {
   return nativeRuntimeRequired(MODULE, "OgImage");
 }
 
-export component Link<TRoute: RoutePath>(
+export component Link<TRoute extends RoutePath>(
   to: TRoute,
   prefetch?: LinkPrefetch,
   children?: React.Node,
@@ -50,10 +45,7 @@ export component Layout(children?: React.Node) renders React.Node {
   return nativeRuntimeRequired(MODULE, "Layout");
 }
 
-export component Time(
-  value: Date | string,
-  format?: string,
-) renders React.Node {
+export component Time(value: Date | string, format?: string) renders React.Node {
   return nativeRuntimeRequired(MODULE, "Time");
 }
 
@@ -71,35 +63,35 @@ export component Picture(
 
 export function useCookie<T>(
   name: string,
-  options?: { +httpOnly?: boolean, +sameSite?: "lax" | "strict" | "none" },
+  options?: { readonly httpOnly?: boolean, readonly sameSite?: "lax" | "strict" | "none" },
 ): [null | T, (next: T) => void] {
   return nativeRuntimeRequired(MODULE, "useCookie");
 }
 
 export function useHead(head: {
-  +title?: string,
-  +meta?: $ReadOnlyArray<{ +name: string, +content: string }>,
-  +links?: $ReadOnlyArray<{ +rel: string, +href: string }>,
+  readonly title?: string,
+  readonly meta?: $ReadOnlyArray<{ readonly name: string, readonly content: string }>,
+  readonly links?: $ReadOnlyArray<{ readonly rel: string, readonly href: string }>,
 }): void {
   return nativeRuntimeRequired(MODULE, "useHead");
 }
 
-export function useRoute<TRoute: RoutePath, TParams: RouteParams>(): {
-  +path: TRoute,
-  +params: TParams,
+export function useRoute<TRoute extends RoutePath, TParams extends RouteParams>(): {
+  readonly path: TRoute,
+  readonly params: TParams,
 } {
   return nativeRuntimeRequired(MODULE, "useRoute");
 }
 
-export function useRouter<TRoute: RoutePath>(): {
-  +push: (to: TRoute) => void,
-  +replace: (to: TRoute) => void,
-  +prefetch: (to: TRoute) => Promise<void>,
+export function useRouter<TRoute extends RoutePath>(): {
+  readonly push: (to: TRoute) => void,
+  readonly replace: (to: TRoute) => void,
+  readonly prefetch: (to: TRoute) => Promise<void>,
 } {
   return nativeRuntimeRequired(MODULE, "useRouter");
 }
 
-export function defineNavigationGuard<TRoute: RoutePath>(
+export function defineNavigationGuard<TRoute extends RoutePath>(
   guard: (to: TRoute, from: TRoute) => boolean | Promise<boolean>,
 ): (to: TRoute, from: TRoute) => Promise<boolean> {
   return nativeRuntimeRequired(MODULE, "defineNavigationGuard");

--- a/tests/library/effect.test.js
+++ b/tests/library/effect.test.js
@@ -390,7 +390,7 @@ describe("resources", () => {
 
 describe("services", () => {
   it("reads a service provided directly", async () => {
-    const Clock = tag<{| +now: () => number |}>("Clock");
+    const Clock = tag<{| readonly now: () => number |}>("Clock");
     const program = flatMap(Clock, (clock) => succeed(clock.now()));
 
     await expect(runPromise(provideService(program, Clock, { now: () => 42 }))).resolves.toBe(42);

--- a/tests/library/hooks.test.js
+++ b/tests/library/hooks.test.js
@@ -29,8 +29,7 @@ import {
   useToggle,
 } from "@uniflowed/hooks";
 
-const tick = (millis: number) =>
-  act(() => new Promise((resolve) => setTimeout(resolve, millis)));
+const tick = (millis: number) => act(() => new Promise((resolve) => setTimeout(resolve, millis)));
 
 describe("useStableCallback", () => {
   it("keeps one identity across renders", async () => {
@@ -171,7 +170,7 @@ describe("useAsync", () => {
       const { error, pending } = useAsync(async () => {
         throw new Error("nope");
       }, []);
-      return <output>{pending ? "pending" : (error?.message ?? "none")}</output>;
+      return <output>{pending ? "pending" : error?.message ?? "none"}</output>;
     }
     render(<Probe />);
     await waitFor(() => {

--- a/tests/library/query.test.js
+++ b/tests/library/query.test.js
@@ -10,13 +10,7 @@
 import * as React from "@uniflowed/react";
 import { describe, expect, fn, it } from "@uniflowed/test";
 import { render, screen, userEvent, waitFor } from "@uniflowed/react-testing";
-import {
-  QueryCache,
-  QueryProvider,
-  hash,
-  useMutation,
-  useQuery,
-} from "@uniflowed/query";
+import { QueryCache, QueryProvider, hash, useMutation, useQuery } from "@uniflowed/query";
 
 const deferred = () => {
   let settle = (value: mixed) => {};
@@ -131,9 +125,7 @@ describe("the cache", () => {
 });
 
 describe("useQuery", () => {
-  const withCache = (cache, ui) => (
-    <QueryProvider cache={cache}>{ui}</QueryProvider>
-  );
+  const withCache = (cache, ui) => <QueryProvider cache={cache}>{ui}</QueryProvider>;
 
   component Thing(cache: QueryCache, query: () => Promise<string>) {
     const { value, loading, error } = useQuery(["thing"], query);
@@ -155,9 +147,7 @@ describe("useQuery", () => {
     const cache = new QueryCache();
     await cache.fetch(["thing"], async () => "cached");
 
-    render(
-      withCache(cache, <Thing cache={cache} query={async () => "refreshed"} />),
-    );
+    render(withCache(cache, <Thing cache={cache} query={async () => "refreshed"} />));
     // The point of stale-while-revalidate: navigating back does not flash a
     // spinner over data that is already there.
     expect(screen.getByText("cached")).toBeInTheDocument();

--- a/tests/library/react-testing.test.js
+++ b/tests/library/react-testing.test.js
@@ -67,11 +67,7 @@ describe("render", () => {
 
 describe("queries", () => {
   it("finds by text, ignoring how the JSX was indented", () => {
-    render(
-      <p>
-        Save all of your changes
-      </p>,
-    );
+    render(<p>Save all of your changes</p>);
     expect(screen.getByText("Save all of your changes")).toBeTruthy();
   });
 
@@ -423,13 +419,7 @@ describe("element matchers", () => {
 
   it("asserts attributes, classes, text and value", () => {
     render(
-      <input
-        aria-label="field"
-        className="a b"
-        defaultValue="typed"
-        placeholder="hint"
-        required
-      />,
+      <input aria-label="field" className="a b" defaultValue="typed" placeholder="hint" required />,
     );
     const field = screen.getByLabelText("field");
     expect(field).toHaveAttribute("placeholder");
@@ -441,12 +431,7 @@ describe("element matchers", () => {
   });
 
   it("collapses whitespace before comparing text", () => {
-    render(
-      <p>
-        Save all of
-        your changes
-      </p>,
-    );
+    render(<p>Save all of your changes</p>);
     expect(screen.getByText(/Save/)).toHaveTextContent("Save all of your changes");
   });
 

--- a/tests/library/ui.test.js
+++ b/tests/library/ui.test.js
@@ -117,9 +117,7 @@ describe("Tabs", () => {
 
   it("keeps exactly one tab in the page's tab order", () => {
     render(<Example />);
-    const stops = screen
-      .getAllByRole("tab")
-      .filter((tab) => tab.getAttribute("tabindex") === "0");
+    const stops = screen.getAllByRole("tab").filter((tab) => tab.getAttribute("tabindex") === "0");
     // The whole point of a roving tabindex: Tab moves past the list in one
     // press instead of one press per tab.
     expect(stops.length).toBe(1);
@@ -225,10 +223,7 @@ describe("Dialog", () => {
   it("is closed until it is opened", () => {
     render(<Example />);
     expect(screen.queryByRole("dialog")).toBe(null);
-    expect(screen.getByRole("button", { name: "Open" })).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    expect(screen.getByRole("button", { name: "Open" })).toHaveAttribute("aria-expanded", "false");
   });
 
   it("opens, and says the rest of the page is unavailable", async () => {

--- a/tests/library/validator.test.js
+++ b/tests/library/validator.test.js
@@ -239,9 +239,7 @@ describe("unions", () => {
 
 describe("lazy", () => {
   it("describes a recursive shape", () => {
-    const comment = lazy<mixed>(() =>
-      object({ text: string(), replies: array(comment) }),
-    );
+    const comment = lazy<mixed>(() => object({ text: string(), replies: array(comment) }));
     const tree = { text: "root", replies: [{ text: "child", replies: [] }] };
     expect(parse(comment, tree)).toEqual(tree);
     expect(safeParse(comment, { text: "root", replies: [{ text: 1, replies: [] }] }).ok).toBe(
@@ -264,7 +262,11 @@ describe("pipe", () => {
   });
 
   it("transforms after validating", () => {
-    const length = pipe(string(), minLength(2), transform((text: string) => text.length));
+    const length = pipe(
+      string(),
+      minLength(2),
+      transform((text: string) => text.length),
+    );
     expect(parse(length, "abc")).toBe(3);
     expect(safeParse(length, "a").ok).toBe(false);
   });
@@ -307,7 +309,10 @@ describe("pipe", () => {
   });
 
   it("takes an arbitrary predicate through check", () => {
-    const even = pipe(number(), check((n: number) => n % 2 === 0, "expected an even number"));
+    const even = pipe(
+      number(),
+      check((n: number) => n % 2 === 0, "expected an even number"),
+    );
     expect(parse(even, 4)).toBe(4);
     const failed = safeParse(even, 5);
     expect(failed.ok).toBe(false);

--- a/uf.config.js
+++ b/uf.config.js
@@ -27,7 +27,15 @@ export default defineConfig({
     // `upstream/` is Meta's and React's source, vendored as submodules. It is
     // not ours to format or lint, and a diff there would be lost on the next
     // sync.
-    ignore: ["upstream", "dist", "target", "node_modules"],
+    //
+    // `crates/` is Rust. The only JavaScript under it is test fixtures — for
+    // the formatter, which needs badly formatted input, and for the checker,
+    // which needs input that fails to check. Both are exercised by the Rust
+    // tests that own them. Checking them again from the repository root would
+    // report every fixture's deliberate defect as this project's defect: 1868
+    // of the 3782 type errors `uf check` used to report here came from
+    // `crates/uf_fmt/tests/fixtures` alone.
+    ignore: ["upstream", "crates", "dist", "target", "node_modules"],
   },
 
   tasks: {


### PR DESCRIPTION
uf's mark is a picture, and it was being approximated out of block characters
because for years that was the only option. It is not any more: kitty, ghostty,
WezTerm, iTerm2, Konsole, VS Code's terminal and Hyper all take an image
inline, and between them they cover most of the terminals anyone installs uf
from.

`uf_term::image` is the whole of it — two protocol encoders, a base64 encoder
written here so the crate keeps its zero dependencies, and detection from the
environment. It never queries the terminal: both protocols have a query form,
but the answer arrives on stdin, and uf's two callers cannot read it — `curl …
| sh` has the script on stdin, and a CLI that blocked on a reply would hang on
every terminal that does not implement the query.

The decision is made once at start-up beside the rest of the terminal's
capability, so no write path re-probes the process it is running in. It is
gated on three separate questions, and all three have to hold: the stream is
one a person is looking at, escape sequences are allowed at all — an image is a
much larger one than a colour — and the terminal speaks a protocol. Inside tmux
or screen it refuses outright, because the failure mode there is not a missing
picture but escape-sequence garbage across the pane. `UF_INLINE_IMAGES` is the
one override, in both directions, and it is an environment variable rather than
a config key because the answer belongs to the terminal a person is sitting at.

Everywhere else, the same block mark as before, in the same 19x5 footprint, so
nothing below the banner moves.

The installer does it too, with the logo embedded as a 240x65 PNG — it must
work before any of uf exists on the machine, and one more network round trip is
one more thing that can fail between `curl` and a working `uf`. That is a
second copy of the detection, in shell, and `tests/installer.rs` is what keeps
the two from drifting: every terminal one knows, the multiplexer refusal, the
override, the chunking, and that the size it declares to iTerm2 is the size it
actually embeds.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791087480&installation_model_id=422833&pr_number=99&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F99&signature=9d7bf20b11d392a2be6dccd3cdeed2f05a8c8fc474ee2b0b71cbc3d32e474cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->