### PR TITLE
fix: uf generated a router its own formatter rejected, and linted for legacy Flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,29 @@ jobs:
       - run: chmod +x target/release/uf
       - run: ./target/release/uf run rust:test
 
+  flow-format:
+    name: Flow format
+    needs: toolchain
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: tools/upstream/sync.sh
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-08-01
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      # `rust:fmt:check` is cargo's half. This is uf's: the formatter this
+      # repository ships, over the Flow this repository is written in. It is
+      # the only thing that checks the shipped packages' formatting at all.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uf-ci
+          path: target/release
+      - run: chmod +x target/release/uf
+      - run: ./target/release/uf run fmt:check
+
   docs:
     name: Docs build
     needs: toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,9 +3536,11 @@ dependencies = [
  "camino",
  "compact_str",
  "criterion",
+ "similar-asserts",
  "tempfile",
  "thiserror",
  "uf_config",
+ "uf_fmt",
  "walkdir",
 ]
 

--- a/crates/uf_config/src/lint.rs
+++ b/crates/uf_config/src/lint.rs
@@ -72,7 +72,11 @@ pub enum FlowLintParser {
 const DEFAULT_LINT_RULES: [(&str, RuleLevel); 53] = [
     // --- Flow built-in lints ------------------------------------------------
     // Exactness must be stated, not inferred from a config flag.
-    ("flow/ambiguous-object-type", RuleLevel::Error),
+    // Off: the ambiguity is gone. Flow has been exact-by-default since 2023 and
+    // rejects `exact_by_default=false` as deprecated, so `{ a: b }` is exact and
+    // the `{| |}` this rule asks for is the legacy spelling. See
+    // `uf_lint::rules::flow::FLOW_META`.
+    ("flow/ambiguous-object-type", RuleLevel::Off),
     // Reading named exports off a default import is a CommonJS interop bug.
     ("flow/default-import-access", RuleLevel::Error),
     // `bool` is a legacy alias for `boolean`; mechanical fix.

--- a/crates/uf_lint/src/rules/flow.rs
+++ b/crates/uf_lint/src/rules/flow.rs
@@ -44,10 +44,19 @@ use RuleRequirement::{SourceText, TypeChecker};
 ///
 /// The order must match [`FlowBuiltinLint`]'s discriminant order.
 pub(crate) static FLOW_META: [FlowLintMeta; FlowBuiltinLint::COUNT] = [
-    // ambiguous-object-type: a large codebase cannot afford object types whose
-    // exactness depends on a config flag; readers must see `{| |}` or `{ ... }`.
+    // ambiguous-object-type: off, because the ambiguity it is named after no
+    // longer exists. The rule dates from when a `.flowconfig` could set
+    // `exact_by_default=false` and `{ a: b }` meant different things in
+    // different projects. Flow has defaulted to exact since 2023 and now
+    // rejects `exact_by_default=false` as deprecated, so `{ a: b }` is exact,
+    // full stop — and the `{| |}` this rule asks for is the legacy spelling of
+    // what the plain braces already say. Left on, it reported 152 errors
+    // against uf's own packages for writing modern Flow.
+    //
+    // Still selectable: a codebase migrating from an older Flow may want every
+    // object type marked while both spellings are in the tree.
     meta(
-        RuleLevel::Error,
+        RuleLevel::Off,
         SourceText,
         "object type annotations must state exactness explicitly",
     ),

--- a/crates/uf_lint/src/tests/flow_type.rs
+++ b/crates/uf_lint/src/tests/flow_type.rs
@@ -90,6 +90,49 @@ fn internal_type_accepts_the_public_equivalents() {
     assert!(diagnostics.is_empty());
 }
 
+/// The rule is off by default, and the reason is a fact about Flow rather than
+/// a matter of taste.
+///
+/// It exists for a world where `exact_by_default=false` was a `.flowconfig`
+/// option and `{ a: b }` meant different things in different projects. Flow has
+/// defaulted to exact since 2023 and now rejects that option as deprecated, so
+/// there is nothing left to disambiguate — and `{| |}`, which the rule asks
+/// for, is the legacy spelling of what plain braces already mean.
+#[test]
+fn ambiguous_object_type_is_off_by_default() {
+    let config = UniflowedConfig::default();
+
+    assert_eq!(
+        config.lint.rules.get("flow/ambiguous-object-type").copied(),
+        Some(RuleLevel::Off)
+    );
+
+    let report =
+        lint_source(&source("// @flow\ntype Props = { id: string };\n"), &config).expect("lint");
+
+    assert!(
+        report.diagnostics.is_empty(),
+        "modern Flow's exact object type must not be a default error: {:?}",
+        report.diagnostics
+    );
+}
+
+/// Off by default is not gone: a codebase migrating from an older Flow may
+/// want every object type marked while both spellings are in the tree.
+#[test]
+fn ambiguous_object_type_can_still_be_switched_on() {
+    let mut config = UniflowedConfig::default();
+    config.lint.rules.insert(
+        CompactString::const_new("flow/ambiguous-object-type"),
+        RuleLevel::Error,
+    );
+
+    let report =
+        lint_source(&source("// @flow\ntype Props = { id: string };\n"), &config).expect("lint");
+
+    assert_eq!(report.diagnostics.len(), 1);
+}
+
 #[test]
 fn ambiguous_object_type_rejects_unmarked_object_types() {
     let diagnostics = lint_js(

--- a/crates/uf_router/Cargo.toml
+++ b/crates/uf_router/Cargo.toml
@@ -17,6 +17,10 @@ walkdir.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+similar-asserts.workspace = true
+# The generated router types are checked against the formatter uf ships, so a
+# project cannot be scaffolded with code `uf fmt --check` rejects.
+uf_fmt = { path = "../uf_fmt" }
 tempfile.workspace = true
 
 [[bench]]

--- a/crates/uf_router/src/lib.rs
+++ b/crates/uf_router/src/lib.rs
@@ -149,20 +149,29 @@ pub fn generate_router_flow(routes: &[Route]) -> String {
 
     // Exact, because the generated table *is* the whole set of routes: an
     // inexact type would let a caller pass a path this router does not serve,
-    // which is the mistake the generated types exist to prevent. It also keeps a
-    // freshly scaffolded project passing `flow/ambiguous-object-type`, which uf
-    // turns on by default — generated code has to satisfy the rules uf ships.
-    output.push_str("export type RouteParams = {|\n");
-    for route in routes {
-        output.push_str(&format!(
-            "  \"{}\": {},\n",
-            route.path,
-            route_params_type(&route.params)
-        ));
+    // which is the mistake the generated types exist to prevent. Plain braces
+    // say exactly that in modern Flow, which has been exact by default since
+    // 2023 — `{| |}` is the legacy spelling of the same thing.
+    if routes.is_empty() {
+        output.push_str("export type RouteParams = {};\n\n");
+    } else {
+        output.push_str("export type RouteParams = {\n");
+        for route in routes {
+            output.push_str(&format!(
+                "  \"{}\": {},\n",
+                route.path,
+                route_params_type(&route.params)
+            ));
+        }
+        output.push_str("};\n\n");
     }
-    output.push_str("|};\n\n");
+    // Written the way `uf fmt` writes it, down to the trailing comma: uf
+    // scaffolds a project and then checks it with its own formatter, so a
+    // generated file the formatter disagrees with fails `uf fmt --check` on
+    // code nobody wrote. `the_generated_router_is_already_formatted` is what
+    // keeps the two in step.
     output.push_str(
-        "declare export function route < Path extends RoutePath > (\n  path: Path,\n  params: RouteParams[Path]\n): string;\n",
+        "declare export function route<Path extends RoutePath>(\n  path: Path,\n  params: RouteParams[Path],\n): string;\n",
     );
     output
 }
@@ -249,143 +258,8 @@ fn route_params_type(params: &[RouteParam]) -> String {
         .join(", ");
     // Exact for the same reason: a route's parameters are exactly the segments
     // in its path.
-    format!("{{| {fields} |}}")
+    format!("{{ {fields} }}")
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn discovers_root_and_dynamic_routes() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app/users/[id]")).unwrap();
-        fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
-        fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
-        fs::write(root.join("app/users/[id]/_uf.page.js"), "// @flow\n").unwrap();
-        fs::write(root.join("app/users/[id]/_uf.middleware.js"), "// @flow\n").unwrap();
-
-        let routes = discover_routes(&root, &UniflowedConfig::default()).unwrap();
-
-        assert_eq!(routes.len(), 2);
-        assert_eq!(routes[0].path, "/");
-        assert!(routes[0].has_layout);
-        assert_eq!(routes[1].path, "/users/:id");
-        assert_eq!(routes[1].params[0].name, "id");
-        assert!(routes[1].has_middleware);
-    }
-
-    #[test]
-    fn generates_router_flow_with_params() {
-        let route = Route {
-            path: "/users/:id".into(),
-            directory: "app/users/[id]".into(),
-            page: "app/users/[id]/_uf.page.js".into(),
-            params: vec![RouteParam {
-                name: "id".into(),
-                kind: RouteParamKind::Single,
-            }],
-            has_layout: false,
-            has_middleware: false,
-        };
-
-        let source = generate_router_flow(&[route]);
-
-        assert!(source.contains("export type RoutePath = \"/users/:id\";"));
-        assert!(source.contains("\"/users/:id\": {| id: string |}"));
-    }
-
-    /// Generated code has to satisfy the rules uf ships enabled.
-    ///
-    /// `flow/ambiguous-object-type` is on by default, so a `{ … }` in the
-    /// generated router made a freshly scaffolded project fail `uf check` on a
-    /// file the user never wrote.
-    #[test]
-    fn generated_router_types_are_exact() {
-        let source = generate_router_flow(&[Route {
-            path: "/users/:id".into(),
-            directory: Utf8PathBuf::from("app/users/[id]"),
-            page: Utf8PathBuf::from("app/users/[id]/_uf.page.js"),
-            params: vec![RouteParam {
-                name: "id".into(),
-                kind: RouteParamKind::Single,
-            }],
-            has_layout: false,
-            has_middleware: false,
-        }]);
-
-        // An object type opens inexactly when `{` is not immediately followed
-        // by `|`, which is exactly what the lint rule looks for.
-        for line in source.lines() {
-            let bytes = line.as_bytes();
-            for (index, byte) in bytes.iter().enumerate() {
-                if *byte != b'{' {
-                    continue;
-                }
-                assert_eq!(
-                    bytes.get(index + 1),
-                    Some(&b'|'),
-                    "generated router opens an inexact object type, which \
-                     `flow/ambiguous-object-type` rejects: {line}"
-                );
-            }
-        }
-        assert!(source.contains("export type RouteParams = {|"));
-        assert!(source.ends_with("string;\n"));
-    }
-
-    #[test]
-    fn an_empty_project_still_generates_exact_types() {
-        let source = generate_router_flow(&[]);
-
-        assert!(source.contains("export type RoutePath = empty;"));
-        assert!(source.contains("export type RouteParams = {|"));
-        assert!(!source.contains("= {\n"));
-    }
-
-    #[test]
-    fn a_route_handler_is_a_reserved_file_rather_than_a_violation() {
-        // `_uf.route.js` answers a request instead of rendering a page. It was
-        // an unknown name until route handlers existed, and the two tests that
-        // used it as their example of an invalid one now use `_uf.handler.js`.
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app/api")).unwrap();
-        fs::write(root.join("app/api/_uf.route.js"), "// @flow\n").unwrap();
-
-        let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
-        assert!(violations.is_empty(), "{violations:?}");
-
-        let classified = classify_reserved_file(RESERVED_ROUTE);
-        assert!(!classified.is_unknown());
-    }
-
-    #[test]
-    fn finds_invalid_reserved_files() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app")).unwrap();
-        fs::write(root.join("app/_uf.handler.js"), "// @flow\n").unwrap();
-
-        let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
-
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].path.file_name(), Some("_uf.handler.js"));
-    }
-
-    #[test]
-    fn writes_router_manifest() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        fs::create_dir_all(root.join("app")).unwrap();
-        fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
-
-        let manifest = write_router_manifest(&root, &UniflowedConfig::default())
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(manifest.file_name(), Some("router.js"));
-        assert!(fs::read_to_string(manifest).unwrap().contains("RoutePath"));
-    }
-}
+mod tests;

--- a/crates/uf_router/src/tests.rs
+++ b/crates/uf_router/src/tests.rs
@@ -1,0 +1,190 @@
+//! Route discovery, the reserved-file grammar, and the generated types.
+
+use super::*;
+
+#[test]
+fn discovers_root_and_dynamic_routes() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app/users/[id]")).unwrap();
+    fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/users/[id]/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/users/[id]/_uf.middleware.js"), "// @flow\n").unwrap();
+
+    let routes = discover_routes(&root, &UniflowedConfig::default()).unwrap();
+
+    assert_eq!(routes.len(), 2);
+    assert_eq!(routes[0].path, "/");
+    assert!(routes[0].has_layout);
+    assert_eq!(routes[1].path, "/users/:id");
+    assert_eq!(routes[1].params[0].name, "id");
+    assert!(routes[1].has_middleware);
+}
+
+#[test]
+fn generates_router_flow_with_params() {
+    let route = Route {
+        path: "/users/:id".into(),
+        directory: "app/users/[id]".into(),
+        page: "app/users/[id]/_uf.page.js".into(),
+        params: vec![RouteParam {
+            name: "id".into(),
+            kind: RouteParamKind::Single,
+        }],
+        has_layout: false,
+        has_middleware: false,
+    };
+
+    let source = generate_router_flow(&[route]);
+
+    assert!(source.contains("export type RoutePath = \"/users/:id\";"));
+    assert!(source.contains("\"/users/:id\": { id: string }"));
+}
+
+/// The generated route table is the whole set of routes, so its types are
+/// exact: an inexact one would let a caller pass a path this router does not
+/// serve, which is the mistake the generated types exist to prevent.
+///
+/// Exactness is now spelled with plain braces. Flow has been exact by default
+/// since 2023 and rejects `exact_by_default=false` as deprecated, so `{ … }`
+/// *is* the exact type and `{| … |}` is the legacy spelling of the same thing.
+/// What actually has to be absent is the `...` that makes a type inexact.
+#[test]
+fn generated_router_types_are_exact() {
+    let source = generate_router_flow(&[Route {
+        path: "/users/:id".into(),
+        directory: Utf8PathBuf::from("app/users/[id]"),
+        page: Utf8PathBuf::from("app/users/[id]/_uf.page.js"),
+        params: vec![RouteParam {
+            name: "id".into(),
+            kind: RouteParamKind::Single,
+        }],
+        has_layout: false,
+        has_middleware: false,
+    }]);
+
+    assert!(
+        !source.contains("..."),
+        "an inexact route table would accept a path this router does not \
+         serve:\n{source}"
+    );
+    assert!(
+        !source.contains("{|"),
+        "the legacy exact spelling is not what uf tells anyone to write:\n{source}"
+    );
+    assert!(source.contains("export type RouteParams = {\n"));
+    assert!(source.contains(r#"  "/users/:id": { id: string },"#));
+    assert!(source.ends_with("string;\n"));
+}
+
+#[test]
+fn an_empty_project_still_generates_exact_types() {
+    let source = generate_router_flow(&[]);
+
+    assert!(source.contains("export type RoutePath = empty;"));
+    assert!(
+        source.contains("export type RouteParams = {};"),
+        "an empty table is an empty exact object:\n{source}"
+    );
+    assert!(!source.contains("..."));
+}
+
+#[test]
+fn a_route_handler_is_a_reserved_file_rather_than_a_violation() {
+    // `_uf.route.js` answers a request instead of rendering a page. It was
+    // an unknown name until route handlers existed, and the two tests that
+    // used it as their example of an invalid one now use `_uf.handler.js`.
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app/api")).unwrap();
+    fs::write(root.join("app/api/_uf.route.js"), "// @flow\n").unwrap();
+
+    let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
+    assert!(violations.is_empty(), "{violations:?}");
+
+    let classified = classify_reserved_file(RESERVED_ROUTE);
+    assert!(!classified.is_unknown());
+}
+
+#[test]
+fn finds_invalid_reserved_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::write(root.join("app/_uf.handler.js"), "// @flow\n").unwrap();
+
+    let violations = find_reserved_file_violations(&root, &UniflowedConfig::default()).unwrap();
+
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0].path.file_name(), Some("_uf.handler.js"));
+}
+
+#[test]
+fn writes_router_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+
+    let manifest = write_router_manifest(&root, &UniflowedConfig::default())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(manifest.file_name(), Some("router.js"));
+    assert!(fs::read_to_string(manifest).unwrap().contains("RoutePath"));
+}
+
+/// The router types uf generates must be what `uf fmt` would write.
+///
+/// uf scaffolds a project and then checks it with its own formatter, so a
+/// generated file the formatter disagrees with makes `uf fmt --check` fail on
+/// code nobody wrote. It did: the declaration was emitted as
+/// `route < Path extends RoutePath > (`, with spaces the printer does not put
+/// there, and `uf fmt --check` failed on `docs/router.js` in uf's own
+/// repository.
+#[test]
+fn the_generated_router_is_already_formatted() {
+    let routes = vec![
+        Route {
+            path: "/".into(),
+            directory: Utf8PathBuf::from("app"),
+            page: Utf8PathBuf::from("app/_uf.page.js"),
+            params: Vec::new(),
+            has_layout: true,
+            has_middleware: false,
+        },
+        Route {
+            path: "/posts/:id".into(),
+            directory: Utf8PathBuf::from("app/posts/[id]"),
+            page: Utf8PathBuf::from("app/posts/[id]/_uf.page.js"),
+            params: vec![RouteParam {
+                name: "id".into(),
+                kind: RouteParamKind::Single,
+            }],
+            has_layout: false,
+            has_middleware: false,
+        },
+    ];
+
+    let generated = generate_router_flow(&routes);
+    let formatted = uf_fmt::format_source(&generated, &uf_config::FmtConfig::default())
+        .expect("the generated router parses");
+
+    similar_asserts::assert_eq!(generated, formatted.output);
+    assert!(
+        !formatted.changed,
+        "uf generated a router the formatter it ships would rewrite"
+    );
+}
+
+/// An empty route table is generated too — a project with no pages yet — and
+/// is held to the same bar.
+#[test]
+fn an_empty_generated_router_is_already_formatted() {
+    let generated = generate_router_flow(&[]);
+    let formatted = uf_fmt::format_source(&generated, &uf_config::FmtConfig::default())
+        .expect("the generated router parses");
+
+    similar_asserts::assert_eq!(generated, formatted.output);
+}

--- a/uf.config.js
+++ b/uf.config.js
@@ -72,11 +72,11 @@ export default defineConfig({
     // check in the pipeline.
     //
     // Not in `ci` yet, and the reason is written down rather than left to be
-    // rediscovered: it reports 467 errors today. A third of them are
-    // `flow/ambiguous-object-type`, a rule whose premise modern Flow has
-    // retired — objects are exact by default now, so `{ a: b }` is not
-    // ambiguous and the `{| |}` the rule asks for is the deprecated spelling.
-    // The rule is wrong before the code is.
+    // rediscovered: it reports 315 errors today. The largest groups are
+    // `flow/unclear-type` (125), `flow/react-intrinsic-overlap` (89) and
+    // `react/hooks-rules` (86), and each needs looking at on its own terms —
+    // some are real findings in uf's packages, and some are rules that are
+    // wrong the way `flow/ambiguous-object-type` was wrong.
     "check:lib": {
       command: "./target/release/uf lint",
       dependsOn: ["build"],
@@ -84,10 +84,6 @@ export default defineConfig({
 
     // The formatter, over the same. `--check` rather than a write, because CI
     // reporting a diff is useful and CI committing one is not.
-    //
-    // Not in `ci` yet either, for a smaller reason: the router types uf
-    // generates are not formatted the way uf formats, so `uf fmt --check`
-    // fails on a file uf wrote itself.
     "fmt:check": {
       command: "./target/release/uf fmt --check",
       dependsOn: ["build"],
@@ -117,6 +113,7 @@ export default defineConfig({
         "rust:fmt:check",
         "rust:clippy",
         "rust:test",
+        "fmt:check",
         "test:lib",
         "docs:build",
         "rust:metadata",


### PR DESCRIPTION
Two things stopped this repository from checking itself, and both were bugs in
uf rather than in the repository.

`uf fmt --check` failed on `docs/router.js` — a file uf writes. The generator
emitted `route < Path extends RoutePath > (`, with spaces the printer does not
put there, and omitted the trailing comma the printer adds. uf scaffolds a
project and then checks it with its own formatter, so this failed on code
nobody wrote, in every generated project. `the_generated_router_is_already_formatted`
runs the generator's output through `uf_fmt` and compares, which is a guarantee
rather than a promise to remember.

`uf lint` reported 152 `flow/ambiguous-object-type` errors against uf's own
packages for writing modern Flow. The rule is named after an ambiguity that no
longer exists: it dates from when a `.flowconfig` could set
`exact_by_default=false` and `{ a: b }` meant different things in different
projects. Flow has defaulted to exact since 2023 and now rejects that option as
deprecated, so `{ a: b }` is exact — and the `{| |}` the rule asks for is the
legacy spelling of what the plain braces already say. It is off by default now,
and still selectable for a codebase migrating from an older Flow with both
spellings in the tree.

The router generator was writing `{| |}` for exactly that rule, and says so in
a comment. It writes plain braces now, which is the same type in the spelling
uf tells everyone to use, and the exactness tests check what actually matters —
that there is no `...` — rather than which spelling was used.

`uf_router`'s tests move out of `lib.rs` into `tests.rs`, matching every other
crate in the workspace.

`uf fmt --check` now passes over this whole repository, so it is in `ci` and
has a job. `uf lint` is at 315 errors and is not: the largest groups are
`flow/unclear-type`, `flow/react-intrinsic-overlap` and `react/hooks-rules`,
and each needs looking at on its own terms — some are real findings, and some
may be wrong the way this one was.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Stacked on #101.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791090520&installation_model_id=422833&pr_number=104&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F104&signature=0caf0141cad560bebc5d6ce47ea16b4b807eb361ce60f546fa9af3cbea6fd484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->