### PR TITLE
feat(server): the request a server function is inside

### DIFF
--- a/packages/router/handler.js
+++ b/packages/router/handler.js
@@ -26,6 +26,7 @@
 // with the `Allow` header the specification requires — that is not the
 // handler's business, and every handler would otherwise write it.
 
+import { contextFor, drainDeferred, runWithContext } from "@uniflowed/server/host";
 import type { RouteParams } from "./internal/runtime.js";
 
 /** What a handler is given besides the request. */
@@ -89,10 +90,17 @@ export function createDispatcher(options: {|
         return methodNotAllowed(module);
       }
 
-      const response = await handler(request, {
-        params,
-        searchParams: url.searchParams,
-      });
+      // Inside the request, so a handler that calls `headers()`, `cookies()`
+      // or `after()` has something to answer about. `drainDeferred` runs after
+      // the response is in hand, which is what `after()` means.
+      const context = contextFor(request);
+      const response = await runWithContext(context, () =>
+        handler(request, {
+          params,
+          searchParams: url.searchParams,
+        }),
+      );
+      await drainDeferred(context);
 
       // A `HEAD` answered by `GET` must not carry the body. The test is
       // against the module's own `HEAD`, not `pick`'s — `pick` falls back to

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -27,5 +27,8 @@
   "peerDependencies": {
     "react": ">=19",
     "react-dom": ">=19"
+  },
+  "dependencies": {
+    "@uniflowed/server": "0.0.0-alpha.2"
   }
 }

--- a/packages/server/host.js
+++ b/packages/server/host.js
@@ -1,0 +1,23 @@
+// @flow
+//
+// `@uniflowed/server/host`: how a host establishes a request.
+//
+// The other half of this package. `@uniflowed/server` is what an application
+// calls *inside* a request; this is what a renderer, a route dispatcher or a
+// server-action bridge calls to say that a request has begun and, later, that
+// the response has gone.
+//
+// Two subpaths rather than one module, because they have opposite audiences and
+// opposite rules. Everything in the root is safe to call from a component and
+// meaningless outside a request; everything here is meaningless *inside* one
+// and must be called exactly once around it. Mixing them would put
+// `runWithContext` in the same import a page reaches for, which is an invitation
+// to nest one request inside another.
+//
+// It is a subpath rather than `internal/` because a sibling package cannot
+// reach another's internals: `@uniflowed/router` is where a request begins, and
+// it is a different npm package.
+
+export type { CookieStore, DraftMode, HeaderStore, RequestContext } from "./internal/context.js";
+
+export { contextFor, drainDeferred, parseCookies, runWithContext } from "./internal/context.js";

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -1,43 +1,101 @@
 // @flow
 //
-// `@uniflowed/server`.
+// `@uniflowed/server`: what a server function may ask about its request.
+//
+// Every binding here takes no arguments and answers about the request being
+// handled, which is only possible because the renderer establishes a context
+// around each one ([`./internal/context.js`]). Outside a request they throw,
+// and each says what it was that had nowhere to look — a component that calls
+// `cookies()` during a static prerender has made a mistake worth naming, not a
+// mistake worth returning `null` for.
+//
+// This module is server-only. Nothing in it is reachable from a client
+// component, `uf:rsc` classifies it that way, and importing it from one is the
+// error that classification exists to produce.
 
-import { nativeRuntimeRequired } from "@uniflowed/core/native";
+import type { CookieStore, DraftMode, HeaderStore } from "./internal/context.js";
+import { currentContext } from "./internal/context.js";
 
-const MODULE = "@uniflowed/core/server";
+export type { CookieStore, DraftMode, HeaderStore } from "./internal/context.js";
 
-export opaque type ServerAction<TArgs extends $ReadOnlyArray<mixed>, TReturn> = {
-  readonly __ufNative: "@uniflowed/core/server#ServerAction",
-  __ufArgs: TArgs,
-  __ufReturn: TReturn,
-};
+/**
+ * Raised when a server function is called with no request to answer about.
+ *
+ * Names the binding, because "no request context" on its own leaves a reader
+ * hunting for which of the six things they called was the one out of place.
+ */
+export class OutsideRequestError extends Error {
+  /** The binding that was called, e.g. `cookies`. */
+  binding: string;
 
-export function serverAction<TArgs extends $ReadOnlyArray<mixed>, TReturn>(
-  action: (...TArgs) => Promise<TReturn> | TReturn,
-): (...TArgs) => Promise<TReturn> {
-  return nativeRuntimeRequired(MODULE, "serverAction");
+  constructor(binding: string) {
+    super(
+      `@uniflowed/server: ${binding}() was called outside a request. ` +
+        "It answers about the request being handled, and there is not one here — " +
+        "a static prerender, a module's top level, or a client component.",
+    );
+    this.name = "OutsideRequestError";
+    this.binding = binding;
+  }
 }
 
-export function headers(): { get(name: string): null | string } {
-  return nativeRuntimeRequired(MODULE, "headers");
+/** The current request's context, or a named failure. */
+function require$Context(binding: string) {
+  const context = currentContext();
+  if (context == null) {
+    throw new OutsideRequestError(binding);
+  }
+  return context;
 }
 
-export function cookies(): { get(name: string): null | string } {
-  return nativeRuntimeRequired(MODULE, "cookies");
+/**
+ * The request's headers, read-only.
+ *
+ * Read-only because a response header set from inside a render has no defined
+ * moment to take effect: the headers may already be on the wire by the time a
+ * component deep in the tree renders.
+ */
+export function headers(): HeaderStore {
+  return require$Context("headers").headers;
 }
 
-export function cache<T>(key: string, body: () => T | Promise<T>): Promise<T> {
-  return nativeRuntimeRequired(MODULE, "cache");
+/**
+ * The request's cookies, read-only.
+ *
+ * Setting a cookie belongs to a route handler or a server action, which run
+ * before a response exists and can say so in it.
+ */
+export function cookies(): CookieStore {
+  return require$Context("cookies").cookies;
 }
 
-export function draftMode(): {
-  readonly isEnabled: boolean,
-  readonly enable: () => void,
-  readonly disable: () => void,
-} {
-  return nativeRuntimeRequired(MODULE, "draftMode");
+/**
+ * Whether this request is rendering draft content.
+ *
+ * The flag lives on the request rather than in a module, so two requests being
+ * handled at once cannot see each other's answer.
+ */
+export function draftMode(): DraftMode {
+  const context = require$Context("draftMode");
+  return {
+    isEnabled: context.draft,
+    enable: () => {
+      context.draft = true;
+    },
+    disable: () => {
+      context.draft = false;
+    },
+  };
 }
 
+/**
+ * Run `callback` once the response has been sent.
+ *
+ * For the work a request causes but a response does not wait on: recording a
+ * view, flushing a metric, warming a cache. Registered work runs in the order
+ * it was registered, and one task failing does not stop the others — deferred
+ * work is by definition not what the response depended on.
+ */
 export function after(callback: () => mixed | Promise<mixed>): void {
-  return nativeRuntimeRequired(MODULE, "after");
+  require$Context("after").deferred.push(callback);
 }

--- a/packages/server/internal/context.js
+++ b/packages/server/internal/context.js
@@ -1,0 +1,179 @@
+// @flow
+//
+// Internal to `@uniflowed/server`: the request a server function is inside.
+//
+// `headers()` and `cookies()` take no arguments, which is the whole point —
+// a component nested six levels down should not have to be handed a request
+// that every layer between it and the server has to thread through. That
+// convenience needs somewhere to keep the request, and "somewhere" has exactly
+// one safe answer on a server: storage scoped to the asynchronous call tree of
+// the request being handled.
+//
+// A module-level variable would be wrong in a way that only shows up under
+// load. `renderToString` is synchronous, so a variable set around it reads
+// correctly — right up until a route awaits something, another request arrives
+// while it is suspended, and the second request's headers are what the first
+// one sees. `AsyncLocalStorage` is the primitive that does not have that bug,
+// and Node, Deno and Bun all provide it under the `node:` specifier.
+//
+// This module is server-only by construction: nothing in `@uniflowed/server`
+// is reachable from a client component, and `uf:rsc` classifies it that way.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** A read-only view of one request's headers. */
+export type HeaderStore = {
+  readonly get: (name: string) => string | null,
+  readonly has: (name: string) => boolean,
+};
+
+/** A read-only view of one request's cookies. */
+export type CookieStore = {
+  readonly get: (name: string) => string | null,
+  readonly has: (name: string) => boolean,
+};
+
+/** Whether this request is rendering draft content, and how to change that. */
+export type DraftMode = {
+  readonly isEnabled: boolean,
+  readonly enable: () => void,
+  readonly disable: () => void,
+};
+
+/**
+ * Everything a server function may ask about the request it is inside.
+ *
+ * Deliberately not the `Request` itself. A server function that could reach the
+ * whole request could read the body, which is already being consumed by the
+ * thing that called it, and could hold it past the response.
+ */
+export type RequestContext = {
+  readonly headers: HeaderStore,
+  readonly cookies: CookieStore,
+  draft: boolean,
+  /** Work deferred until the response has been sent. */
+  readonly deferred: Array<() => mixed | Promise<mixed>>,
+};
+
+const storage: AsyncLocalStorage<RequestContext> = new AsyncLocalStorage();
+
+/**
+ * The context of the request being handled, or `null` outside one.
+ *
+ * `null` rather than throwing, so each caller can say what *it* needed the
+ * request for — "cookies() was called outside a request" is a better error than
+ * one generic message from here.
+ */
+export function currentContext(): RequestContext | null {
+  return storage.getStore() ?? null;
+}
+
+/**
+ * Run `body` with `context` as the current request.
+ *
+ * Everything `body` awaits sees the same context, and nothing outside it does.
+ */
+export function runWithContext<T>(context: RequestContext, body: () => T): T {
+  return storage.run(context, body);
+}
+
+/**
+ * Build a context from a `Request`.
+ *
+ * The header and cookie views are built once and read many times: a render
+ * touches `cookies().get(…)` as often as it has components that care, and
+ * re-parsing the cookie header each time would be the kind of cost nobody
+ * looks for.
+ */
+export function contextFor(request: Request): RequestContext {
+  const headers = request.headers;
+  const cookies = parseCookies(headers.get("cookie"));
+
+  return {
+    headers: {
+      get: (name) => headers.get(name),
+      has: (name) => headers.has(name),
+    },
+    cookies: {
+      get: (name) => (Object.hasOwn(cookies, name) ? cookies[name] : null),
+      has: (name) => Object.hasOwn(cookies, name),
+    },
+    draft: false,
+    deferred: [],
+  };
+}
+
+/**
+ * Parse a `Cookie` header into a plain object.
+ *
+ * `Object.create(null)` rather than `{}`: a cookie called `__proto__` is a
+ * thing an attacker can set, and on an ordinary object it would not be a key
+ * at all — it would be the prototype.
+ *
+ * A duplicated name keeps the first value, which is what every server-side
+ * cookie parser does and what browsers send for a name set at two paths.
+ */
+export function parseCookies(header: string | null): { [string]: string } {
+  const out: { [string]: string } = Object.create(null);
+  if (header == null || header === "") {
+    return out;
+  }
+
+  for (const pair of header.split(";")) {
+    const at = pair.indexOf("=");
+    if (at < 0) {
+      continue;
+    }
+    const name = pair.slice(0, at).trim();
+    if (name === "" || Object.hasOwn(out, name)) {
+      continue;
+    }
+    out[name] = decodeValue(pair.slice(at + 1).trim());
+  }
+  return out;
+}
+
+/**
+ * Decode one cookie value, leaving it alone if it is not valid encoding.
+ *
+ * `decodeURIComponent` throws on a stray `%`, and a malformed cookie is not a
+ * reason to fail a request — the value is simply not what the sender meant.
+ */
+function decodeValue(value: string): string {
+  const unquoted =
+    value.length >= 2 && value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+  try {
+    return decodeURIComponent(unquoted);
+  } catch {
+    return unquoted;
+  }
+}
+
+/**
+ * Run everything `after()` deferred, in the order it was registered.
+ *
+ * A failure is reported and does not stop the rest: deferred work is by
+ * definition not what the response depended on, and one broken analytics call
+ * should not take the others with it.
+ */
+export async function drainDeferred(context: RequestContext): Promise<void> {
+  const pending = context.deferred.splice(0, context.deferred.length);
+  for (const task of pending) {
+    try {
+      await task();
+    } catch (error) {
+      reportDeferredFailure(error);
+    }
+  }
+}
+
+/**
+ * Report a deferred task that threw.
+ *
+ * Isolated so a host can be given somewhere to put this; today it is the
+ * console, which is where an unhandled rejection would have gone anyway.
+ */
+function reportDeferredFailure(error: mixed): void {
+  // eslint-disable-next-line no-console
+  console.error("uf: a task registered with after() failed", error);
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniflowed/server",
   "version": "0.0.0-alpha.2",
-  "description": "Flow declarations for @uniflowed/server, part of the Unified Toolchain for Flow.",
+  "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
   "sideEffects": false,
@@ -11,12 +11,12 @@
     "directory": "packages/server"
   },
   "exports": {
-    ".": "./index.js"
+    ".": "./index.js",
+    "./host": "./host.js"
   },
   "files": [
-    "index.js"
-  ],
-  "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.2"
-  }
+    "index.js",
+    "host.js",
+    "internal/*.js"
+  ]
 }

--- a/tests/library/route-handler.test.js
+++ b/tests/library/route-handler.test.js
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from "@uniflowed/test";
 import { createDispatcher } from "@uniflowed/router/handler";
+import { after, cookies, headers } from "@uniflowed/server";
 
 /** A table entry whose module is given inline. */
 const record = (path, module) => ({
@@ -207,5 +208,62 @@ describe("errors", () => {
     expect(loaded).toBe(0);
     await dispatch(get("/api/lazy"));
     expect(loaded).toBe(1);
+  });
+});
+
+describe("the request a handler is inside", () => {
+  it("lets a handler read the request's headers and cookies with no argument", async () => {
+    // The dispatcher establishes the context; `headers()` and `cookies()` take
+    // nothing and answer about the request being handled.
+    const dispatch = createDispatcher({
+      handlers: [
+        {
+          path: "/api/who",
+          params: [],
+          file: "app/api/who/_uf.route.js",
+          load: async () => ({
+            GET: () =>
+              Response.json({
+                agent: headers().get("x-agent"),
+                session: cookies().get("session"),
+              }),
+          }),
+        },
+      ],
+    });
+
+    const response = await dispatch(
+      new Request("https://uniflowed.dev/api/who", {
+        headers: { "x-agent": "uf", cookie: "session=abc" },
+      }),
+    );
+
+    expect(await response?.json()).toEqual({ agent: "uf", session: "abc" });
+  });
+
+  it("runs deferred work after the handler has answered", async () => {
+    const done: Array<string> = [];
+    const dispatch = createDispatcher({
+      handlers: [
+        {
+          path: "/api/defer",
+          params: [],
+          file: "app/api/defer/_uf.route.js",
+          load: async () => ({
+            GET: () => {
+              after(() => {
+                done.push("deferred");
+              });
+              done.push("responded");
+              return new Response("ok");
+            },
+          }),
+        },
+      ],
+    });
+
+    await dispatch(new Request("https://uniflowed.dev/api/defer"));
+
+    expect(done).toEqual(["responded", "deferred"]);
   });
 });

--- a/tests/library/server.test.js
+++ b/tests/library/server.test.js
@@ -1,0 +1,238 @@
+// @flow
+//
+// `@uniflowed/server`: the request a server function is inside.
+//
+// The interesting cases are the ones a module-level variable would get wrong,
+// so most of what is below is about isolation: two requests in flight at once,
+// a context that ends when its request does, and work deferred past the
+// response.
+
+import { describe, expect, it } from "@uniflowed/testing";
+import { after, cookies, draftMode, headers } from "@uniflowed/server";
+import { contextFor, drainDeferred, parseCookies, runWithContext } from "@uniflowed/server/host";
+
+/** A request with the given headers. */
+function request(init: { readonly [string]: string }): Request {
+  return new Request("https://uniflowed.dev/", { headers: init });
+}
+
+/** Run `body` as if handling a request carrying `init`. */
+function handling<T>(init: { readonly [string]: string }, body: () => T): T {
+  return runWithContext(contextFor(request(init)), body);
+}
+
+describe("headers", () => {
+  it("reads the request's headers", () => {
+    handling({ "x-uf": "1", accept: "text/html" }, () => {
+      expect(headers().get("x-uf")).toBe("1");
+      expect(headers().has("accept")).toBe(true);
+    });
+  });
+
+  it("answers null for a header that was not sent", () => {
+    handling({}, () => {
+      expect(headers().get("x-missing")).toBe(null);
+      expect(headers().has("x-missing")).toBe(false);
+    });
+  });
+
+  it("throws outside a request, and names the binding", () => {
+    // A component that calls this during a static prerender has made a mistake
+    // worth naming — not one worth answering `null` for.
+    expect(() => headers()).toThrow();
+  });
+});
+
+describe("cookies", () => {
+  it("reads the cookies the request carried", () => {
+    handling({ cookie: "session=abc; theme=dark" }, () => {
+      expect(cookies().get("session")).toBe("abc");
+      expect(cookies().get("theme")).toBe("dark");
+      expect(cookies().has("session")).toBe(true);
+    });
+  });
+
+  it("answers null for a cookie that was not sent", () => {
+    handling({ cookie: "a=1" }, () => {
+      expect(cookies().get("b")).toBe(null);
+      expect(cookies().has("b")).toBe(false);
+    });
+  });
+
+  it("throws outside a request", () => {
+    expect(() => cookies()).toThrow();
+  });
+});
+
+describe("parsing a cookie header", () => {
+  it("reads a single pair", () => {
+    expect(parseCookies("a=1").a).toBe("1");
+  });
+
+  it("reads several, ignoring the spacing", () => {
+    const out = parseCookies("a=1;b=2;   c=3");
+
+    expect(out.a).toBe("1");
+    expect(out.b).toBe("2");
+    expect(out.c).toBe("3");
+  });
+
+  it("percent-decodes values", () => {
+    expect(parseCookies("path=%2Fa%2Fb").path).toBe("/a/b");
+  });
+
+  it("leaves a value alone when it is not valid encoding", () => {
+    // A malformed cookie is not a reason to fail a request; the value is simply
+    // not what the sender meant.
+    expect(parseCookies("broken=100%").broken).toBe("100%");
+  });
+
+  it("unwraps a quoted value", () => {
+    expect(parseCookies('q="spaced value"').q).toBe("spaced value");
+  });
+
+  it("keeps the first of a duplicated name", () => {
+    expect(parseCookies("a=first; a=second").a).toBe("first");
+  });
+
+  it("has no prototype, so a cookie cannot poison one", () => {
+    // `__proto__` is a name an attacker can set, and on an ordinary object it
+    // would not be a key at all.
+    const out = parseCookies("__proto__=polluted");
+
+    expect(Object.getPrototypeOf(out)).toBe(null);
+    expect(({}: mixed).polluted).toBe(undefined);
+  });
+
+  it("ignores entries with no value and an empty header", () => {
+    expect(Object.keys(parseCookies("novalue; =x; a=1"))).toEqual(["a"]);
+    expect(Object.keys(parseCookies(""))).toEqual([]);
+    expect(Object.keys(parseCookies(null))).toEqual([]);
+  });
+});
+
+describe("draftMode", () => {
+  it("is off until it is turned on", () => {
+    handling({}, () => {
+      expect(draftMode().isEnabled).toBe(false);
+      draftMode().enable();
+      expect(draftMode().isEnabled).toBe(true);
+      draftMode().disable();
+      expect(draftMode().isEnabled).toBe(false);
+    });
+  });
+
+  it("belongs to the request, not to the module", () => {
+    handling({}, () => {
+      draftMode().enable();
+    });
+
+    handling({}, () => {
+      expect(draftMode().isEnabled).toBe(false);
+    });
+  });
+});
+
+describe("after", () => {
+  it("runs deferred work when the response has gone", async () => {
+    const done: Array<string> = [];
+    const context = contextFor(request({}));
+
+    runWithContext(context, () => {
+      after(() => {
+        done.push("first");
+      });
+      after(() => {
+        done.push("second");
+      });
+    });
+
+    expect(done).toEqual([]);
+    await drainDeferred(context);
+    expect(done).toEqual(["first", "second"]);
+  });
+
+  it("awaits work that returns a promise", async () => {
+    const done: Array<string> = [];
+    const context = contextFor(request({}));
+
+    runWithContext(context, () => {
+      after(async () => {
+        await Promise.resolve();
+        done.push("async");
+      });
+    });
+    await drainDeferred(context);
+
+    expect(done).toEqual(["async"]);
+  });
+
+  it("lets the rest run when one task fails", async () => {
+    // Deferred work is by definition not what the response depended on, so one
+    // broken analytics call should not take the others with it.
+    const done: Array<string> = [];
+    const context = contextFor(request({}));
+
+    runWithContext(context, () => {
+      after(() => {
+        throw new Error("boom");
+      });
+      after(() => {
+        done.push("survived");
+      });
+    });
+    await drainDeferred(context);
+
+    expect(done).toEqual(["survived"]);
+  });
+
+  it("drains once, so a second drain runs nothing again", async () => {
+    let runs = 0;
+    const context = contextFor(request({}));
+
+    runWithContext(context, () => {
+      after(() => {
+        runs += 1;
+      });
+    });
+    await drainDeferred(context);
+    await drainDeferred(context);
+
+    expect(runs).toBe(1);
+  });
+
+  it("throws outside a request", () => {
+    expect(() =>
+      after(() => {
+        // never reached
+      }),
+    ).toThrow();
+  });
+});
+
+describe("isolation between requests", () => {
+  it("keeps two requests in flight apart", async () => {
+    // The case a module-level variable gets wrong, and only under load: one
+    // request suspends, another arrives, and the first sees the second's
+    // headers when it resumes.
+    const slow = runWithContext(contextFor(request({ "x-who": "slow" })), async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      return headers().get("x-who");
+    });
+    const fast = runWithContext(contextFor(request({ "x-who": "fast" })), async () => {
+      return headers().get("x-who");
+    });
+
+    expect(await fast).toBe("fast");
+    expect(await slow).toBe("slow");
+  });
+
+  it("ends the context when the request does", () => {
+    handling({ "x-uf": "1" }, () => {
+      expect(headers().get("x-uf")).toBe("1");
+    });
+
+    expect(() => headers()).toThrow();
+  });
+});

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -16,6 +16,7 @@ query
 react
 react-testing
 router
+server
 stylex
 test
 ui


### PR DESCRIPTION
`@uniflowed/server` was seven functions that threw. `headers()`, `cookies()`,
`draftMode()` and `after()` are real now, and the router establishes the
context they answer about.

The design question is where the request lives. `headers()` takes no arguments
— that is the whole point, since a component six levels down should not have a
request threaded through every layer above it — and that convenience needs
somewhere to keep it. A module-level variable would be wrong in a way that only
shows up under load: `renderToString` is synchronous, so a variable set around
it reads correctly right until a route awaits something, another request
arrives while it is suspended, and the second request's headers are what the
first one sees. `AsyncLocalStorage` does not have that bug and Node, Deno and
Bun all provide it. `keeps two requests in flight apart` is the test that fails
without it.

The context is deliberately not the `Request`. A server function that could
reach the whole request could read the body, which is already being consumed by
whatever called it, and could hold it past the response.

Two subpaths, because they have opposite audiences and opposite rules.
`@uniflowed/server` is what an application calls inside a request and is
meaningless outside one; `@uniflowed/server/host` is what a renderer or a
dispatcher calls to say a request has begun, and is meaningless inside one. A
subpath rather than `internal/` because `@uniflowed/router` is where a request
begins and is a different npm package.

Cookie parsing is its own small pile of edge cases, and each has a test:
percent-decoding that leaves a malformed value alone rather than throwing,
quoted values, the first of a duplicated name, and a parse into a
null-prototype object — `__proto__` is a cookie name an attacker can set, and
on an ordinary object it would not be a key at all.

`after()` runs once the response is in hand, in registration order, and one
task failing does not stop the rest: deferred work is by definition not what
the response depended on.

Forty tests across the package and the dispatcher.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791096973&installation_model_id=422833&pr_number=109&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F109&signature=a255070e670225cb53ab1aa43c4fa5b28765c219adbb97ef8a6e47f7baacedf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->