### PR TITLE
feat(stylex): the compiler was written and nothing ever called it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,6 +3363,7 @@ dependencies = [
  "uf_router",
  "uf_rsc",
  "uf_runtime",
+ "uf_stylex",
  "uf_term",
  "uf_test",
  "uf_transform",

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -44,6 +44,7 @@ uf_rm = { path = "../uf_rm" }
 uf_router = { path = "../uf_router" }
 uf_rsc = { path = "../uf_rsc" }
 uf_runtime = { path = "../uf_runtime" }
+uf_stylex = { path = "../uf_stylex" }
 uf_term = { path = "../uf_term" }
 uf_test = { path = "../uf_test" }
 uf_transform = { path = "../uf_transform" }

--- a/crates/uf_cli/src/commands/transform.rs
+++ b/crates/uf_cli/src/commands/transform.rs
@@ -80,6 +80,13 @@ struct Reply {
     code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     map: Option<String>,
+    /// The CSS this module's StyleX rules produced, when it has any.
+    ///
+    /// Absent rather than empty for a module with no styles: the caller keys
+    /// "this module has a stylesheet" off the field being there at all, and an
+    /// empty string would make it import a stylesheet with nothing in it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    css: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     diagnostics: Vec<CompilerDiagnostic>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -161,6 +168,40 @@ fn serve(input: impl Read, out: &mut impl Write, project: &ProjectTransform) -> 
     Ok(())
 }
 
+/// One module's code after StyleX, and the CSS it contributed.
+struct Styled {
+    code: String,
+    css: Option<String>,
+}
+
+/// Compile a module's StyleX calls, or leave it exactly as it was.
+///
+/// A module that does not use StyleX comes back untouched and contributes no
+/// CSS, which is the overwhelmingly common case and costs one parse.
+///
+/// A module the StyleX compiler cannot read is *not* an error. The compiler
+/// parses JavaScript that has already been through the whole Flow chain, so a
+/// failure here is a disagreement between two parsers about valid code rather
+/// than a problem with the user's module — and failing the transform would
+/// turn a style that could not be extracted into a build that will not run.
+/// The `uf:style` plugin reports its own diagnostics for the cases that are
+/// genuinely the module's fault.
+fn compile_styles(code: &str) -> Styled {
+    match uf_stylex::compile_module(code) {
+        Ok(compiled) if compiled.changed => {
+            let css = compiled.sheet.to_css();
+            Styled {
+                code: compiled.code,
+                css: (!css.is_empty()).then_some(css),
+            }
+        }
+        Ok(_) | Err(_) => Styled {
+            code: code.to_owned(),
+            css: None,
+        },
+    }
+}
+
 fn handle(request: &Request, project: &ProjectTransform) -> Reply {
     if !is_flow_module(&request.id) {
         return Reply {
@@ -170,13 +211,22 @@ fn handle(request: &Request, project: &ProjectTransform) -> Reply {
     }
     let options = project.options(&request.id, &request.options);
     match transform(&request.code, &options) {
-        Ok(transformed) => Reply {
-            id: request.id.clone(),
-            code: Some(transformed.code),
-            map: transformed.map,
-            diagnostics: transformed.compiler_diagnostics,
-            ..Reply::default()
-        },
+        Ok(transformed) => {
+            // StyleX last, over the JavaScript the Flow chain produced. It is a
+            // source-to-source rewrite of `stylex.create` calls into the class
+            // names its stylesheet declares, so it wants the code in the shape
+            // the browser will see it — after the types are gone and after the
+            // React Compiler has had its pass.
+            let styled = compile_styles(&transformed.code);
+            Reply {
+                id: request.id.clone(),
+                code: Some(styled.code),
+                map: transformed.map,
+                css: styled.css,
+                diagnostics: transformed.compiler_diagnostics,
+                ..Reply::default()
+            }
+        }
         Err(error) => {
             let (line, column) = match &error {
                 TransformError::Syntax { line, column, .. } => (Some(*line), Some(*column)),
@@ -210,6 +260,50 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str(line).unwrap())
             .collect()
+    }
+
+    /// StyleX is uf's style engine, and a module that uses it has to come back
+    /// with its rules extracted — not with the `stylex.create` call still in it.
+    ///
+    /// The compiler crate existed and nothing called it: `uf:style` was in the
+    /// resolved pipeline, `uf inspect` listed it, and `stylex.create({...})`
+    /// went through `uf transform` untouched and reached the runtime stub,
+    /// which throws.
+    #[test]
+    fn a_stylex_module_comes_back_compiled_and_with_its_css() {
+        let source = "// @flow\nimport { stylex } from \"@uniflowed/stylex\";\n\
+                      const styles = stylex.create({ root: { color: \"red\" } });\n\
+                      export const used: mixed = stylex.props(styles.root);\n";
+        let request = serde_json::json!({ "id": "/app/box.js", "code": source });
+        let replies = replies(&format!("{request}\n"));
+
+        let reply = &replies[0];
+        assert!(reply["error"].is_null(), "{reply}");
+
+        let css = reply["css"].as_str().unwrap_or_default();
+        assert!(
+            css.contains("color:red") || css.contains("color: red"),
+            "the module's rules must come back as CSS, got {css:?}"
+        );
+
+        let code = reply["code"].as_str().unwrap_or_default();
+        assert!(
+            !code.contains("stylex.create"),
+            "the call must be compiled away, got {code}"
+        );
+    }
+
+    /// A module with no styles must not carry an empty CSS payload: the caller
+    /// keys "this module has a stylesheet" off the field being present.
+    #[test]
+    fn a_module_without_styles_has_no_css() {
+        let request = serde_json::json!({
+            "id": "/app/plain.js",
+            "code": "// @flow\nexport const v: number = 1;\n",
+        });
+        let replies = replies(&format!("{request}\n"));
+
+        assert!(replies[0]["css"].is_null(), "{}", replies[0]);
     }
 
     #[test]

--- a/crates/uf_project/src/template.rs
+++ b/crates/uf_project/src/template.rs
@@ -66,8 +66,10 @@ fn lib_package_json(name: &str) -> String {
   "exports": {{
     ".": "./index.js"
   }},
-  "dependencies": {{
-    "@uniflowed/core": "latest"
+  "devDependencies": {{
+    "@uniflowed/config": "latest",
+    "@uniflowed/test": "latest",
+    "@uniflowed/vite": "latest"
   }}
 }}
 "#

--- a/crates/uf_project/src/tests.rs
+++ b/crates/uf_project/src/tests.rs
@@ -231,3 +231,57 @@ fn scaffolded_tasks_name_real_commands() {
         }
     }
 }
+
+/// Every `@uniflowed/*` a template scaffolds has to be a package that is
+/// actually published.
+///
+/// `uf create` writes a `package.json` and the next thing anyone runs is
+/// `uf install`. A dependency on a name npm does not serve makes that fail with
+/// a 404 — not uf's error message, npm's — and the project is unusable before
+/// it has been opened. This repository has shipped that failure before, with a
+/// scaffold that imported ten packages which did not exist.
+///
+/// `tools/release/published-packages.txt` is the list of names a release
+/// publishes, and it is deliberately shorter than `packages/`: most of those
+/// are declarations whose functions throw. A package earns its way onto that
+/// list by being implemented, and only then may a template depend on it.
+#[test]
+fn every_scaffolded_dependency_is_a_published_package() {
+    let list = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tools/release/published-packages.txt"),
+    )
+    .expect("the publish list is readable");
+    let published = list
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|name| format!("@uniflowed/{name}"))
+        .collect::<std::collections::BTreeSet<_>>();
+
+    let mut unpublished = Vec::new();
+    for (kind, files) in [("app", app_react_files("demo")), ("lib", lib_files("demo"))] {
+        let manifest = files
+            .iter()
+            .find(|(path, _)| *path == "package.json")
+            .map(|(_, contents)| contents.clone())
+            .expect("a manifest");
+
+        for line in manifest.lines() {
+            let Some(name) = line.split('"').nth(1) else {
+                continue;
+            };
+            if !name.starts_with("@uniflowed/") || published.contains(name) {
+                continue;
+            }
+            unpublished.push(format!("the {kind} template depends on {name}"));
+        }
+    }
+
+    assert!(
+        unpublished.is_empty(),
+        "{}\n\nadd the package to tools/release/published-packages.txt once it is \
+         implemented, and depend on it once a release has published it",
+        unpublished.join("\n")
+    );
+}

--- a/packages/stylex/index.js
+++ b/packages/stylex/index.js
@@ -1,37 +1,162 @@
 // @flow
 //
-// `@uniflowed/stylex`.
+// `@uniflowed/stylex`: uf's style engine, as the thing that runs.
+//
+// Almost all of StyleX happens at compile time. `uf transform` rewrites every
+// `stylex.create({ … })` into a plain object of class names and collects the
+// rules into a stylesheet, so by the time this module is loaded there are no
+// style values left — only names.
+//
+// What remains is `props`, and it is here because it cannot be anywhere else:
+// its arguments are usually conditional (`active && styles.on`), and a compiler
+// cannot fold a value it does not know. Everything else in this module exists
+// so that a call the compiler failed to see fails loudly rather than silently
+// rendering an application with no styles.
+//
+// The merge is specified in `crates/uf_stylex/src/props.rs` and modelled there
+// at compile time, which is what lets its ordering be tested. This
+// implementation and that model have to agree.
 
 import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
-const MODULE = "@uniflowed/core/stylex";
+const MODULE = "@uniflowed/stylex";
 
-export interface StyleXSheet {
-  readonly [string]: mixed;
+/**
+ * A compiled style namespace.
+ *
+ * `$$css` marks an object the compiler produced. Every other key is a CSS
+ * property mapped to the class name that sets it — or to `null`, which is how
+ * a namespace says it deliberately unsets that property.
+ */
+export type CompiledStyle = {
+  readonly $$css: true,
+  readonly [property: string]: string | null | true,
+};
+
+/** What a call site may pass: a namespace, something falsy, or a list. */
+export type StyleArgument = mixed;
+
+/** What `props` hands to an element. */
+export type StyleProps = { readonly className?: string };
+
+/**
+ * Merge compiled namespaces into a `className`, left to right.
+ *
+ * The **property** is the unit of merging: a later namespace that sets `color`
+ * replaces everything an earlier one said about `color`, its `:hover` value
+ * included. That is what a later `color:` in a stylesheet does, and it is why a
+ * later namespace cannot leave a stray hover state behind.
+ *
+ * Falsy arguments are skipped, because `active && styles.on` is the idiom this
+ * function exists for, and arrays are flattened so a list built elsewhere can
+ * be passed without spreading it.
+ *
+ * Returns an object rather than a string so the call site stays
+ * `<div {...stylex.props(a, b)} />` — the same shape whether or not anything
+ * survived.
+ */
+export function props(...styles: $ReadOnlyArray<StyleArgument>): StyleProps {
+  const winners: { [string]: string | null } = {};
+  collect(styles, winners);
+
+  let className = "";
+  for (const property of Object.keys(winners)) {
+    const name = winners[property];
+    // `null` is a deliberate unset: the property has an owner, and that owner
+    // said there should be no class for it.
+    if (name == null) {
+      continue;
+    }
+    className = className === "" ? name : className + " " + name;
+  }
+
+  return className === "" ? {} : { className };
 }
 
-export interface StyleX {
-  create<T extends { readonly [string]: mixed }>(styles: T): T;
-  props(...styles: $ReadOnlyArray<mixed>): { readonly [string]: mixed };
-  defineVars<T extends { readonly [string]: string | number }>(tokens: T): T;
-  createTheme<T extends { readonly [string]: string | number }>(tokens: T): T;
+/**
+ * Fold arguments into `winners`, flattening arrays.
+ *
+ * Insertion order is the order a property was *first* claimed, and assigning
+ * over an existing key does not move it — so two namespaces that both set
+ * `color` produce one class in the position the first one had. The class list
+ * is a function of the properties involved, not of how many namespaces
+ * mentioned them.
+ */
+function collect(
+  styles: $ReadOnlyArray<StyleArgument>,
+  winners: { [string]: string | null },
+): void {
+  for (const style of styles) {
+    if (style == null || style === false || style === true) {
+      continue;
+    }
+    if (Array.isArray(style)) {
+      collect(style, winners);
+      continue;
+    }
+    if (typeof style !== "object") {
+      continue;
+    }
+    const namespace = style as $FlowFixMe;
+    for (const property of Object.keys(namespace)) {
+      if (property === "$$css") {
+        continue;
+      }
+      const value = namespace[property];
+      if (typeof value === "string" || value === null) {
+        winners[property] = value;
+      }
+    }
+  }
 }
 
+/**
+ * Declare a set of style namespaces.
+ *
+ * Never runs. `uf transform` replaces the whole call with the object it
+ * computed, so reaching this means the module was loaded without going through
+ * uf — a bundler configured by hand, a plain `node` invocation — and the styles
+ * it declares are in no stylesheet. Throwing says so; returning the input would
+ * render an application with no styles and no explanation.
+ */
+export function create<T extends { readonly [string]: mixed }>(styles: T): T {
+  return nativeRuntimeRequired(MODULE, "stylex.create");
+}
+
+/**
+ * Declare design tokens, and hand back the `var(--…)` references to them.
+ *
+ * Compile-time, for the same reason as `create`.
+ */
 export function defineVars<T extends { readonly [string]: string | number }>(tokens: T): T {
-  return nativeRuntimeRequired(MODULE, "defineVars");
+  return nativeRuntimeRequired(MODULE, "stylex.defineVars");
 }
 
+/**
+ * Override a set of tokens for a subtree.
+ *
+ * Compile-time, for the same reason as `create`.
+ */
 export function createTheme<T extends { readonly [string]: string | number }>(tokens: T): T {
-  return nativeRuntimeRequired(MODULE, "createTheme");
+  return nativeRuntimeRequired(MODULE, "stylex.createTheme");
 }
 
-export const stylex: StyleX = {
-  create<T extends { readonly [string]: mixed }>(styles: T): T {
-    return nativeRuntimeRequired(MODULE, "stylex.create");
-  },
-  props(...styles: $ReadOnlyArray<mixed>): { readonly [string]: mixed } {
-    return nativeRuntimeRequired(MODULE, "stylex.props");
-  },
+/**
+ * The namespace form, so `stylex.create` and `stylex.props` read the way
+ * StyleX documents them.
+ *
+ * The named exports are the ones a bundler can drop individually; this object
+ * is for call sites that prefer the qualified spelling, and the compiler
+ * recognises both.
+ */
+export const stylex: {
+  readonly create: typeof create,
+  readonly props: typeof props,
+  readonly defineVars: typeof defineVars,
+  readonly createTheme: typeof createTheme,
+} = {
+  create,
+  props,
   defineVars,
   createTheme,
 };

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -55,6 +55,16 @@ import { TransformService, isFlowModule } from "./transform.js";
 const resolved = (id) => `\0${id}`;
 const VIRTUAL_IDS = new Set(Object.values(VIRTUAL));
 
+/**
+ * Prefix of the virtual module that carries one source module's StyleX rules.
+ *
+ * Not NUL-prefixed, unlike the virtual modules above: Vite's CSS pipeline keys
+ * off the `.css` extension of a *resolvable* id, and a NUL-prefixed id is
+ * excluded from it. The prefix is distinctive enough that nothing else can
+ * collide with it.
+ */
+const STYLE_PREFIX = "uf-style:";
+
 /** The URL a NUL-prefixed module is served at in development. */
 export function devUrlFor(id) {
   return `/@id/__x00__${id}`;
@@ -94,6 +104,15 @@ function flowPlugin({ routerRoot, appEntry, command }) {
   let server = null;
   /** @type {TransformService | null} */
   let service = null;
+  /**
+   * Each module's compiled stylesheet, keyed by the virtual id serving it.
+   *
+   * A map rather than one accumulated sheet: Vite asks for a module's CSS when
+   * it loads that module, re-asks when the module changes, and drops it when
+   * the module goes away. One shared sheet would have to be invalidated by
+   * hand, which is the part that goes wrong.
+   */
+  const styles = new Map();
 
   const ensureService = () => {
     service ??= new TransformService({ command, root });
@@ -149,6 +168,10 @@ function flowPlugin({ routerRoot, appEntry, command }) {
     resolveId(id) {
       if (id === RUNTIME_PUBLIC_PATH) return RUNTIME_RESOLVED_ID;
       if (VIRTUAL_IDS.has(id)) return resolved(id);
+      // A module's own stylesheet, which `transform` below asked for by
+      // importing this id. Returning it unchanged marks it resolved without
+      // Vite going to the filesystem for a file that does not exist.
+      if (id.startsWith(STYLE_PREFIX)) return id;
       return null;
     },
 
@@ -157,6 +180,7 @@ function flowPlugin({ routerRoot, appEntry, command }) {
       if (id === resolved(VIRTUAL.routes)) return routesModuleSource(scanRoutes(appRoot));
       if (id === resolved(VIRTUAL.client)) return clientModuleSource(entryPath);
       if (id === resolved(VIRTUAL.server)) return serverModuleSource(entryPath);
+      if (id.startsWith(STYLE_PREFIX)) return styles.get(id) ?? "";
       return null;
     },
 
@@ -174,9 +198,24 @@ function flowPlugin({ routerRoot, appEntry, command }) {
         this.warn?.(`${diagnostic.function ?? "a function"}: ${diagnostic.message}`);
       }
       const map = out.map == null ? null : JSON.parse(out.map);
-      if (!refresh) return { code: out.code, map };
+      // StyleX. `uf transform` compiled the module's `stylex.create` calls into
+      // class names and handed back the rules they declared; the rules become a
+      // module of their own that this one imports.
+      //
+      // Handing the CSS to Vite as a module, rather than collecting it here and
+      // writing a stylesheet at the end, is what keeps uf out of the CSS
+      // business: Vite already injects a stylesheet in dev, extracts it in a
+      // build, code-splits it per chunk, and replaces it over HMR. A module
+      // whose styles are gone stops importing it, and Vite notices.
+      let output = out.code;
+      if (out.css != null && out.css !== "") {
+        const styleId = `${STYLE_PREFIX}${cleanId(id)}.css`;
+        styles.set(styleId, out.css);
+        output = `import ${JSON.stringify(styleId)};\n${output}`;
+      }
+      if (!refresh) return { code: output, map };
       const relative = path.relative(root, cleanId(id)).split(path.sep).join("/");
-      return addRefreshWrapper(out.code, map, relative);
+      return addRefreshWrapper(output, map, relative);
     },
 
     buildEnd() {

--- a/tests/library/stylex.test.js
+++ b/tests/library/stylex.test.js
@@ -1,0 +1,98 @@
+// @flow
+//
+// `stylex.props`, the one part of StyleX that runs.
+//
+// Everything else is compiled away by `uf transform`, so these tests hand
+// `props` the shape the compiler produces — an object with `$$css: true` and a
+// class name per property — rather than calling `create`, which throws when it
+// is reached at runtime precisely because reaching it means the compiler did
+// not see the call.
+//
+// The merge is modelled a second time in `crates/uf_stylex/src/props.rs`, which
+// is what lets its ordering be tested at compile time. The two have to agree,
+// and the cases below are the ones where they could disagree.
+
+import { describe, expect, it } from "@uniflowed/testing";
+import { props, stylex } from "@uniflowed/stylex";
+
+/** A compiled namespace, in the shape `uf transform` emits. */
+function compiled(properties: { readonly [string]: string | null }): mixed {
+  return { $$css: true, ...properties };
+}
+
+describe("stylex.props", () => {
+  it("returns the class for a single namespace", () => {
+    expect(props(compiled({ color: "c1" }))).toEqual({ className: "c1" });
+  });
+
+  it("joins the classes of disjoint properties with a space", () => {
+    const out = props(compiled({ color: "c1", paddingTop: "p1" }));
+
+    expect(out.className).toBe("c1 p1");
+  });
+
+  it("lets a later namespace replace an earlier one property by property", () => {
+    const out = props(compiled({ color: "c1" }), compiled({ color: "c2" }));
+
+    expect(out).toEqual({ className: "c2" });
+  });
+
+  it("keeps the properties a later namespace did not mention", () => {
+    const out = props(compiled({ color: "c1", paddingTop: "p1" }), compiled({ color: "c2" }));
+
+    expect(out.className).toBe("c2 p1");
+  });
+
+  it("skips falsy arguments, which is what conditional styles are", () => {
+    const active = false;
+    const out = props(compiled({ color: "c1" }), active && compiled({ color: "c2" }));
+
+    expect(out).toEqual({ className: "c1" });
+    expect(props(null, undefined, false)).toEqual({});
+  });
+
+  it("flattens a list of namespaces", () => {
+    const out = props([compiled({ color: "c1" }), compiled({ paddingTop: "p1" })]);
+
+    expect(out.className).toBe("c1 p1");
+  });
+
+  it("treats null as a deliberate unset rather than a class", () => {
+    const out = props(compiled({ color: "c1" }), compiled({ color: null }));
+
+    expect(out).toEqual({});
+  });
+
+  it("returns an empty object when nothing survives, not an empty className", () => {
+    // `{...stylex.props()}` has to spread to nothing, or every element gets
+    // `class=""`.
+    expect(props()).toEqual({});
+  });
+
+  it("orders classes by the property that first claimed one", () => {
+    // `color` is claimed first and keeps its position even though the class
+    // that wins it comes from the second namespace.
+    const out = props(
+      compiled({ color: "c1", paddingTop: "p1" }),
+      compiled({ paddingTop: "p2", color: "c2" }),
+    );
+
+    expect(out.className).toBe("c2 p2");
+  });
+
+  it("is reachable under its qualified name too", () => {
+    expect(stylex.props(compiled({ color: "c1" }))).toEqual({ className: "c1" });
+  });
+});
+
+describe("the compile-time surface", () => {
+  it("throws when a create call reached the runtime", () => {
+    // Reaching `create` means the compiler never saw the call, so the styles it
+    // declares are in no stylesheet. Failing loudly is the only honest answer:
+    // handing the input back renders an application with no styles and no
+    // explanation.
+    expect(() => stylex.create({ root: { color: "red" } })).toThrow();
+    expect(() => stylex.defineVars({ accent: "#35D6F6" })).toThrow();
+    expect(() => stylex.createTheme({ accent: "#D84BFF" })).toThrow();
+  });
+});

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -16,6 +16,7 @@ query
 react
 react-testing
 router
+stylex
 test
 ui
 vite


### PR DESCRIPTION
`uf inspect` listed `uf:style` in the resolved pipeline. `uf_stylex` was 4,597
lines of tested compiler. And `stylex.create({ root: { color: "red" } })` went
through `uf transform` untouched, reached the runtime, and threw — because
`@uniflowed/stylex` was a declaration module whose every export raised "requires
the uf native runtime".

Three pieces, and all three had to exist before any of it worked.

**The transform runs the compiler.** Last, over the JavaScript the Flow chain
produced: StyleX rewrites `stylex.create` into the class names its stylesheet
declares, so it wants the code in the shape the browser will see it. A module
the compiler cannot read is not an error — it has already been through two
other parsers, so a failure there is a disagreement between parsers rather than
a problem with the module, and failing the transform would turn a style that
could not be extracted into a build that will not run.

**The runtime is real.** `props` is the one part of StyleX that cannot be
compiled away, because its arguments are conditional — `active && styles.on` is
the idiom it exists for. The property is the unit of merging, so a later
namespace setting `color` replaces everything an earlier one said about
`color`, its `:hover` included; `null` is a deliberate unset rather than a
class; falsy arguments and nested arrays are skipped and flattened; and nothing
surviving returns `{}` rather than `{className: ""}`, so `{...stylex.props()}`
spreads to nothing instead of putting `class=""` on every element. Eleven tests
against `crates/uf_stylex/src/props.rs`, which models the same merge at compile
time. `create`, `defineVars` and `createTheme` still throw, and that is the
design: reaching one means the compiler never saw the call, so the styles are
in no stylesheet, and handing the input back would render an application with
no styles and no explanation.

**Vite owns the CSS.** Each module's rules become a virtual module that the
module imports, rather than a sheet uf accumulates and writes at the end. Vite
already injects a stylesheet in dev, extracts it in a build, splits it per
chunk and replaces it over HMR — and a module whose styles are gone stops
importing it, which is the invalidation that would otherwise have to be done by
hand.

A bug fell out of trying to scaffold it. Adding `@uniflowed/stylex` to the app
template broke `uf create` -> `uf install` with an npm 404, because the package
is implemented but not yet published — so the dependency waits for a release,
and `every_scaffolded_dependency_is_a_published_package` now fails on any
template that depends on a name a release does not publish.

That test immediately found the same bug already shipped: the `lib` template
depended on `@uniflowed/core`, which is not on the publish list and 404s on npm
— so `uf create lib` followed by `uf install` has been failing outright. It
depends on what it actually uses now, `@uniflowed/test` and `@uniflowed/vite`,
both published, both dev dependencies. `uf create lib` -> `uf install` ->
`uf run test` runs end to end for the first time.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791095928&installation_model_id=422833&pr_number=108&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F108&signature=aedf8132722a268a6f3e914cc06ccd21418dd642a945735d0eacb5d20ce4f93e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added StyleX compilation to transformed Flow modules, including generated CSS output.
  - Added Vite support for serving per-module StyleX stylesheets automatically.
  - Added runtime `stylex.props` support for merging conditional and overlapping styles.
  - Published the StyleX package for npm consumers.

- **Bug Fixes**
  - Plain modules now remain unchanged and do not produce unnecessary CSS.

- **Scaffolding**
  - Updated library templates to use the current development tooling packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->