### PR TITLE
feat(test): the matchers that stand in for a value instead of being one

### DIFF
--- a/packages/test/internal/asymmetric.js
+++ b/packages/test/internal/asymmetric.js
@@ -1,0 +1,184 @@
+// @flow
+//
+// Internal to `@uniflowed/test`: `expect.any`, `expect.objectContaining`, and
+// the rest of the matchers that stand in for a value instead of being one.
+//
+// They exist because most assertions are about the parts of a value a test
+// controls, and equality is about all of it. `expect(user).toEqual({ id:
+// expect.any(String), name: "uf" })` says what the test means; spelling out the
+// id would either be a lie or a second source of truth.
+//
+// The mechanism is one method. A matcher is an object carrying
+// `asymmetricMatch(received)`, and `equals` asks any value it meets whether it
+// is one — so a matcher nested six levels down inside an expected object works
+// for the same reason a top-level one does, with no special case anywhere.
+// Vitest and Jest use the same protocol, which is why a matcher from either
+// works here.
+
+// `equality` and this module are mutually recursive, and that is the domain:
+// comparing two values has to recognise a matcher, and a matcher has to compare
+// recursively. ESM handles a cycle between hoisted function declarations — by
+// the time any matcher runs, both modules have finished evaluating — and the
+// alternative was wiring the comparison in at load, which is an import-time side
+// effect and the one thing every shipped module here is forbidden.
+import { equals } from "./equality.js";
+
+/** The brand every matcher carries, so `equals` can recognise one. */
+const ASYMMETRIC = "$$uf.asymmetricMatch";
+
+/** A stand-in for a value, rather than a value. */
+export type AsymmetricMatcher = {
+  readonly [typeof ASYMMETRIC]: true,
+  readonly asymmetricMatch: (received: mixed) => boolean,
+  readonly toString: () => string,
+};
+
+/**
+ * Whether `value` is a matcher rather than something to compare against.
+ *
+ * Duck-typed on `asymmetricMatch` as well as uf's own brand, so a matcher built
+ * by Jest or Vitest — or by a project's own helper — is recognised too. The
+ * protocol is the interface; the brand is only a fast path.
+ */
+export function isAsymmetric(value: mixed): boolean {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as $FlowFixMe;
+  return candidate[ASYMMETRIC] === true || typeof candidate.asymmetricMatch === "function";
+}
+
+/** Ask a matcher whether `received` satisfies it. */
+export function matchesAsymmetric(matcher: mixed, received: mixed): boolean {
+  return (matcher as $FlowFixMe).asymmetricMatch(received) === true;
+}
+
+/** Build a matcher from a predicate and how it describes itself. */
+function matcher(label: string, predicate: (received: mixed) => boolean): AsymmetricMatcher {
+  return {
+    [ASYMMETRIC]: true,
+    asymmetricMatch: predicate,
+    toString: () => label,
+  };
+}
+
+/**
+ * Anything constructed by `constructor`, or any value of a primitive's type.
+ *
+ * `expect.any(String)` accepts `"uf"` as well as `new String("uf")`, because a
+ * string literal is not an instance of anything and a test that wrote
+ * `expect.any(String)` meant the type rather than the wrapper. The same for
+ * `Number`, `Boolean`, `BigInt`, `Symbol` and `Function`.
+ */
+export function any(constructor: mixed): AsymmetricMatcher {
+  const name = (constructor as $FlowFixMe)?.name ?? String(constructor);
+  return matcher(`Any<${name}>`, (received) => {
+    switch (constructor) {
+      case String:
+        return typeof received === "string" || received instanceof String;
+      case Number:
+        return typeof received === "number" || received instanceof Number;
+      case Boolean:
+        return typeof received === "boolean" || received instanceof Boolean;
+      case BigInt:
+        return typeof received === "bigint";
+      case Symbol:
+        return typeof received === "symbol";
+      case Function:
+        return typeof received === "function";
+      case Object:
+        // `Object` means "any non-null object", which is what a test asking for
+        // one means — not "has Object.prototype in its chain", which a
+        // null-prototype object would fail and a test would find baffling.
+        return received != null && (typeof received === "object" || typeof received === "function");
+      default:
+        return typeof constructor === "function" && received instanceof constructor;
+    }
+  });
+}
+
+/** Anything at all except `null` and `undefined`. */
+export function anything(): AsymmetricMatcher {
+  return matcher("Anything", (received) => received != null);
+}
+
+/**
+ * An object with at least these properties, compared with `equals`.
+ *
+ * The comparison is recursive, so a matcher nested inside `expected` works.
+ */
+export function objectContaining(expected: interface {}): AsymmetricMatcher {
+  return matcher(`ObjectContaining(${describe(expected)})`, (received) => {
+    if (received == null || typeof received !== "object") {
+      return false;
+    }
+    const target = received as $FlowFixMe;
+    const source = expected as $FlowFixMe;
+    for (const key of Object.keys(source)) {
+      if (!(key in target) || !equals(target[key], source[key])) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+/** An array holding at least these elements, in any order. */
+export function arrayContaining(expected: $ReadOnlyArray<mixed>): AsymmetricMatcher {
+  return matcher(`ArrayContaining(${describe(expected)})`, (received) => {
+    if (!Array.isArray(received)) {
+      return false;
+    }
+    return expected.every((wanted) => received.some((item) => equals(item, wanted)));
+  });
+}
+
+/** A string containing `substring`. */
+export function stringContaining(substring: string): AsymmetricMatcher {
+  return matcher(`StringContaining(${JSON.stringify(substring)})`, (received) => {
+    return typeof received === "string" && received.includes(substring);
+  });
+}
+
+/** A string the pattern matches. */
+export function stringMatching(pattern: string | RegExp): AsymmetricMatcher {
+  return matcher(`StringMatching(${String(pattern)})`, (received) => {
+    if (typeof received !== "string") {
+      return false;
+    }
+    return typeof pattern === "string" ? received.includes(pattern) : pattern.test(received);
+  });
+}
+
+/** Default digits of precision for `closeTo`, matching Jest and Vitest. */
+const CLOSE_TO_DIGITS = 2;
+
+/**
+ * A number within `10 ** -digits / 2` of `expected`.
+ *
+ * The same tolerance `toBeCloseTo` uses, so the asymmetric form and the matcher
+ * agree — a test that moves an assertion from one to the other should not have
+ * its verdict change.
+ */
+export function closeTo(expected: number, digits: number = CLOSE_TO_DIGITS): AsymmetricMatcher {
+  const tolerance = 10 ** -digits / 2;
+  return matcher(`CloseTo(${expected}, ${digits})`, (received) => {
+    return typeof received === "number" && Math.abs(received - expected) < tolerance;
+  });
+}
+
+/** A matcher that holds when `inner` does not. */
+export function not(inner: AsymmetricMatcher): AsymmetricMatcher {
+  return matcher(`Not(${inner.toString()})`, (received) => !matchesAsymmetric(inner, received));
+}
+
+/** A short rendering of an expected value, for a matcher's own name. */
+function describe(value: mixed): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    // A cyclic or otherwise unserialisable expectation still has to have a
+    // name; what it is called matters less than that naming it cannot throw.
+    return String(value);
+  }
+}

--- a/packages/test/internal/equality.js
+++ b/packages/test/internal/equality.js
@@ -18,6 +18,8 @@
 // * `toEqual` ignores `undefined` properties and `toStrictEqual` does not,
 //   which is the one place the two matchers differ besides prototypes.
 
+import { isAsymmetric, matchesAsymmetric } from "./asymmetric.js";
+
 /** How strictly two values are compared. */
 export type Strictness = "loose" | "strict";
 
@@ -119,6 +121,16 @@ export function equals(
   if (Object.is(left, right)) {
     return true;
   }
+  // A matcher stands in for a value rather than being one, and either side may
+  // be the expectation depending on which way round the caller passed them.
+  // Asking here rather than at the top level is what makes a matcher nested six
+  // levels down work for the same reason a top-level one does.
+  if (isAsymmetric(right)) {
+    return matchesAsymmetric(right, left);
+  }
+  if (isAsymmetric(left)) {
+    return matchesAsymmetric(left, right);
+  }
   if (!isObject(left) || !isObject(right)) {
     return false;
   }
@@ -204,6 +216,9 @@ export function equals(
  * fine, missing or different ones are not.
  */
 export function matchesObject(received: mixed, expected: mixed, seen: Array<Pair> = []): boolean {
+  if (isAsymmetric(expected)) {
+    return matchesAsymmetric(expected, received);
+  }
   if (!isObject(expected) || !isObject(received)) {
     return equals(received, expected, seen);
   }

--- a/packages/test/internal/expect.js
+++ b/packages/test/internal/expect.js
@@ -13,6 +13,7 @@
 // the way the synchronous form does.
 
 import type { SpyCall } from "./spy.js";
+import * as asymmetric from "./asymmetric.js";
 import { isSpy } from "./spy.js";
 import { equals, matchesObject, render } from "./equality.js";
 
@@ -538,7 +539,7 @@ function settled(promise: mixed, wanted: "resolve" | "reject", negated: boolean)
  * await expect(load()).resolves.toHaveLength(3);
  * ```
  */
-export function expect(received: mixed): $FlowFixMe {
+function expectValue(received: mixed): $FlowFixMe {
   const expectation: $FlowFixMe = bind(received, false);
   Object.defineProperty(expectation, "resolves", {
     get: () => settled(received, "resolve", false),
@@ -546,3 +547,41 @@ export function expect(received: mixed): $FlowFixMe {
   Object.defineProperty(expectation, "rejects", { get: () => settled(received, "reject", false) });
   return expectation;
 }
+
+/**
+ * Assert about a value.
+ *
+ * Declared with its matchers attached rather than assigned afterwards: a
+ * shipped module may only declare, import and export at its top level, and
+ * `expect.any = …` is a statement that runs when the module is imported.
+ *
+ * The `expect.*` half are the matchers that stand in for a value instead of
+ * being one. `expect(user).toEqual({ id: expect.any(String), name: "uf" })`
+ * says what a test means; spelling out the id would either be a lie or a second
+ * source of truth. They work at any depth, because `equals` asks every value it
+ * meets whether it is one.
+ *
+ * `expect.not.*` is the negated form, spelled the way Jest and Vitest spell it
+ * — `expect.not.objectContaining({ error: expect.anything() })` reads better
+ * than a negated assertion around the whole object, and is the form a suite
+ * being ported will already have.
+ */
+export const expect: $FlowFixMe = Object.assign(expectValue, {
+  any: asymmetric.any,
+  anything: asymmetric.anything,
+  objectContaining: asymmetric.objectContaining,
+  arrayContaining: asymmetric.arrayContaining,
+  stringContaining: asymmetric.stringContaining,
+  stringMatching: asymmetric.stringMatching,
+  closeTo: asymmetric.closeTo,
+  not: {
+    objectContaining: (expected: interface {}) =>
+      asymmetric.not(asymmetric.objectContaining(expected)),
+    arrayContaining: (expected: $ReadOnlyArray<mixed>) =>
+      asymmetric.not(asymmetric.arrayContaining(expected)),
+    stringContaining: (substring: string) => asymmetric.not(asymmetric.stringContaining(substring)),
+    stringMatching: (pattern: string | RegExp) =>
+      asymmetric.not(asymmetric.stringMatching(pattern)),
+    closeTo: (value: number, digits?: number) => asymmetric.not(asymmetric.closeTo(value, digits)),
+  },
+});

--- a/tests/library/asymmetric.test.js
+++ b/tests/library/asymmetric.test.js
@@ -1,0 +1,150 @@
+// @flow
+//
+// `expect.any` and the rest of the matchers that stand in for a value.
+//
+// The point of most of these tests is *depth*: a matcher nested inside an
+// expected object has to work for the same reason a top-level one does, because
+// `equals` asks every value it meets whether it is a matcher rather than
+// special-casing the outermost one.
+
+import { describe, expect, it } from "@uniflowed/test";
+
+describe("expect.any", () => {
+  it("accepts a primitive as well as its wrapper", () => {
+    // A string literal is not an instance of anything, and a test that wrote
+    // `expect.any(String)` meant the type rather than the wrapper.
+    expect("uf").toEqual(expect.any(String));
+    expect(1).toEqual(expect.any(Number));
+    expect(true).toEqual(expect.any(Boolean));
+    expect(1n).toEqual(expect.any(BigInt));
+    expect(() => {}).toEqual(expect.any(Function));
+  });
+
+  it("accepts an instance of a class", () => {
+    class Token {}
+
+    expect(new Token()).toEqual(expect.any(Token));
+    expect(new Date()).toEqual(expect.any(Date));
+  });
+
+  it("rejects the wrong type", () => {
+    expect(1).not.toEqual(expect.any(String));
+    expect("1").not.toEqual(expect.any(Number));
+    expect(null).not.toEqual(expect.any(Object));
+  });
+
+  it("treats Object as any non-null object", () => {
+    // Not "has Object.prototype in its chain": a null-prototype object would
+    // fail that, and a test would find it baffling.
+    expect({}).toEqual(expect.any(Object));
+    expect(Object.create(null)).toEqual(expect.any(Object));
+  });
+});
+
+describe("expect.anything", () => {
+  it("accepts everything except null and undefined", () => {
+    expect(0).toEqual(expect.anything());
+    expect("").toEqual(expect.anything());
+    expect(false).toEqual(expect.anything());
+    expect(null).not.toEqual(expect.anything());
+    expect(undefined).not.toEqual(expect.anything());
+  });
+});
+
+describe("expect.objectContaining", () => {
+  it("ignores the properties it was not asked about", () => {
+    expect({ id: "1", name: "uf", extra: true }).toEqual(expect.objectContaining({ name: "uf" }));
+  });
+
+  it("fails when a named property is absent or different", () => {
+    expect({ name: "uf" }).not.toEqual(expect.objectContaining({ missing: 1 }));
+    expect({ name: "uf" }).not.toEqual(expect.objectContaining({ name: "other" }));
+  });
+
+  it("nests, and holds matchers inside itself", () => {
+    expect({ user: { id: "abc", age: 3 } }).toEqual(
+      expect.objectContaining({ user: expect.objectContaining({ id: expect.any(String) }) }),
+    );
+  });
+});
+
+describe("expect.arrayContaining", () => {
+  it("holds when every wanted element is somewhere in the array", () => {
+    expect([1, 2, 3]).toEqual(expect.arrayContaining([3, 1]));
+    expect([1, 2]).not.toEqual(expect.arrayContaining([4]));
+  });
+
+  it("compares elements structurally, and by matcher", () => {
+    expect([{ id: 1 }, { id: 2 }]).toEqual(expect.arrayContaining([{ id: 2 }]));
+    expect(["a", "b"]).toEqual(expect.arrayContaining([expect.any(String)]));
+  });
+
+  it("rejects something that is not an array", () => {
+    expect("abc").not.toEqual(expect.arrayContaining(["a"]));
+  });
+});
+
+describe("string matchers", () => {
+  it("stringContaining looks for a substring", () => {
+    expect("uniflowed").toEqual(expect.stringContaining("flow"));
+    expect("uniflowed").not.toEqual(expect.stringContaining("react"));
+    expect(1).not.toEqual(expect.stringContaining("1"));
+  });
+
+  it("stringMatching takes a pattern or a substring", () => {
+    expect("uf-2026").toEqual(expect.stringMatching(/^uf-\d+$/));
+    expect("uf-2026").toEqual(expect.stringMatching("2026"));
+    expect("uf").not.toEqual(expect.stringMatching(/^\d+$/));
+  });
+});
+
+describe("expect.closeTo", () => {
+  it("uses the same tolerance as toBeCloseTo", () => {
+    // A test that moves an assertion from one to the other should not have its
+    // verdict change.
+    expect(0.1 + 0.2).toEqual(expect.closeTo(0.3));
+    expect(0.1 + 0.2).toBeCloseTo(0.3);
+    expect(1.005).toEqual(expect.closeTo(1.0, 1));
+    expect(1.5).not.toEqual(expect.closeTo(1.0, 1));
+  });
+});
+
+describe("expect.not", () => {
+  it("negates a matcher in place", () => {
+    expect({ ok: true }).toEqual(expect.not.objectContaining({ error: expect.anything() }));
+    expect("uf").toEqual(expect.not.stringContaining("react"));
+    expect([1]).toEqual(expect.not.arrayContaining([2]));
+  });
+});
+
+describe("depth", () => {
+  it("works wherever a matcher is nested", () => {
+    const payload = {
+      meta: { requestId: "r-1", at: new Date() },
+      items: [{ id: 1, tags: ["a"] }],
+    };
+
+    expect(payload).toEqual({
+      meta: { requestId: expect.stringMatching(/^r-/), at: expect.any(Date) },
+      items: expect.arrayContaining([
+        expect.objectContaining({ tags: expect.arrayContaining([expect.any(String)]) }),
+      ]),
+    });
+  });
+
+  it("works through toMatchObject too", () => {
+    expect({ a: 1, b: { c: "x", d: 2 } }).toMatchObject({
+      b: { c: expect.any(String) },
+    });
+  });
+
+  it("works in a spy's recorded arguments", () => {
+    // The most common real use: asserting on a call without pinning every
+    // field of every argument.
+    const send = expect;
+    const calls = [["POST", { id: "generated-id", body: "hi" }]];
+
+    expect(calls[0]).toEqual(["POST", expect.objectContaining({ body: "hi" })]);
+    expect(send).toBeDefined();
+  });
+});


### PR DESCRIPTION
`expect.any`, `expect.anything`, `expect.objectContaining`,
`expect.arrayContaining`, `expect.stringContaining`, `expect.stringMatching`,
`expect.closeTo`, and `expect.not.*` for the negated forms.

They exist because most assertions are about the parts of a value a test
controls, and equality is about all of it. `expect(user).toEqual({ id:
expect.any(String), name: "uf" })` says what the test means; spelling out a
generated id would either be a lie or a second source of truth.

The mechanism is one method, and it is Jest's and Vitest's: a matcher carries
`asymmetricMatch(received)`, and `equals` asks every value it meets whether it
is one. That is why a matcher nested six levels down works for the same reason
a top-level one does, with no special case anywhere — and why a matcher built
by Jest, by Vitest, or by a project's own helper is recognised here.

Two details that are easy to get wrong. `expect.any(String)` accepts a string
literal as well as `new String(…)`, because a literal is not an instance of
anything and a test that wrote it meant the type. And `expect.any(Object)`
means any non-null object rather than "has `Object.prototype` in its chain",
which a null-prototype object would fail and a reader would find baffling.

`closeTo` uses the same tolerance as `toBeCloseTo`, so moving an assertion
between the two forms cannot change its verdict.

`asymmetric` and `equality` import each other, and that is the domain rather
than an accident: comparing two values has to recognise a matcher, and a
matcher has to compare recursively. The first attempt wired the comparison in
at load instead, which `shipped_modules_have_no_import_time_side_effects`
rejected — correctly, and twice: `expect.any = …` is also a statement that runs
when the module is imported, so the matchers are part of `expect`'s declaration
now rather than attached after it.

Eighteen tests, most of them about depth.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791104009&installation_model_id=422833&pr_number=114&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F114&signature=0e5d2b1b49c0ff6dab311342366c32bf9190328bd99d046a28999bcc5b19456f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->