### PR TITLE
ci(release): see a half-sent release before tagging, not during

### DIFF
--- a/tools/release/preflight.sh
+++ b/tools/release/preflight.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# What a `uf@*` tag would publish, and what would stop it.
+#
+# `publish.yml` publishes every name in `published-packages.txt` over OIDC, and
+# a name that `npm trust` has not bound to that workflow fails there — after the
+# names before it have already gone out. That is recoverable, because npm is
+# additive and re-running the job publishes the rest, but it means a release can
+# be half-sent by adding a package to the list and tagging without running
+# `trust-npm.sh`.
+#
+# This is the check to run before tagging. It cannot read the bindings — `npm
+# trust list` reads them as the *user*, and an unauthenticated read returns
+# nothing — so it reports what is on the registry instead. A name that is not
+# there yet is a name to confirm is bound, not proof that it is not.
+set -eu
+
+repo_root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+list="tools/release/published-packages.txt"
+missing=""
+count=0
+
+for name in $(grep -v '^#' "$list" | grep -v '^[[:space:]]*$'); do
+  count=$((count + 1))
+  url="https://registry.npmjs.org/@uniflowed%2f$name"
+  status="$(curl -fsS -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || echo 000)"
+  if [ "$status" = "200" ]; then
+    printf '  on npm      @uniflowed/%s\n' "$name"
+  else
+    printf '  not yet     @uniflowed/%s\n' "$name"
+    missing="$missing $name"
+  fi
+done
+
+printf '\n%s packages listed\n' "$count"
+
+if [ -n "$missing" ]; then
+  cat >&2 <<MESSAGE
+
+Not on the registry yet:$missing
+
+Each has to be bound to this repository's publish workflow before a tag can
+send it. The binding is made as you, not as the workflow, so it is one command
+on a machine you are logged in on:
+
+  npm login
+  tools/release/trust-npm.sh
+
+It is idempotent — a name that is already bound is reported and left alone —
+and it binds names that have never been published, which is what lets the first
+release go out over OIDC like every one after it.
+
+Tagging before that leaves a release half-sent: the bound names publish and the
+first unbound one fails the job.
+MESSAGE
+  exit 1
+fi
+
+printf 'every listed package is on the registry\n'

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -9,6 +9,16 @@
 # This list is the closure a real uf project needs, plus the test runner. Add a
 # package here when it is implemented, not when it is declared. `uf_lib`'s
 # registry is the source of truth for what each one is.
+#
+# Adding a name here is half the job. `publish.yml` publishes over OIDC, and a
+# name that `npm trust` has not bound to that workflow fails the job *after* the
+# names before it have gone out — so a release is half-sent by adding a package
+# and tagging. Pair every addition with:
+#
+#   npm login
+#   tools/release/trust-npm.sh
+#
+# and run `uf run release:preflight` before tagging to see where things stand.
 config
 fetch
 graphql

--- a/uf.config.js
+++ b/uf.config.js
@@ -121,6 +121,11 @@ export default defineConfig({
     // Each is a step the release workflow runs, named so it can be run by
     // hand first. A release step nobody can rehearse is a release step that
     // is debugged in production.
+    //
+    // `release:preflight` is the one to run before tagging: a name `npm trust`
+    // has not bound fails the publish job *after* the names before it have
+    // gone out, which half-sends a release.
+    "release:preflight": "tools/release/preflight.sh",
     "install:test": "tools/release/test-install.sh",
     "release:manifest": "tools/release/build-manifest.sh",
     "release:package": "tools/release/package-binaries.sh",


### PR DESCRIPTION
`publish.yml` publishes every name in `published-packages.txt` over OIDC, and a
name `npm trust` has not bound to that workflow fails the job — *after* the
names before it have already gone out. The workflow's own comment says so. What
was missing was a way to find out before tagging.

`uf run release:preflight` reports which listed packages are on the registry and
which are not, and says what to do about the gap. It cannot read the bindings —
`npm trust list` reads them as the user, and an unauthenticated read returns
nothing, which an earlier attempt at this discovered by reporting every package
as unbound including the five that were bound — so it reports registry presence
instead, and says that a name not there yet is a name to confirm rather than
proof of anything.

It matters right now. The list names fifteen packages and five are on the
registry; ten are not, five of which this session added. Tagging today would
publish those five and fail on the sixth.

The list itself now says that adding a name is half the job, with the command
that is the other half. That command has to run as a person rather than as the
workflow, so it is not something CI can do for anybody.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791110500&installation_model_id=422833&pr_number=117&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F117&signature=28039085acd5de8f68bce2b1cfb4222b94ddc8523dbb90c504be028e56c8f35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->