### PR TITLE
docs: what closing each red line would take, and the failure none of them prevent

### DIFF
--- a/docs/app/guide/architecture/_uf.page.mdx
+++ b/docs/app/guide/architecture/_uf.page.mdx
@@ -106,10 +106,12 @@ to produce a bundle for a Cloudflare Worker.
 
 A list of rules with no audit against it is decoration.
 
-**Mirroring Vite's schema (2).** `dev` and `build` in `uf.config.js` re-declare
-Vite's options one at a time, and the driver maps them across by hand. A Vite
-option uf has not heard of is unreachable — exactly the `react-scripts`
-failure. uf should keep only what it genuinely owns and pass the rest through.
+**Mirroring Vite's schema (2), half closed.** The `vite` key in `uf.config.js`
+is merged over what uf generates, so a Vite option uf has never heard of is
+reachable — that was the part of the `react-scripts` failure that actually
+stranded people. What remains: `dev` and `build` still re-declare Vite's options
+one at a time, and every one of those is a second name for a setting that
+already has one.
 
 **Replaceability is aspirational (3).** The lint engine, the formatter's
 parser, the task runner and the package resolver are each an enumeration with
@@ -120,14 +122,52 @@ exactly and one script sets them all. That is right while the packages are one
 thing, and it is the beginning of the chokepoint. Adapters need to move
 independently before 1.0.
 
-**Inspectability is partial (7).** `uf inspect --json` prints the resolved
-configuration. Nothing yet says which provider runs each stage of `uf dev`, at
-what version, and which files the configuration came from.
+**Inspectability, met (7).** `uf inspect --json` prints the resolved
+configuration, and `uf explain <command>` names the provider for every stage of
+`dev`, `build`, `test`, `fmt`, `lint` and `check` — which binary runs it and
+what it does. A stage that cannot be explained is a stage that should not
+exist.
 
 **uf owns two tools (10).** The formatter and the test runner are uf's own
 implementations rather than orchestrated providers — a deliberate choice, since
 a Flow-aware version of neither existed. Each has to stay replaceable, or it
 becomes the thing this page is about.
+
+## How the open lines get closed
+
+Naming a violation is the easy half, and "we should fix that" is how a red line
+becomes a permanent footnote. Each one has an exit criterion:
+
+| Line | Closed when |
+| --- | --- |
+| 2 — Vite's schema | a test fails on any config key whose only consumer is `viteConfig()` |
+| 3 — replaceability | one provider enumeration has a second variant a project can select, and `uf explain` names it |
+| 5 — lockstep versions | a sibling dependency is a range, and one package can be released without the rest |
+| 10 — the two owned tools | `uf fmt` and `uf test` resolve through the same seam as the bundler |
+
+## Not on the table
+
+Each of these sounds reasonable and is a step toward the thing this page is
+about.
+
+- **An `eject` command, in any spelling** — including a "print the effective
+  Vite config so you can copy it" flag, which becomes one in practice.
+- **A uf-shaped name for something Flow already names.** `@noflow` is how a
+  file says it is plain JavaScript; a `check.exclude` list would have been a
+  second answer to a question that has one.
+- **Vendoring a provider to make it fit.** Upstream or a plugin, never a fork.
+
+## The failure no red line prevents
+
+CRA's third failure was not architectural. It solved the build and stopped, and
+every production application built its own framework on top of the tool that
+existed to remove that work.
+
+Nothing above prevents that. It is prevented by uf being a framework as well as
+a toolchain — the router, the RSC graph, server actions, the data layer — and by
+those being answers uf ships rather than integration points it documents. The
+audit is about not becoming a bottleneck; this is about being worth using at
+all.
 
 The full record, including the reasoning, is
 [`docs/red-lines.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/red-lines.md).

--- a/docs/red-lines.md
+++ b/docs/red-lines.md
@@ -87,14 +87,15 @@ exotic one.
 
 Writing the list is worth nothing without saying where we stand against it.
 
-**Red line 2 is violated today.** `uf_config`'s `dev` and `build` re-declare
+**Red line 2 is half closed.** The `vite` key in `uf.config.js` is merged over
+what uf generates, so a Vite option uf has never heard of is now reachable —
+which is the part of the `react-scripts` failure that actually stranded people.
+What remains is the other half: `uf_config`'s `dev` and `build` still re-declare
 Vite's options one at a time — `host`, `port`, `strictPort`, `allowedHosts`,
 `fs.allow`, `fs.deny`, `outDir`, `sourcemap` — and `viteConfig()` in
-`@uniflowed/vite` maps them across by hand. A Vite option uf has not heard of
-is unreachable, which is precisely the `react-scripts` failure. Fixing this
-means uf keeping only the settings it genuinely owns (the ones with
-cross-tool meaning, or that uf *enforces*, such as the `allowedHosts` gate on
-binding a routable address) and passing everything else through natively.
+`@uniflowed/vite` maps them across by hand. Every one of those is a second name
+for a setting that already has one, and a second name is a thing to keep in
+sync.
 
 **Red line 3 is aspirational.** `LintEngine`, `FlowFormatParser`,
 `TaskRunnerEngine` and `PackageManagerResolver` are enumerations with exactly
@@ -108,16 +109,93 @@ siblings exactly. That is right for a pre-release where the packages are one
 thing, and it is the beginning of lockstep. Adapters need to be able to move
 independently before 1.0.
 
-**Red line 7 is partly met.** `uf inspect --json` prints the resolved
-configuration and the route table. There is no `uf explain <command>` yet:
-nothing says which provider will run each stage, at which version, and which
-files the configuration came from.
+**Red line 7 is met.** `uf inspect --json` prints the resolved configuration
+and the route table, and `uf explain <command>` names the provider for every
+stage of `dev`, `build`, `test`, `fmt`, `lint` and `check` — which binary runs
+it, and what it does. It stays met by covering every command a person runs, so
+a stage that cannot be explained is a stage that should not exist.
 
 **Red line 10 is the one to watch.** `uf_fmt` and `uf_test` are uf's own
 implementations rather than orchestrated providers. That is a deliberate
 choice — a Flow-aware formatter and a Flow-aware test runner did not exist —
 but each is a place where uf owns a tool rather than the graph, and each has
 to stay replaceable or it becomes the thing this document is about.
+
+## How each open line gets closed
+
+Naming a violation is the easy half. This is what closing each one looks like,
+and what would prove it closed — because "we should fix that" is how a red line
+becomes a permanent footnote.
+
+**Line 2 — stop re-declaring Vite's schema.** Keep only the settings uf
+genuinely owns: the ones with cross-tool meaning, and the ones uf *enforces*
+rather than forwards. `dev.allowedHosts` is the clearest keeper — uf refuses to
+bind a routable address without it, so it is a uf rule that happens to look like
+a Vite option. `build.budgets` is uf's own and has no Vite equivalent. Every
+remaining key whose entire effect is to be copied into Vite's config should go,
+and the `vite` passthrough is where it goes.
+
+*Closed when:* a test walks the config schema and fails on any key whose only
+consumer is `viteConfig()`.
+
+**Line 3 — make one provider actually replaceable.** `LintEngine`,
+`FlowFormatParser`, `TaskRunnerEngine` and `PackageManagerResolver` are each an
+enumeration with one variant, which is the shape of replaceability with none of
+the substance. The nearest real second variant is already half-specified: the
+formatter is supposed to route `.json`, `.jsonc`, `.css` and `.ts` to Biome, and
+today the config key exists and the routing does not.
+
+*Closed when:* at least one of those enumerations has a second variant that a
+project can select, `uf explain fmt` names whichever was selected, and the
+non-default one is exercised by a test.
+
+**Line 5 — let the adapters move apart.** `tools/release/bump-version.sh` sets
+every version in the repository to one value and every `@uniflowed/*` package
+pins its siblings exactly. That is honest for a pre-release where the packages
+are one thing shipped in pieces, and it is exactly the structure red line 5
+exists to forbid, so it has to end before the structure calcifies.
+
+*Closed when:* a sibling dependency is a range rather than an exact pin, and the
+release script can bump one package without bumping the rest.
+
+**Line 10 — keep the two owned tools replaceable.** `uf_fmt` and `uf_test` are
+uf's own implementations, and that will not change: a Flow-aware formatter and a
+Flow-aware test runner did not exist. What has to be true is that they are
+reached the same way every other provider is, so a project that wants a
+different one is configuring uf rather than fighting it.
+
+*Closed when:* `uf fmt` and `uf test` resolve their implementation through the
+same seam as the bundler and the dev server, and `uf explain` reports it.
+
+## What is not on the table
+
+Some things are worth naming as permanently out of scope, because each is a
+plausible-sounding step toward the thing this document is about.
+
+- **An `eject` command**, in any spelling. Not `uf eject`, not
+  `uf config --write`, not a "print the effective Vite config so you can copy
+  it" flag that becomes one in practice. The continuum above is the whole
+  answer, and every step on it is reversible.
+- **A uf-shaped name for a thing Flow already names.** `@noflow` is how a file
+  says it is plain JavaScript; a `check.exclude` list would have been a second
+  answer to a question with one, in a place a reader is not looking.
+- **Vendoring a provider to make it fit.** If uf needs behaviour Vite does not
+  have, the fix is upstream or a plugin, never a fork — red line 1, and the
+  reason it is first.
+
+## The failure this does not prevent
+
+CRA's third failure was not architectural. It solved the build and stopped:
+routing, data fetching and code splitting turned out to be one problem rather
+than three, CRA could not integrate them, and every production application built
+its own framework on top of the tool that existed to remove that work.
+
+No red line prevents that one. It is prevented by uf being a framework as well
+as a toolchain — the router, the RSC graph, server actions and the data layer —
+and by those being answers uf actually ships rather than integration points it
+documents. The audit above is about not becoming a bottleneck. This is about
+being worth using in the first place, and the roadmap is the only defence
+against it.
 
 ## Why this is written down
 


### PR DESCRIPTION
The CRA record already had the history and the audit. It was missing the half
that turns an audit into a plan, and it had gone stale in two places.

Missing: every open red line said what was wrong and nothing said what fixing
it looks like. "We should fix that" is how a red line becomes a permanent
footnote, so each now has an exit criterion — a thing that would be true, and
in three of the four cases a test that would fail until it is. Line 2 closes
when a test fails on any config key whose only consumer is `viteConfig()`; line
3 when one provider enumeration has a second variant a project can actually
select; line 5 when a sibling dependency is a range and one package can ship
without the rest; line 10 when `uf fmt` and `uf test` resolve through the same
seam as the bundler.

Also missing: the things that are permanently out of scope, because each of
them sounds reasonable on the way to becoming the problem. An `eject` in any
spelling, including a "print the effective Vite config" flag that becomes one
in practice. A uf-shaped name for something Flow already names — the reason
`uf check` reads `@noflow` rather than growing a `check.exclude` list. And
vendoring a provider to make it fit.

And the failure no red line prevents: CRA solved the build and stopped, and
every production application built its own framework on top of the tool that
existed to remove that work. Nothing in an architecture document prevents that
one. It is prevented by shipping the framework layer, which makes the roadmap
the only defence — worth saying out loud next to a list that is entirely about
not becoming a bottleneck.

Stale: red line 7 was recorded as partly met, and `uf explain` has met it since
— it names the provider for every stage of six commands. Red line 2 was
recorded as violated outright, and the `vite` passthrough has closed the half
that actually stranded people; what remains is the duplicate names, not the
unreachable options.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791088469&installation_model_id=422833&pr_number=102&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F102&signature=2aed416c4c4e337cee81d5f1f1a00b33beedf4b4a88a524512a7338531e34bfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->