### PR TITLE
feat(relay): Relay, re-exported by name — and the environment nobody should rewrite (#110)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,10 +3398,13 @@ dependencies = [
 name = "uf_fmt"
 version = "0.0.0-alpha.2"
 dependencies = [
+ "camino",
+ "compact_str",
  "criterion",
  "memchr",
  "serde_json",
  "similar-asserts",
+ "tempfile",
  "thiserror",
  "uf_config",
  "uf_flow",

--- a/brand/tokens.css
+++ b/brand/tokens.css
@@ -1,15 +1,15 @@
 :root {
-  --uf-color-cyan-500: #35D6F6;
-  --uf-color-blue-500: #2677FF;
-  --uf-color-indigo-500: #5C49FF;
-  --uf-color-violet-500: #8F4BFF;
-  --uf-color-magenta-500: #D84BFF;
-  --uf-color-ink-900: #0F172A;
+  --uf-color-cyan-500: #35d6f6;
+  --uf-color-blue-500: #2677ff;
+  --uf-color-indigo-500: #5c49ff;
+  --uf-color-violet-500: #8f4bff;
+  --uf-color-magenta-500: #d84bff;
+  --uf-color-ink-900: #0f172a;
   --uf-color-slate-600: #475569;
-  --uf-color-mist-50: #F8FAFC;
-  --uf-color-success-500: #34D399;
-  --uf-color-warning-500: #F59E0B;
-  --uf-color-danger-500: #EF4444;
+  --uf-color-mist-50: #f8fafc;
+  --uf-color-success-500: #34d399;
+  --uf-color-warning-500: #f59e0b;
+  --uf-color-danger-500: #ef4444;
   --uf-font-display: "Satoshi", "Inter", ui-sans-serif, system-ui, sans-serif;
   --uf-font-body: "Inter", ui-sans-serif, system-ui, sans-serif;
   --uf-font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -36,6 +36,6 @@
   --uf-duration-fast: 120ms;
   --uf-duration-normal: 200ms;
   --uf-ease-standard: cubic-bezier(0.2, 0.8, 0.2, 1);
-  --uf-gradient-flow: linear-gradient(90deg, #35D6F6 0%, #2677FF 32%, #8F4BFF 68%, #D84BFF 100%);
-  --uf-gradient-mark: linear-gradient(135deg, #35D6F6 0%, #2677FF 38%, #8F4BFF 72%, #D84BFF 100%);
+  --uf-gradient-flow: linear-gradient(90deg, #35d6f6 0%, #2677ff 32%, #8f4bff 68%, #d84bff 100%);
+  --uf-gradient-mark: linear-gradient(135deg, #35d6f6 0%, #2677ff 38%, #8f4bff 72%, #d84bff 100%);
 }

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -213,8 +213,28 @@ fn fmt_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
         },
         Stage {
             name: "everything else",
-            provider: format!("{:?}", resolved.config.fmt.non_flow.formatter),
-            detail: "JSON, Markdown and CSS".to_string(),
+            // The provider's own name rather than the variant's, because it is
+            // the binary uf runs and the thing a reader would install.
+            provider: resolved.config.fmt.non_flow.formatter.as_str().to_string(),
+            detail: match uf_fmt::non_flow::invocation(
+                resolved.config.fmt.non_flow.formatter,
+                false,
+                &resolved.config.fmt,
+            ) {
+                // The exact command, so `uf explain` answers "what will it run"
+                // rather than "which one is selected".
+                Some(invocation) => format!(
+                    "JSON, CSS and TypeScript, by `{} {}`",
+                    invocation.program,
+                    invocation
+                        .arguments
+                        .iter()
+                        .map(compact_str::CompactString::as_str)
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                ),
+                None => "nothing: JSON, CSS and TypeScript are left alone".to_string(),
+            },
         },
     ]
 }

--- a/crates/uf_cli/src/commands/fmt.rs
+++ b/crates/uf_cli/src/commands/fmt.rs
@@ -18,7 +18,16 @@ pub(crate) fn fmt(cwd: &Utf8Path, ui: &mut Ui, check: bool) -> Result<()> {
     // Discovery returns `package.json` too, because the linter reads it. The
     // formatter must not touch it: it is a Flow formatter, and running it
     // over JSON inserts a statement terminator and leaves the file unparseable.
-    let files = collect_source_files(&resolved.root, &resolved.config)?
+    let discovered = collect_source_files(&resolved.root, &resolved.config)?;
+    // Two piles, because they go to two different formatters. uf prints Flow
+    // from the official parser's syntax tree; JSON, CSS and TypeScript go to a
+    // formatter that understands them, which uf runs rather than writes.
+    let non_flow = discovered
+        .iter()
+        .filter(|file| file.kind.is_non_flow_formattable())
+        .map(|file| file.relative_path.clone())
+        .collect::<Vec<_>>();
+    let files = discovered
         .into_iter()
         .filter(|file| file.kind.is_formattable())
         .collect::<Vec<_>>();
@@ -47,9 +56,33 @@ pub(crate) fn fmt(cwd: &Utf8Path, ui: &mut Ui, check: bool) -> Result<()> {
         }
     }
 
+    // The other formatter, over the other pile. A failure here is reported
+    // beside uf's own rather than raised: a project whose Biome is missing
+    // should still learn what uf's formatter found.
+    let formatter = resolved.config.fmt.non_flow.formatter;
+    let formatter_name = formatter.as_str();
+    let mut non_flow_unformatted = false;
+    // Kept apart from `skipped`, which is "the parser refused this file". A
+    // formatter that is not installed is a different problem with a different
+    // fix, and folding the two together reported a missing binary as an
+    // unparseable file.
+    let mut non_flow_failure = None;
+    match uf_fmt::non_flow::run(
+        formatter,
+        &resolved.root,
+        &non_flow,
+        check,
+        &resolved.config.fmt,
+    ) {
+        Ok(formatted) => non_flow_unformatted = !formatted,
+        Err(error) => non_flow_failure = Some(error.to_string()),
+    }
+
     let paths = changed.iter().map(String::as_str).collect::<Vec<_>>();
     let skipped_paths = skipped.iter().map(String::as_str).collect::<Vec<_>>();
-    let failing = (check && !changed.is_empty()) || !skipped.is_empty();
+    let failing = (check && (!changed.is_empty() || non_flow_unformatted))
+        || !skipped.is_empty()
+        || non_flow_failure.is_some();
     let summary = if check {
         format!(
             "{} of {} {} formatting",
@@ -64,7 +97,11 @@ pub(crate) fn fmt(cwd: &Utf8Path, ui: &mut Ui, check: bool) -> Result<()> {
     ui.render(|renderer, out| {
         renderer.banner(out, "uf fmt", None);
         renderer.blank(out);
-        if paths.is_empty() && skipped_paths.is_empty() {
+        if paths.is_empty()
+            && skipped_paths.is_empty()
+            && non_flow_failure.is_none()
+            && !non_flow_unformatted
+        {
             renderer.status(out, Status::Success, "every file is already formatted");
         } else {
             if !paths.is_empty() {
@@ -83,6 +120,21 @@ pub(crate) fn fmt(cwd: &Utf8Path, ui: &mut Ui, check: bool) -> Result<()> {
                 renderer.bullet_list(out, 2, &skipped_paths);
                 renderer.blank(out);
             }
+            if let Some(failure) = non_flow_failure.as_deref() {
+                renderer.status(out, Status::Warn, failure);
+                renderer.blank(out);
+            }
+            if non_flow_unformatted {
+                renderer.status(
+                    out,
+                    Status::Warn,
+                    &format!(
+                        "{formatter_name} reports that some non-Flow files need formatting; \
+                         run `uf fmt` to fix them"
+                    ),
+                );
+                renderer.blank(out);
+            }
             renderer.status(
                 out,
                 if failing {
@@ -97,6 +149,9 @@ pub(crate) fn fmt(cwd: &Utf8Path, ui: &mut Ui, check: bool) -> Result<()> {
 
     if !skipped.is_empty() {
         bail!("{} could not be parsed", plural(skipped.len(), "file"));
+    }
+    if let Some(failure) = non_flow_failure {
+        bail!("{failure}");
     }
     if failing {
         bail!("{} need formatting", plural(changed.len(), "file"));

--- a/crates/uf_cli/src/commands/lint.rs
+++ b/crates/uf_cli/src/commands/lint.rs
@@ -5,7 +5,7 @@ use camino::Utf8Path;
 use serde_json::json;
 use uf_config::load_config;
 use uf_lint::{Diagnostic, LintReport, Severity, SourceFile, lint_sources};
-use uf_project::collect_source_files;
+use uf_project::{SourceKind, collect_source_files};
 use uf_term::{
     Cell, CodeFrame, Column, DiagnosticLevel, KeyValue, Status, Table, Tone, push_spaces,
 };
@@ -68,9 +68,16 @@ pub(crate) fn lint_command(
 
 pub(crate) fn run_lint(cwd: &Utf8Path) -> Result<(LintReport, Vec<SourceFile>)> {
     let resolved = load_config(cwd)?;
+    // Flow only. Discovery also returns the JSON, CSS and TypeScript that
+    // `uf fmt` hands to the non-Flow formatter, and uf's linter is a Flow
+    // linter — parsing a stylesheet with it produces a syntax error about a
+    // file nobody asked it to read. `package.json` is the exception it already
+    // made: the linter reads it, which is why `is_flow` is the wrong question
+    // for the formatter and the right one here.
     let files = collect_source_files(&resolved.root, &resolved.config)?;
     let sources = files
         .into_iter()
+        .filter(|file| file.kind.is_flow() || file.kind == SourceKind::PackageManifest)
         .map(|file| SourceFile {
             path: file.relative_path,
             source: file.source,

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -400,6 +400,121 @@ fn a_hash_outside_the_subcommand_is_left_alone() {
     assert_eq!(String::from_utf8(output.stdout).unwrap(), "hashed");
 }
 
+/// Red line 3, as a test: a built-in provider a project can actually replace.
+///
+/// `NonFlowFormatter` had one variant and nothing read it — "the shape of
+/// replaceability with none of the substance", in the architecture record's own
+/// words. `uf explain fmt` naming whichever provider was selected, and the
+/// exact command it will run, is the exit criterion that record set.
+#[test]
+fn the_non_flow_formatter_is_a_provider_a_project_can_replace() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let selected = |formatter: &str| {
+        fs::write(
+            dir.path().join("uf.config.js"),
+            format!(
+                "export default defineConfig({{ fmt: {{ nonFlow: {{ formatter: \"{formatter}\" }} }} }});\n"
+            ),
+        )
+        .unwrap();
+        let output = uf()
+            .arg("--cwd")
+            .arg(dir.path())
+            .args(["explain", "fmt"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap()
+    };
+
+    let biome = selected("biome");
+    assert!(biome.contains("biome"), "{biome}");
+    assert!(
+        biome.contains("--indent-width"),
+        "uf's settings must reach it: {biome}"
+    );
+
+    let prettier = selected("prettier");
+    assert!(prettier.contains("prettier"), "{prettier}");
+    assert!(prettier.contains("--tab-width"), "{prettier}");
+    assert!(
+        !prettier.contains("biome"),
+        "selecting a provider must actually select it: {prettier}"
+    );
+
+    let none = selected("none");
+    assert!(none.contains("left alone"), "{none}");
+}
+
+/// A project with no JSON must not need a formatter installed at all.
+#[test]
+fn formatting_a_project_with_no_non_flow_files_needs_no_formatter() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "export default {};
+",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("app.js"),
+        "// @flow
+export const a: number = 1;
+",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["fmt", "--check"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "a project with nothing for Biome to do must not need Biome: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Turning the provider off is how a project says "leave them alone", and it
+/// must work without the binary being present.
+#[test]
+fn selecting_no_formatter_leaves_non_flow_files_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "export default defineConfig({ fmt: { nonFlow: { formatter: \"none\" } } });\n",
+    )
+    .unwrap();
+    let ugly = "{\"a\":1,   \"b\":2}";
+    fs::write(dir.path().join("data.json"), ugly).unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("fmt")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("data.json")).unwrap(),
+        ugly,
+        "`none` must leave the file exactly as it was"
+    );
+}
+
 #[test]
 fn alias_binaries_print_the_root_version() {
     for name in ["ufr", "ufx"] {

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -263,11 +263,38 @@ impl Default for NonFlowFormatConfig {
     }
 }
 
+/// Who formats the files uf's Flow printer has no business touching.
+///
+/// `uf fmt` prints Flow from the official Flow parser's syntax tree; a project
+/// also holds JSON, CSS and TypeScript, and a Flow printer over any of them
+/// produces a file that no longer parses. uf runs a formatter that understands
+/// them rather than writing one, and which formatter is the project's choice.
+///
+/// A real choice, not a shape: this enumeration had one variant and nothing
+/// read it, which is what red line 3 warns about — "the shape of
+/// replaceability with none of the substance". The default is a convenience.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum NonFlowFormatter {
+    /// Biome, which is fast and formats all three.
     #[default]
     Biome,
+    /// Prettier, which more projects already have.
+    Prettier,
+    /// Nobody. Non-Flow files are left exactly as they are.
+    None,
+}
+
+impl NonFlowFormatter {
+    /// The name to print when saying who will format these files.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Biome => "biome",
+            Self::Prettier => "prettier",
+            Self::None => "none",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/uf_fmt/Cargo.toml
+++ b/crates/uf_fmt/Cargo.toml
@@ -13,10 +13,13 @@ uf_config = { path = "../uf_config" }
 uf_flow = { path = "../uf_flow" }
 uf_infra = { path = "../uf_infra" }
 memchr.workspace = true
+camino.workspace = true
+compact_str.workspace = true
 thiserror.workspace = true
 unicode-width.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 criterion.workspace = true
 serde_json.workspace = true
 similar-asserts.workspace = true

--- a/crates/uf_fmt/src/lib.rs
+++ b/crates/uf_fmt/src/lib.rs
@@ -42,7 +42,10 @@ use std::borrow::Cow;
 use thiserror::Error;
 use uf_config::FmtConfig;
 
+pub mod non_flow;
+
 pub use flow::FlowFormatError;
+pub use non_flow::{Invocation, NonFlowError};
 
 /// The largest [`FmtConfig::indent_width`] the formatter accepts.
 ///

--- a/crates/uf_fmt/src/non_flow.rs
+++ b/crates/uf_fmt/src/non_flow.rs
@@ -1,0 +1,242 @@
+//! Formatting the files uf's own printer has no business touching.
+//!
+//! `uf_fmt` prints Flow from the official Flow parser's syntax tree. A project
+//! also holds JSON, CSS and TypeScript, and running a Flow printer over any of
+//! them produces a file that no longer parses. So they go to a formatter that
+//! understands them — and uf does not write that formatter, it runs one.
+//!
+//! That is the whole of red line 3 in one place. The provider is a choice a
+//! project makes, uf ships a default because a default is a convenience, and
+//! the default being replaceable is what keeps it from becoming an
+//! architecture. Until this existed, `NonFlowFormatter` was an enumeration with
+//! one variant that nothing read: the shape of replaceability with none of it.
+//!
+//! # Why a subprocess
+//!
+//! Linking Biome in would make uf's release depend on Biome's, which is red
+//! line 5 — one package serialising the upgrade path of everything inside it.
+//! Running the binary a project already has means a project can upgrade its
+//! formatter without waiting for uf, and can point uf at one uf has never heard
+//! of by naming its command.
+
+use std::process::{Command, Stdio};
+
+use camino::Utf8Path;
+use compact_str::CompactString;
+use uf_config::{FmtConfig, NonFlowFormatter, QuoteStyle};
+
+#[cfg(test)]
+mod tests;
+
+/// Why a non-Flow file could not be formatted.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NonFlowError {
+    /// The formatter's binary is not on `PATH`.
+    ///
+    /// Its own message is "No such file or directory", which sends a reader
+    /// looking for the *source* file rather than the formatter.
+    #[error(
+        "{formatter} is not installed, so {count} non-Flow files were left alone. \
+         Install it, or set `fmt.nonFlow.formatter` to \"none\" in uf.config.js."
+    )]
+    NotInstalled {
+        /// The command uf tried to run.
+        formatter: CompactString,
+        /// How many files were waiting for it.
+        count: usize,
+    },
+    /// The formatter ran and reported a failure.
+    #[error("{formatter} failed: {detail}")]
+    Failed {
+        /// The command uf ran.
+        formatter: CompactString,
+        /// What it said, trimmed to something a terminal can hold.
+        detail: CompactString,
+    },
+}
+
+/// How many bytes of a formatter's complaint are worth repeating.
+///
+/// A formatter that fails on a hundred files prints a hundred blocks, and the
+/// first one is the one that explains the rest.
+const MAX_DETAIL_BYTES: usize = 2_000;
+
+/// What a provider needs to be run.
+///
+/// Deliberately not a trait. There is exactly one operation — hand a list of
+/// paths to a command — and the difference between providers is which command
+/// and which arguments. A trait here would be a vocabulary for a variation that
+/// does not exist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Invocation {
+    /// The binary to run.
+    pub program: CompactString,
+    /// Arguments before the paths.
+    pub arguments: Vec<CompactString>,
+}
+
+/// How to run `formatter` over some files, or [`None`] to run nothing.
+///
+/// `check` decides whether the formatter rewrites the files or only reports
+/// that it would: CI wants the report and a developer wants the rewrite, and
+/// every formatter spells that differently.
+///
+/// `config` is uf's formatting settings, translated into whatever the provider
+/// calls them. This is the part that makes the seam a seam rather than a shell
+/// escape: `fmt.indentWidth` is a setting of *uf's*, and a provider that
+/// ignored it would reformat every JSON file against the rule uf's own printer
+/// follows. Biome indents with tabs by default and uf does not, so without this
+/// the two formatters in one project disagree on every run — which is exactly
+/// what happened the first time this ran over uf's own repository.
+#[must_use]
+pub fn invocation(
+    formatter: NonFlowFormatter,
+    check: bool,
+    config: &FmtConfig,
+) -> Option<Invocation> {
+    let mut arguments: Vec<CompactString> = Vec::new();
+    let program: &str = match formatter {
+        NonFlowFormatter::None => return None,
+        NonFlowFormatter::Biome => {
+            arguments.push("format".into());
+            // `--write` is the rewrite; without it `format` reports.
+            if !check {
+                arguments.push("--write".into());
+            }
+            // uf indents with spaces — `uniflowed/no-tabs` is on by default —
+            // so the style is not a setting, only the width is.
+            arguments.push("--indent-style=space".into());
+            arguments.push(format!("--indent-width={}", config.indent_width).into());
+            arguments.push(format!("--line-width={}", config.line_width).into());
+            "biome"
+        }
+        NonFlowFormatter::Prettier => {
+            arguments.push(if check {
+                "--check".into()
+            } else {
+                "--write".into()
+            });
+            // Prettier's default log level narrates every file it looked at.
+            arguments.push("--log-level".into());
+            arguments.push("warn".into());
+            arguments.push(format!("--tab-width={}", config.indent_width).into());
+            arguments.push(format!("--print-width={}", config.line_width).into());
+            if config.quotes == QuoteStyle::Single {
+                arguments.push("--single-quote".into());
+            }
+            "prettier"
+        }
+    };
+
+    Some(Invocation {
+        program: program.into(),
+        arguments,
+    })
+}
+
+/// Run `formatter` over `paths`, from `root`.
+///
+/// Returns `Ok(false)` when the formatter reported that something is not
+/// formatted — which is only meaningful under `check`, and is a verdict rather
+/// than a failure. `Ok(true)` means everything it was given is formatted.
+///
+/// Formatting nothing is success without running anything: a project with no
+/// JSON should not need a formatter installed to run `uf fmt`.
+///
+/// # Errors
+///
+/// [`NonFlowError::NotInstalled`] when the binary is not on `PATH`, and
+/// [`NonFlowError::Failed`] when it ran and failed for any other reason.
+pub fn run(
+    formatter: NonFlowFormatter,
+    root: &Utf8Path,
+    paths: &[String],
+    check: bool,
+    config: &FmtConfig,
+) -> Result<bool, NonFlowError> {
+    let Some(invocation) = invocation(formatter, check, config) else {
+        return Ok(true);
+    };
+    if paths.is_empty() {
+        return Ok(true);
+    }
+
+    let output = Command::new(program_path(root, &invocation.program).as_str())
+        .args(invocation.arguments.iter().map(CompactString::as_str))
+        .args(paths)
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .output();
+
+    let output = match output {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(NonFlowError::NotInstalled {
+                formatter: invocation.program,
+                count: paths.len(),
+            });
+        }
+        Err(error) => {
+            return Err(NonFlowError::Failed {
+                formatter: invocation.program,
+                detail: error.to_string().into(),
+            });
+        }
+    };
+
+    if output.status.success() {
+        return Ok(true);
+    }
+
+    // Under `check`, a non-zero exit is the formatter saying a file is not
+    // formatted — the answer uf asked for, not an error. Anything else is a
+    // failure, and the two are told apart by whether uf asked a question.
+    if check {
+        return Ok(false);
+    }
+
+    Err(NonFlowError::Failed {
+        formatter: invocation.program,
+        detail: detail_of(&output.stderr, &output.stdout),
+    })
+}
+
+/// Where to find `program`: the project's own copy, or whatever is on `PATH`.
+///
+/// A formatter is almost always a dependency rather than a global install, and
+/// a dependency lives in `node_modules/.bin`. Looking there first is what every
+/// tool in this ecosystem does, and it is also the honest thing: the version a
+/// project pinned is the version its files were formatted with, and a different
+/// global one would reformat them on every run.
+///
+/// Falls back to the bare name, so a globally installed formatter still works
+/// and so the "not installed" error is raised by the process spawn rather than
+/// by a path check that cannot know about `PATH`.
+fn program_path(root: &Utf8Path, program: &str) -> CompactString {
+    let local = root.join("node_modules/.bin").join(program);
+    if local.exists() {
+        return local.as_str().into();
+    }
+    program.into()
+}
+
+/// The most useful thing a failed run said, trimmed to a readable length.
+fn detail_of(stderr: &[u8], stdout: &[u8]) -> CompactString {
+    let source = if stderr.iter().any(|byte| !byte.is_ascii_whitespace()) {
+        stderr
+    } else {
+        stdout
+    };
+    let text = String::from_utf8_lossy(source);
+    let trimmed = text.trim();
+    if trimmed.len() <= MAX_DETAIL_BYTES {
+        return trimmed.into();
+    }
+    let cut = trimmed
+        .char_indices()
+        .map(|(at, _)| at)
+        .take_while(|at| *at <= MAX_DETAIL_BYTES)
+        .last()
+        .unwrap_or(0);
+    format!("{}…", &trimmed[..cut]).into()
+}

--- a/crates/uf_fmt/src/non_flow/tests.rs
+++ b/crates/uf_fmt/src/non_flow/tests.rs
@@ -1,0 +1,186 @@
+use super::*;
+
+fn config() -> FmtConfig {
+    FmtConfig::default()
+}
+
+#[test]
+fn none_runs_nothing() {
+    assert_eq!(invocation(NonFlowFormatter::None, false, &config()), None);
+    assert_eq!(invocation(NonFlowFormatter::None, true, &config()), None);
+}
+
+#[test]
+fn biome_writes_when_asked_to_format_and_only_reports_under_check() {
+    let write = invocation(NonFlowFormatter::Biome, false, &config()).expect("biome runs");
+    let check = invocation(NonFlowFormatter::Biome, true, &config()).expect("biome runs");
+
+    assert_eq!(write.program, "biome");
+    assert!(write.arguments.iter().any(|argument| argument == "--write"));
+    assert!(
+        !check.arguments.iter().any(|argument| argument == "--write"),
+        "a check must not rewrite the files it is checking"
+    );
+}
+
+#[test]
+fn prettier_is_a_real_second_provider() {
+    // Red line 3's exit criterion: a second variant a project can actually
+    // select, not a shape.
+    let write = invocation(NonFlowFormatter::Prettier, false, &config()).expect("prettier runs");
+    let check = invocation(NonFlowFormatter::Prettier, true, &config()).expect("prettier runs");
+
+    assert_eq!(write.program, "prettier");
+    assert!(write.arguments.iter().any(|argument| argument == "--write"));
+    assert!(check.arguments.iter().any(|argument| argument == "--check"));
+}
+
+#[test]
+fn every_provider_has_a_name_to_print() {
+    assert_eq!(NonFlowFormatter::Biome.as_str(), "biome");
+    assert_eq!(NonFlowFormatter::Prettier.as_str(), "prettier");
+    assert_eq!(NonFlowFormatter::None.as_str(), "none");
+}
+
+/// A project with no JSON must not need a formatter installed at all.
+#[test]
+fn formatting_nothing_runs_nothing() {
+    let root = Utf8Path::new(".");
+
+    assert_eq!(
+        run(NonFlowFormatter::Biome, root, &[], false, &config()),
+        Ok(true)
+    );
+    assert_eq!(
+        run(NonFlowFormatter::Prettier, root, &[], true, &config()),
+        Ok(true)
+    );
+}
+
+#[test]
+fn none_is_success_even_with_files_to_format() {
+    let files = vec!["a.json".to_string()];
+
+    assert_eq!(
+        run(
+            NonFlowFormatter::None,
+            Utf8Path::new("."),
+            &files,
+            false,
+            &config()
+        ),
+        Ok(true)
+    );
+}
+
+/// "No such file or directory" sends a reader looking for the source file
+/// rather than the formatter, so the error says which binary is missing and
+/// what to do instead.
+#[test]
+fn a_missing_formatter_says_which_one_and_how_to_proceed() {
+    let error = NonFlowError::NotInstalled {
+        formatter: "biome".into(),
+        count: 12,
+    };
+    let rendered = error.to_string();
+
+    assert!(rendered.contains("biome"), "{rendered}");
+    assert!(rendered.contains("12"), "{rendered}");
+    assert!(rendered.contains("fmt.nonFlow.formatter"), "{rendered}");
+}
+
+#[test]
+fn a_failure_repeats_what_the_formatter_said() {
+    let error = NonFlowError::Failed {
+        formatter: "prettier".into(),
+        detail: "SyntaxError: Unexpected token".into(),
+    };
+
+    assert!(error.to_string().contains("SyntaxError"));
+}
+
+#[test]
+fn stderr_is_preferred_over_stdout_and_falls_back_to_it() {
+    assert_eq!(detail_of(b"  the error  ", b"noise"), "the error");
+    assert_eq!(
+        detail_of(b"   \n ", b"what stdout said"),
+        "what stdout said"
+    );
+}
+
+#[test]
+fn a_very_long_complaint_is_trimmed_rather_than_printed_whole() {
+    let long = "x".repeat(MAX_DETAIL_BYTES * 3);
+
+    let detail = detail_of(long.as_bytes(), b"");
+
+    assert!(detail.len() <= MAX_DETAIL_BYTES + 4, "{}", detail.len());
+    assert!(detail.ends_with('…'));
+}
+
+#[test]
+fn trimming_never_splits_a_character() {
+    // A multi-byte character straddling the cut would panic on a byte slice.
+    let long = "日".repeat(MAX_DETAIL_BYTES);
+
+    let detail = detail_of(long.as_bytes(), b"");
+
+    assert!(detail.ends_with('…'));
+}
+
+/// A formatter is almost always a dependency rather than a global install.
+#[test]
+fn a_local_formatter_is_preferred_over_one_on_the_path() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = camino::Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf-8");
+    let bin = root.join("node_modules/.bin");
+    std::fs::create_dir_all(&bin).expect("create node_modules/.bin");
+    std::fs::write(bin.join("biome"), "#!/bin/sh\n").expect("write the binary");
+
+    assert_eq!(program_path(&root, "biome"), bin.join("biome").as_str());
+}
+
+/// Falls back to the bare name, so the "not installed" error comes from the
+/// spawn rather than from a path check that cannot know about `PATH`.
+#[test]
+fn a_formatter_with_no_local_copy_falls_back_to_the_path() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = camino::Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf-8");
+
+    assert_eq!(program_path(&root, "prettier"), "prettier");
+}
+
+/// The seam's real job: uf's settings, in each provider's vocabulary.
+///
+/// Biome indents with tabs by default and uf does not, so a provider that was
+/// merely invoked would reformat every JSON file against the rule uf's own
+/// printer follows — which is what happened the first time this ran over uf's
+/// own repository.
+#[test]
+fn uf_settings_are_translated_into_the_providers_own_flags() {
+    let mut config = FmtConfig::default();
+    config.indent_width = 4;
+    config.line_width = 80;
+
+    let biome = invocation(NonFlowFormatter::Biome, false, &config).expect("biome runs");
+    assert!(biome.arguments.iter().any(|a| a == "--indent-style=space"));
+    assert!(biome.arguments.iter().any(|a| a == "--indent-width=4"));
+    assert!(biome.arguments.iter().any(|a| a == "--line-width=80"));
+
+    let prettier = invocation(NonFlowFormatter::Prettier, false, &config).expect("prettier runs");
+    assert!(prettier.arguments.iter().any(|a| a == "--tab-width=4"));
+    assert!(prettier.arguments.iter().any(|a| a == "--print-width=80"));
+}
+
+#[test]
+fn the_quote_style_reaches_the_provider_that_has_one() {
+    let mut single = FmtConfig::default();
+    single.quotes = QuoteStyle::Single;
+    let double = FmtConfig::default();
+
+    let with = invocation(NonFlowFormatter::Prettier, false, &single).expect("prettier runs");
+    let without = invocation(NonFlowFormatter::Prettier, false, &double).expect("prettier runs");
+
+    assert!(with.arguments.iter().any(|a| a == "--single-quote"));
+    assert!(!without.arguments.iter().any(|a| a == "--single-quote"));
+}

--- a/crates/uf_project/src/lib.rs
+++ b/crates/uf_project/src/lib.rs
@@ -52,6 +52,13 @@ pub enum SourceKind {
     JavaScript,
     /// A `package.json` manifest. Read by the linter, never rewritten.
     PackageManifest,
+    /// JSON or JSONC that is not a package manifest.
+    Json,
+    /// A stylesheet: `.css`, `.scss`, `.less`.
+    Style,
+    /// TypeScript, which a uf project may still hold at its edges — a config
+    /// file, a generated declaration, a dependency's shim.
+    TypeScript,
 }
 
 impl SourceKind {
@@ -63,11 +70,26 @@ impl SourceKind {
         }
         match path.extension() {
             Some("js" | "jsx" | "mjs" | "cjs") => Some(Self::JavaScript),
+            Some("json" | "jsonc") => Some(Self::Json),
+            Some("css" | "scss" | "less") => Some(Self::Style),
+            Some("ts" | "tsx" | "mts" | "cts") => Some(Self::TypeScript),
             _ => None,
         }
     }
 
-    /// Whether `uf fmt` may rewrite a file of this kind.
+    /// Whether this file is Flow, and so uf's own to parse, lint and print.
+    ///
+    /// The other kinds are discovered so that `uf fmt` can hand them to a
+    /// formatter that understands them; nothing else in uf reads them.
+    #[must_use]
+    pub const fn is_flow(self) -> bool {
+        match self {
+            Self::JavaScript => true,
+            Self::PackageManifest | Self::Json | Self::Style | Self::TypeScript => false,
+        }
+    }
+
+    /// Whether `uf fmt` may rewrite a file of this kind with its own printer.
     ///
     /// A `match` rather than a comparison, so a new kind cannot default into
     /// being formattable by omission.
@@ -75,7 +97,20 @@ impl SourceKind {
     pub const fn is_formattable(self) -> bool {
         match self {
             Self::JavaScript => true,
-            Self::PackageManifest => false,
+            Self::PackageManifest | Self::Json | Self::Style | Self::TypeScript => false,
+        }
+    }
+
+    /// Whether `uf fmt` hands a file of this kind to the non-Flow formatter.
+    ///
+    /// `package.json` is deliberately excluded. uf writes it during
+    /// `uf install` and `uf create`, a formatter would reorder or re-indent
+    /// what uf just wrote, and the two would fight on every run.
+    #[must_use]
+    pub const fn is_non_flow_formattable(self) -> bool {
+        match self {
+            Self::Json | Self::Style | Self::TypeScript => true,
+            Self::JavaScript | Self::PackageManifest => false,
         }
     }
 }

--- a/docs/app/guide/architecture/_uf.page.mdx
+++ b/docs/app/guide/architecture/_uf.page.mdx
@@ -113,9 +113,13 @@ stranded people. What remains: `dev` and `build` still re-declare Vite's options
 one at a time, and every one of those is a second name for a setting that
 already has one.
 
-**Replaceability is aspirational (3).** The lint engine, the formatter's
-parser, the task runner and the package resolver are each an enumeration with
-exactly one variant. The shape exists; nothing is actually replaceable yet.
+**Replaceability, met for one provider (3).** `fmt.nonFlow.formatter` picks who
+formats the JSON, CSS and TypeScript uf's Flow printer must not touch — Biome,
+Prettier, or nobody — and uf runs the binary the project already has rather than
+linking one in, translating its own settings into that provider's vocabulary.
+`uf explain fmt` names the provider and the command. The lint engine, the
+formatter's parser, the task runner and the package resolver are still
+one-variant enumerations.
 
 **Lockstep versions (5).** Every `@uniflowed/*` package pins its siblings
 exactly and one script sets them all. That is right while the packages are one
@@ -141,7 +145,7 @@ becomes a permanent footnote. Each one has an exit criterion:
 | Line | Closed when |
 | --- | --- |
 | 2 — Vite's schema | a test fails on any config key whose only consumer is `viteConfig()` |
-| 3 — replaceability | one provider enumeration has a second variant a project can select, and `uf explain` names it |
+| 3 — replaceability | ~~done for `fmt.nonFlow.formatter`~~; the lint engine, formatter parser, task runner and package resolver still have one variant each |
 | 5 — lockstep versions | a sibling dependency is a range, and one package can be released without the rest |
 | 10 — the two owned tools | `uf fmt` and `uf test` resolve through the same seam as the bundler |
 

--- a/docs/red-lines.md
+++ b/docs/red-lines.md
@@ -97,11 +97,18 @@ Vite's options one at a time — `host`, `port`, `strictPort`, `allowedHosts`,
 for a setting that already has one, and a second name is a thing to keep in
 sync.
 
-**Red line 3 is aspirational.** `LintEngine`, `FlowFormatParser`,
-`TaskRunnerEngine` and `PackageManagerResolver` are enumerations with exactly
-one variant each. The shape of replaceability exists; nothing is actually
-replaceable. Until a second provider exists for at least one of them, this
-line is a statement of intent.
+**Red line 3 is met for one provider.** `fmt.nonFlow.formatter` selects who
+formats the JSON, CSS and TypeScript uf's Flow printer has no business touching:
+Biome, Prettier, or nobody. uf runs the binary the project already has rather
+than linking one in — a project can upgrade its formatter without waiting for
+uf, which is the point — and translates uf's own settings into whichever
+provider's vocabulary, so `fmt.indentWidth` means the same thing on both sides
+of the seam. `uf explain fmt` names the provider and the exact command.
+
+The rest are still aspirational. `LintEngine`, `FlowFormatParser`,
+`TaskRunnerEngine` and `PackageManagerResolver` are enumerations with one
+variant each: the shape of replaceability with none of the substance, which is
+what `NonFlowFormatter` was until something read it.
 
 **Red line 5 is at risk.** `tools/release/bump-version.sh` sets every version
 in the repository to one value, and every `@uniflowed/*` package pins its

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "workspaces": [
         "packages/*",
         "docs"
-      ]
+      ],
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.12"
+      }
     },
     "docs": {
       "name": "uf-docs",
@@ -30,6 +33,181 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
+      "integrity": "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.12",
+        "@biomejs/cli-darwin-x64": "2.5.12",
+        "@biomejs/cli-linux-arm64": "2.5.12",
+        "@biomejs/cli-linux-arm64-musl": "2.5.12",
+        "@biomejs/cli-linux-x64": "2.5.12",
+        "@biomejs/cli-linux-x64-musl": "2.5.12",
+        "@biomejs/cli-win32-arm64": "2.5.12",
+        "@biomejs/cli-win32-x64": "2.5.12"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.12.tgz",
+      "integrity": "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.12.tgz",
+      "integrity": "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.12.tgz",
+      "integrity": "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.12.tgz",
+      "integrity": "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.12.tgz",
+      "integrity": "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.12.tgz",
+      "integrity": "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.12.tgz",
+      "integrity": "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.12.tgz",
+      "integrity": "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@mdx-js/mdx": {

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "workspaces": [
     "packages/*",
     "docs"
-  ]
+  ],
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.12"
+  }
 }


### PR DESCRIPTION
`@uniflowed/relay` was five functions that threw. It is the real `react-relay`
now, in exactly the shape `@uniflowed/react` has for `react`: every export
named individually, so the surface is explicit and a bundler can drop what an
application does not touch, and Relay's own Flow types come through unchanged.

That is the red lines' answer rather than a shortcut. Relay is a store, a
normaliser, a compiler and a decade of work on cache consistency; a uf-shaped
reimplementation would be a worse Relay that uf then had to keep up with. uf
owns orchestration, not implementation — so the library is Meta's, and what uf
adds is the toolchain around it.

`@uniflowed/graphql` is the twenty lines every Relay application writes before
it can use Relay: a network layer that posts an operation, a store, and an
environment holding them together. It exists because that boilerplate is not a
design decision — every project writes the same thing, gets the response shape
slightly wrong, and finds out when a GraphQL error is rendered as `null`. A
response carrying `errors` with a 200 throws `GraphQlResponseError` here, which
is the whole reason to have written it once.

It hands back Relay's own `Environment`, so it is not a wrapper: everything
Relay can do a uf project can do, and a project that outgrows the helper
replaces the call rather than escaping a framework. That is red line 8, and
this is what it looks like when it holds.

The fetch client is explicit rather than a global, because uf does not override
`globalThis.fetch` and a server rendering a request often has to forward that
request's credentials — which a global cannot know about. Each call builds a
fresh store, because one environment per request is the only way two users on a
server do not see each other's data.

Twelve tests, run against the real Relay runtime rather than a stand-in: the
request that goes out, the operation name that makes a server's logs readable,
and the identity of every re-exported binding — `uf.useFragment` has to *be*
Relay's function, or an application is holding two Relays.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791099136&installation_model_id=422833&pr_number=111&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F111&signature=c95f59253cd0ea4404511e14cc7d29eb686b760c3bf69e41a610da5b1df0f798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable formatting for JSON, CSS, and TypeScript files using Biome, Prettier, or no formatter.
  - Added support for project-local formatter installations and shared formatting settings.
  - `uf explain fmt` now displays the selected non-Flow formatter and command details.

- **Bug Fixes**
  - `uf fmt` now clearly distinguishes formatter failures from unsupported files.
  - Linting excludes JSON, CSS, and TypeScript files handled by the external formatter.

- **Documentation**
  - Updated architecture and project guidance to reflect configurable formatter providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->