### PR TITLE
refactor(infra): schedule uf's own work, and drop rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,12 +3299,12 @@ dependencies = [
  "compact_str",
  "criterion",
  "flate2",
- "rayon",
  "serde",
  "serde_json",
  "smallvec",
  "tempfile",
  "thiserror",
+ "uf_infra",
 ]
 
 [[package]]
@@ -3441,7 +3441,6 @@ version = "0.0.0-alpha.2"
 dependencies = [
  "criterion",
  "phf",
- "rayon",
  "serde",
  "thiserror",
  "uf_config",
@@ -3549,7 +3548,6 @@ dependencies = [
  "camino",
  "compact_str",
  "criterion",
- "rayon",
  "serde",
  "serde_json",
  "sha2",
@@ -3613,7 +3611,6 @@ dependencies = [
  "camino",
  "compact_str",
  "criterion",
- "rayon",
  "serde",
  "serde_json",
  "similar-asserts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ json5 = "1.3.1"
 memchr = "2.7.6"
 mimalloc = "0.1.52"
 phf = { version = "0.14.0", features = ["macros"] }
-rayon = "1.11.0"
 react_compiler = "0.1.0"
 react_compiler_ast = "0.1.0"
 rustc-hash = "2.1.1"

--- a/crates/uf_bundle/Cargo.toml
+++ b/crates/uf_bundle/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+uf_infra = { path = "../uf_infra" }
 brotli.workspace = true
 camino.workspace = true
 compact_str.workspace = true
 flate2.workspace = true
-rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true

--- a/crates/uf_bundle/src/report.rs
+++ b/crates/uf_bundle/src/report.rs
@@ -5,7 +5,6 @@ use std::fs;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::{CompactString, ToCompactString};
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -278,25 +277,22 @@ pub fn collect_assets(
         }
     }
 
-    let mut assets = files
-        .into_par_iter()
-        .map(|(path, relative)| {
-            let contents = fs::read(&path).map_err(|source| ReportError::Read {
-                path: path.clone(),
-                source,
-            })?;
-            let size = measure(&contents).map_err(|source| ReportError::Measure {
-                path: path.clone(),
-                source,
-            })?;
+    let mut assets = uf_infra::parallel::map(&files, |(path, relative)| {
+        let contents = fs::read(path).map_err(|source| ReportError::Read {
+            path: path.clone(),
+            source,
+        })?;
+        let size = measure(&contents).map_err(|source| ReportError::Measure {
+            path: path.clone(),
+            source,
+        })?;
 
-            Ok(AssetEntry {
-                kind: AssetKind::from_path(&path),
-                path: relative,
-                size,
-            })
+        Ok(AssetEntry {
+            kind: AssetKind::from_path(path),
+            path: relative.clone(),
+            size,
         })
-        .collect::<Result<Vec<_>, ReportError>>()?;
+    })?;
 
     assets.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(assets)

--- a/crates/uf_infra/src/lib.rs
+++ b/crates/uf_infra/src/lib.rs
@@ -4,6 +4,8 @@
 //! change as benchmarks teach us more, while downstream crates get one stable
 //! import path for the fast defaults we want everywhere.
 
+pub mod parallel;
+
 pub use bumpalo::{Bump, collections::Vec as ArenaVec};
 pub use compact_str::CompactString;
 pub use memchr::{memchr, memchr_iter};

--- a/crates/uf_infra/src/parallel.rs
+++ b/crates/uf_infra/src/parallel.rs
@@ -1,0 +1,178 @@
+//! Running one function over a slice on every core.
+//!
+//! This is the entire shape of uf's data parallelism. `uf_lint` lints each
+//! file, `uf_rsc` reads and classifies each module, `uf_bundle` measures each
+//! emitted asset: three crates, one operation — map a fallible function over a
+//! slice, keep the input's order, stop at the first error. Nothing needs
+//! nested parallelism, a global pool, futures, or work-stealing deques.
+//!
+//! So it is written here rather than depended on. rayon is an excellent crate
+//! and it is also a general-purpose parallel iterator framework; sixty lines of
+//! scoped threads over an atomic cursor gives uf the one thing it actually
+//! uses, with no global thread pool living in the process and nothing to
+//! configure. `uf_test` already schedules its own work this way.
+//!
+//! There is no `unsafe` here. Each thread collects its own results and they are
+//! placed by index after every thread has been joined, which is both simpler
+//! than sharing the output buffer and, at these sizes, not measurably slower:
+//! the work is reading and parsing files, not moving a `Vec` around.
+//!
+//! # Scheduling
+//!
+//! Threads pull indices off a shared atomic cursor rather than being handed a
+//! contiguous block each. Blocks would be simpler and would be wrong here: lint
+//! cost is proportional to file size, and files are not the same size, so a
+//! thread handed the block containing the four biggest files finishes long
+//! after the rest. Pulling one index at a time costs a single relaxed
+//! fetch-add per item and keeps every core busy to the end.
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+#[cfg(test)]
+mod tests;
+
+/// Below this many items, the threads cost more than they save.
+///
+/// Spawning is on the order of tens of microseconds per thread; a handful of
+/// items is done before a pool would have finished starting.
+const SERIAL_THRESHOLD: usize = 8;
+
+/// How many threads [`map`] will use for `items` items on `cores` cores.
+///
+/// Never more threads than there is work, and never more than the machine has
+/// cores. One means the caller runs the work on its own thread.
+fn threads_for(items: usize, cores: NonZeroUsize) -> usize {
+    if items < SERIAL_THRESHOLD {
+        return 1;
+    }
+    cores.get().min(items)
+}
+
+/// The number of cores to schedule across.
+fn available_cores() -> NonZeroUsize {
+    std::thread::available_parallelism().unwrap_or(NonZeroUsize::MIN)
+}
+
+/// Map `body` over `items` in parallel, in order, stopping at the first error.
+///
+/// The result is exactly `items.iter().map(body).collect::<Result<Vec<_>, _>>()`
+/// — same values, same order, same error — computed on every core. That
+/// equivalence is the contract, and it is what lets a caller reach for this
+/// without thinking about threads at all.
+///
+/// # Errors
+///
+/// Returns the error from the lowest-indexed item that produced one, so a
+/// failing run reports the same error every time however the threads
+/// interleaved. Once any item fails, threads stop claiming new work; items
+/// already in flight run to completion.
+///
+/// # Panics
+///
+/// A panic in `body` propagates once every thread has been joined, as
+/// [`std::thread::scope`] does.
+pub fn map<T, U, E, F>(items: &[T], body: F) -> Result<Vec<U>, E>
+where
+    T: Sync,
+    U: Send,
+    E: Send,
+    F: Fn(&T) -> Result<U, E> + Sync,
+{
+    map_with_cores(items, available_cores(), body)
+}
+
+/// [`map`], with the core count given rather than detected.
+///
+/// Separated so the scheduler can be tested at a fixed width: a test that only
+/// ran on however many cores the machine happens to have would prove something
+/// different on every machine.
+fn map_with_cores<T, U, E, F>(items: &[T], cores: NonZeroUsize, body: F) -> Result<Vec<U>, E>
+where
+    T: Sync,
+    U: Send,
+    E: Send,
+    F: Fn(&T) -> Result<U, E> + Sync,
+{
+    let threads = threads_for(items.len(), cores);
+    if threads == 1 {
+        return items.iter().map(body).collect();
+    }
+
+    let cursor = AtomicUsize::new(0);
+    let failed = AtomicBool::new(false);
+    let body = &body;
+    let cursor = &cursor;
+    let failed = &failed;
+
+    let claimed = std::thread::scope(|scope| {
+        let handles = (0..threads)
+            .map(|_| {
+                scope.spawn(move || {
+                    let mut mine: Vec<(usize, Result<U, E>)> = Vec::new();
+                    loop {
+                        // Relaxed throughout: the cursor only has to hand out
+                        // each index once, and the flag only has to be seen
+                        // eventually. Every result is published by the join,
+                        // which is what orders the writes against the reader.
+                        if failed.load(Ordering::Relaxed) {
+                            return mine;
+                        }
+                        let index = cursor.fetch_add(1, Ordering::Relaxed);
+                        if index >= items.len() {
+                            return mine;
+                        }
+                        let outcome = body(&items[index]);
+                        if outcome.is_err() {
+                            failed.store(true, Ordering::Relaxed);
+                        }
+                        mine.push((index, outcome));
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("a worker thread panicked"))
+            .collect::<Vec<_>>()
+    });
+
+    collect_in_order(claimed, items.len())
+}
+
+/// Put `claimed` results back into input order and unwrap them.
+///
+/// Returns the error belonging to the lowest index, which is exactly the error
+/// the serial equivalent would have returned. Indices are claimed in increasing
+/// order, so every index below a failing one was claimed and will have
+/// finished; the ones that were never started are all *above* it, and are the
+/// same ones a serial run would never have reached.
+///
+/// The error is looked for before the values are unwrapped, rather than while:
+/// unwrapping in order would meet an unclaimed slot first whenever the failure
+/// was far enough along for the other threads to have stopped.
+fn collect_in_order<U, E>(claimed: Vec<(usize, Result<U, E>)>, length: usize) -> Result<Vec<U>, E> {
+    let mut slots: Vec<Option<Result<U, E>>> = (0..length).map(|_| None).collect();
+    for (index, outcome) in claimed {
+        slots[index] = Some(outcome);
+    }
+
+    if let Some(index) = slots.iter().position(|slot| matches!(slot, Some(Err(_)))) {
+        match slots.swap_remove(index) {
+            Some(Err(error)) => return Err(error),
+            _ => unreachable!("the slot at this index was just matched as an error"),
+        }
+    }
+
+    let results = slots
+        .into_iter()
+        .map(|slot| match slot {
+            Some(Ok(value)) => value,
+            // Threads only stop claiming work when something failed, and
+            // nothing did, so every index was claimed and succeeded.
+            _ => unreachable!("an index was skipped without any item failing"),
+        })
+        .collect();
+    Ok(results)
+}

--- a/crates/uf_infra/src/parallel/tests.rs
+++ b/crates/uf_infra/src/parallel/tests.rs
@@ -1,0 +1,190 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::*;
+
+fn cores(count: usize) -> NonZeroUsize {
+    NonZeroUsize::new(count).expect("a positive core count")
+}
+
+/// The contract, stated as a test: the parallel result is the serial result.
+#[test]
+fn a_parallel_map_is_the_serial_map() {
+    let items = (0..500u64).collect::<Vec<_>>();
+    let double = |item: &u64| Ok::<_, ()>(item * 2);
+
+    let serial = items.iter().map(double).collect::<Result<Vec<_>, ()>>();
+    let parallel = map_with_cores(&items, cores(8), double);
+
+    assert_eq!(parallel, serial);
+}
+
+#[test]
+fn results_come_back_in_input_order_however_the_work_interleaved() {
+    // Reversing the cost makes the first items the slowest, so a scheduler
+    // that returned completion order would return something close to reversed.
+    let items = (0..200usize).collect::<Vec<_>>();
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        for _ in 0..(200 - item) * 50 {
+            std::hint::black_box(item);
+        }
+        Ok::<_, ()>(*item)
+    })
+    .expect("nothing fails");
+
+    assert_eq!(out, items);
+}
+
+#[test]
+fn every_item_is_visited_exactly_once() {
+    let items = (0..1000usize).collect::<Vec<_>>();
+    let calls = AtomicUsize::new(0);
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Ok::<_, ()>(*item)
+    })
+    .expect("nothing fails");
+
+    assert_eq!(calls.load(Ordering::Relaxed), items.len());
+    assert_eq!(out.len(), items.len());
+}
+
+#[test]
+fn an_empty_slice_is_an_empty_result() {
+    let items: [u8; 0] = [];
+
+    assert_eq!(map(&items, |item: &u8| Ok::<_, ()>(*item)), Ok(Vec::new()));
+}
+
+#[test]
+fn a_single_item_does_not_start_a_thread() {
+    assert_eq!(threads_for(1, cores(16)), 1);
+    assert_eq!(map(&[7u8], |item| Ok::<_, ()>(*item * 2)), Ok(vec![14]));
+}
+
+/// The reported error must not depend on which thread happened to finish first.
+#[test]
+fn the_lowest_indexed_error_is_the_one_reported() {
+    let items = (0..500usize).collect::<Vec<_>>();
+
+    for _ in 0..32 {
+        let out = map_with_cores(&items, cores(8), |item| {
+            if *item == 100 || *item == 300 {
+                Err(*item)
+            } else {
+                Ok(*item)
+            }
+        });
+
+        assert_eq!(out, Err(100));
+    }
+}
+
+/// An error far enough along that the other threads stop before claiming the
+/// indices after it. Those unclaimed slots must not be mistaken for a bug.
+#[test]
+fn an_error_leaves_later_items_unclaimed_without_panicking() {
+    let items = (0..5000usize).collect::<Vec<_>>();
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        if *item == 10 {
+            Err("failed")
+        } else {
+            Ok(*item)
+        }
+    });
+
+    assert_eq!(out, Err("failed"));
+}
+
+/// Once something fails, the remaining work is abandoned rather than run.
+#[test]
+fn a_failure_stops_the_threads_claiming_more_work() {
+    let items = (0..100_000usize).collect::<Vec<_>>();
+    let calls = AtomicUsize::new(0);
+
+    let out = map_with_cores(&items, cores(8), |item| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        if *item == 0 { Err(()) } else { Ok(*item) }
+    });
+
+    assert_eq!(out, Err(()));
+    assert!(
+        calls.load(Ordering::Relaxed) < items.len(),
+        "every one of {} items ran even though the first failed",
+        items.len()
+    );
+}
+
+// --- the scheduler -----------------------------------------------------
+
+#[test]
+fn small_inputs_stay_on_the_calling_thread() {
+    for length in 0..SERIAL_THRESHOLD {
+        assert_eq!(
+            threads_for(length, cores(16)),
+            1,
+            "{length} items is not worth a thread"
+        );
+    }
+    assert!(threads_for(SERIAL_THRESHOLD, cores(16)) > 1);
+}
+
+#[test]
+fn there_are_never_more_threads_than_work_or_cores() {
+    assert_eq!(threads_for(10, cores(16)), 10, "no idle threads");
+    assert_eq!(threads_for(1000, cores(4)), 4, "no oversubscription");
+    assert_eq!(threads_for(1000, cores(1)), 1);
+}
+
+#[test]
+fn one_core_is_the_serial_path() {
+    let items = (0..100u32).collect::<Vec<_>>();
+
+    let out = map_with_cores(&items, cores(1), |item| Ok::<_, ()>(*item + 1));
+
+    assert_eq!(out, Ok((1..101u32).collect::<Vec<_>>()));
+}
+
+// --- ordering of collected results -------------------------------------
+
+#[test]
+fn collecting_places_results_by_index_rather_than_by_arrival() {
+    let claimed = vec![
+        (2usize, Ok::<&str, ()>("third")),
+        (0, Ok("first")),
+        (1, Ok("second")),
+    ];
+
+    assert_eq!(
+        collect_in_order(claimed, 3),
+        Ok(vec!["first", "second", "third"])
+    );
+}
+
+#[test]
+fn collecting_reports_the_lowest_indexed_error_past_an_unclaimed_slot() {
+    // Index 1 was never claimed; index 2 failed. The unclaimed slot must not
+    // shadow the error.
+    let claimed = vec![(0usize, Ok::<u8, &str>(1)), (2, Err("boom"))];
+
+    assert_eq!(collect_in_order(claimed, 4), Err("boom"));
+}
+
+#[test]
+fn a_panicking_body_propagates() {
+    let items = (0..64usize).collect::<Vec<_>>();
+
+    let panicked = std::panic::catch_unwind(|| {
+        map_with_cores(&items, cores(4), |item| {
+            assert_ne!(*item, 32, "deliberate");
+            Ok::<_, ()>(*item)
+        })
+    });
+
+    assert!(
+        panicked.is_err(),
+        "a panic in the body must not be swallowed"
+    );
+}

--- a/crates/uf_infra/tests/dependencies.rs
+++ b/crates/uf_infra/tests/dependencies.rs
@@ -1,0 +1,127 @@
+//! What uf's own crates are allowed to depend on.
+//!
+//! uf schedules its own work. `uf_infra::parallel` is the one data-parallel
+//! primitive the toolchain needs, `uf_test` runs its own worker pool, and
+//! nothing in uf is asynchronous — so neither a parallel iterator framework nor
+//! an async runtime has a place in the dependency graph, and the way to keep
+//! one out is to say so somewhere that fails.
+//!
+//! This is about uf's crates only. `upstream/flow` is Meta's source, vendored
+//! as a submodule, and it uses rayon itself; that is its business and not ours
+//! to rewrite.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Crates uf may not depend on, and what to reach for instead.
+const BANNED: &[(&str, &str)] = &[
+    ("rayon", "uf_infra::parallel::map"),
+    ("tokio", "std::thread, as uf_test does"),
+    ("async-std", "std::thread, as uf_test does"),
+    ("smol", "std::thread, as uf_test does"),
+    ("futures", "std::thread, as uf_test does"),
+];
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the crate lives inside the workspace")
+}
+
+/// Every `crates/*/Cargo.toml`, which is every crate uf owns.
+fn uf_manifests() -> Vec<PathBuf> {
+    let mut manifests = fs::read_dir(workspace_root().join("crates"))
+        .expect("the workspace has a crates directory")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("Cargo.toml"))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    manifests.sort();
+    manifests
+}
+
+/// The dependency names one manifest declares, in any of its three tables.
+fn declared_dependencies(manifest: &str) -> Vec<String> {
+    manifest
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.starts_with('#') && !line.starts_with('['))
+        .filter_map(|line| line.split_once(['=', '.']))
+        .map(|(name, _)| name.trim().trim_matches('"').to_owned())
+        .collect()
+}
+
+#[test]
+fn no_uf_crate_depends_on_a_parallel_or_async_runtime() {
+    let mut offenders = Vec::new();
+
+    for manifest in uf_manifests() {
+        let source = fs::read_to_string(&manifest).expect("a readable manifest");
+        let declared = declared_dependencies(&source);
+        for (banned, instead) in BANNED {
+            if declared.iter().any(|name| name == banned) {
+                let crate_name = manifest
+                    .parent()
+                    .and_then(Path::file_name)
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                offenders.push(format!("{crate_name} depends on {banned}; use {instead}"));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "{}\n\nuf schedules its own work; see crates/uf_infra/src/parallel.rs",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn the_workspace_does_not_offer_one_either() {
+    let root = fs::read_to_string(workspace_root().join("Cargo.toml")).expect("a root manifest");
+    let declared = declared_dependencies(&root);
+
+    for (banned, instead) in BANNED {
+        assert!(
+            !declared.iter().any(|name| name == banned),
+            "the workspace still offers {banned} to any crate that asks; use {instead}"
+        );
+    }
+}
+
+/// The parser reads what a manifest actually declares, in every table shape.
+#[test]
+fn dependencies_are_read_from_every_table_shape() {
+    let manifest = r#"
+[package]
+name = "example"
+
+[dependencies]
+plain = "1"
+detailed = { version = "1", features = ["x"] }
+workspace-style.workspace = true
+
+[dev-dependencies]
+only-for-tests = "1"
+
+[build-dependencies]
+only-for-build = "1"
+"#;
+
+    let declared = declared_dependencies(manifest);
+
+    for expected in [
+        "plain",
+        "detailed",
+        "workspace-style",
+        "only-for-tests",
+        "only-for-build",
+    ] {
+        assert!(
+            declared.iter().any(|name| name == expected),
+            "{expected} was not read out of the manifest, got {declared:?}"
+        );
+    }
+}

--- a/crates/uf_lint/Cargo.toml
+++ b/crates/uf_lint/Cargo.toml
@@ -15,7 +15,6 @@ uf_infra = { path = "../uf_infra" }
 uf_react_compiler = { path = "../uf_react_compiler" }
 uf_router = { path = "../uf_router" }
 phf.workspace = true
-rayon.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 

--- a/crates/uf_lint/src/lib.rs
+++ b/crates/uf_lint/src/lib.rs
@@ -27,7 +27,6 @@ mod runner;
 mod scan;
 mod suppression;
 
-use rayon::prelude::*;
 use thiserror::Error;
 use uf_config::{RuleLevel, UniflowedConfig};
 
@@ -147,10 +146,7 @@ pub fn lint_sources(
     files: &[SourceFile],
     config: &UniflowedConfig,
 ) -> Result<LintReport, LintError> {
-    let per_file = files
-        .par_iter()
-        .map(|file| lint_file(file, config))
-        .collect::<Result<Vec<_>, _>>()?;
+    let per_file = uf_infra::parallel::map(files, |file| lint_file(file, config))?;
 
     let mut diagnostics = per_file.into_iter().flatten().collect::<Vec<_>>();
     sort_diagnostics(&mut diagnostics);

--- a/crates/uf_rsc/Cargo.toml
+++ b/crates/uf_rsc/Cargo.toml
@@ -11,7 +11,6 @@ authors.workspace = true
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true
-rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/uf_rsc/src/project.rs
+++ b/crates/uf_rsc/src/project.rs
@@ -14,7 +14,6 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::CompactString;
-use rayon::prelude::*;
 use walkdir::WalkDir;
 
 use crate::RscError;
@@ -97,19 +96,16 @@ pub fn analyze_project(
 ) -> Result<RscAnalysis, RscError> {
     let paths = collect_module_paths(root, options)?;
 
-    let modules = paths
-        .par_iter()
-        .map(|(absolute, relative)| {
-            let bytes = std::fs::read(absolute).map_err(|source| RscError::Read {
-                path: relative.clone(),
-                source,
-            })?;
-            let source = uf_infra::validate_utf8(&bytes).map_err(|_| RscError::NonUtf8Source {
-                path: relative.clone(),
-            })?;
-            Ok(RscModuleInput::from_source(relative.clone(), source))
-        })
-        .collect::<Result<Vec<_>, RscError>>()?;
+    let modules = uf_infra::parallel::map(&paths, |(absolute, relative)| {
+        let bytes = std::fs::read(absolute).map_err(|source| RscError::Read {
+            path: relative.clone(),
+            source,
+        })?;
+        let source = uf_infra::validate_utf8(&bytes).map_err(|_| RscError::NonUtf8Source {
+            path: relative.clone(),
+        })?;
+        Ok(RscModuleInput::from_source(relative.clone(), source))
+    })?;
 
     let mut builder = RscGraphBuilder::new();
     for module in modules {

--- a/crates/uf_test/Cargo.toml
+++ b/crates/uf_test/Cargo.toml
@@ -13,7 +13,6 @@ uf_infra = { path = "../uf_infra" }
 uf_rsc = { path = "../uf_rsc" }
 camino.workspace = true
 compact_str.workspace = true
-rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true


### PR DESCRIPTION
Three crates used rayon, and all three used it for the same thing:
`slice.par_iter().map(f).collect::<Result<Vec<_>, E>>()`. `uf_lint` lints each
file, `uf_rsc` reads and classifies each module, `uf_bundle` measures each
emitted asset. Nothing needed nested parallelism, a global pool, or a
work-stealing deque — and `uf_test` was already scheduling its own work with
`std::thread::scope`.

So `uf_infra::parallel::map` is that one operation, in sixty lines and no
`unsafe`. Threads pull indices off an atomic cursor rather than taking a
contiguous block each: lint cost tracks file size, files are not the same size,
and a thread handed the block with the four biggest files finishes long after
the rest.

The contract is an equality, which is what makes it safe to reach for without
thinking about threads: the result is exactly what
`items.iter().map(body).collect::<Result<Vec<_>, _>>()` would produce — same
values, same order, same error. The error part is not free. Indices are claimed
in increasing order, so every index below a failing one was claimed and will
finish, and the ones abandoned when the threads stop are all above it — the
same ones a serial run would never have reached. Returning the lowest-indexed
error therefore returns the serial error, every time, however the threads
interleaved.

Fourteen tests, including that equality against the serial map, that the
lowest-indexed error wins across 32 runs, and that an error far enough along to
leave later slots unclaimed does not trip the collector.

rayon is still in the lock file: `upstream/flow` uses it. That is Meta's
source, vendored, and not ours to rewrite. No crate under `crates/` depends on
it now, and `tests/dependencies.rs` fails if one starts to — along with tokio,
async-std, smol and futures, for the same reason.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791087482&installation_model_id=422833&pr_number=100&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F100&signature=a4056b0318947c3d5ae6cd237ae3fa3f60de383545dbe4ef3c39a84dbb04e744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->