### PR TITLE
feat(cli): `uf dev#docs` — name which project in the repository you mean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,34 @@ jobs:
       - run: chmod +x target/release/uf
       - run: ./target/release/uf run rust:test
 
+  docs:
+    name: Docs build
+    needs: toolchain
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: tools/upstream/sync.sh
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-08-01
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - run: npm ci --no-audit --no-fund
+      # The documentation site is a uf project in this repository, built by
+      # `uf build#docs`. The Docs workflow builds it too, on its own trigger;
+      # this job is what makes a pull request that breaks the site fail before
+      # it is merged rather than after.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run docs:build
+
   library:
     name: Library
     needs: toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ name = "uf_project"
 version = "0.0.0-alpha.2"
 dependencies = [
  "camino",
+ "compact_str",
  "tempfile",
  "thiserror",
  "uf_config",

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -36,8 +36,8 @@ struct Cli {
 }
 
 pub fn main() -> ExitCode {
-    let cli = match parse_cli() {
-        Ok(cli) => cli,
+    let (cli, target) = match parse_cli() {
+        Ok(parsed) => parsed,
         Err(error) => return report_startup_error(&error),
     };
     let mode = if cli.command.wants_json() || cli.command.owns_stdout() {
@@ -47,7 +47,7 @@ pub fn main() -> ExitCode {
     };
     let mut ui = Ui::new(cli.color.into(), mode);
 
-    match run(cli, &mut ui) {
+    match run(cli, target.as_deref(), &mut ui) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             ui.error(&error);
@@ -75,8 +75,12 @@ fn report_startup_error(error: &anyhow::Error) -> ExitCode {
     ExitCode::FAILURE
 }
 
-fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
+fn run(cli: Cli, target: Option<&str>, ui: &mut Ui) -> Result<()> {
     let cwd = resolve_cwd(cli.cwd)?;
+    let cwd = match target {
+        Some(target) => enter_workspace(&cwd, target)?,
+        None => cwd,
+    };
 
     match cli.command {
         Commands::Build { size_report } => commands::build::build(&cwd, ui, size_report),
@@ -146,7 +150,7 @@ fn run(cli: Cli, ui: &mut Ui) -> Result<()> {
 /// after installation, before any project or script exists, so `ufr --version`
 /// and `ufx --version` must never be interpreted as `uf run --version` or
 /// `uf exec --version`.
-fn parse_cli() -> Result<Cli> {
+fn parse_cli() -> Result<(Cli, Option<String>)> {
     let mut args = std::env::args_os().collect::<Vec<_>>();
     let bin_name = args
         .first()
@@ -155,16 +159,56 @@ fn parse_cli() -> Result<Cli> {
         .unwrap_or("uf");
 
     match bin_name {
-        "ufr" if !args_request_root_version(&args) => {
-            args.insert(1, "run".into());
-            Cli::try_parse_from(args).map_err(Into::into)
-        }
-        "ufx" if !args_request_root_version(&args) => {
-            args.insert(1, "exec".into());
-            Cli::try_parse_from(args).map_err(Into::into)
-        }
-        _ => Cli::try_parse_from(args).map_err(Into::into),
+        "ufr" if !args_request_root_version(&args) => args.insert(1, "run".into()),
+        "ufx" if !args_request_root_version(&args) => args.insert(1, "exec".into()),
+        _ => {}
     }
+
+    let target = take_workspace_selector(&mut args);
+    Ok((Cli::try_parse_from(args)?, target))
+}
+
+/// Split a `#member` selector off the subcommand, if there is one.
+///
+/// `uf dev#docs` runs `uf dev` in the `docs` member. The selector is written on
+/// the command rather than as a flag because it changes *where* the command
+/// runs rather than how, and because it reads in the order it happens — which
+/// is also why it is stripped here, before clap sees an argument it would
+/// otherwise reject as an unknown subcommand.
+///
+/// Only the subcommand carries one. A `#` anywhere else belongs to whatever
+/// argument it is part of: a task name, a filter, a path.
+fn take_workspace_selector(args: &mut [std::ffi::OsString]) -> Option<String> {
+    let at = subcommand_index(args)?;
+    let (command, target) = args[at].to_str()?.split_once('#')?;
+    if target.is_empty() {
+        return None;
+    }
+    let target = target.to_owned();
+    args[at] = command.into();
+    Some(target)
+}
+
+/// Where the subcommand is, skipping the global flags and their values.
+///
+/// `--cwd` and `--color` take a value, and that value is not the subcommand —
+/// which is what `uf --cwd /tmp dev#docs` gets wrong if the first non-flag
+/// argument is taken to be one.
+fn subcommand_index(args: &[std::ffi::OsString]) -> Option<usize> {
+    let mut index = 1;
+    while index < args.len() {
+        let argument = args[index].to_str()?;
+        if argument == "--cwd" || argument == "--color" {
+            index += 2;
+            continue;
+        }
+        if argument.starts_with('-') || argument.is_empty() {
+            index += 1;
+            continue;
+        }
+        return Some(index);
+    }
+    None
 }
 
 fn args_request_root_version(args: &[std::ffi::OsString]) -> bool {
@@ -180,6 +224,38 @@ fn args_request_root_version(args: &[std::ffi::OsString]) -> bool {
         }
     }
     false
+}
+
+/// The directory the `#member` selector names.
+///
+/// # Errors
+///
+/// Names the members that do exist, and the closest spellings of the one that
+/// does not, because "no such workspace" on its own is the least useful thing
+/// this could say.
+fn enter_workspace(cwd: &Utf8PathBuf, target: &str) -> Result<Utf8PathBuf> {
+    let resolved = uf_config::load_config(cwd)?;
+    let workspaces = uf_project::discover_workspaces(&resolved.root, &resolved.config);
+
+    match uf_project::resolve_workspace(&workspaces, target) {
+        Ok(workspace) => Ok(resolved.root.join(&workspace.path)),
+        Err(available) if available.is_empty() => Err(anyhow!(
+            "no workspace named {target:?}\n\n  this project has no members; a member is a \
+             directory with its own uf.config.js"
+        )),
+        Err(available) => {
+            let names = available.iter().map(compact_str::CompactString::as_str);
+            let suggestions = crate::suggest::closest(target, names.clone());
+            let mut message = format!("no workspace named {target:?}");
+            if !suggestions.is_empty() {
+                message.push_str("\n\n  did you mean: ");
+                message.push_str(&suggestions.join(", "));
+            }
+            message.push_str("\n\n  workspaces: ");
+            message.push_str(&names.collect::<Vec<_>>().join(", "));
+            Err(anyhow!(message))
+        }
+    }
 }
 
 fn resolve_cwd(cwd: Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {
@@ -220,6 +296,64 @@ mod tests {
     #[test]
     fn an_unknown_color_value_is_rejected() {
         assert!(Cli::try_parse_from(["uf", "build", "--color", "beige"]).is_err());
+    }
+
+    fn args(line: &[&str]) -> Vec<std::ffi::OsString> {
+        line.iter().map(Into::into).collect()
+    }
+
+    #[test]
+    fn a_selector_is_taken_off_the_subcommand() {
+        let mut line = args(&["uf", "dev#docs"]);
+
+        assert_eq!(take_workspace_selector(&mut line), Some("docs".to_owned()));
+        assert_eq!(line, args(&["uf", "dev"]));
+    }
+
+    /// `--cwd` takes a value, and that value is not the subcommand.
+    #[test]
+    fn global_flags_before_the_subcommand_do_not_hide_it() {
+        let mut line = args(&["uf", "--cwd", "/tmp", "--color", "never", "build#site"]);
+
+        assert_eq!(take_workspace_selector(&mut line), Some("site".to_owned()));
+        assert_eq!(
+            line,
+            args(&["uf", "--cwd", "/tmp", "--color", "never", "build"])
+        );
+    }
+
+    /// Only the subcommand carries a selector. A `#` in a task name, a filter
+    /// or a path belongs to that argument.
+    #[test]
+    fn a_hash_after_the_subcommand_is_left_alone() {
+        let mut line = args(&["uf", "run", "build#2"]);
+
+        assert_eq!(take_workspace_selector(&mut line), None);
+        assert_eq!(line, args(&["uf", "run", "build#2"]));
+    }
+
+    #[test]
+    fn a_command_with_no_selector_is_untouched() {
+        let mut line = args(&["uf", "dev"]);
+
+        assert_eq!(take_workspace_selector(&mut line), None);
+        assert_eq!(line, args(&["uf", "dev"]));
+    }
+
+    /// An empty selector is a typo, not a request for the root; leaving the
+    /// `#` on makes clap say so rather than silently running somewhere.
+    #[test]
+    fn an_empty_selector_is_not_a_selector() {
+        let mut line = args(&["uf", "dev#"]);
+
+        assert_eq!(take_workspace_selector(&mut line), None);
+        assert_eq!(line, args(&["uf", "dev#"]));
+    }
+
+    #[test]
+    fn a_line_with_no_subcommand_has_no_selector() {
+        assert_eq!(take_workspace_selector(&mut args(&["uf"])), None);
+        assert_eq!(take_workspace_selector(&mut args(&["uf", "--help"])), None);
     }
 
     #[test]

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -266,6 +266,140 @@ fn run_without_a_task_lists_them() {
     assert!(stdout.contains("uf run <task>"), "{stdout}");
 }
 
+/// A repository is commonly more than one project, and `uf dev#docs` is how a
+/// command says which one it means.
+#[test]
+fn a_command_runs_in_the_workspace_its_selector_names() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { root: { command: "printf root" } },
+            });
+        "#,
+    )
+    .unwrap();
+    let member = dir.path().join("site");
+    fs::create_dir_all(&member).unwrap();
+    fs::write(
+        member.join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { inner: { command: "printf inner" } },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["run#site", "inner"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "inner");
+}
+
+/// The root is still the root when no selector is given.
+#[test]
+fn no_selector_leaves_the_command_where_it_was() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { root: { command: "printf root" } },
+            });
+        "#,
+    )
+    .unwrap();
+    let member = dir.path().join("site");
+    fs::create_dir_all(&member).unwrap();
+    fs::write(
+        member.join("uf.config.js"),
+        "export default {};
+",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["run", "root"])
+        .output()
+        .unwrap();
+
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "root");
+}
+
+#[test]
+fn an_unknown_workspace_names_the_ones_that_exist() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "export default {};
+",
+    )
+    .unwrap();
+    let member = dir.path().join("docs");
+    fs::create_dir_all(&member).unwrap();
+    fs::write(
+        member.join("uf.config.js"),
+        "export default {};
+",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("inspect#dcos")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("did you mean"), "{stderr}");
+    assert!(stderr.contains("docs"), "{stderr}");
+}
+
+/// A `#` in an argument is part of that argument. Only the subcommand carries
+/// a selector, or a task named `build#2` would become a workspace lookup.
+#[test]
+fn a_hash_outside_the_subcommand_is_left_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        r#"
+            export default defineConfig({
+              tasks: { "build#2": { command: "printf hashed" } },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["run", "build#2"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "hashed");
+}
+
 #[test]
 fn alias_binaries_print_the_root_version() {
     for name in ["ufr", "ufx"] {

--- a/crates/uf_project/Cargo.toml
+++ b/crates/uf_project/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+compact_str.workspace = true
 camino.workspace = true
 uf_config = { path = "../uf_config" }
 thiserror.workspace = true

--- a/crates/uf_project/src/lib.rs
+++ b/crates/uf_project/src/lib.rs
@@ -6,8 +6,10 @@ use uf_config::UniflowedConfig;
 use walkdir::WalkDir;
 
 mod template;
+pub mod workspace;
 
 use template::{app_react_files, lib_files};
+pub use workspace::{Workspace, discover_workspaces, resolve_workspace};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CreateKind {

--- a/crates/uf_project/src/workspace.rs
+++ b/crates/uf_project/src/workspace.rs
@@ -1,0 +1,136 @@
+//! The uf projects inside a uf project.
+//!
+//! A repository is commonly more than one thing: this one is the toolchain, a
+//! documentation site, and a library test suite, and each has its own
+//! `uf.config.js` because each is genuinely a different project. `uf dev` at
+//! the root cannot serve all three, and asking someone to `cd docs` first is
+//! asking them to know the layout before they can use the tool.
+//!
+//! So a command may name which one it means: `uf dev#docs`. The selector is on
+//! the command rather than a flag because it changes *where the command runs*
+//! rather than how, and reads in the order it happens.
+//!
+//! # What counts as a member
+//!
+//! A directory with its own `uf.config.js`. Nothing is declared, because a
+//! declaration would be a second list to keep in step with the first — and the
+//! first already exists, in the form of the config files themselves. The root's
+//! own config is not a member: `uf dev` already means the root.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::{CompactString, ToCompactString};
+
+use uf_config::{CONFIG_FILES, UniflowedConfig};
+
+use crate::is_ignored;
+
+#[cfg(test)]
+mod tests;
+
+/// How deep below the root a member is looked for.
+///
+/// `docs` is one level down and `tests/library` is two, which is where projects
+/// in a repository actually live. Going deeper means walking into build output
+/// and vendored trees for no gain, and a member buried four levels down is not
+/// discoverable by a person either.
+const MAX_DEPTH: usize = 3;
+
+/// One uf project inside another.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Workspace {
+    /// What `uf <command>#<name>` calls it: the directory's own name.
+    pub name: CompactString,
+    /// Where it is, relative to the root.
+    pub path: Utf8PathBuf,
+}
+
+impl Workspace {
+    /// Whether `selector` names this member.
+    ///
+    /// Both the short name and the path are accepted, because both are things
+    /// someone reasonably types: `docs` is what it is called, and
+    /// `tests/library` is what it is. A path selector settles the ambiguity
+    /// when two directories share a name.
+    #[must_use]
+    pub fn matches(&self, selector: &str) -> bool {
+        self.name == selector || self.path == selector
+    }
+}
+
+/// Every uf project under `root`, excluding `root` itself, sorted by path.
+///
+/// Ignored directories are skipped using the project's own ignore list, so a
+/// `uf.config.js` inside `node_modules` or a build output directory is not a
+/// member of anything.
+pub fn discover_workspaces(root: &Utf8Path, config: &UniflowedConfig) -> Vec<Workspace> {
+    let mut found = Vec::new();
+    visit(root, root, config, 0, &mut found);
+    found.sort();
+    found
+}
+
+fn visit(
+    root: &Utf8Path,
+    dir: &Utf8Path,
+    config: &UniflowedConfig,
+    depth: usize,
+    found: &mut Vec<Workspace>,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let Ok(path) = Utf8PathBuf::from_path_buf(entry.path()) else {
+            continue;
+        };
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) || is_ignored(root, &path, config) {
+            continue;
+        }
+        // Another repository's contents are not this project's members, for the
+        // same reason they are not this project's source files.
+        if path.join(".git").exists() {
+            continue;
+        }
+
+        if CONFIG_FILES.iter().any(|name| path.join(name).exists())
+            && let Some(name) = path.file_name()
+            && let Ok(relative) = path.strip_prefix(root)
+        {
+            found.push(Workspace {
+                name: name.to_compact_string(),
+                path: relative.to_path_buf(),
+            });
+            // A project inside a project is that project's business, not this
+            // one's: `uf dev#docs` selects `docs`, and what `docs` contains is
+            // resolved from there.
+            continue;
+        }
+
+        visit(root, &path, config, depth + 1, found);
+    }
+}
+
+/// The member `selector` names, or an error naming what was available.
+///
+/// # Errors
+///
+/// Returns the list of member names when nothing matched, so a caller can say
+/// what could have been meant rather than only that this was not it.
+pub fn resolve_workspace<'a>(
+    workspaces: &'a [Workspace],
+    selector: &str,
+) -> Result<&'a Workspace, Vec<CompactString>> {
+    workspaces
+        .iter()
+        .find(|workspace| workspace.matches(selector))
+        .ok_or_else(|| {
+            workspaces
+                .iter()
+                .map(|workspace| workspace.name.clone())
+                .collect()
+        })
+}

--- a/crates/uf_project/src/workspace/tests.rs
+++ b/crates/uf_project/src/workspace/tests.rs
@@ -1,0 +1,159 @@
+use std::fs;
+
+use camino::Utf8PathBuf;
+
+use super::*;
+
+/// A project tree with a `uf.config.js` at each of `members`.
+fn tree(members: &[&str]) -> (tempfile::TempDir, Utf8PathBuf) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("a UTF-8 path");
+    fs::write(root.join("uf.config.js"), "export default {};\n").expect("write the root config");
+
+    for member in members {
+        let path = root.join(member);
+        fs::create_dir_all(&path).expect("create the member");
+        fs::write(path.join("uf.config.js"), "export default {};\n").expect("write its config");
+    }
+    (dir, root)
+}
+
+fn names(workspaces: &[Workspace]) -> Vec<&str> {
+    workspaces
+        .iter()
+        .map(|workspace| workspace.name.as_str())
+        .collect()
+}
+
+#[test]
+fn a_directory_with_its_own_config_is_a_member() {
+    let (_dir, root) = tree(&["docs", "site"]);
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(names(&found), vec!["docs", "site"]);
+}
+
+/// `uf dev` already means the root, so the root is not one of its own members.
+#[test]
+fn the_root_is_not_a_member_of_itself() {
+    let (_dir, root) = tree(&[]);
+
+    assert!(discover_workspaces(&root, &UniflowedConfig::default()).is_empty());
+}
+
+#[test]
+fn a_member_may_be_nested() {
+    let (_dir, root) = tree(&["tests/library"]);
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(names(&found), vec!["library"]);
+    assert_eq!(found[0].path, "tests/library");
+}
+
+/// A project inside a member is that member's business. Descending into it
+/// would offer `uf dev#example` for something the root cannot meaningfully run.
+#[test]
+fn a_member_inside_a_member_is_not_discovered() {
+    let (_dir, root) = tree(&["docs", "docs/example"]);
+
+    assert_eq!(
+        names(&discover_workspaces(&root, &UniflowedConfig::default())),
+        vec!["docs"]
+    );
+}
+
+#[test]
+fn ignored_directories_hold_no_members() {
+    let (_dir, root) = tree(&["node_modules/pkg", "docs"]);
+
+    assert_eq!(
+        names(&discover_workspaces(&root, &UniflowedConfig::default())),
+        vec!["docs"],
+        "a config inside node_modules is somebody else's"
+    );
+}
+
+/// A checkout inside a checkout is another repository, and its projects are
+/// not this one's — the same rule `collect_source_files` applies.
+#[test]
+fn another_repository_holds_no_members() {
+    let (_dir, root) = tree(&["vendor"]);
+    fs::create_dir_all(root.join("vendor/.git")).expect("make it a repository");
+
+    assert!(discover_workspaces(&root, &UniflowedConfig::default()).is_empty());
+}
+
+#[test]
+fn discovery_is_bounded_by_depth() {
+    let (_dir, root) = tree(&["a/b/c/d/deep"]);
+
+    assert!(
+        discover_workspaces(&root, &UniflowedConfig::default()).is_empty(),
+        "a project five levels down is not discoverable by a person either"
+    );
+}
+
+#[test]
+fn members_come_back_in_a_stable_order() {
+    let (_dir, root) = tree(&["zebra", "alpha", "middle"]);
+
+    let first = discover_workspaces(&root, &UniflowedConfig::default());
+    for _ in 0..8 {
+        assert_eq!(
+            discover_workspaces(&root, &UniflowedConfig::default()),
+            first
+        );
+    }
+    assert_eq!(names(&first), vec!["alpha", "middle", "zebra"]);
+}
+
+// --- selecting one ------------------------------------------------------
+
+fn members() -> Vec<Workspace> {
+    vec![
+        Workspace {
+            name: "docs".into(),
+            path: "docs".into(),
+        },
+        Workspace {
+            name: "library".into(),
+            path: "tests/library".into(),
+        },
+    ]
+}
+
+#[test]
+fn a_member_is_selected_by_its_name() {
+    let members = members();
+    let found = resolve_workspace(&members, "docs").expect("docs is a member");
+
+    assert_eq!(found.path, "docs");
+}
+
+/// Both spellings are things someone reasonably types, and the path is the one
+/// that settles an ambiguity between two directories with the same name.
+#[test]
+fn a_member_is_also_selected_by_its_path() {
+    let members = members();
+    let found = resolve_workspace(&members, "tests/library").expect("the path selects it");
+
+    assert_eq!(found.name, "library");
+}
+
+#[test]
+fn selecting_nothing_reports_what_there_was() {
+    let members = members();
+    let available = resolve_workspace(&members, "dcos").expect_err("no such member");
+
+    assert_eq!(available, vec!["docs", "library"]);
+}
+
+#[test]
+fn selecting_in_a_project_with_no_members_reports_an_empty_list() {
+    assert_eq!(
+        resolve_workspace(&[], "docs").expect_err("nothing to select"),
+        Vec::<CompactString>::new()
+    );
+}

--- a/tools/docs/build.sh
+++ b/tools/docs/build.sh
@@ -40,9 +40,11 @@ done
   # `UF_BIN` is set by anything that has already built the toolchain — CI
   # builds it once and shares it, and rebuilding here would cost minutes for
   # a binary that is already on disk.
+  # `build#docs` rather than `--cwd docs`: the workspace selector is what a
+  # person types, so it is what this runs, and a break in it breaks here first.
   if [ -n "${UF_BIN:-}" ]; then
-    "$UF_BIN" --cwd docs build --size-report
+    "$UF_BIN" build#docs --size-report
   else
-    cargo run --release --package uf_cli --bin uf -- --cwd docs build --size-report
+    cargo run --release --package uf_cli --bin uf -- build#docs --size-report
   fi
 )

--- a/uf.config.js
+++ b/uf.config.js
@@ -53,16 +53,52 @@ export default defineConfig({
     "flow:test": "cargo test -p uf_flow",
 
     // --- The toolchain, used on itself ---------------------------------
+    //
+    // Each of these is a first-class uf command run against a workspace of
+    // this repository, not a script that reimplements one. `uf test#library`
+    // is the command a contributor types; the task exists so CI types it too,
+    // and so `uf run ci` covers it.
     build: "cargo build --release --bin uf",
 
     // Every `@uniflowed/*` package is Flow, so `cargo test` cannot run a line
     // of it. These are uf tests, run by the runner this repository ships.
     "test:lib": {
-      command: "./target/release/uf --cwd tests/library test",
+      command: "./target/release/uf test#library",
       dependsOn: ["build"],
     },
+
+    // The linter, over this repository's own Flow. uf is the only thing that
+    // can lint uf's packages, so a regression here is invisible to every other
+    // check in the pipeline.
+    //
+    // Not in `ci` yet, and the reason is written down rather than left to be
+    // rediscovered: it reports 467 errors today. A third of them are
+    // `flow/ambiguous-object-type`, a rule whose premise modern Flow has
+    // retired — objects are exact by default now, so `{ a: b }` is not
+    // ambiguous and the `{| |}` the rule asks for is the deprecated spelling.
+    // The rule is wrong before the code is.
+    "check:lib": {
+      command: "./target/release/uf lint",
+      dependsOn: ["build"],
+    },
+
+    // The formatter, over the same. `--check` rather than a write, because CI
+    // reporting a diff is useful and CI committing one is not.
+    //
+    // Not in `ci` yet either, for a smaller reason: the router types uf
+    // generates are not formatted the way uf formats, so `uf fmt --check`
+    // fails on a file uf wrote itself.
+    "fmt:check": {
+      command: "./target/release/uf fmt --check",
+      dependsOn: ["build"],
+    },
+
+    // The documentation site, built by the framework it documents. The script
+    // stages the brand assets — shared with the README and the release pages,
+    // so they live at the repository root — into Vite's public directory
+    // first, and then runs `uf build#docs`.
     "docs:build": {
-      command: "tools/docs/build.sh",
+      command: "UF_BIN=./target/release/uf tools/docs/build.sh",
       dependsOn: ["build"],
     },
     "install:test": "tools/release/test-install.sh",
@@ -82,6 +118,7 @@ export default defineConfig({
         "rust:clippy",
         "rust:test",
         "test:lib",
+        "docs:build",
         "rust:metadata",
         "manifests",
       ],


### PR DESCRIPTION
A repository is commonly more than one uf project. This one is the toolchain,
a documentation site and a library test suite, each with its own
`uf.config.js` because each genuinely is a different project. `uf dev` at the
root cannot serve all three, and telling someone to `cd docs` first is telling
them to know the layout before they can use the tool.

So a command can name which one it means: `uf dev#docs`, `uf test#library`,
`uf build#docs`. The selector goes on the command rather than in a flag because
it changes *where* the command runs rather than how, and reads in the order it
happens. It is stripped before clap sees it, which is also why only the
subcommand carries one — a `#` in a task name, a filter or a path belongs to
that argument, and `uf run build#2` still runs the task called `build#2`.

Membership is discovered, not declared: a member is a directory with its own
`uf.config.js`. A declaration would be a second list to keep in step with a
first that already exists. Ignored directories, other repositories, and
projects nested inside members are all skipped, for the reasons
`collect_source_files` skips them.

A selector that names nothing says what does exist and what was probably meant,
through the same suggestion engine `uf run` uses.

This repository now uses it on itself. `test:lib` is `uf test#library`, the
docs build is `uf build#docs`, and a new CI job builds the site on every pull
request rather than only on the Docs workflow's own trigger.

Two self-checks are written down and deliberately not in `ci` yet, with the
reason in the config rather than left to be rediscovered. `uf lint` reports 467
errors on this repository, a third of them `flow/ambiguous-object-type` — a
rule whose premise modern Flow has retired, since objects are exact by default
and the `{| |}` it asks for is the deprecated spelling. And `uf fmt --check`
fails on `docs/router.js`, which uf generates itself and does not format the
way uf formats. Both are bugs in uf, not in the repository, and both are next.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Stacked on #101.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791089737&installation_model_id=422833&pr_number=103&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F103&signature=bb9a1ae76f0371e2fa23f8c83a18d6a31a277ca3714b0275a96c734de464b75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->