### PR TITLE
docs: everything after one bootstrap line is a `uf` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,28 @@
 # Contributing
 
-## Clone
-
-`uf_flow` builds against Meta's official Flow Rust port, which is not published
-to crates.io, so the repository carries it as the `upstream/flow` submodule.
-Cargo resolves path dependencies even when the feature that uses them is off, so
-the submodule must exist before any cargo command:
+## Getting a checkout working
 
 ```sh
 git clone https://github.com/ubugeeei-prod/uf
 cd uf
-tools/upstream/sync.sh
+nix develop
+tools/upstream/sync.sh && cargo build --release --bin uf   # the bootstrap
+uf run setup
 ```
 
-`tools/upstream/sync.sh` fetches one shallow, blobless commit and checks out only
-`rust_port/`, which costs about 40 MB instead of the full 190 MB repository. It
-is idempotent, so re-run it after pulling a submodule bump.
+After that one bootstrap line, everything in this repository is a `uf` command.
+`uf run` on its own lists them.
+
+The bootstrap cannot itself be a `uf` command, and the reason is structural
+rather than an oversight: `upstream/flow` is a *path* dependency, so cargo
+cannot build `uf` until the submodule is checked out, and `uf run` needs a
+built `uf`. One command breaks that circle.
+
+`uf run upstream:sync` fetches one shallow, blobless commit of Meta's official
+Flow Rust port and checks out only `rust_port/`, which costs about 40 MB
+instead of the full 190 MB repository. `uf_flow` builds against that port,
+which is not published to crates.io. The sync is idempotent, so re-run it after
+pulling a submodule bump — `uf run setup` does.
 
 ## Commit Style
 
@@ -49,13 +56,29 @@ Use `nix develop ./tools/nix` for the pinned development environment.
 
 ## Verification
 
-Run the local gate before opening a PR:
+One command, and it is the one CI runs:
 
 ```sh
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
-cargo bench --workspace --no-run
+uf run ci
+```
+
+This repository is a uf project, so its pipeline uses the toolchain it ships
+rather than a second description of the same checks. A check that is in CI and
+not in `uf run ci` is a check a contributor cannot run before pushing, which is
+the thing that arrangement exists to prevent.
+
+The individual steps have names too, for when one of them is what you are
+working on:
+
+```sh
+uf run rust:fmt:check   # cargo fmt --all -- --check
+uf run rust:clippy      # cargo clippy --workspace --all-targets -- -D warnings
+uf run rust:test        # cargo test --workspace
+uf run rust:bench       # cargo bench --workspace --no-run
+uf run fmt:check        # uf's own formatter, over this repository's Flow
+uf run test:lib         # uf test#library, the @uniflowed/* suite
+uf run docs:build       # uf build#docs
+uf run docs:dev         # uf dev#docs, to look at the site while editing it
 ```
 
 `rust-toolchain.toml` pins `nightly-2026-08-01`, and every command above uses
@@ -64,7 +87,7 @@ with Meta's official Rust port, 23 of whose crates declare
 `#![feature(box_patterns)]` — a feature the compiler removed around the
 2026-09-01 nightly. That date is the newest nightly that still accepts it.
 
-Run `tools/upstream/sync.sh` before any cargo command; the port lives in the
+Run `uf run upstream:sync` before any cargo command; the port lives in the
 `upstream/flow` submodule and nothing builds without it.
 
 The `Upstream Flow` CI job builds the parser alone on the floating `nightly`

--- a/uf.config.js
+++ b/uf.config.js
@@ -39,6 +39,19 @@ export default defineConfig({
   },
 
   tasks: {
+    // --- Getting a checkout working ------------------------------------
+    //
+    // Everything after the bootstrap is a `uf run`. The bootstrap itself
+    // cannot be, and the reason is structural rather than an oversight:
+    // `upstream/flow` is a *path* dependency, so cargo cannot build `uf`
+    // until the submodule is checked out, and `uf run` needs a built `uf`.
+    // One command breaks that circle, and it is in CONTRIBUTING.md.
+    "upstream:sync": "tools/upstream/sync.sh",
+    setup: {
+      command: "echo 'ready: run `uf run ci` to check everything'",
+      dependsOn: ["upstream:sync", "build"],
+    },
+
     // --- Rust ----------------------------------------------------------
     "rust:fmt": "cargo fmt --all",
     "rust:fmt:check": "cargo fmt --all -- --check",
@@ -97,7 +110,21 @@ export default defineConfig({
       command: "UF_BIN=./target/release/uf tools/docs/build.sh",
       dependsOn: ["build"],
     },
+    // The documentation site, in a browser, while you edit it.
+    "docs:dev": {
+      command: "./target/release/uf dev#docs",
+      dependsOn: ["build"],
+    },
+
+    // --- Release --------------------------------------------------------
+    //
+    // Each is a step the release workflow runs, named so it can be run by
+    // hand first. A release step nobody can rehearse is a release step that
+    // is debugged in production.
     "install:test": "tools/release/test-install.sh",
+    "release:manifest": "tools/release/build-manifest.sh",
+    "release:package": "tools/release/package-binaries.sh",
+    "release:bump": "tools/release/bump-version.sh",
 
     // --- Manifests -----------------------------------------------------
     manifests:


### PR DESCRIPTION
CONTRIBUTING told contributors to run `tools/upstream/sync.sh` and four raw
`cargo` commands. This repository is a uf project and its pipeline already goes
through `uf run`; the instructions had not caught up, so a contributor learned
the shell scripts and CI learned the tasks.

Now: `nix develop`, one bootstrap line, then `uf run setup`. After that, `uf
run` on its own lists everything there is to do, and `uf run ci` is the whole
gate — the same one CI runs, which is the point of a project using the
toolchain it ships.

The bootstrap cannot itself be a `uf` command, and that is structural rather
than an oversight: `upstream/flow` is a *path* dependency, so cargo cannot
build `uf` until the submodule is checked out, and `uf run` needs a built `uf`.
One command breaks the circle, and CONTRIBUTING says why rather than leaving a
reader to wonder.

Six tasks that had no name gained one: `upstream:sync`, `setup`, `docs:dev`,
and the three release steps. The release ones matter for a reason worth
stating — a release step nobody can rehearse is a release step that gets
debugged in production.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791109561&installation_model_id=422833&pr_number=116&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F116&signature=382a049808baad35e4c6638e1d9420ced3603ee505af5fd9469d72029899e48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->