### PR TITLE
feat(test): the `vi` namespace, under Vitest's own name

### DIFF
--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -67,6 +67,8 @@ pub fn builtin_modules() -> Vec<NativeModule> {
                 "test",
                 "expect",
                 "fn",
+                "spyOn",
+                "vi",
                 "beforeAll",
                 "afterAll",
                 "beforeEach",

--- a/packages/test/index.js
+++ b/packages/test/index.js
@@ -15,7 +15,7 @@
 export type { Body as TestBody, Case, Modifier, Suite, TestOptions } from "./internal/registry.js";
 export type { Outcome, Result, RunOptions } from "./internal/run.js";
 export type { Site } from "./internal/frames.js";
-export type { SpyCall } from "./internal/expect.js";
+export type { SpyCall, SpyResult } from "./internal/spy.js";
 export type { Strictness } from "./internal/equality.js";
 
 export {
@@ -28,7 +28,19 @@ export {
   test,
 } from "./internal/registry.js";
 
-export { AssertionError, expect, fn } from "./internal/expect.js";
+export { AssertionError, expect } from "./internal/expect.js";
+
+export { fn, spyOn } from "./internal/spy.js";
+
+/**
+ * Vitest's namespace, under its own name.
+ *
+ * A project moving to uf should not have to rewrite the parts of its tests
+ * that were never about Vite: `vi.fn`, `vi.spyOn` and `vi.stubEnv` are a
+ * vocabulary, and a second one for the same operations would cost every
+ * migration and buy nothing.
+ */
+export { UnsupportedError, vi } from "./internal/vi.js";
 
 export { DEFAULT_TIMEOUT_MS, NAME_SEPARATOR } from "./internal/run.js";
 

--- a/packages/test/internal/expect.js
+++ b/packages/test/internal/expect.js
@@ -12,6 +12,8 @@
 // matcher table to what came out, so `await expect(p).resolves.toBe(1)` reads
 // the way the synchronous form does.
 
+import type { SpyCall } from "./spy.js";
+import { isSpy } from "./spy.js";
 import { equals, matchesObject, render } from "./equality.js";
 
 /** Thrown when a matcher does not hold. */
@@ -40,61 +42,6 @@ type Verdict = {|
   readonly expected?: string,
   readonly received?: string,
 |};
-
-/** One recorded call to a spy. */
-export type SpyCall = {|
-  readonly args: $ReadOnlyArray<mixed>,
-  readonly returned?: mixed,
-  readonly threw?: mixed,
-|};
-
-/**
- * A spy that records its calls.
- *
- * `fn()` records and returns `undefined`; `fn(implementation)` records and
- * delegates. A throw is recorded and then re-thrown, so wrapping a function in
- * a spy never changes whether the code under test fails.
- */
-export function fn(implementation?: (...args: $ReadOnlyArray<mixed>) => mixed): $FlowFixMe {
-  const calls: Array<SpyCall> = [];
-  let current = implementation;
-
-  const spy: $FlowFixMe = (...args: $ReadOnlyArray<mixed>) => {
-    try {
-      const returned = current == null ? undefined : current(...args);
-      calls.push({ args, returned });
-      return returned;
-    } catch (thrown) {
-      calls.push({ args, threw: thrown });
-      throw thrown;
-    }
-  };
-  spy.mock = { calls };
-  spy.mockClear = () => {
-    calls.length = 0;
-  };
-  spy.mockReturnValue = (value: mixed) => {
-    current = () => value;
-    return spy;
-  };
-  spy.mockResolvedValue = (value: mixed) => {
-    current = () => Promise.resolve(value);
-    return spy;
-  };
-  spy.mockRejectedValue = (reason: mixed) => {
-    current = () => Promise.reject(reason);
-    return spy;
-  };
-  spy.mockImplementation = (next: (...args: $ReadOnlyArray<mixed>) => mixed) => {
-    current = next;
-    return spy;
-  };
-  return spy;
-}
-
-function isSpy(value: mixed): boolean {
-  return typeof value === "function" && (value as $FlowFixMe).mock != null;
-}
 
 function propertyAt(
   value: mixed,

--- a/packages/test/internal/spy.js
+++ b/packages/test/internal/spy.js
@@ -1,0 +1,236 @@
+// @flow
+//
+// Internal to `@uniflowed/test`: the spy behind `fn` and `vi.spyOn`.
+//
+// Shaped after Vitest's, because a project moving to uf should not have to
+// rewrite its assertions. That means `mock.calls`, `mock.results`,
+// `mock.lastCall`, the `Once` variants, and `mockReset` and `mockRestore`
+// meaning the two different things they mean there.
+//
+// The three reset verbs are easy to conflate and are genuinely different:
+//
+// * `mockClear` forgets the calls, and keeps the implementation.
+// * `mockReset` forgets the calls *and* the implementation, leaving the
+//   original one a `spyOn` captured — or nothing, for a bare `fn`.
+// * `mockRestore` does what `mockReset` does and then puts the real method
+//   back on the object, which only a `spyOn` has to put back.
+//
+// Every spy is registered, so `vi.clearAllMocks` and its siblings can reach the
+// ones a test never held a reference to.
+
+/** One call: what went in, and what came out. */
+export type SpyCall = {
+  readonly args: $ReadOnlyArray<mixed>,
+  readonly returned?: mixed,
+  readonly threw?: mixed,
+};
+
+/** One call's outcome, in the shape Vitest reports it. */
+export type SpyResult =
+  | { readonly type: "return", readonly value: mixed }
+  | { readonly type: "throw", readonly value: mixed };
+
+/** Every spy made in this process, so the `All` verbs can reach them. */
+const registry: Array<$FlowFixMe> = [];
+
+/** How a spy puts back what it replaced, when it replaced something. */
+type Restore = null | (() => void);
+
+/**
+ * A spy, optionally standing in for something it can put back.
+ *
+ * `restore` is what separates `fn()` from `spyOn(object, "method")`: the second
+ * took something off an object and owes it back.
+ */
+function makeSpy(implementation: mixed, restore: Restore, name: string): $FlowFixMe {
+  const calls: Array<SpyCall> = [];
+  const results: Array<SpyResult> = [];
+  const instances: Array<mixed> = [];
+  // Implementations queued by the `Once` variants, taken from the front.
+  const queued: Array<mixed> = [];
+
+  const original = implementation;
+  let current = implementation;
+  let mockName = name;
+
+  const spy: $FlowFixMe = function (...args: $ReadOnlyArray<mixed>) {
+    // `this` is recorded because a spy on a method is often called as one, and
+    // `mock.instances` is how a test asserts on the receiver.
+    instances.push(this);
+    const body = queued.length > 0 ? queued.shift() : current;
+    try {
+      const returned = typeof body === "function" ? body.apply(this, args) : undefined;
+      calls.push({ args, returned });
+      results.push({ type: "return", value: returned });
+      return returned;
+    } catch (thrown) {
+      calls.push({ args, threw: thrown });
+      results.push({ type: "throw", value: thrown });
+      throw thrown;
+    }
+  };
+
+  spy.mock = {
+    calls,
+    results,
+    instances,
+    get lastCall(): $ReadOnlyArray<mixed> | void {
+      return calls.length === 0 ? undefined : calls[calls.length - 1].args;
+    },
+  };
+
+  spy.mockClear = () => {
+    calls.length = 0;
+    results.length = 0;
+    instances.length = 0;
+    return spy;
+  };
+  spy.mockReset = () => {
+    spy.mockClear();
+    queued.length = 0;
+    current = original;
+    return spy;
+  };
+  spy.mockRestore = () => {
+    spy.mockReset();
+    if (restore != null) {
+      restore();
+    }
+    return spy;
+  };
+
+  spy.mockImplementation = (next: mixed) => {
+    current = next;
+    return spy;
+  };
+  spy.mockImplementationOnce = (next: mixed) => {
+    queued.push(next);
+    return spy;
+  };
+  spy.withImplementation = (next: mixed, body: () => mixed) => {
+    const previous = current;
+    current = next;
+    try {
+      const out = body();
+      // An async body has to put the implementation back when it settles, not
+      // when it starts, or the next test runs against this one's stand-in.
+      if (out != null && typeof (out: $FlowFixMe).then === "function") {
+        return (out: $FlowFixMe).finally(() => {
+          current = previous;
+        });
+      }
+      current = previous;
+      return out;
+    } catch (thrown) {
+      current = previous;
+      throw thrown;
+    }
+  };
+
+  spy.mockReturnValue = (value: mixed) => spy.mockImplementation(() => value);
+  spy.mockReturnValueOnce = (value: mixed) => spy.mockImplementationOnce(() => value);
+  spy.mockResolvedValue = (value: mixed) => spy.mockImplementation(() => Promise.resolve(value));
+  spy.mockResolvedValueOnce = (value: mixed) =>
+    spy.mockImplementationOnce(() => Promise.resolve(value));
+  spy.mockRejectedValue = (reason: mixed) => spy.mockImplementation(() => Promise.reject(reason));
+  spy.mockRejectedValueOnce = (reason: mixed) =>
+    spy.mockImplementationOnce(() => Promise.reject(reason));
+  spy.mockReturnThis = () =>
+    spy.mockImplementation(function () {
+      return this;
+    });
+
+  spy.mockName = (next: string) => {
+    mockName = next;
+    return spy;
+  };
+  spy.getMockName = () => mockName;
+
+  registry.push(spy);
+  return spy;
+}
+
+/**
+ * A spy with no original behind it.
+ *
+ * `fn()` records and returns `undefined`; `fn(body)` records and runs `body`.
+ */
+export function fn(implementation?: mixed): $FlowFixMe {
+  return makeSpy(implementation, null, "spy");
+}
+
+/**
+ * Replace `object[method]` with a spy that calls through to it.
+ *
+ * Calls through by default, which is what makes `spyOn` an observation rather
+ * than a replacement — a test that only wants to know a method was called does
+ * not have to reimplement it. `mockImplementation` is how a test says it wants
+ * the other thing.
+ *
+ * The original is put back by `mockRestore`, and by `vi.restoreAllMocks`.
+ */
+export function spyOn(object: mixed, method: string): $FlowFixMe {
+  if (object == null || (typeof object !== "object" && typeof object !== "function")) {
+    throw new TypeError(`vi.spyOn: cannot spy on ${describe(object)}`);
+  }
+  const target = object as $FlowFixMe;
+  const original = target[method];
+  if (typeof original !== "function") {
+    throw new TypeError(
+      `vi.spyOn: ${method} is ${describe(original)}, and only a method can be spied on`,
+    );
+  }
+
+  const owned = Object.hasOwn(target, method);
+  const spy = makeSpy(
+    original,
+    () => {
+      // Deleting rather than reassigning when the method was inherited: writing
+      // the original onto the instance would leave a copy the prototype no longer
+      // controls, and the next change to the prototype would not be seen.
+      if (owned) {
+        target[method] = original;
+      } else {
+        delete target[method];
+      }
+    },
+    method,
+  );
+
+  target[method] = spy;
+  return spy;
+}
+
+/** Whether `value` is one of these spies. */
+export function isSpy(value: mixed): boolean {
+  return typeof value === "function" && (value: $FlowFixMe).mock != null;
+}
+
+/** Forget every spy's calls, keeping their implementations. */
+export function clearAllMocks(): void {
+  for (const spy of registry) {
+    spy.mockClear();
+  }
+}
+
+/** Forget every spy's calls and implementations. */
+export function resetAllMocks(): void {
+  for (const spy of registry) {
+    spy.mockReset();
+  }
+}
+
+/** Put back everything `spyOn` replaced. */
+export function restoreAllMocks(): void {
+  for (const spy of registry) {
+    spy.mockRestore();
+  }
+}
+
+/** A readable name for a value, for an error message. */
+function describe(value: mixed): string {
+  if (value === null) {
+    return "null";
+  }
+  return typeof value;
+}

--- a/packages/test/internal/vi.js
+++ b/packages/test/internal/vi.js
@@ -1,0 +1,225 @@
+// @flow
+//
+// Internal to `@uniflowed/test`: the `vi` namespace.
+//
+// Vitest's name, deliberately. A project moving to uf should not have to
+// rewrite the parts of its tests that were never about Vite — `vi.fn`,
+// `vi.spyOn`, `vi.stubEnv` are a vocabulary, and inventing a second one for the
+// same operations would buy nothing and cost every migration.
+//
+// What is *not* here is as deliberate. `vi.mock` intercepts a module before it
+// is imported, which needs the loader rather than the runner, and uf's loader is
+// `@uniflowed/host` — so it is a real piece of work rather than a wrapper, and
+// it is not pretended at here. A missing binding throws with what it would take;
+// a binding that silently did nothing would be worse than not having it.
+
+import { clearAllMocks, fn, resetAllMocks, restoreAllMocks, spyOn } from "./spy.js";
+
+/** Environment variables `stubEnv` replaced, and what they were. */
+const stubbedEnv: Map<string, string | void> = new Map();
+
+/** Globals `stubGlobal` replaced, and what they were. */
+const stubbedGlobals: Map<string, { readonly owned: boolean, readonly value: mixed }> = new Map();
+
+/**
+ * Raised for a `vi` binding uf has not implemented.
+ *
+ * Names what the binding needs rather than only that it is missing: `vi.mock`
+ * is absent because module interception belongs to the loader, and a reader who
+ * knows that can decide whether to wait or to restructure the test.
+ */
+export class UnsupportedError extends Error {
+  /** The binding that was called. */
+  binding: string;
+
+  constructor(binding: string, reason: string) {
+    super(`vi.${binding} is not implemented yet: ${reason}`);
+    this.name = "UnsupportedError";
+    this.binding = binding;
+  }
+}
+
+/**
+ * Read the process environment, whichever host this is.
+ *
+ * Node, Deno and Bun all expose `process.env`; Deno also has `Deno.env`, and
+ * reaching for `process` first keeps one code path across the three.
+ */
+function environment(): { [string]: string } | null {
+  const host = globalThis as $FlowFixMe;
+  return host.process?.env ?? null;
+}
+
+/**
+ * Replace an environment variable for the rest of the test.
+ *
+ * Undone by `unstubAllEnvs`, which the runner calls between files — a stub that
+ * outlived its test would be a test that passes alone and fails in a suite.
+ */
+export function stubEnv(name: string, value: string | void): void {
+  const env = environment();
+  if (env == null) {
+    throw new UnsupportedError("stubEnv", "this host exposes no process environment");
+  }
+  if (!stubbedEnv.has(name)) {
+    stubbedEnv.set(name, Object.hasOwn(env, name) ? env[name] : undefined);
+  }
+  if (value === undefined) {
+    delete env[name];
+  } else {
+    env[name] = value;
+  }
+}
+
+/** Put every environment variable `stubEnv` replaced back. */
+export function unstubAllEnvs(): void {
+  const env = environment();
+  if (env == null) {
+    stubbedEnv.clear();
+    return;
+  }
+  for (const [name, previous] of stubbedEnv) {
+    if (previous === undefined) {
+      delete env[name];
+    } else {
+      env[name] = previous;
+    }
+  }
+  stubbedEnv.clear();
+}
+
+/**
+ * Replace a global for the rest of the test.
+ *
+ * Whether the global was the object's own property is recorded, because putting
+ * back an inherited one by assignment would leave a copy that shadows whatever
+ * it was inherited from.
+ */
+export function stubGlobal(name: string, value: mixed): void {
+  const host = globalThis as $FlowFixMe;
+  if (!stubbedGlobals.has(name)) {
+    stubbedGlobals.set(name, {
+      owned: Object.hasOwn(host, name),
+      value: host[name],
+    });
+  }
+  host[name] = value;
+}
+
+/** Put every global `stubGlobal` replaced back. */
+export function unstubAllGlobals(): void {
+  const host = globalThis as $FlowFixMe;
+  for (const [name, previous] of stubbedGlobals) {
+    if (previous.owned) {
+      host[name] = previous.value;
+    } else {
+      delete host[name];
+    }
+  }
+  stubbedGlobals.clear();
+}
+
+/** How often `waitFor` re-runs its body while it is failing. */
+const WAIT_INTERVAL_MS = 20;
+
+/** How long `waitFor` keeps trying before giving up. */
+const WAIT_TIMEOUT_MS = 1_000;
+
+/**
+ * Run `body` until it stops throwing, or the timeout passes.
+ *
+ * The last failure is what is raised, not a timeout — "expected 2, got 1" says
+ * what went wrong, and "timed out" says only that something did.
+ */
+export async function waitFor<T>(
+  body: () => T | Promise<T>,
+  options?: { readonly timeout?: number, readonly interval?: number },
+): Promise<T> {
+  const timeout = options?.timeout ?? WAIT_TIMEOUT_MS;
+  const interval = options?.interval ?? WAIT_INTERVAL_MS;
+  const deadline = Date.now() + timeout;
+  let last: mixed = null;
+
+  for (;;) {
+    try {
+      return await body();
+    } catch (thrown) {
+      last = thrown;
+    }
+    if (Date.now() >= deadline) {
+      throw last ?? new Error(`vi.waitFor: gave up after ${timeout}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+/** Run `body` until it returns something truthy, or the timeout passes. */
+export async function waitUntil(
+  body: () => mixed | Promise<mixed>,
+  options?: { readonly timeout?: number, readonly interval?: number },
+): Promise<mixed> {
+  return waitFor(async () => {
+    const value = await body();
+    if (value == null || value === false) {
+      throw new Error("vi.waitUntil: the condition is not true yet");
+    }
+    return value;
+  }, options);
+}
+
+/**
+ * Hand a value back with its mock methods visible to the type checker.
+ *
+ * Purely a type-level convenience, exactly as in Vitest: at runtime it is the
+ * identity function, and its whole job is letting a test write
+ * `vi.mocked(client.send).mockReturnValue(…)` without a cast.
+ */
+export function mocked<T>(value: T): $FlowFixMe {
+  return value;
+}
+
+/** Not implemented, and specific about what it would take. */
+function unsupported(binding: string, reason: string): () => empty {
+  return () => {
+    throw new UnsupportedError(binding, reason);
+  };
+}
+
+/** The reason every module-interception binding is absent. */
+const NEEDS_LOADER =
+  "intercepting a module before it is imported belongs to the loader " +
+  "(`@uniflowed/host`), not to the runner, and uf has not wired it yet";
+
+/**
+ * The `vi` namespace.
+ *
+ * A frozen object rather than a class: it is a namespace, nothing about it is
+ * per-instance, and freezing it means a test cannot leave a monkey-patch behind
+ * for the next one.
+ */
+export const vi: $FlowFixMe = Object.freeze({
+  fn,
+  spyOn,
+  mocked,
+
+  clearAllMocks,
+  resetAllMocks,
+  restoreAllMocks,
+
+  stubEnv,
+  unstubAllEnvs,
+  stubGlobal,
+  unstubAllGlobals,
+
+  waitFor,
+  waitUntil,
+
+  // Module interception. Absent rather than faked; see `NEEDS_LOADER`.
+  mock: unsupported("mock", NEEDS_LOADER),
+  doMock: unsupported("doMock", NEEDS_LOADER),
+  unmock: unsupported("unmock", NEEDS_LOADER),
+  doUnmock: unsupported("doUnmock", NEEDS_LOADER),
+  importActual: unsupported("importActual", NEEDS_LOADER),
+  importMock: unsupported("importMock", NEEDS_LOADER),
+  resetModules: unsupported("resetModules", NEEDS_LOADER),
+});

--- a/tests/library/vi.test.js
+++ b/tests/library/vi.test.js
@@ -1,0 +1,256 @@
+// @flow
+//
+// The `vi` namespace, and the spy behind it.
+//
+// Shaped after Vitest's, so most of what is asserted here is that a habit
+// carried over from a Vitest project still works. The parts worth reading are
+// the three reset verbs, which are easy to conflate, and `spyOn`'s restore,
+// which has to put an inherited method back without leaving a copy behind.
+
+import { describe, expect, it, vi } from "@uniflowed/test";
+
+describe("vi.fn", () => {
+  it("records the calls and what they returned", () => {
+    const add = vi.fn((a: number, b: number) => a + b);
+
+    expect(add(1, 2)).toBe(3);
+    expect(add(3, 4)).toBe(7);
+    expect(add.mock.calls.length).toBe(2);
+    expect(add.mock.calls[0].args).toEqual([1, 2]);
+    expect(add.mock.results[1]).toEqual({ type: "return", value: 7 });
+    expect(add.mock.lastCall).toEqual([3, 4]);
+  });
+
+  it("records a throw as a throw rather than a return", () => {
+    const boom = vi.fn(() => {
+      throw new Error("no");
+    });
+
+    expect(() => boom()).toThrow();
+    expect(boom.mock.results[0].type).toBe("throw");
+  });
+
+  it("has no calls and no lastCall before it is called", () => {
+    const spy = vi.fn();
+
+    expect(spy.mock.calls).toEqual([]);
+    expect(spy.mock.lastCall).toBe(undefined);
+  });
+
+  it("queues the Once variants and falls back to the standing one", () => {
+    const spy = vi.fn().mockReturnValue("standing");
+    spy.mockReturnValueOnce("first").mockReturnValueOnce("second");
+
+    expect(spy()).toBe("first");
+    expect(spy()).toBe("second");
+    expect(spy()).toBe("standing");
+    expect(spy()).toBe("standing");
+  });
+
+  it("resolves and rejects", async () => {
+    const spy = vi.fn().mockResolvedValue(1);
+
+    expect(await spy()).toBe(1);
+
+    const failing = vi.fn().mockRejectedValue(new Error("nope"));
+    let thrown = null;
+    try {
+      await failing();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).not.toBe(null);
+  });
+
+  it("carries a name", () => {
+    const spy = vi.fn().mockName("send");
+
+    expect(spy.getMockName()).toBe("send");
+  });
+});
+
+describe("the three reset verbs", () => {
+  it("mockClear forgets the calls and keeps the implementation", () => {
+    const spy = vi.fn().mockReturnValue("kept");
+    spy();
+
+    spy.mockClear();
+
+    expect(spy.mock.calls).toEqual([]);
+    expect(spy()).toBe("kept");
+  });
+
+  it("mockReset forgets the implementation too", () => {
+    const spy = vi.fn().mockReturnValue("gone");
+    spy();
+
+    spy.mockReset();
+
+    expect(spy.mock.calls).toEqual([]);
+    expect(spy()).toBe(undefined);
+  });
+
+  it("mockReset restores the original a spyOn captured", () => {
+    const object = { greet: () => "real" };
+    const spy = vi.spyOn(object, "greet").mockReturnValue("stubbed");
+
+    expect(object.greet()).toBe("stubbed");
+    spy.mockReset();
+    expect(object.greet()).toBe("real");
+  });
+});
+
+describe("vi.spyOn", () => {
+  it("calls through by default, so watching is not replacing", () => {
+    const object = { greet: (name: string) => `hello ${name}` };
+    const spy = vi.spyOn(object, "greet");
+
+    expect(object.greet("uf")).toBe("hello uf");
+    expect(spy.mock.calls.length).toBe(1);
+  });
+
+  it("puts the method back on restore", () => {
+    const object = { greet: () => "real" };
+    const original = object.greet;
+    const spy = vi.spyOn(object, "greet").mockReturnValue("stubbed");
+
+    expect(object.greet()).toBe("stubbed");
+    spy.mockRestore();
+    expect(object.greet).toBe(original);
+  });
+
+  it("removes an inherited method rather than copying it onto the instance", () => {
+    // Reassigning would leave a copy the prototype no longer controls, and the
+    // next change to the prototype would not be seen.
+    const prototype = { greet: () => "from the prototype" };
+    const object = Object.create(prototype);
+
+    const spy = vi.spyOn(object, "greet");
+    spy.mockRestore();
+
+    expect(Object.hasOwn(object, "greet")).toBe(false);
+    expect(object.greet()).toBe("from the prototype");
+  });
+
+  it("refuses what cannot be spied on, and says what it found", () => {
+    expect(() => vi.spyOn(null, "x")).toThrow();
+    expect(() => vi.spyOn({ a: 1 }, "a")).toThrow();
+  });
+
+  it("records the receiver", () => {
+    const object = {
+      value: 7,
+      read() {
+        return this.value;
+      },
+    };
+    vi.spyOn(object, "read");
+
+    object.read();
+
+    expect(object.read.mock.instances[0]).toBe(object);
+  });
+});
+
+describe("stubbing the environment", () => {
+  it("replaces a variable and puts it back", () => {
+    const before = process.env.UF_VI_TEST;
+
+    vi.stubEnv("UF_VI_TEST", "stubbed");
+    expect(process.env.UF_VI_TEST).toBe("stubbed");
+
+    vi.unstubAllEnvs();
+    expect(process.env.UF_VI_TEST).toBe(before);
+  });
+
+  it("removes a variable when the value is undefined", () => {
+    vi.stubEnv("UF_VI_GONE", "here");
+    vi.stubEnv("UF_VI_GONE", undefined);
+
+    expect(process.env.UF_VI_GONE).toBe(undefined);
+    vi.unstubAllEnvs();
+  });
+
+  it("remembers the first value across repeated stubs", () => {
+    vi.stubEnv("UF_VI_ONCE", "one");
+    vi.stubEnv("UF_VI_ONCE", "two");
+
+    vi.unstubAllEnvs();
+
+    expect(process.env.UF_VI_ONCE).toBe(undefined);
+  });
+});
+
+describe("stubbing a global", () => {
+  it("replaces and puts back", () => {
+    vi.stubGlobal("__ufViProbe", 1);
+    expect((globalThis: $FlowFixMe).__ufViProbe).toBe(1);
+
+    vi.unstubAllGlobals();
+    expect(Object.hasOwn(globalThis, "__ufViProbe")).toBe(false);
+  });
+});
+
+describe("vi.waitFor", () => {
+  it("returns once the body stops throwing", async () => {
+    let attempts = 0;
+
+    const out = await vi.waitFor(
+      () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error("not yet");
+        }
+        return attempts;
+      },
+      { interval: 1 },
+    );
+
+    expect(out).toBe(3);
+  });
+
+  it("raises the last failure rather than a timeout", async () => {
+    // "expected 2, got 1" says what went wrong; "timed out" says only that
+    // something did.
+    let thrown = null;
+    try {
+      await vi.waitFor(
+        () => {
+          throw new Error("the real reason");
+        },
+        { timeout: 20, interval: 1 },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(String(thrown)).toContain("the real reason");
+  });
+
+  it("waitUntil waits for something truthy", async () => {
+    let ready = false;
+    setTimeout(() => {
+      ready = true;
+    }, 5);
+
+    expect(await vi.waitUntil(() => ready, { interval: 1 })).toBe(true);
+  });
+});
+
+describe("what is deliberately missing", () => {
+  it("says what vi.mock would take rather than doing nothing", () => {
+    // A binding that silently did nothing would be worse than not having it: a
+    // test would pass while mocking nothing at all.
+    for (const binding of ["mock", "unmock", "importActual", "importMock", "resetModules"]) {
+      expect(() => (vi: $FlowFixMe)[binding]()).toThrow();
+    }
+
+    let message = "";
+    try {
+      vi.mock("./somewhere.js");
+    } catch (error) {
+      message = String(error);
+    }
+    expect(message).toContain("loader");
+  });
+});


### PR DESCRIPTION
A project moving to uf should not have to rewrite the parts of its tests that
were never about Vite. `vi.fn`, `vi.spyOn`, `vi.stubEnv` are a vocabulary, and
a second one for the same operations would cost every migration and buy
nothing — so this is Vitest's name for Vitest's API.

The spy moves out of `expect.js` into its own module and grows what a Vitest
test expects of one: `mock.results`, `mock.instances`, `mock.lastCall`, the
`Once` variants, `withImplementation`, `mockReturnThis`, and a name. The three
reset verbs are implemented as the three different things they are, because
conflating them is the usual bug — `mockClear` forgets the calls, `mockReset`
forgets the implementation too, and `mockRestore` puts the real method back.

`spyOn` calls through by default, which is what makes it an observation rather
than a replacement: a test that only wants to know a method was called should
not have to reimplement it. Restoring an *inherited* method deletes the
property rather than assigning the original onto the instance — assigning would
leave a copy the prototype no longer controls, and the next change to the
prototype would not be seen.

`stubEnv` and `stubGlobal` remember the first value across repeated stubs, so
unstubbing returns to what was there before the test rather than to what the
test set a moment ago. `waitFor` raises the *last failure* rather than a
timeout, because "expected 2, got 1" says what went wrong and "timed out" says
only that something did.

`vi.mock` and its siblings are absent, and say so. Intercepting a module before
it is imported belongs to the loader — `@uniflowed/host` — rather than to the
runner, so it is real work rather than a wrapper. Each throws with what it
would take. A binding that silently did nothing would be worse than not having
one: a test would pass while mocking nothing at all.

Twenty tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Stacked on #112.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791103125&installation_model_id=422833&pr_number=113&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F113&signature=125e44ad7e06bbcdc11d511d6639654d81b6638cd428fd41ca59f2ae4dacb146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->