### PR TITLE
feat(cli): completion that knows this project, and errors that name the fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,29 @@ jobs:
       - run: chmod +x target/release/uf
       - run: ./target/release/uf run rust:test
 
+  flow-format:
+    name: Flow format
+    needs: toolchain
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: tools/upstream/sync.sh
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-08-01
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      # `rust:fmt:check` is cargo's half. This is uf's: the formatter this
+      # repository ships, over the Flow this repository is written in. It is
+      # the only thing that checks the shipped packages' formatting at all.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run fmt:check
+
   docs:
     name: Docs build
     needs: toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,34 @@ jobs:
       - run: chmod +x target/release/uf
       - run: ./target/release/uf run rust:test
 
+  docs:
+    name: Docs build
+    needs: toolchain
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: tools/upstream/sync.sh
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-08-01
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - run: npm ci --no-audit --no-fund
+      # The documentation site is a uf project in this repository, built by
+      # `uf build#docs`. The Docs workflow builds it too, on its own trigger;
+      # this job is what makes a pull request that breaks the site fail before
+      # it is merged rather than after.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run docs:build
+
   library:
     name: Library
     needs: toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ name = "uf_project"
 version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
+ "compact_str",
  "tempfile",
  "thiserror",
  "uf_config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,9 +3536,11 @@ dependencies = [
  "camino",
  "compact_str",
  "criterion",
+ "similar-asserts",
  "tempfile",
  "thiserror",
  "uf_config",
+ "uf_fmt",
  "walkdir",
 ]
 

--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -48,6 +48,22 @@ pub(crate) enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Print a shell completion script.
+    ///
+    /// The script asks `uf` what may follow what, so a task added to
+    /// `uf.config.js` completes immediately with nothing to regenerate.
+    Completion {
+        /// The shell to generate for.
+        #[arg(value_enum)]
+        shell: Shell,
+    },
+    /// Answer a completion request. Not a command a person runs.
+    #[command(hide = true, name = "__complete")]
+    Complete {
+        /// The words typed after `uf`, with the one being completed last.
+        #[arg(trailing_var_arg = true)]
+        words: Vec<String>,
+    },
     /// Scaffold a new application or library.
     Create {
         #[command(subcommand)]
@@ -130,10 +146,11 @@ pub(crate) enum Commands {
         #[arg(value_enum)]
         bump: ReleaseBump,
     },
-    /// Run a task from `uf.config.js`. Also `ufr`.
+    /// Run a task from `uf.config.js`, or list them. Also `ufr`.
     Run {
         /// The task to run, as named under `tasks` in `uf.config.js`.
-        script: String,
+        /// Omit it to see what this project defines.
+        script: Option<String>,
         /// Everything after the task name, handed to it untouched.
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
@@ -192,8 +209,18 @@ impl Commands {
 
     /// Whether this invocation hands stdout to a protocol or a child process
     /// rather than to a reader, in which case nothing may be rendered onto it.
+    ///
+    /// `uf run` with no task name is the exception in its own command: it runs
+    /// nothing and lists what it could have run, so stdout is a reader's again.
     pub(crate) fn owns_stdout(&self) -> bool {
-        matches!(self, Self::Lsp | Self::Run { .. } | Self::Transform)
+        match self {
+            // `uf completion` is piped into `eval` and `uf __complete` into a
+            // completion list; a banner on either is a syntax error in
+            // somebody's shell.
+            Self::Complete { .. } | Self::Completion { .. } | Self::Lsp | Self::Transform => true,
+            Self::Run { script, .. } => script.is_some(),
+            _ => false,
+        }
     }
 }
 
@@ -215,6 +242,20 @@ pub(crate) enum CreateCommand {
         #[arg(long)]
         force: bool,
     },
+}
+
+/// A shell uf can generate completion for.
+// `PowerShell` ends in the enum's own name, which clippy reads as a stutter.
+// It is the shell's name, and renaming it would be worse than the lint.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+    Elvish,
+    #[value(name = "powershell")]
+    PowerShell,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -254,10 +295,18 @@ mod tests {
         assert!(Commands::Lsp.owns_stdout());
         assert!(
             Commands::Run {
-                script: "build".to_string(),
+                script: Some("build".to_string()),
                 args: Vec::new(),
             }
             .owns_stdout()
+        );
+        assert!(
+            !Commands::Run {
+                script: None,
+                args: Vec::new(),
+            }
+            .owns_stdout(),
+            "listing tasks renders, so it must keep stdout"
         );
         assert!(!Commands::Build { size_report: false }.owns_stdout());
     }

--- a/crates/uf_cli/src/commands.rs
+++ b/crates/uf_cli/src/commands.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod build;
 pub(crate) mod check;
+pub(crate) mod completion;
 pub(crate) mod create;
 pub(crate) mod dev;
 pub(crate) mod env;

--- a/crates/uf_cli/src/commands/completion.rs
+++ b/crates/uf_cli/src/commands/completion.rs
@@ -1,0 +1,174 @@
+//! `uf completion`: shell completion, including the parts only uf knows.
+//!
+//! Generated completion is normally a static picture of the argument parser,
+//! taken at build time. That covers subcommand and flag names and stops exactly
+//! where it gets interesting: the argument someone actually mistypes is a *task
+//! name*, which lives in `uf.config.js` and is different in every project.
+//!
+//! So the shipped scripts are thin. Each one collects the words typed so far
+//! and asks `uf __complete` what could come next; the answer is computed by the
+//! same binary, reading the same config, so a task added to `uf.config.js` is
+//! completable immediately with no regeneration and nothing to reinstall.
+//!
+//! [`candidates`] is that answer, and it is a pure function of the words and
+//! the project — which is what makes it testable without a shell.
+
+mod scripts;
+
+#[cfg(test)]
+mod tests;
+
+use anyhow::Result;
+use camino::Utf8Path;
+use uf_config::load_config;
+
+use crate::cli::Shell;
+use crate::ui::Ui;
+
+/// Every subcommand `uf` accepts, in help order.
+///
+/// Written out rather than read from clap: `Commands` is an enum whose variants
+/// clap knows the spelling of, and asking clap for them at runtime costs a
+/// command tree build on a path that has to feel instant. The list is checked
+/// against clap's own in `tests`, so it cannot drift.
+const COMMANDS: &[&str] = &[
+    "build",
+    "check",
+    "create",
+    "dev",
+    "env",
+    "exec",
+    "explain",
+    "fmt",
+    "info",
+    "inspect",
+    "install",
+    "i",
+    "lint",
+    "lsp",
+    "prepare",
+    "publish",
+    "release",
+    "run",
+    "test",
+    "upgrade",
+    "use",
+    "completion",
+    "help",
+];
+
+/// Flags accepted anywhere.
+const GLOBAL_FLAGS: &[&str] = &["--cwd", "--color", "--help", "--version"];
+
+/// What `--color` takes.
+const COLOR_VALUES: &[&str] = &["auto", "always", "never"];
+
+/// What `uf release` takes.
+const RELEASE_BUMPS: &[&str] = &["alpha", "patch", "minor", "major"];
+
+/// What `uf create` takes.
+const CREATE_KINDS: &[&str] = &["app", "lib"];
+
+/// What `uf explain` knows how to describe.
+const EXPLAINABLE: &[&str] = &["dev", "build", "test", "fmt", "lint", "check"];
+
+/// Print the completion script for `shell`.
+pub(crate) fn completion(ui: &mut Ui, shell: Shell) {
+    ui.plain(scripts::script(shell));
+}
+
+/// Print one candidate per line, for the shipped scripts to consume.
+///
+/// `words` is everything typed after `uf`, with the word being completed last —
+/// possibly empty, which is what "the cursor is at a fresh word" looks like.
+pub(crate) fn complete(cwd: &Utf8Path, ui: &mut Ui, words: &[String]) -> Result<()> {
+    let tasks = task_names(cwd);
+    let names = tasks.iter().map(String::as_str).collect::<Vec<_>>();
+    let candidates = candidates(words, &names);
+
+    let mut out = String::new();
+    for candidate in &candidates {
+        out.push_str(candidate);
+        out.push('\n');
+    }
+    ui.plain(&out);
+    Ok(())
+}
+
+/// The project's task names, or nothing when there is no readable project.
+///
+/// A completion that failed loudly would print an error into the middle of
+/// someone's command line. There is nothing to say here: either uf knows the
+/// tasks or it does not, and not knowing them completes to nothing.
+fn task_names(cwd: &Utf8Path) -> Vec<String> {
+    load_config(cwd).map_or_else(
+        |_| Vec::new(),
+        |resolved| {
+            resolved
+                .config
+                .tasks
+                .keys()
+                .map(ToString::to_string)
+                .collect()
+        },
+    )
+}
+
+/// What could come next, given the words typed so far.
+///
+/// Pure, so the whole surface is testable without a shell or a project on disk.
+fn candidates(words: &[String], tasks: &[&str]) -> Vec<String> {
+    let (current, before) = match words.split_last() {
+        Some((current, before)) => (current.as_str(), before),
+        None => ("", &[][..]),
+    };
+
+    // A value that belongs to the flag before it, rather than a fresh word.
+    if let Some(previous) = before.last() {
+        match previous.as_str() {
+            "--color" => return matching(current, COLOR_VALUES.iter().copied()),
+            // A directory, which the shell completes better than uf can.
+            "--cwd" => return Vec::new(),
+            _ => {}
+        }
+    }
+
+    if current.starts_with('-') {
+        return matching(current, GLOBAL_FLAGS.iter().copied());
+    }
+
+    // The subcommand: the first word that is not a global flag or its value.
+    let mut positional = Vec::new();
+    let mut skip_next = false;
+    for word in before {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if word == "--cwd" || word == "--color" {
+            skip_next = true;
+            continue;
+        }
+        if !word.starts_with('-') {
+            positional.push(word.as_str());
+        }
+    }
+
+    match positional.as_slice() {
+        [] => matching(current, COMMANDS.iter().copied()),
+        ["run"] => matching(current, tasks.iter().copied()),
+        ["release"] => matching(current, RELEASE_BUMPS.iter().copied()),
+        ["create"] => matching(current, CREATE_KINDS.iter().copied()),
+        ["explain"] => matching(current, EXPLAINABLE.iter().copied()),
+        ["env"] => matching(current, ["doctor", "use"]),
+        _ => Vec::new(),
+    }
+}
+
+/// Those of `pool` that start with `prefix`, in the order `pool` gave them.
+fn matching<'a>(prefix: &str, pool: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    pool.into_iter()
+        .filter(|candidate| candidate.starts_with(prefix))
+        .map(ToOwned::to_owned)
+        .collect()
+}

--- a/crates/uf_cli/src/commands/completion/scripts.rs
+++ b/crates/uf_cli/src/commands/completion/scripts.rs
@@ -1,0 +1,80 @@
+//! The shipped completion scripts, one per shell.
+//!
+//! Each is a few lines because none of them decide anything: they collect the
+//! words typed so far, hand them to `uf __complete`, and offer whatever comes
+//! back. That keeps every rule about what may follow what in one place, in
+//! Rust, where it is tested — and it means the scripts never go stale, because
+//! there is nothing in them to go stale.
+
+use crate::cli::Shell;
+
+/// The completion script for `shell`.
+pub(super) fn script(shell: Shell) -> &'static str {
+    match shell {
+        Shell::Bash => BASH,
+        Shell::Zsh => ZSH,
+        Shell::Fish => FISH,
+        Shell::Elvish => ELVISH,
+        Shell::PowerShell => POWERSHELL,
+    }
+}
+
+/// `COMP_WORDS` includes the command itself, so it is dropped; `COMP_CWORD` is
+/// the index being completed, which may be past the end when the cursor is on a
+/// fresh word, and the empty string is exactly what `__complete` expects there.
+const BASH: &str = r#"# uf completion for bash. Add to ~/.bashrc:
+#   eval "$(uf completion bash)"
+_uf_complete() {
+  local words index
+  words=("${COMP_WORDS[@]:1:COMP_CWORD}")
+  COMPREPLY=($(compgen -W "$(uf __complete -- "${words[@]}" 2>/dev/null)" -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+complete -F _uf_complete uf ufr ufx
+"#;
+
+/// `words` holds the whole line including the command; `CURRENT` is 1-based.
+/// `compadd -- ${(f)...}` splits the reply on newlines, so a candidate that
+/// contains a space still arrives as one candidate.
+const ZSH: &str = r#"# uf completion for zsh. Add to ~/.zshrc:
+#   eval "$(uf completion zsh)"
+_uf_complete() {
+  local -a candidates
+  candidates=(${(f)"$(uf __complete -- ${words[2,CURRENT]} 2>/dev/null)"})
+  compadd -- $candidates
+}
+compdef _uf_complete uf ufr ufx
+"#;
+
+/// fish completes one token at a time and has no notion of "the words so far"
+/// as an array, so the current buffer is split by `commandline -opc`.
+const FISH: &str = r#"# uf completion for fish. Add to ~/.config/fish/config.fish:
+#   uf completion fish | source
+function __uf_complete
+    set -l words (commandline -opc) (commandline -ct)
+    uf __complete -- $words[2..-1] 2>/dev/null
+end
+complete -c uf -f -a '(__uf_complete)'
+complete -c ufr -f -a '(__uf_complete)'
+complete -c ufx -f -a '(__uf_complete)'
+"#;
+
+const ELVISH: &str = r#"# uf completion for elvish. Add to ~/.config/elvish/rc.elv:
+#   eval (uf completion elvish | slurp)
+set edit:completion:arg-completer[uf] = {|@words|
+  var rest = $words[1..]
+  each {|candidate| put $candidate } [(uf __complete -- $@rest 2>/dev/null)]
+}
+set edit:completion:arg-completer[ufr] = $edit:completion:arg-completer[uf]
+set edit:completion:arg-completer[ufx] = $edit:completion:arg-completer[uf]
+"#;
+
+const POWERSHELL: &str = r#"# uf completion for PowerShell. Add to $PROFILE:
+#   uf completion powershell | Out-String | Invoke-Expression
+Register-ArgumentCompleter -Native -CommandName uf, ufr, ufx -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $words = $commandAst.CommandElements | Select-Object -Skip 1 | ForEach-Object { $_.ToString() }
+    uf __complete -- @words 2>$null | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+    }
+}
+"#;

--- a/crates/uf_cli/src/commands/completion/tests.rs
+++ b/crates/uf_cli/src/commands/completion/tests.rs
@@ -1,0 +1,161 @@
+use clap::CommandFactory;
+
+use super::*;
+
+/// This repository's own task names.
+const TASKS: &[&str] = &["build", "ci", "docs:build", "rust:test", "test:lib"];
+
+fn words(line: &[&str]) -> Vec<String> {
+    line.iter().map(ToString::to_string).collect()
+}
+
+fn complete_line(line: &[&str]) -> Vec<String> {
+    candidates(&words(line), TASKS)
+}
+
+#[test]
+fn a_fresh_command_line_offers_every_subcommand() {
+    let out = complete_line(&[""]);
+
+    for command in ["build", "check", "dev", "run", "test"] {
+        assert!(out.contains(&command.to_string()), "{command} missing");
+    }
+}
+
+#[test]
+fn a_partial_subcommand_narrows_to_what_starts_with_it() {
+    assert_eq!(complete_line(&["ru"]), vec!["run"]);
+    assert_eq!(complete_line(&["in"]), vec!["info", "inspect", "install"]);
+}
+
+/// The whole point: task names come from the project, not from the parser.
+#[test]
+fn run_completes_the_projects_own_task_names() {
+    assert_eq!(complete_line(&["run", ""]), TASKS);
+    assert_eq!(
+        complete_line(&["run", "rust"]),
+        vec!["rust:test"],
+        "a prefix narrows to the tasks that start with it"
+    );
+    assert_eq!(complete_line(&["run", "docs"]), vec!["docs:build"]);
+}
+
+#[test]
+fn a_task_name_that_matches_nothing_completes_to_nothing() {
+    assert!(complete_line(&["run", "zzz"]).is_empty());
+}
+
+#[test]
+fn enum_arguments_complete_to_their_variants() {
+    assert_eq!(
+        complete_line(&["release", ""]),
+        vec!["alpha", "patch", "minor", "major"]
+    );
+    assert_eq!(complete_line(&["create", ""]), vec!["app", "lib"]);
+    assert_eq!(complete_line(&["env", ""]), vec!["doctor", "use"]);
+    assert!(complete_line(&["explain", ""]).contains(&"build".to_string()));
+}
+
+#[test]
+fn a_flag_completes_to_the_global_flags() {
+    assert_eq!(complete_line(&["--c"]), vec!["--cwd", "--color"]);
+    assert!(complete_line(&["build", "--"]).contains(&"--help".to_string()));
+}
+
+#[test]
+fn a_flags_value_completes_to_that_flags_values() {
+    assert_eq!(
+        complete_line(&["--color", ""]),
+        vec!["auto", "always", "never"]
+    );
+    assert_eq!(complete_line(&["--color", "a"]), vec!["auto", "always"]);
+}
+
+/// A directory is something the shell completes better than uf can, so uf says
+/// nothing rather than offering a worse list.
+#[test]
+fn a_directory_argument_is_left_to_the_shell() {
+    assert!(complete_line(&["--cwd", ""]).is_empty());
+}
+
+/// The subcommand is the first *positional* word, so a global flag before it
+/// must not be mistaken for one.
+#[test]
+fn global_flags_before_the_subcommand_do_not_confuse_it() {
+    assert_eq!(
+        complete_line(&["--color", "never", "run", "ru"]),
+        vec!["rust:test"]
+    );
+    assert_eq!(complete_line(&["--cwd", "/tmp", "run", "ci"]), vec!["ci"]);
+}
+
+#[test]
+fn an_argument_nothing_is_known_about_completes_to_nothing() {
+    assert!(complete_line(&["lsp", ""]).is_empty());
+    assert!(complete_line(&["run", "build", ""]).is_empty());
+}
+
+#[test]
+fn an_empty_word_list_offers_the_subcommands() {
+    assert!(candidates(&[], TASKS).contains(&"build".to_string()));
+}
+
+/// The hand-written table has to be clap's, or completion offers a command
+/// that does not exist and hides one that does.
+///
+/// Hidden commands are deliberately absent: `uf transform` is spawned by the
+/// Vite plugin and `uf __complete` by a completion script, and neither is a
+/// thing a person types. `help` is present and is clap's own, which is why it
+/// is added here rather than found among the subcommands.
+#[test]
+fn the_command_list_matches_the_argument_parser() {
+    let command = crate::Cli::command();
+    let mut from_clap = command
+        .get_subcommands()
+        .filter(|sub| !sub.is_hide_set())
+        .flat_map(|sub| {
+            std::iter::once(sub.get_name().to_owned())
+                .chain(sub.get_all_aliases().map(ToOwned::to_owned))
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    from_clap.insert("help".to_owned());
+
+    let ours = COMMANDS
+        .iter()
+        .map(ToString::to_string)
+        .collect::<std::collections::BTreeSet<_>>();
+
+    assert_eq!(
+        ours, from_clap,
+        "the completion command list and the parser disagree"
+    );
+}
+
+// --- the shipped scripts -----------------------------------------------
+
+#[test]
+fn every_shell_ships_a_script_that_calls_back_into_uf() {
+    for shell in [
+        Shell::Bash,
+        Shell::Zsh,
+        Shell::Fish,
+        Shell::Elvish,
+        Shell::PowerShell,
+    ] {
+        let script = scripts::script(shell);
+
+        assert!(!script.is_empty(), "{shell:?} ships no script");
+        assert!(
+            script.contains("uf __complete"),
+            "{shell:?} does not ask uf for candidates, so task names will not complete"
+        );
+        assert!(
+            script.contains("ufr") && script.contains("ufx"),
+            "{shell:?} does not complete the alias binaries"
+        );
+        assert!(
+            script.contains("# uf completion for"),
+            "{shell:?} does not say how to install it"
+        );
+    }
+}

--- a/crates/uf_cli/src/commands/task.rs
+++ b/crates/uf_cli/src/commands/task.rs
@@ -10,17 +10,114 @@ use camino::{Utf8Path, Utf8PathBuf};
 use serde_json::json;
 use uf_config::{ResolvedConfig, TaskDefinition, TaskRunnerEngine, load_config};
 use uf_pm::PackageManagerPlan;
-use uf_term::{KeyValue, Status, Tone};
+use uf_term::{Cell, Column, KeyValue, Status, Table, Tone, display_width, truncate_to_width};
 
 use crate::cli::{AppTemplate, CreateCommand};
 use crate::commands::{create, pm, test};
-use crate::support::{safe_file_label, write_json_file};
+use crate::suggest::closest;
+use crate::support::{plural, project_label, safe_file_label, write_json_file};
 use crate::ui::Ui;
 
 pub(crate) fn run_task(cwd: &Utf8Path, script: &str, args: &[String]) -> Result<()> {
     let resolved = load_config(cwd)?;
     let mut visited = BTreeSet::new();
     run_named_task(&resolved, script, args, &mut visited)
+}
+
+/// Widest a command is printed at in the task table.
+///
+/// A task may legitimately be a hundred characters of shell — this repository
+/// has one — and printing it in full pushes every column after it off the
+/// screen. The name is what the reader needs; the command is context.
+const COMMAND_WIDTH: usize = 56;
+
+/// `text`, cut to `width` columns with a trailing ellipsis if it did not fit.
+fn elide(text: &str, width: usize) -> String {
+    if display_width(text) <= width {
+        return text.to_owned();
+    }
+    let mut out = truncate_to_width(text, width.saturating_sub(1)).to_owned();
+    out.push('…');
+    out
+}
+
+/// `uf run` with no task name: what this project can do.
+///
+/// A tool that requires a name before it will tell you the names is a tool you
+/// have to read the config to use. This is the answer to "what can I run here",
+/// and it is the same list the unknown-task error points at.
+pub(crate) fn list_tasks(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
+    let resolved = load_config(cwd)?;
+    let tasks = &resolved.config.tasks;
+
+    if tasks.is_empty() {
+        ui.render(|renderer, out| {
+            renderer.banner(out, "uf run", None);
+            renderer.blank(out);
+            renderer.status(
+                out,
+                Status::Info,
+                "this project defines no tasks; add them under `tasks` in uf.config.js",
+            );
+        });
+        return Ok(());
+    }
+
+    // Owned first, borrowed second: `Table` holds `&str`, so every cell's text
+    // has to outlive the table rather than be built into it.
+    let rows = tasks
+        .iter()
+        .map(|(name, task)| {
+            let (command, after) = match task {
+                TaskDefinition::Command(command) => (command.to_string(), String::new()),
+                TaskDefinition::Detailed(details) => (
+                    details.command.to_string(),
+                    details
+                        .depends_on
+                        .iter()
+                        .map(compact_str::CompactString::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ),
+            };
+            // A task with no command of its own is Vite Task's, and saying so
+            // is more useful than an empty cell.
+            let runs = if command.trim().is_empty() {
+                String::from("vite task")
+            } else {
+                elide(&command, COMMAND_WIDTH)
+            };
+            (name.to_string(), runs, after)
+        })
+        .collect::<Vec<_>>();
+
+    let mut table = Table::new(vec![
+        Column::left("task"),
+        Column::left("runs"),
+        Column::left("after"),
+    ]);
+    for (name, runs, after) in &rows {
+        table.push(vec![
+            Cell::toned(name, Tone::Accent),
+            Cell::new(runs),
+            Cell::toned(after, Tone::Muted),
+        ]);
+    }
+
+    let count = tasks.len();
+    ui.render(|renderer, out| {
+        renderer.banner(out, "uf run", Some(project_label(&resolved.root)));
+        renderer.blank(out);
+        renderer.table(out, 2, &table);
+        renderer.blank(out);
+        renderer.status(
+            out,
+            Status::Info,
+            &format!("{}; run one with `uf run <task>`", plural(count, "task")),
+        );
+    });
+
+    Ok(())
 }
 
 fn run_named_task(
@@ -34,7 +131,7 @@ fn run_named_task(
     }
 
     let Some(task) = resolved.config.tasks.get(script) else {
-        bail!("task {script:?} is not defined in uf.config.js");
+        bail!(unknown_task(resolved, script));
     };
 
     if let TaskDefinition::Detailed(details) = task {
@@ -44,6 +141,50 @@ fn run_named_task(
     }
 
     execute_task(resolved, script, task, args)
+}
+
+/// The error for a task name that is not in `uf.config.js`.
+///
+/// `task "biuld" is not defined in uf.config.js` is true and unhelpful: the
+/// reader knows what they typed, and what they want is the name they meant.
+/// So the message names the closest tasks, and — when there are few enough to
+/// read — every task the project defines, because someone who has just arrived
+/// in a repository does not know what is on offer and should not have to open
+/// the config to find out.
+fn unknown_task(resolved: &ResolvedConfig, script: &str) -> String {
+    let names = resolved
+        .config
+        .tasks
+        .keys()
+        .map(compact_str::CompactString::as_str)
+        .collect::<Vec<_>>();
+
+    let mut message = format!("task {script:?} is not defined in uf.config.js");
+    if names.is_empty() {
+        message.push_str("\n\n  this project defines no tasks");
+        return message;
+    }
+
+    let suggestions = closest(script, names.iter().copied());
+    if !suggestions.is_empty() {
+        message.push_str("\n\n  did you mean: ");
+        message.push_str(&suggestions.join(", "));
+    }
+
+    // A long list is a wall of text rather than an answer; past this many, the
+    // suggestions are the help and `uf run` with no task name is where the rest
+    // lives.
+    const LISTED_IN_FULL: usize = 12;
+    if names.len() <= LISTED_IN_FULL {
+        message.push_str("\n\n  tasks: ");
+        message.push_str(&names.join(", "));
+    } else {
+        message.push_str(&format!(
+            "\n\n  {} tasks are defined; `uf run` lists them",
+            names.len()
+        ));
+    }
+    message
 }
 
 /// Run one task.

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -7,6 +7,7 @@
 mod brand;
 mod cli;
 mod commands;
+mod suggest;
 mod support;
 mod ui;
 
@@ -80,6 +81,11 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
     match cli.command {
         Commands::Build { size_report } => commands::build::build(&cwd, ui, size_report),
         Commands::Check { json } => commands::check::check(&cwd, ui, json),
+        Commands::Completion { shell } => {
+            commands::completion::completion(ui, shell);
+            Ok(())
+        }
+        Commands::Complete { words } => commands::completion::complete(&cwd, ui, &words),
         Commands::Create { command } => commands::create::create(&cwd, ui, command),
         Commands::Dev { host, port } => {
             commands::dev::dev(&cwd, ui, commands::dev::DevArgs { host, port })
@@ -99,7 +105,10 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
         Commands::Prepare => commands::release::prepare(&cwd, ui),
         Commands::Publish => commands::release::publish(&cwd, ui),
         Commands::Release { bump } => commands::release::release(&cwd, ui, bump),
-        Commands::Run { script, args } => commands::task::run_task(&cwd, &script, &args),
+        Commands::Run { script, args } => match script {
+            Some(script) => commands::task::run_task(&cwd, &script, &args),
+            None => commands::task::list_tasks(&cwd, ui),
+        },
         Commands::Test {
             list,
             watch,

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -36,8 +36,8 @@ struct Cli {
 }
 
 pub fn main() -> ExitCode {
-    let cli = match parse_cli() {
-        Ok(cli) => cli,
+    let (cli, target) = match parse_cli() {
+        Ok(parsed) => parsed,
         Err(error) => return report_startup_error(&error),
     };
     let mode = if cli.command.wants_json() || cli.command.owns_stdout() {
@@ -47,7 +47,7 @@ pub fn main() -> ExitCode {
     };
     let mut ui = Ui::new(cli.color.into(), mode);
 
-    match run(cli, &mut ui) {
+    match run(cli, target.as_deref(), &mut ui) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             ui.error(&error);
@@ -75,8 +75,12 @@ fn report_startup_error(error: &anyhow::Error) -> ExitCode {
     ExitCode::FAILURE
 }
 
-fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
+fn run(cli: Cli, target: Option<&str>, ui: &mut Ui) -> Result<()> {
     let cwd = resolve_cwd(cli.cwd)?;
+    let cwd = match target {
+        Some(target) => enter_workspace(&cwd, target)?,
+        None => cwd,
+    };
 
     match cli.command {
         Commands::Build { size_report } => commands::build::build(&cwd, ui, size_report),
@@ -146,7 +150,7 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
 /// after installation, before any project or script exists, so `ufr --version`
 /// and `ufx --version` must never be interpreted as `uf run --version` or
 /// `uf exec --version`.
-fn parse_cli() -> Result<Cli> {
+fn parse_cli() -> Result<(Cli, Option<String>)> {
     let mut args = std::env::args_os().collect::<Vec<_>>();
     let bin_name = args
         .first()
@@ -155,16 +159,56 @@ fn parse_cli() -> Result<Cli> {
         .unwrap_or("uf");
 
     match bin_name {
-        "ufr" if !args_request_root_version(&args) => {
-            args.insert(1, "run".into());
-            Cli::try_parse_from(args).map_err(Into::into)
-        }
-        "ufx" if !args_request_root_version(&args) => {
-            args.insert(1, "exec".into());
-            Cli::try_parse_from(args).map_err(Into::into)
-        }
-        _ => Cli::try_parse_from(args).map_err(Into::into),
+        "ufr" if !args_request_root_version(&args) => args.insert(1, "run".into()),
+        "ufx" if !args_request_root_version(&args) => args.insert(1, "exec".into()),
+        _ => {}
     }
+
+    let target = take_workspace_selector(&mut args);
+    Ok((Cli::try_parse_from(args)?, target))
+}
+
+/// Split a `#member` selector off the subcommand, if there is one.
+///
+/// `uf dev#docs` runs `uf dev` in the `docs` member. The selector is written on
+/// the command rather than as a flag because it changes *where* the command
+/// runs rather than how, and because it reads in the order it happens — which
+/// is also why it is stripped here, before clap sees an argument it would
+/// otherwise reject as an unknown subcommand.
+///
+/// Only the subcommand carries one. A `#` anywhere else belongs to whatever
+/// argument it is part of: a task name, a filter, a path.
+fn take_workspace_selector(args: &mut [std::ffi::OsString]) -> Option<String> {
+    let at = subcommand_index(args)?;
+    let (command, target) = args[at].to_str()?.split_once('#')?;
+    if target.is_empty() {
+        return None;
+    }
+    let target = target.to_owned();
+    args[at] = command.into();
+    Some(target)
+}
+
+/// Where the subcommand is, skipping the global flags and their values.
+///
+/// `--cwd` and `--color` take a value, and that value is not the subcommand —
+/// which is what `uf --cwd /tmp dev#docs` gets wrong if the first non-flag
+/// argument is taken to be one.
+fn subcommand_index(args: &[std::ffi::OsString]) -> Option<usize> {
+    let mut index = 1;
+    while index < args.len() {
+        let argument = args[index].to_str()?;
+        if argument == "--cwd" || argument == "--color" {
+            index += 2;
+            continue;
+        }
+        if argument.starts_with('-') || argument.is_empty() {
+            index += 1;
+            continue;
+        }
+        return Some(index);
+    }
+    None
 }
 
 fn args_request_root_version(args: &[std::ffi::OsString]) -> bool {
@@ -180,6 +224,38 @@ fn args_request_root_version(args: &[std::ffi::OsString]) -> bool {
         }
     }
     false
+}
+
+/// The directory the `#member` selector names.
+///
+/// # Errors
+///
+/// Names the members that do exist, and the closest spellings of the one that
+/// does not, because "no such workspace" on its own is the least useful thing
+/// this could say.
+fn enter_workspace(cwd: &Utf8PathBuf, target: &str) -> Result<Utf8PathBuf> {
+    let resolved = uf_config::load_config(cwd)?;
+    let workspaces = uf_project::discover_workspaces(&resolved.root, &resolved.config);
+
+    match uf_project::resolve_workspace(&workspaces, target) {
+        Ok(workspace) => Ok(resolved.root.join(&workspace.path)),
+        Err(available) if available.is_empty() => Err(anyhow!(
+            "no workspace named {target:?}\n\n  this project has no members; a member is a \
+             directory with its own uf.config.js"
+        )),
+        Err(available) => {
+            let names = available.iter().map(compact_str::CompactString::as_str);
+            let suggestions = crate::suggest::closest(target, names.clone());
+            let mut message = format!("no workspace named {target:?}");
+            if !suggestions.is_empty() {
+                message.push_str("\n\n  did you mean: ");
+                message.push_str(&suggestions.join(", "));
+            }
+            message.push_str("\n\n  workspaces: ");
+            message.push_str(&names.collect::<Vec<_>>().join(", "));
+            Err(anyhow!(message))
+        }
+    }
 }
 
 fn resolve_cwd(cwd: Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {
@@ -220,6 +296,64 @@ mod tests {
     #[test]
     fn an_unknown_color_value_is_rejected() {
         assert!(Cli::try_parse_from(["uf", "build", "--color", "beige"]).is_err());
+    }
+
+    fn args(line: &[&str]) -> Vec<std::ffi::OsString> {
+        line.iter().map(Into::into).collect()
+    }
+
+    #[test]
+    fn a_selector_is_taken_off_the_subcommand() {
+        let mut line = args(&["uf", "dev#docs"]);
+
+        assert_eq!(take_workspace_selector(&mut line), Some("docs".to_owned()));
+        assert_eq!(line, args(&["uf", "dev"]));
+    }
+
+    /// `--cwd` takes a value, and that value is not the subcommand.
+    #[test]
+    fn global_flags_before_the_subcommand_do_not_hide_it() {
+        let mut line = args(&["uf", "--cwd", "/tmp", "--color", "never", "build#site"]);
+
+        assert_eq!(take_workspace_selector(&mut line), Some("site".to_owned()));
+        assert_eq!(
+            line,
+            args(&["uf", "--cwd", "/tmp", "--color", "never", "build"])
+        );
+    }
+
+    /// Only the subcommand carries a selector. A `#` in a task name, a filter
+    /// or a path belongs to that argument.
+    #[test]
+    fn a_hash_after_the_subcommand_is_left_alone() {
+        let mut line = args(&["uf", "run", "build#2"]);
+
+        assert_eq!(take_workspace_selector(&mut line), None);
+        assert_eq!(line, args(&["uf", "run", "build#2"]));
+    }
+
+    #[test]
+    fn a_command_with_no_selector_is_untouched() {
+        let mut line = args(&["uf", "dev"]);
+
+        assert_eq!(take_workspace_selector(&mut line), None);
+        assert_eq!(line, args(&["uf", "dev"]));
+    }
+
+    /// An empty selector is a typo, not a request for the root; leaving the
+    /// `#` on makes clap say so rather than silently running somewhere.
+    #[test]
+    fn an_empty_selector_is_not_a_selector() {
+        let mut line = args(&["uf", "dev#"]);
+
+        assert_eq!(take_workspace_selector(&mut line), None);
+        assert_eq!(line, args(&["uf", "dev#"]));
+    }
+
+    #[test]
+    fn a_line_with_no_subcommand_has_no_selector() {
+        assert_eq!(take_workspace_selector(&mut args(&["uf"])), None);
+        assert_eq!(take_workspace_selector(&mut args(&["uf", "--help"])), None);
     }
 
     #[test]

--- a/crates/uf_cli/src/suggest.rs
+++ b/crates/uf_cli/src/suggest.rs
@@ -1,0 +1,128 @@
+//! "Did you mean …" — finding what someone meant from what they typed.
+//!
+//! clap does this for subcommand names, and stops there. Everything else uf
+//! takes by name it took silently: a mistyped task name got
+//! `task "biuld" is not defined in uf.config.js` and no hint that `build` was
+//! sitting right there, which is the most common typo anyone makes with this
+//! tool because it is the name they type most often.
+//!
+//! The measure is Damerau–Levenshtein — insertions, deletions, substitutions
+//! and *transpositions* — because the typo that matters here is almost always
+//! two adjacent letters swapped, and plain Levenshtein charges two edits for
+//! that where a human sees one.
+
+#[cfg(test)]
+mod tests;
+
+/// How many suggestions to offer at most.
+///
+/// One is a guess and reads as a correction; a screenful is a list the reader
+/// has to search. Three is enough to cover a genuine ambiguity.
+const MAX_SUGGESTIONS: usize = 3;
+
+/// The largest edit distance still worth offering, by length of what was typed.
+///
+/// A fixed threshold is wrong at both ends: at distance 2, `ci` and `up` are
+/// "similar" to almost anything short, while a 20-character name with two typos
+/// in it is obviously the one that was meant. So the budget grows with length,
+/// and a very short word gets almost none.
+fn distance_budget(typed: &str) -> usize {
+    match typed.chars().count() {
+        0..=2 => 0,
+        3..=5 => 1,
+        6..=10 => 2,
+        _ => 3,
+    }
+}
+
+/// The candidates closest to `typed`, best first.
+///
+/// A candidate that contains what was typed — or is contained by it — is always
+/// offered, whatever the edit distance says: someone who types `test` at a
+/// project with `test:lib` and `test:e2e` has not made a typo, they have been
+/// insufficiently specific, and both answers are useful. Otherwise a candidate
+/// has to be within [`distance_budget`].
+///
+/// Ties are broken by the candidate's own name so the same input always
+/// produces the same list.
+pub(crate) fn closest<'a>(
+    typed: &str,
+    candidates: impl IntoIterator<Item = &'a str>,
+) -> Vec<&'a str> {
+    let budget = distance_budget(typed);
+    let lowered = typed.to_lowercase();
+
+    let mut scored = candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let folded = candidate.to_lowercase();
+            // Rank 0 is "one of these is a longer or shorter spelling of what
+            // you typed", which beats any edit distance. Within it, the
+            // candidate closest in length is closest to what was meant, so an
+            // exact match comes first and `test` offers `test:lib` before
+            // `install:test`.
+            if folded.contains(&lowered) || lowered.contains(&folded) {
+                let spread = folded.chars().count().abs_diff(lowered.chars().count());
+                return Some((0usize, spread, candidate));
+            }
+            let distance = damerau_levenshtein(&lowered, &folded);
+            (distance <= budget).then_some((1, distance, candidate))
+        })
+        .collect::<Vec<_>>();
+
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.2.cmp(b.2)));
+    scored.truncate(MAX_SUGGESTIONS);
+    scored.into_iter().map(|(_, _, name)| name).collect()
+}
+
+/// Damerau–Levenshtein distance between two strings, over characters.
+///
+/// The restricted ("optimal string alignment") variant: a substring may be
+/// edited once, so `ca` -> `abc` is three edits rather than two. That is the
+/// variant every "did you mean" uses, it is the one with a simple bound, and
+/// the difference only shows up on inputs far past any threshold worth
+/// offering.
+///
+/// Two rows rather than a full matrix would be the usual optimisation; three
+/// are needed to see a transposition, and the names being compared are a
+/// handful of characters long, so the table is small either way.
+fn damerau_levenshtein(left: &str, right: &str) -> usize {
+    let left = left.chars().collect::<Vec<_>>();
+    let right = right.chars().collect::<Vec<_>>();
+
+    if left.is_empty() {
+        return right.len();
+    }
+    if right.is_empty() {
+        return left.len();
+    }
+
+    let width = right.len() + 1;
+    let mut previous_previous = vec![0usize; width];
+    let mut previous = (0..width).collect::<Vec<_>>();
+    let mut current = vec![0usize; width];
+
+    for (row, &left_char) in left.iter().enumerate() {
+        current[0] = row + 1;
+        for (column, &right_char) in right.iter().enumerate() {
+            let substitution = usize::from(left_char != right_char);
+            current[column + 1] = (current[column] + 1)
+                .min(previous[column + 1] + 1)
+                .min(previous[column] + substitution);
+
+            // A transposition: this pair of characters is the previous pair,
+            // swapped. One edit, not two.
+            if row > 0
+                && column > 0
+                && left_char == right[column - 1]
+                && left[row - 1] == right_char
+            {
+                current[column + 1] = current[column + 1].min(previous_previous[column - 1] + 1);
+            }
+        }
+        std::mem::swap(&mut previous_previous, &mut previous);
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[right.len()]
+}

--- a/crates/uf_cli/src/suggest/tests.rs
+++ b/crates/uf_cli/src/suggest/tests.rs
@@ -1,0 +1,167 @@
+use super::*;
+
+/// The tasks in this repository's own `uf.config.js`, which is the list a
+/// contributor actually mistypes.
+const TASKS: &[&str] = &[
+    "build",
+    "ci",
+    "docs:build",
+    "flow:clippy",
+    "flow:test",
+    "install:test",
+    "manifests",
+    "rust:bench",
+    "rust:clippy",
+    "rust:fmt",
+    "rust:fmt:check",
+    "rust:metadata",
+    "rust:test",
+    "test:lib",
+];
+
+#[test]
+fn a_transposition_is_one_edit_not_two() {
+    assert_eq!(damerau_levenshtein("build", "biuld"), 1);
+    assert_eq!(damerau_levenshtein("test", "tset"), 1);
+}
+
+#[test]
+fn the_usual_edits_cost_what_they_should() {
+    assert_eq!(damerau_levenshtein("build", "build"), 0);
+    assert_eq!(damerau_levenshtein("build", "buil"), 1, "a deletion");
+    assert_eq!(damerau_levenshtein("build", "builds"), 1, "an insertion");
+    assert_eq!(damerau_levenshtein("build", "bujld"), 1, "a substitution");
+    assert_eq!(damerau_levenshtein("", "build"), 5);
+    assert_eq!(damerau_levenshtein("build", ""), 5);
+    assert_eq!(damerau_levenshtein("", ""), 0);
+}
+
+#[test]
+fn distance_is_symmetric() {
+    for (left, right) in [
+        ("build", "biuld"),
+        ("rust:test", "rust:tset"),
+        ("ci", "cli"),
+        ("", "x"),
+    ] {
+        assert_eq!(
+            damerau_levenshtein(left, right),
+            damerau_levenshtein(right, left),
+            "{left} vs {right}"
+        );
+    }
+}
+
+#[test]
+fn distance_counts_characters_rather_than_bytes() {
+    // Two characters, six bytes. A byte-wise measure would call this distance 6.
+    assert_eq!(damerau_levenshtein("日本", "日本"), 0);
+    assert_eq!(damerau_levenshtein("日本", "日水"), 1);
+}
+
+#[test]
+fn the_obvious_typo_is_the_first_suggestion() {
+    assert_eq!(closest("biuld", TASKS.iter().copied()), vec!["build"]);
+    assert_eq!(
+        closest("rust:tset", TASKS.iter().copied()).first(),
+        Some(&"rust:test")
+    );
+}
+
+/// Not a typo — an ambiguity. Both answers are useful, so both are offered.
+#[test]
+fn a_prefix_offers_every_name_it_could_have_meant() {
+    let out = closest("rust:fmt", TASKS.iter().copied());
+
+    assert!(out.contains(&"rust:fmt"), "{out:?}");
+    assert!(out.contains(&"rust:fmt:check"), "{out:?}");
+}
+
+#[test]
+fn a_substring_match_beats_a_close_spelling() {
+    // `test` is inside four task names and one edit from none of them.
+    let out = closest("test", TASKS.iter().copied());
+
+    assert!(!out.is_empty());
+    assert!(
+        out.iter().all(|name| name.contains("test")),
+        "a containing name should outrank a merely similar one, got {out:?}"
+    );
+}
+
+#[test]
+fn matching_ignores_case() {
+    // `docs:build` contains `build`, so it is offered too — the same rule that
+    // makes `rust:fmt` offer `rust:fmt:check`. What matters is which comes
+    // first, and an exact match sorts ahead of a name that merely contains it.
+    assert_eq!(
+        closest("BUILD", TASKS.iter().copied()),
+        vec!["build", "docs:build"]
+    );
+    assert_eq!(
+        closest("Rust:Test", TASKS.iter().copied()).first(),
+        Some(&"rust:test")
+    );
+}
+
+/// Within the containment rank, the shortest name is the closest thing to what
+/// was typed, and an exact match is the shortest of all.
+#[test]
+fn an_exact_match_outranks_a_name_that_merely_contains_it() {
+    assert_eq!(
+        closest("build", ["docs:build", "rebuild", "build"]).first(),
+        Some(&"build")
+    );
+}
+
+#[test]
+fn nothing_similar_suggests_nothing() {
+    assert!(closest("wibble", TASKS.iter().copied()).is_empty());
+    assert!(closest("zzzzzzzzzzzz", TASKS.iter().copied()).is_empty());
+}
+
+/// A very short word is close to everything, and a suggestion drawn from that
+/// is noise rather than help.
+#[test]
+fn a_word_too_short_to_be_a_typo_gets_no_distance_budget() {
+    assert_eq!(distance_budget("ci"), 0);
+    assert_eq!(distance_budget("a"), 0);
+    assert_eq!(distance_budget(""), 0);
+
+    // `cli` is one edit from `ci`, and is not offered.
+    assert!(closest("xy", ["ci", "build"]).is_empty());
+    // An exact match still works, through the containment rule.
+    assert_eq!(closest("ci", TASKS.iter().copied()).first(), Some(&"ci"));
+}
+
+#[test]
+fn the_budget_grows_with_the_length_of_what_was_typed() {
+    assert_eq!(distance_budget("abc"), 1);
+    assert_eq!(distance_budget("abcdef"), 2);
+    assert_eq!(distance_budget("abcdefghijk"), 3);
+}
+
+#[test]
+fn no_more_than_three_suggestions_are_offered() {
+    let many = [
+        "aaaa", "aaab", "aaac", "aaad", "aaae", "aaaf", "aaag", "aaah",
+    ];
+
+    assert!(closest("aaaa", many).len() <= MAX_SUGGESTIONS);
+}
+
+/// The same input must produce the same list, or a test that asserts on the
+/// message becomes flaky and a reader sees a different hint each time.
+#[test]
+fn suggestions_are_ordered_deterministically() {
+    let first = closest("rust", TASKS.iter().copied());
+
+    for _ in 0..16 {
+        assert_eq!(closest("rust", TASKS.iter().copied()), first);
+    }
+}
+
+#[test]
+fn an_empty_candidate_list_suggests_nothing() {
+    assert!(closest("build", std::iter::empty()).is_empty());
+}

--- a/crates/uf_cli/src/ui.rs
+++ b/crates/uf_cli/src/ui.rs
@@ -67,6 +67,19 @@ impl Ui {
         write_all(&mut io::stderr().lock(), &self.buffer);
     }
 
+    /// Write text to stdout exactly as given, with no styling and no framing.
+    ///
+    /// The third kind of output, and genuinely distinct from the other two: a
+    /// rendered block is for a person, JSON is for a program, and this is for
+    /// another *language*. `uf completion bash` is piped into `eval` and
+    /// `uf __complete` into a completion list, so a banner, a colour, or a
+    /// trailing status line is a syntax error in somebody's shell — but so is
+    /// the silence [`Ui::render`] would give it, since both commands are in
+    /// JSON mode precisely because they own stdout.
+    pub(crate) fn plain(&mut self, text: &str) {
+        write_all(&mut io::stdout().lock(), text);
+    }
+
     /// Emit machine-readable JSON on stdout with no styling of any kind.
     pub(crate) fn json(&mut self, value: &serde_json::Value) -> serde_json::Result<()> {
         let mut rendered = serde_json::to_string_pretty(value)?;

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -117,6 +117,155 @@ fn alias_binaries_are_documented_as_the_commands_they_expand_to() {
     }
 }
 
+/// Completion output is consumed by a shell, so it must be nothing but the
+/// script: no banner, no colour, no status line.
+#[test]
+fn a_completion_script_is_the_script_and_nothing_else() {
+    for shell in ["bash", "zsh", "fish", "elvish", "powershell"] {
+        let output = uf().args(["completion", shell]).output().unwrap();
+
+        assert!(
+            output.status.success(),
+            "{shell}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            stdout.starts_with("# uf completion for"),
+            "{shell}: {stdout:?}"
+        );
+        assert!(
+            !stdout.contains('\u{1b}'),
+            "{shell}: a completion script must carry no escape sequences"
+        );
+        assert!(
+            stdout.contains("uf __complete"),
+            "{shell}: the script must ask uf for candidates"
+        );
+    }
+}
+
+/// The reason completion is computed by the binary rather than generated: a
+/// task added to `uf.config.js` is completable immediately.
+#[test]
+fn completion_offers_the_projects_own_task_names() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: {
+                "smoke:test": { command: "true" },
+                "smoke:build": { command: "true" },
+                unrelated: { command: "true" },
+              },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["__complete", "--", "run", "smoke"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut lines = String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    lines.sort();
+
+    assert_eq!(lines, vec!["smoke:build", "smoke:test"]);
+}
+
+/// Completion in a directory with no project must be silent, not an error: an
+/// error here prints into the middle of somebody's command line.
+#[test]
+fn completion_outside_a_project_says_nothing_rather_than_failing() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["__complete", "--", "run", ""])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty(), "{:?}", output.stdout);
+}
+
+/// A mistyped task name should name the task that was meant.
+#[test]
+fn an_unknown_task_suggests_the_one_that_was_meant() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { build: { command: "true" }, check: { command: "true" } },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["run", "biuld"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("did you mean"), "{stderr}");
+    assert!(stderr.contains("build"), "{stderr}");
+    assert!(
+        stderr.contains("check"),
+        "a short list of tasks should be named in full: {stderr}"
+    );
+}
+
+/// `uf run` with no task name lists what the project defines.
+#[test]
+fn run_without_a_task_lists_them() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { build: { command: "cargo build" } },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("run")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("build"), "{stdout}");
+    assert!(stdout.contains("cargo build"), "{stdout}");
+    assert!(stdout.contains("uf run <task>"), "{stdout}");
+}
+
 #[test]
 fn alias_binaries_print_the_root_version() {
     for name in ["ufr", "ufx"] {

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -266,6 +266,140 @@ fn run_without_a_task_lists_them() {
     assert!(stdout.contains("uf run <task>"), "{stdout}");
 }
 
+/// A repository is commonly more than one project, and `uf dev#docs` is how a
+/// command says which one it means.
+#[test]
+fn a_command_runs_in_the_workspace_its_selector_names() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { root: { command: "printf root" } },
+            });
+        "#,
+    )
+    .unwrap();
+    let member = dir.path().join("site");
+    fs::create_dir_all(&member).unwrap();
+    fs::write(
+        member.join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { inner: { command: "printf inner" } },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["run#site", "inner"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "inner");
+}
+
+/// The root is still the root when no selector is given.
+#[test]
+fn no_selector_leaves_the_command_where_it_was() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { root: { command: "printf root" } },
+            });
+        "#,
+    )
+    .unwrap();
+    let member = dir.path().join("site");
+    fs::create_dir_all(&member).unwrap();
+    fs::write(
+        member.join("uf.config.js"),
+        "export default {};
+",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["run", "root"])
+        .output()
+        .unwrap();
+
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "root");
+}
+
+#[test]
+fn an_unknown_workspace_names_the_ones_that_exist() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "export default {};
+",
+    )
+    .unwrap();
+    let member = dir.path().join("docs");
+    fs::create_dir_all(&member).unwrap();
+    fs::write(
+        member.join("uf.config.js"),
+        "export default {};
+",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("inspect#dcos")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("did you mean"), "{stderr}");
+    assert!(stderr.contains("docs"), "{stderr}");
+}
+
+/// A `#` in an argument is part of that argument. Only the subcommand carries
+/// a selector, or a task named `build#2` would become a workspace lookup.
+#[test]
+fn a_hash_outside_the_subcommand_is_left_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { "build#2": { command: "printf hashed" } },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["run", "build#2"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "hashed");
+}
+
 #[test]
 fn alias_binaries_print_the_root_version() {
     for name in ["ufr", "ufx"] {

--- a/crates/uf_config/src/lint.rs
+++ b/crates/uf_config/src/lint.rs
@@ -72,7 +72,11 @@ pub enum FlowLintParser {
 const DEFAULT_LINT_RULES: [(&str, RuleLevel); 53] = [
     // --- Flow built-in lints ------------------------------------------------
     // Exactness must be stated, not inferred from a config flag.
-    ("flow/ambiguous-object-type", RuleLevel::Error),
+    // Off: the ambiguity is gone. Flow has been exact-by-default since 2023 and
+    // rejects `exact_by_default=false` as deprecated, so `{ a: b }` is exact and
+    // the `{| |}` this rule asks for is the legacy spelling. See
+    // `uf_lint::rules::flow::FLOW_META`.
+    ("flow/ambiguous-object-type", RuleLevel::Off),
     // Reading named exports off a default import is a CommonJS interop bug.
     ("flow/default-import-access", RuleLevel::Error),
     // `bool` is a legacy alias for `boolean`; mechanical fix.

--- a/crates/uf_lint/src/rules/flow.rs
+++ b/crates/uf_lint/src/rules/flow.rs
@@ -44,10 +44,19 @@ use RuleRequirement::{SourceText, TypeChecker};
 ///
 /// The order must match [`FlowBuiltinLint`]'s discriminant order.
 pub(crate) static FLOW_META: [FlowLintMeta; FlowBuiltinLint::COUNT] = [
-    // ambiguous-object-type: a large codebase cannot afford object types whose
-    // exactness depends on a config flag; readers must see `{| |}` or `{ ... }`.
+    // ambiguous-object-type: off, because the ambiguity it is named after no
+    // longer exists. The rule dates from when a `.flowconfig` could set
+    // `exact_by_default=false` and `{ a: b }` meant different things in
+    // different projects. Flow has defaulted to exact since 2023 and now
+    // rejects `exact_by_default=false` as deprecated, so `{ a: b }` is exact,
+    // full stop — and the `{| |}` this rule asks for is the legacy spelling of
+    // what the plain braces already say. Left on, it reported 152 errors
+    // against uf's own packages for writing modern Flow.
+    //
+    // Still selectable: a codebase migrating from an older Flow may want every
+    // object type marked while both spellings are in the tree.
     meta(
-        RuleLevel::Error,
+        RuleLevel::Off,
         SourceText,
         "object type annotations must state exactness explicitly",
     ),

--- a/crates/uf_lint/src/tests/flow_type.rs
+++ b/crates/uf_lint/src/tests/flow_type.rs
@@ -90,6 +90,49 @@ fn internal_type_accepts_the_public_equivalents() {
     assert!(diagnostics.is_empty());
 }
 
+/// The rule is off by default, and the reason is a fact about Flow rather than
+/// a matter of taste.
+///
+/// It exists for a world where `exact_by_default=false` was a `.flowconfig`
+/// option and `{ a: b }` meant different things in different projects. Flow has
+/// defaulted to exact since 2023 and now rejects that option as deprecated, so
+/// there is nothing left to disambiguate — and `{| |}`, which the rule asks
+/// for, is the legacy spelling of what plain braces already mean.
+#[test]
+fn ambiguous_object_type_is_off_by_default() {
+    let config = UniflowedConfig::default();
+
+    assert_eq!(
+        config.lint.rules.get("flow/ambiguous-object-type").copied(),
+        Some(RuleLevel::Off)
+    );
+
+    let report =
+        lint_source(&source("// @flow\ntype Props = { id: string };\n"), &config).expect("lint");
+
+    assert!(
+        report.diagnostics.is_empty(),
+        "modern Flow's exact object type must not be a default error: {:?}",
+        report.diagnostics
+    );
+}
+
+/// Off by default is not gone: a codebase migrating from an older Flow may
+/// want every object type marked while both spellings are in the tree.
+#[test]
+fn ambiguous_object_type_can_still_be_switched_on() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.insert(
+        CompactString::const_new("flow/ambiguous-object-type"),
+        RuleLevel::Error,
+    );
+
+    let report =
+        lint_source(&source("// @flow\ntype Props = { id: string };\n"), &config).expect("lint");
+
+    assert_eq!(report.diagnostics.len(), 1);
+}
+
 #[test]
 fn ambiguous_object_type_rejects_unmarked_object_types() {
     let diagnostics = lint_js(

--- a/crates/uf_project/Cargo.toml
+++ b/crates/uf_project/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+compact_str.workspace = true
 camino.workspace = true
 uf_config = { path = "../uf_config" }
 thiserror.workspace = true

--- a/crates/uf_project/src/lib.rs
+++ b/crates/uf_project/src/lib.rs
@@ -6,8 +6,10 @@ use uf_config::UniflowedConfig;
 use walkdir::WalkDir;
 
 mod template;
+pub mod workspace;
 
 use template::{app_react_files, lib_files};
+pub use workspace::{Workspace, discover_workspaces, resolve_workspace};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CreateKind {

--- a/crates/uf_project/src/template.rs
+++ b/crates/uf_project/src/template.rs
@@ -85,7 +85,7 @@ export default defineConfig({
     check: { command: "uf check" },
     lint: { command: "uf lint" },
     fmt: { command: "uf fmt" },
-    test: { command: "uf test --list" },
+    test: { command: "uf test" },
   },
 });
 "#
@@ -107,7 +107,7 @@ export default defineConfig({
     check: { command: "uf check" },
     lint: { command: "uf lint" },
     fmt: { command: "uf fmt" },
-    test: { command: "uf test --list" },
+    test: { command: "uf test" },
   },
 });
 "#

--- a/crates/uf_project/src/tests.rs
+++ b/crates/uf_project/src/tests.rs
@@ -173,3 +173,61 @@ fn an_ignore_entry_with_a_separator_still_means_one_place() {
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].relative_path, "lib/generated/keep.js");
 }
+
+/// The `test` task a scaffolded project gets must run its tests.
+///
+/// Both templates shipped `uf test --list`, which lists what would run and
+/// runs none of it. A generated project therefore had a green `uf run test`
+/// that executed nothing, which is worse than having no task at all: it is a
+/// check that reports success without checking.
+#[test]
+fn a_scaffolded_project_gets_a_test_task_that_runs_tests() {
+    for (kind, files) in [("app", app_react_files("demo")), ("lib", lib_files("demo"))] {
+        let config = files
+            .iter()
+            .find(|(path, _)| *path == "uf.config.js")
+            .map(|(_, contents)| contents.clone())
+            .unwrap_or_else(|| panic!("the {kind} template writes a uf.config.js"));
+
+        assert!(
+            config.contains(r#"test: { command: "uf test" }"#),
+            "the {kind} template's test task must run the tests:\n{config}"
+        );
+        assert!(
+            !config.contains("--list"),
+            "`uf test --list` runs nothing, so a task that uses it always passes:\n{config}"
+        );
+    }
+}
+
+/// Every task a template scaffolds has to name a command uf actually has.
+#[test]
+fn scaffolded_tasks_name_real_commands() {
+    const COMMANDS: &[&str] = &[
+        "build", "check", "create", "dev", "env", "exec", "explain", "fmt", "info", "inspect",
+        "install", "lint", "lsp", "prepare", "publish", "release", "run", "test", "upgrade", "use",
+    ];
+
+    for (kind, files) in [("app", app_react_files("demo")), ("lib", lib_files("demo"))] {
+        let config = files
+            .iter()
+            .find(|(path, _)| *path == "uf.config.js")
+            .map(|(_, contents)| contents.clone())
+            .expect("a config");
+
+        for line in config.lines() {
+            let Some(rest) = line.split_once(r#"command: "uf "#) else {
+                continue;
+            };
+            let command = rest
+                .1
+                .split([' ', '"'])
+                .next()
+                .expect("a command follows `uf `");
+            assert!(
+                COMMANDS.contains(&command),
+                "the {kind} template scaffolds `uf {command}`, which is not a uf command"
+            );
+        }
+    }
+}

--- a/crates/uf_project/src/workspace.rs
+++ b/crates/uf_project/src/workspace.rs
@@ -1,0 +1,136 @@
+//! The uf projects inside a uf project.
+//!
+//! A repository is commonly more than one thing: this one is the toolchain, a
+//! documentation site, and a library test suite, and each has its own
+//! `uf.config.js` because each is genuinely a different project. `uf dev` at
+//! the root cannot serve all three, and asking someone to `cd docs` first is
+//! asking them to know the layout before they can use the tool.
+//!
+//! So a command may name which one it means: `uf dev#docs`. The selector is on
+//! the command rather than a flag because it changes *where the command runs*
+//! rather than how, and reads in the order it happens.
+//!
+//! # What counts as a member
+//!
+//! A directory with its own `uf.config.js`. Nothing is declared, because a
+//! declaration would be a second list to keep in step with the first — and the
+//! first already exists, in the form of the config files themselves. The root's
+//! own config is not a member: `uf dev` already means the root.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::{CompactString, ToCompactString};
+
+use uf_config::{CONFIG_FILES, UniflowedConfig};
+
+use crate::is_ignored;
+
+#[cfg(test)]
+mod tests;
+
+/// How deep below the root a member is looked for.
+///
+/// `docs` is one level down and `tests/library` is two, which is where projects
+/// in a repository actually live. Going deeper means walking into build output
+/// and vendored trees for no gain, and a member buried four levels down is not
+/// discoverable by a person either.
+const MAX_DEPTH: usize = 3;
+
+/// One uf project inside another.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Workspace {
+    /// What `uf <command>#<name>` calls it: the directory's own name.
+    pub name: CompactString,
+    /// Where it is, relative to the root.
+    pub path: Utf8PathBuf,
+}
+
+impl Workspace {
+    /// Whether `selector` names this member.
+    ///
+    /// Both the short name and the path are accepted, because both are things
+    /// someone reasonably types: `docs` is what it is called, and
+    /// `tests/library` is what it is. A path selector settles the ambiguity
+    /// when two directories share a name.
+    #[must_use]
+    pub fn matches(&self, selector: &str) -> bool {
+        self.name == selector || self.path == selector
+    }
+}
+
+/// Every uf project under `root`, excluding `root` itself, sorted by path.
+///
+/// Ignored directories are skipped using the project's own ignore list, so a
+/// `uf.config.js` inside `node_modules` or a build output directory is not a
+/// member of anything.
+pub fn discover_workspaces(root: &Utf8Path, config: &UniflowedConfig) -> Vec<Workspace> {
+    let mut found = Vec::new();
+    visit(root, root, config, 0, &mut found);
+    found.sort();
+    found
+}
+
+fn visit(
+    root: &Utf8Path,
+    dir: &Utf8Path,
+    config: &UniflowedConfig,
+    depth: usize,
+    found: &mut Vec<Workspace>,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let Ok(path) = Utf8PathBuf::from_path_buf(entry.path()) else {
+            continue;
+        };
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) || is_ignored(root, &path, config) {
+            continue;
+        }
+        // Another repository's contents are not this project's members, for the
+        // same reason they are not this project's source files.
+        if path.join(".git").exists() {
+            continue;
+        }
+
+        if CONFIG_FILES.iter().any(|name| path.join(name).exists())
+            && let Some(name) = path.file_name()
+            && let Ok(relative) = path.strip_prefix(root)
+        {
+            found.push(Workspace {
+                name: name.to_compact_string(),
+                path: relative.to_path_buf(),
+            });
+            // A project inside a project is that project's business, not this
+            // one's: `uf dev#docs` selects `docs`, and what `docs` contains is
+            // resolved from there.
+            continue;
+        }
+
+        visit(root, &path, config, depth + 1, found);
+    }
+}
+
+/// The member `selector` names, or an error naming what was available.
+///
+/// # Errors
+///
+/// Returns the list of member names when nothing matched, so a caller can say
+/// what could have been meant rather than only that this was not it.
+pub fn resolve_workspace<'a>(
+    workspaces: &'a [Workspace],
+    selector: &str,
+) -> Result<&'a Workspace, Vec<CompactString>> {
+    workspaces
+        .iter()
+        .find(|workspace| workspace.matches(selector))
+        .ok_or_else(|| {
+            workspaces
+                .iter()
+                .map(|workspace| workspace.name.clone())
+                .collect()
+        })
+}

--- a/crates/uf_project/src/workspace/tests.rs
+++ b/crates/uf_project/src/workspace/tests.rs
@@ -1,0 +1,159 @@
+use std::fs;
+
+use camino::Utf8PathBuf;
+
+use super::*;
+
+/// A project tree with a `uf.config.js` at each of `members`.
+fn tree(members: &[&str]) -> (tempfile::TempDir, Utf8PathBuf) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("a UTF-8 path");
+    fs::write(root.join("uf.config.js"), "export default {};\n").expect("write the root config");
+
+    for member in members {
+        let path = root.join(member);
+        fs::create_dir_all(&path).expect("create the member");
+        fs::write(path.join("uf.config.js"), "export default {};\n").expect("write its config");
+    }
+    (dir, root)
+}
+
+fn names(workspaces: &[Workspace]) -> Vec<&str> {
+    workspaces
+        .iter()
+        .map(|workspace| workspace.name.as_str())
+        .collect()
+}
+
+#[test]
+fn a_directory_with_its_own_config_is_a_member() {
+    let (_dir, root) = tree(&["docs", "site"]);
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(names(&found), vec!["docs", "site"]);
+}
+
+/// `uf dev` already means the root, so the root is not one of its own members.
+#[test]
+fn the_root_is_not_a_member_of_itself() {
+    let (_dir, root) = tree(&[]);
+
+    assert!(discover_workspaces(&root, &UniflowedConfig::default()).is_empty());
+}
+
+#[test]
+fn a_member_may_be_nested() {
+    let (_dir, root) = tree(&["tests/library"]);
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(names(&found), vec!["library"]);
+    assert_eq!(found[0].path, "tests/library");
+}
+
+/// A project inside a member is that member's business. Descending into it
+/// would offer `uf dev#example` for something the root cannot meaningfully run.
+#[test]
+fn a_member_inside_a_member_is_not_discovered() {
+    let (_dir, root) = tree(&["docs", "docs/example"]);
+
+    assert_eq!(
+        names(&discover_workspaces(&root, &UniflowedConfig::default())),
+        vec!["docs"]
+    );
+}
+
+#[test]
+fn ignored_directories_hold_no_members() {
+    let (_dir, root) = tree(&["node_modules/pkg", "docs"]);
+
+    assert_eq!(
+        names(&discover_workspaces(&root, &UniflowedConfig::default())),
+        vec!["docs"],
+        "a config inside node_modules is somebody else's"
+    );
+}
+
+/// A checkout inside a checkout is another repository, and its projects are
+/// not this one's — the same rule `collect_source_files` applies.
+#[test]
+fn another_repository_holds_no_members() {
+    let (_dir, root) = tree(&["vendor"]);
+    fs::create_dir_all(root.join("vendor/.git")).expect("make it a repository");
+
+    assert!(discover_workspaces(&root, &UniflowedConfig::default()).is_empty());
+}
+
+#[test]
+fn discovery_is_bounded_by_depth() {
+    let (_dir, root) = tree(&["a/b/c/d/deep"]);
+
+    assert!(
+        discover_workspaces(&root, &UniflowedConfig::default()).is_empty(),
+        "a project five levels down is not discoverable by a person either"
+    );
+}
+
+#[test]
+fn members_come_back_in_a_stable_order() {
+    let (_dir, root) = tree(&["zebra", "alpha", "middle"]);
+
+    let first = discover_workspaces(&root, &UniflowedConfig::default());
+    for _ in 0..8 {
+        assert_eq!(
+            discover_workspaces(&root, &UniflowedConfig::default()),
+            first
+        );
+    }
+    assert_eq!(names(&first), vec!["alpha", "middle", "zebra"]);
+}
+
+// --- selecting one ------------------------------------------------------
+
+fn members() -> Vec<Workspace> {
+    vec![
+        Workspace {
+            name: "docs".into(),
+            path: "docs".into(),
+        },
+        Workspace {
+            name: "library".into(),
+            path: "tests/library".into(),
+        },
+    ]
+}
+
+#[test]
+fn a_member_is_selected_by_its_name() {
+    let members = members();
+    let found = resolve_workspace(&members, "docs").expect("docs is a member");
+
+    assert_eq!(found.path, "docs");
+}
+
+/// Both spellings are things someone reasonably types, and the path is the one
+/// that settles an ambiguity between two directories with the same name.
+#[test]
+fn a_member_is_also_selected_by_its_path() {
+    let members = members();
+    let found = resolve_workspace(&members, "tests/library").expect("the path selects it");
+
+    assert_eq!(found.name, "library");
+}
+
+#[test]
+fn selecting_nothing_reports_what_there_was() {
+    let members = members();
+    let available = resolve_workspace(&members, "dcos").expect_err("no such member");
+
+    assert_eq!(available, vec!["docs", "library"]);
+}
+
+#[test]
+fn selecting_in_a_project_with_no_members_reports_an_empty_list() {
+    assert_eq!(
+        resolve_workspace(&[], "docs").expect_err("nothing to select"),
+        Vec::<CompactString>::new()
+    );
+}

--- a/crates/uf_router/Cargo.toml
+++ b/crates/uf_router/Cargo.toml
@@ -17,6 +17,10 @@ walkdir.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+similar-asserts.workspace = true
+# The generated router types are checked against the formatter uf ships, so a
+# project cannot be scaffolded with code `uf fmt --check` rejects.
+uf_fmt = { path = "../uf_fmt" }
 tempfile.workspace = true
 
 [[bench]]

--- a/crates/uf_router/src/lib.rs
+++ b/crates/uf_router/src/lib.rs
@@ -149,20 +149,29 @@ pub fn generate_router_flow(routes: &[Route]) -> String {
 
     // Exact, because the generated table *is* the whole set of routes: an
     // inexact type would let a caller pass a path this router does not serve,
-    // which is the mistake the generated types exist to prevent. It also keeps a
-    // freshly scaffolded project passing `flow/ambiguous-object-type`, which uf
-    // turns on by default — generated code has to satisfy the rules uf ships.
-    output.push_str("export type RouteParams = {|\n");
-    for route in routes {
-        output.push_str(&format!(
-            "  \"{}\": {},\n",
-            route.path,
-            route_params_type(&route.params)
-        ));
+    // which is the mistake the generated types exist to prevent. Plain braces
+    // say exactly that in modern Flow, which has been exact by default since
+    // 2023 — `{| |}` is the legacy spelling of the same thing.
+    if routes.is_empty() {
+        output.push_str("export type RouteParams = {};\n\n");
+    } else {
+        output.push_str("export type RouteParams = {\n");
+        for route in routes {
+            output.push_str(&format!(
+                "  \"{}\": {},\n",
+                route.path,
+                route_params_type(&route.params)
+            ));
+        }
+        output.push_str("};\n\n");
     }
-    output.push_str("|};\n\n");
+    // Written the way `uf fmt` writes it, down to the trailing comma: uf
+    // scaffolds a project and then checks it with its own formatter, so a
+    // generated file the formatter disagrees with fails `uf fmt --check` on
+    // code nobody wrote. `the_generated_router_is_already_formatted` is what
+    // keeps the two in step.
     output.push_str(
-        "declare export function route < Path extends RoutePath > (\n  path: Path,\n  params: RouteParams[Path]\n): string;\n",
+        "declare export function route<Path extends RoutePath>(\n  path: Path,\n  params: RouteParams[Path],\n): string;\n",
     );
     output
 }
@@ -249,143 +258,8 @@ fn route_params_type(params: &[RouteParam]) -> String {
         .join(", ");
     // Exact for the same reason: a route's parameters are exactly the segments
     // in its path.
-    format!("{{| {fields} |}}")
+    format!("{{ {fields} }}")
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn discovers_root_and_dynamic_routes() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app/users/[id]")).unwrap();
-        fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
-        fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
-        fs::write(root.join("app/users/[id]/_uf.page.js"), "// @flow\n").unwrap();
-        fs::write(root.join("app/users/[id]/_uf.middleware.js"), "// @flow\n").unwrap();
-
-        let routes = discover_routes(&root, &UniflowedConfig::default()).unwrap();
-
-        assert_eq!(routes.len(), 2);
-        assert_eq!(routes[0].path, "/");
-        assert!(routes[0].has_layout);
-        assert_eq!(routes[1].path, "/users/:id");
-        assert_eq!(routes[1].params[0].name, "id");
-        assert!(routes[1].has_middleware);
-    }
-
-    #[test]
-    fn generates_router_flow_with_params() {
-        let route = Route {
-            path: "/users/:id".into(),
-            directory: "app/users/[id]".into(),
-            page: "app/users/[id]/_uf.page.js".into(),
-            params: vec![RouteParam {
-                name: "id".into(),
-                kind: RouteParamKind::Single,
-            }],
-            has_layout: false,
-            has_middleware: false,
-        };
-
-        let source = generate_router_flow(&[route]);
-
-        assert!(source.contains("export type RoutePath = \"/users/:id\";"));
-        assert!(source.contains("\"/users/:id\": {| id: string |}"));
-    }
-
-    /// Generated code has to satisfy the rules uf ships enabled.
-    ///
-    /// `flow/ambiguous-object-type` is on by default, so a `{ … }` in the
-    /// generated router made a freshly scaffolded project fail `uf check` on a
-    /// file the user never wrote.
-    #[test]
-    fn generated_router_types_are_exact() {
-        let source = generate_router_flow(&[Route {
-            path: "/users/:id".into(),
-            directory: Utf8PathBuf::from("app/users/[id]"),
-            page: Utf8PathBuf::from("app/users/[id]/_uf.page.js"),
-            params: vec![RouteParam {
-                name: "id".into(),
-                kind: RouteParamKind::Single,
-            }],
-            has_layout: false,
-            has_middleware: false,
-        }]);
-
-        // An object type opens inexactly when `{` is not immediately followed
-        // by `|`, which is exactly what the lint rule looks for.
-        for line in source.lines() {
-            let bytes = line.as_bytes();
-            for (index, byte) in bytes.iter().enumerate() {
-                if *byte != b'{' {
-                    continue;
-                }
-                assert_eq!(
-                    bytes.get(index + 1),
-                    Some(&b'|'),
-                    "generated router opens an inexact object type, which \
-                     `flow/ambiguous-object-type` rejects: {line}"
-                );
-            }
-        }
-        assert!(source.contains("export type RouteParams = {|"));
-        assert!(source.ends_with("string;\n"));
-    }
-
-    #[test]
-    fn an_empty_project_still_generates_exact_types() {
-        let source = generate_router_flow(&[]);
-
-        assert!(source.contains("export type RoutePath = empty;"));
-        assert!(source.contains("export type RouteParams = {|"));
-        assert!(!source.contains("= {\n"));
-    }
-
-    #[test]
-    fn a_route_handler_is_a_reserved_file_rather_than_a_violation() {
-        // `_uf.route.js` answers a request instead of rendering a page. It was
-        // an unknown name until route handlers existed, and the two tests that
-        // used it as their example of an invalid one now use `_uf.handler.js`.
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app/api")).unwrap();
-        fs::write(root.join("app/api/_uf.route.js"), "// @flow\n").unwrap();
-
-        let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
-        assert!(violations.is_empty(), "{violations:?}");
-
-        let classified = classify_reserved_file(RESERVED_ROUTE);
-        assert!(!classified.is_unknown());
-    }
-
-    #[test]
-    fn finds_invalid_reserved_files() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app")).unwrap();
-        fs::write(root.join("app/_uf.handler.js"), "// @flow\n").unwrap();
-
-        let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
-
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].path.file_name(), Some("_uf.handler.js"));
-    }
-
-    #[test]
-    fn writes_router_manifest() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app")).unwrap();
-        fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
-
-        let manifest = write_router_manifest(&root, &UniflowedConfig::default())
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(manifest.file_name(), Some("router.js"));
-        assert!(fs::read_to_string(manifest).unwrap().contains("RoutePath"));
-    }
-}
+mod tests;

--- a/crates/uf_router/src/tests.rs
+++ b/crates/uf_router/src/tests.rs
@@ -1,0 +1,190 @@
+//! Route discovery, the reserved-file grammar, and the generated types.
+
+use super::*;
+
+#[test]
+fn discovers_root_and_dynamic_routes() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app/users/[id]")).unwrap();
+    fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/users/[id]/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/users/[id]/_uf.middleware.js"), "// @flow\n").unwrap();
+
+    let routes = discover_routes(&root, &UniflowedConfig::default()).unwrap();
+
+    assert_eq!(routes.len(), 2);
+    assert_eq!(routes[0].path, "/");
+    assert!(routes[0].has_layout);
+    assert_eq!(routes[1].path, "/users/:id");
+    assert_eq!(routes[1].params[0].name, "id");
+    assert!(routes[1].has_middleware);
+}
+
+#[test]
+fn generates_router_flow_with_params() {
+    let route = Route {
+        path: "/users/:id".into(),
+        directory: "app/users/[id]".into(),
+        page: "app/users/[id]/_uf.page.js".into(),
+        params: vec![RouteParam {
+            name: "id".into(),
+            kind: RouteParamKind::Single,
+        }],
+        has_layout: false,
+        has_middleware: false,
+    };
+
+    let source = generate_router_flow(&[route]);
+
+    assert!(source.contains("export type RoutePath = \"/users/:id\";"));
+    assert!(source.contains("\"/users/:id\": { id: string }"));
+}
+
+/// The generated route table is the whole set of routes, so its types are
+/// exact: an inexact one would let a caller pass a path this router does not
+/// serve, which is the mistake the generated types exist to prevent.
+///
+/// Exactness is now spelled with plain braces. Flow has been exact by default
+/// since 2023 and rejects `exact_by_default=false` as deprecated, so `{ … }`
+/// *is* the exact type and `{| … |}` is the legacy spelling of the same thing.
+/// What actually has to be absent is the `...` that makes a type inexact.
+#[test]
+fn generated_router_types_are_exact() {
+    let source = generate_router_flow(&[Route {
+        path: "/users/:id".into(),
+        directory: Utf8PathBuf::from("app/users/[id]"),
+        page: Utf8PathBuf::from("app/users/[id]/_uf.page.js"),
+        params: vec![RouteParam {
+            name: "id".into(),
+            kind: RouteParamKind::Single,
+        }],
+        has_layout: false,
+        has_middleware: false,
+    }]);
+
+    assert!(
+        !source.contains("..."),
+        "an inexact route table would accept a path this router does not \
+         serve:\n{source}"
+    );
+    assert!(
+        !source.contains("{|"),
+        "the legacy exact spelling is not what uf tells anyone to write:\n{source}"
+    );
+    assert!(source.contains("export type RouteParams = {\n"));
+    assert!(source.contains(r#"  "/users/:id": { id: string },"#));
+    assert!(source.ends_with("string;\n"));
+}
+
+#[test]
+fn an_empty_project_still_generates_exact_types() {
+    let source = generate_router_flow(&[]);
+
+    assert!(source.contains("export type RoutePath = empty;"));
+    assert!(
+        source.contains("export type RouteParams = {};"),
+        "an empty table is an empty exact object:\n{source}"
+    );
+    assert!(!source.contains("..."));
+}
+
+#[test]
+fn a_route_handler_is_a_reserved_file_rather_than_a_violation() {
+    // `_uf.route.js` answers a request instead of rendering a page. It was
+    // an unknown name until route handlers existed, and the two tests that
+    // used it as their example of an invalid one now use `_uf.handler.js`.
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app/api")).unwrap();
+    fs::write(root.join("app/api/_uf.route.js"), "// @flow\n").unwrap();
+
+    let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
+    assert!(violations.is_empty(), "{violations:?}");
+
+    let classified = classify_reserved_file(RESERVED_ROUTE);
+    assert!(!classified.is_unknown());
+}
+
+#[test]
+fn finds_invalid_reserved_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::write(root.join("app/_uf.handler.js"), "// @flow\n").unwrap();
+
+    let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
+
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0].path.file_name(), Some("_uf.handler.js"));
+}
+
+#[test]
+fn writes_router_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+
+    let manifest = write_router_manifest(&root, &UniflowedConfig::default())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(manifest.file_name(), Some("router.js"));
+    assert!(fs::read_to_string(manifest).unwrap().contains("RoutePath"));
+}
+
+/// The router types uf generates must be what `uf fmt` would write.
+///
+/// uf scaffolds a project and then checks it with its own formatter, so a
+/// generated file the formatter disagrees with makes `uf fmt --check` fail on
+/// code nobody wrote. It did: the declaration was emitted as
+/// `route < Path extends RoutePath > (`, with spaces the printer does not put
+/// there, and `uf fmt --check` failed on `docs/router.js` in uf's own
+/// repository.
+#[test]
+fn the_generated_router_is_already_formatted() {
+    let routes = vec![
+        Route {
+            path: "/".into(),
+            directory: Utf8PathBuf::from("app"),
+            page: Utf8PathBuf::from("app/_uf.page.js"),
+            params: Vec::new(),
+            has_layout: true,
+            has_middleware: false,
+        },
+        Route {
+            path: "/posts/:id".into(),
+            directory: Utf8PathBuf::from("app/posts/[id]"),
+            page: Utf8PathBuf::from("app/posts/[id]/_uf.page.js"),
+            params: vec![RouteParam {
+                name: "id".into(),
+                kind: RouteParamKind::Single,
+            }],
+            has_layout: false,
+            has_middleware: false,
+        },
+    ];
+
+    let generated = generate_router_flow(&routes);
+    let formatted = uf_fmt::format_source(&generated, &uf_config::FmtConfig::default())
+        .expect("the generated router parses");
+
+    similar_asserts::assert_eq!(generated, formatted.output);
+    assert!(
+        !formatted.changed,
+        "uf generated a router the formatter it ships would rewrite"
+    );
+}
+
+/// An empty route table is generated too — a project with no pages yet — and
+/// is held to the same bar.
+#[test]
+fn an_empty_generated_router_is_already_formatted() {
+    let generated = generate_router_flow(&[]);
+    let formatted = uf_fmt::format_source(&generated, &uf_config::FmtConfig::default())
+        .expect("the generated router parses");
+
+    similar_asserts::assert_eq!(generated, formatted.output);
+}

--- a/tools/docs/build.sh
+++ b/tools/docs/build.sh
@@ -40,9 +40,11 @@ done
   # `UF_BIN` is set by anything that has already built the toolchain — CI
   # builds it once and shares it, and rebuilding here would cost minutes for
   # a binary that is already on disk.
+  # `build#docs` rather than `--cwd docs`: the workspace selector is what a
+  # person types, so it is what this runs, and a break in it breaks here first.
   if [ -n "${UF_BIN:-}" ]; then
-    "$UF_BIN" --cwd docs build --size-report
+    "$UF_BIN" build#docs --size-report
   else
-    cargo run --release --package uf_cli --bin uf -- --cwd docs build --size-report
+    cargo run --release --package uf_cli --bin uf -- build#docs --size-report
   fi
 )

--- a/uf.config.js
+++ b/uf.config.js
@@ -72,11 +72,11 @@ export default defineConfig({
     // check in the pipeline.
     //
     // Not in `ci` yet, and the reason is written down rather than left to be
-    // rediscovered: it reports 467 errors today. A third of them are
-    // `flow/ambiguous-object-type`, a rule whose premise modern Flow has
-    // retired — objects are exact by default now, so `{ a: b }` is not
-    // ambiguous and the `{| |}` the rule asks for is the deprecated spelling.
-    // The rule is wrong before the code is.
+    // rediscovered: it reports 315 errors today. The largest groups are
+    // `flow/unclear-type` (125), `flow/react-intrinsic-overlap` (89) and
+    // `react/hooks-rules` (86), and each needs looking at on its own terms —
+    // some are real findings in uf's packages, and some are rules that are
+    // wrong the way `flow/ambiguous-object-type` was wrong.
     "check:lib": {
       command: "./target/release/uf lint",
       dependsOn: ["build"],
@@ -84,10 +84,6 @@ export default defineConfig({
 
     // The formatter, over the same. `--check` rather than a write, because CI
     // reporting a diff is useful and CI committing one is not.
-    //
-    // Not in `ci` yet either, for a smaller reason: the router types uf
-    // generates are not formatted the way uf formats, so `uf fmt --check`
-    // fails on a file uf wrote itself.
     "fmt:check": {
       command: "./target/release/uf fmt --check",
       dependsOn: ["build"],
@@ -117,6 +113,7 @@ export default defineConfig({
         "rust:fmt:check",
         "rust:clippy",
         "rust:test",
+        "fmt:check",
         "test:lib",
         "docs:build",
         "rust:metadata",

--- a/uf.config.js
+++ b/uf.config.js
@@ -53,16 +53,52 @@ export default defineConfig({
     "flow:test": "cargo test -p uf_flow",
 
     // --- The toolchain, used on itself ---------------------------------
+    //
+    // Each of these is a first-class uf command run against a workspace of
+    // this repository, not a script that reimplements one. `uf test#library`
+    // is the command a contributor types; the task exists so CI types it too,
+    // and so `uf run ci` covers it.
     build: "cargo build --release --bin uf",
 
     // Every `@uniflowed/*` package is Flow, so `cargo test` cannot run a line
     // of it. These are uf tests, run by the runner this repository ships.
     "test:lib": {
-      command: "./target/release/uf --cwd tests/library test",
+      command: "./target/release/uf test#library",
       dependsOn: ["build"],
     },
+
+    // The linter, over this repository's own Flow. uf is the only thing that
+    // can lint uf's packages, so a regression here is invisible to every other
+    // check in the pipeline.
+    //
+    // Not in `ci` yet, and the reason is written down rather than left to be
+    // rediscovered: it reports 467 errors today. A third of them are
+    // `flow/ambiguous-object-type`, a rule whose premise modern Flow has
+    // retired — objects are exact by default now, so `{ a: b }` is not
+    // ambiguous and the `{| |}` the rule asks for is the deprecated spelling.
+    // The rule is wrong before the code is.
+    "check:lib": {
+      command: "./target/release/uf lint",
+      dependsOn: ["build"],
+    },
+
+    // The formatter, over the same. `--check` rather than a write, because CI
+    // reporting a diff is useful and CI committing one is not.
+    //
+    // Not in `ci` yet either, for a smaller reason: the router types uf
+    // generates are not formatted the way uf formats, so `uf fmt --check`
+    // fails on a file uf wrote itself.
+    "fmt:check": {
+      command: "./target/release/uf fmt --check",
+      dependsOn: ["build"],
+    },
+
+    // The documentation site, built by the framework it documents. The script
+    // stages the brand assets — shared with the README and the release pages,
+    // so they live at the repository root — into Vite's public directory
+    // first, and then runs `uf build#docs`.
     "docs:build": {
-      command: "tools/docs/build.sh",
+      command: "UF_BIN=./target/release/uf tools/docs/build.sh",
       dependsOn: ["build"],
     },
     "install:test": "tools/release/test-install.sh",
@@ -82,6 +118,7 @@ export default defineConfig({
         "rust:clippy",
         "rust:test",
         "test:lib",
+        "docs:build",
         "rust:metadata",
         "manifests",
       ],


### PR DESCRIPTION
Three holes, all in the same place: uf took names and never helped anyone
spell them.

`uf run <typo>` said `task "biuld" is not defined in uf.config.js` — true, and
no use to a reader who knows perfectly well what they typed. It now names the
closest tasks and, when the list is short enough to read, every task the
project defines. The measure is Damerau–Levenshtein, because the typo that
matters here is two adjacent letters swapped and plain Levenshtein charges two
edits for what a human sees as one. The distance budget grows with the length
of the word: at a fixed threshold of two, `ci` is "similar" to almost anything.

`uf run` with no task name was a usage error. It is now the answer to "what can
I run here" — a table of every task, what it runs, and what it runs after,
which is the list the unknown-task error points at.

`uf completion <shell>` ships bash, zsh, fish, elvish and PowerShell. The
scripts are four lines each because they decide nothing: they hand the words
typed so far to `uf __complete` and offer what comes back. That is what makes
task names completable — they live in `uf.config.js`, not in the argument
parser, so a generated script could never have known them, and a task added to
the config completes immediately with nothing to regenerate. Completion in a
directory with no project is silent rather than an error: an error there prints
into the middle of somebody's command line.

`Ui::plain` is the third kind of output, and genuinely distinct: a rendered
block is for a person, JSON is for a program, and a completion script is for
another language.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791088308&installation_model_id=422833&pr_number=101&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F101&signature=68cc2b41ae07b0e65b5cc038b353e41e4b9e9bc7febd354ad8664523f326972a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell completion support for Bash, Zsh, Fish, Elvish, and PowerShell.
  * `uf run` without a task now displays available tasks and their dependencies.
  * Added “did you mean” suggestions for mistyped task names.
* **Improvements**
  * Unknown task errors now provide relevant suggested task names.
  * Added cleaner output for shell completion results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->