### PR TITLE
feat(cli): a menu instead of a list, and an installer that does not repeat itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,19 @@ walkdir = "2.5.0"
 # what a backtrace actually reads. `debug = true` gives a debugger local
 # variables as well; a contributor who wants that can turn it back on for the
 # one crate they are in, and pay for it there rather than everywhere.
+# Incremental is off for the same reason, and it is the larger half: its cache
+# reached 10 GB, and the six biggest entries in it were `flow_typing_utils`,
+# `flow_typing`, `flow_typing_statement`, `flow_typing_flow_js`,
+# `flow_typing_flow_common` and `flow_parser` — 2.5 GB between them, all of it
+# caching rebuilds of a submodule that changes only on an upstream sync.
+#
+# Cargo has no per-package switch for it, so this is all or nothing, and off is
+# the right side: the crates that would benefit are the two or three uf's own
+# work touches, and a full rebuild of one of those is under a minute. Set
+# `CARGO_INCREMENTAL=1` for a session spent inside a single crate.
 [profile.dev]
 debug = "line-tables-only"
+incremental = false
 
 [profile.dev.package."*"]
 debug = false

--- a/crates/uf_cli/src/commands/task.rs
+++ b/crates/uf_cli/src/commands/task.rs
@@ -24,6 +24,36 @@ pub(crate) fn run_task(cwd: &Utf8Path, script: &str, args: &[String]) -> Result<
     run_named_task(&resolved, script, args, &mut visited)
 }
 
+/// Widest a task's command is shown at on the menu.
+///
+/// Shorter than [`COMMAND_WIDTH`] because the menu also carries a name column
+/// and a two-space gutter, and a row that wraps stops being a row.
+const MENU_COMMAND_WIDTH: usize = 44;
+
+/// Every task this project defines: its name, and what it runs.
+///
+/// Returns nothing rather than an error when there is no config or it does not
+/// load. This is asked on the way to drawing a menu, and a directory that is
+/// not a uf project should get a menu of uf's commands rather than a parse
+/// error about a file the reader has not written yet.
+pub(crate) fn task_names(cwd: &Utf8Path) -> Vec<(String, String)> {
+    let Ok(resolved) = load_config(cwd) else {
+        return Vec::new();
+    };
+    resolved
+        .config
+        .tasks
+        .iter()
+        .map(|(name, task)| {
+            let command = match task {
+                TaskDefinition::Command(command) => command.to_string(),
+                TaskDefinition::Detailed(details) => details.command.to_string(),
+            };
+            (name.to_string(), elide(&command, MENU_COMMAND_WIDTH))
+        })
+        .collect()
+}
+
 /// Widest a command is printed at in the task table.
 ///
 /// A task may legitimately be a hundred characters of shell — this repository

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -7,6 +7,7 @@
 mod brand;
 mod cli;
 mod commands;
+mod menu;
 mod suggest;
 mod support;
 mod ui;
@@ -38,6 +39,13 @@ struct Cli {
 pub fn main() -> ExitCode {
     let (cli, target) = match parse_cli() {
         Ok(parsed) => parsed,
+        Err(error) if is_bare_uf(&error) => match ask_what_to_run() {
+            Asked::Run(parsed) => parsed,
+            Asked::Help => return report_startup_error(&error),
+            // The reader opened the menu and closed it. Nothing happened, and
+            // saying so would be one more line to dismiss.
+            Asked::Nothing => return ExitCode::SUCCESS,
+        },
         Err(error) => return report_startup_error(&error),
     };
     let mode = if cli.command.wants_json() || cli.command.owns_stdout() {
@@ -53,6 +61,63 @@ pub fn main() -> ExitCode {
             ui.error(&error);
             ExitCode::FAILURE
         }
+    }
+}
+
+/// What asking the reader came back with.
+enum Asked {
+    /// Run this, as if it had been typed.
+    Run((Cli, Option<String>)),
+    /// Print the help, which is what `uf` alone did before there was a menu.
+    Help,
+    /// The reader changed their mind.
+    Nothing,
+}
+
+/// Whether this is `uf` typed on its own, with nothing after it.
+///
+/// Nothing after it, and not merely "no subcommand": `uf --cwd elsewhere` is
+/// also missing a subcommand, and a menu built for one directory that then ran
+/// a command in another would be answering a question it had not been asked.
+/// The flag is rare and the help is a fine answer to it.
+fn is_bare_uf(error: &anyhow::Error) -> bool {
+    let Some(error) = error.downcast_ref::<clap::Error>() else {
+        return false;
+    };
+    if !matches!(
+        error.kind(),
+        ErrorKind::MissingSubcommand | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+    ) {
+        return false;
+    }
+    std::env::args_os().count() == 1
+}
+
+/// Offer the menu, and turn what was chosen back into parsed arguments.
+fn ask_what_to_run() -> Asked {
+    let Ok(cwd) = std::env::current_dir() else {
+        return Asked::Help;
+    };
+    let Ok(cwd) = Utf8PathBuf::from_path_buf(cwd) else {
+        return Asked::Help;
+    };
+
+    let words = match menu::choose(&cwd) {
+        menu::Chosen::Run(words) => words,
+        menu::Chosen::Help => return Asked::Help,
+        menu::Chosen::Nothing => return Asked::Nothing,
+    };
+
+    // Back through the same parser the typed form goes through, so a menu
+    // entry cannot mean something the command line could not have said.
+    let mut args = vec!["uf".to_owned()];
+    args.extend(words);
+    match Cli::try_parse_from(&args) {
+        Ok(cli) => Asked::Run((cli, None)),
+        // Unreachable while the menu's entries are checked against the parser
+        // in `menu::tests`, and the help is the honest answer if that ever
+        // stops being true.
+        Err(_) => Asked::Help,
     }
 }
 
@@ -271,6 +336,24 @@ fn resolve_cwd(cwd: Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {
 fn current_dir() -> Result<Utf8PathBuf> {
     Utf8PathBuf::from_path_buf(std::env::current_dir()?)
         .map_err(|path| anyhow!("current directory is not UTF-8: {}", path.display()))
+}
+
+/// Whether `uf <name>` parses as a command at all.
+///
+/// For the menu's own tests: an entry that is not a command is one that fails
+/// in front of whoever chose it.
+#[cfg(test)]
+fn parses_as_command(name: &str) -> bool {
+    !matches!(
+        Cli::try_parse_from(["uf", name]).err().map(|e| e.kind()),
+        Some(ErrorKind::InvalidSubcommand | ErrorKind::UnknownArgument)
+    )
+}
+
+/// Whether `uf <name>` needs nothing else to run.
+#[cfg(test)]
+fn runs_with_no_arguments(name: &str) -> bool {
+    Cli::try_parse_from(["uf", name]).is_ok()
 }
 
 #[cfg(test)]

--- a/crates/uf_cli/src/menu.rs
+++ b/crates/uf_cli/src/menu.rs
@@ -1,0 +1,143 @@
+//! What `uf` on its own does.
+//!
+//! It used to print the help: twenty commands, each a name and a sentence, and
+//! then a prompt for the reader to type one of the names they had just read.
+//! The list was the answer to a question nobody asked — someone who runs `uf`
+//! with no arguments is not looking for documentation, they are deciding what
+//! to do next — so it is a menu now, and the thing they were going to type is
+//! the thing they press Enter on.
+//!
+//! The help has not gone anywhere. `uf --help` is still the help, and so is
+//! `uf` itself the moment there is nobody to ask: a pipeline, a CI job, a
+//! `dumb` terminal. Every one of those gets exactly what it got before, which
+//! is what keeps a menu from being a breaking change.
+//!
+//! The project's own tasks are on the menu beside the commands, because
+//! `uf run` is most of what a repository's own contributors type and a menu
+//! that omitted them would be a menu of the half they use least.
+
+use camino::Utf8Path;
+use uf_term::prompt::{Choice, Outcome, Request, select};
+
+use crate::commands::task::task_names;
+
+/// The commands that need no arguments, in the order they should be offered.
+///
+/// Ordered by how often a person reaches for them rather than alphabetically:
+/// a menu is read from the top, and `use` being three rows above `test` would
+/// be alphabetical and wrong.
+///
+/// The list is deliberately not every command. `create`, `exec`, `explain` and
+/// `use` all *require* an argument, and offering them here would mean choosing
+/// one and being told off by the parser — a menu whose entries do not work is
+/// worse than a list. They are still one `uf --help` away, and the last row
+/// says so.
+const RUNNABLE: &[(&str, &str)] = &[
+    ("dev", "Start the development server"),
+    ("build", "Build the project for production"),
+    ("test", "Run the test suite"),
+    ("check", "Lint the project, then type check it with Flow"),
+    ("lint", "Lint the project"),
+    ("fmt", "Format every file uf understands"),
+    ("install", "Install the project's dependencies"),
+    ("info", "Describe the project uf sees"),
+    ("inspect", "Show the resolved pipeline, stage by stage"),
+    ("prepare", "Get the working tree ready to release"),
+    ("publish", "Publish what `uf prepare` staged"),
+    ("upgrade", "Update uf itself"),
+];
+
+/// The row that goes back to what `uf` used to print.
+const HELP: (&str, &str) = ("help", "Every command, including the ones taking arguments");
+
+/// The heading over the commands.
+const COMMANDS: &str = "commands";
+/// The heading over the project's own tasks.
+const TASKS: &str = "tasks";
+
+/// What the reader chose, as the words they would otherwise have typed.
+///
+/// `Some(["run", "ci"])` for a task, `Some(["build"])` for a command, and
+/// `None` when there is nothing to run — either because nobody was there to
+/// ask or because they changed their mind.
+pub(crate) enum Chosen {
+    /// Run this, as if it had been typed.
+    Run(Vec<String>),
+    /// Print the help, which is what `uf` did before there was a menu.
+    Help,
+    /// Do nothing at all, quietly.
+    Nothing,
+}
+
+/// Offer the commands and the project's tasks, and return what was picked.
+pub(crate) fn choose(cwd: &Utf8Path) -> Chosen {
+    // Owned first: `Choice` borrows its strings, so every task name has to
+    // outlive the menu rather than be built into it.
+    let tasks = task_names(cwd);
+    let mut labels: Vec<String> = Vec::with_capacity(tasks.len());
+    for (name, _) in &tasks {
+        labels.push(format!("run {name}"));
+    }
+
+    let mut choices: Vec<Choice<'_>> = Vec::with_capacity(RUNNABLE.len() + tasks.len() + 1);
+    for (name, about) in RUNNABLE {
+        choices.push(Choice::grouped(name, about, COMMANDS));
+    }
+    for (label, (_, command)) in labels.iter().zip(&tasks) {
+        // The command it runs, rather than nothing: a task's name says what it
+        // is for and the command says what it will actually do, which is the
+        // thing a reader is checking before they press Enter.
+        choices.push(Choice::grouped(label, command, TASKS));
+    }
+    choices.push(Choice::grouped(HELP.0, HELP.1, COMMANDS));
+
+    let request = Request::new("What would you like to run?", &choices);
+    match select(&request) {
+        Outcome::Chose(choice) if choice.name == HELP.0 => Chosen::Help,
+        Outcome::Chose(choice) => Chosen::Run(
+            choice
+                .name
+                .split_whitespace()
+                .map(ToOwned::to_owned)
+                .collect(),
+        ),
+        // No terminal: whatever `uf` printed before a menu existed, it still
+        // prints, so nothing reading uf's output has to know this is here.
+        Outcome::NotInteractive => Chosen::Help,
+        Outcome::Cancelled => Chosen::Nothing,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_offered_command_is_one_the_parser_accepts() {
+        // A menu entry that does not parse is a menu entry that fails in front
+        // of the person who chose it.
+        for (name, _) in RUNNABLE {
+            assert!(
+                crate::parses_as_command(name),
+                "`uf {name}` is on the menu and is not a command"
+            );
+        }
+    }
+
+    #[test]
+    fn no_offered_command_requires_an_argument() {
+        // The whole reason the menu is a subset: choosing `create` would parse
+        // as a command and then be rejected for the argument it did not get.
+        for (name, _) in RUNNABLE {
+            assert!(
+                crate::runs_with_no_arguments(name),
+                "`uf {name}` needs an argument and cannot be a menu entry"
+            );
+        }
+    }
+
+    #[test]
+    fn the_help_row_is_not_mistaken_for_a_command() {
+        assert!(!RUNNABLE.iter().any(|(name, _)| *name == HELP.0));
+    }
+}

--- a/crates/uf_term/src/lib.rs
+++ b/crates/uf_term/src/lib.rs
@@ -57,6 +57,7 @@ mod diagnostic;
 mod glyph;
 mod image;
 mod progress;
+pub mod prompt;
 mod render;
 mod style;
 mod table;

--- a/crates/uf_term/src/prompt.rs
+++ b/crates/uf_term/src/prompt.rs
@@ -1,0 +1,198 @@
+//! Asking the reader to pick one thing.
+//!
+//! The rest of this crate writes and never reads. This module is the one place
+//! that takes keystrokes, and it exists because a list of twenty commands is
+//! something to choose from rather than something to read: printing the list
+//! and leaving the reader to retype one of its entries is asking them to do
+//! the part a terminal is good at.
+//!
+//! # What it will not do
+//!
+//! It refuses unless a person is watching. A prompt in a pipeline is a hang
+//! nobody can see, so [`select`] returns [`Outcome::NotInteractive`] when
+//! either stream is redirected, when `TERM` is `dumb`, and when `CI` is set —
+//! and the caller prints whatever it would have printed before. Nothing that
+//! reads uf's output has to know a menu exists.
+//!
+//! # The frame
+//!
+//! Drawing is a redraw of the same block in place: the cursor goes back up as
+//! many lines as were written, and each line clears to the right edge as it is
+//! rewritten. Nothing scrolls, nothing flickers, and the scrollback afterwards
+//! holds one frame rather than one per keystroke.
+//!
+//! ```no_run
+//! use uf_term::prompt::{Choice, Outcome, Request, select};
+//!
+//! let choices = [
+//!     Choice::new("build", "Build the project for production"),
+//!     Choice::new("test", "Run the test suite"),
+//! ];
+//! match select(&Request::new("What would you like to run?", &choices)) {
+//!     Outcome::Chose(choice) => println!("running {}", choice.name),
+//!     Outcome::Cancelled => println!("nothing chosen"),
+//!     Outcome::NotInteractive => println!("no terminal; print the help instead"),
+//! }
+//! ```
+
+mod draw;
+mod key;
+mod menu;
+mod raw;
+
+#[cfg(test)]
+mod tests;
+
+use std::io::{self, IsTerminal, Write};
+
+use crate::capability::{Capabilities, ColorChoice, TerminalEnv};
+use crate::theme::Theme;
+
+pub use menu::{Choice, VISIBLE};
+
+use key::{Key, read_key};
+use menu::Menu;
+use raw::RawMode;
+
+/// What to ask, and what the answers are.
+#[derive(Debug, Clone)]
+pub struct Request<'a> {
+    /// The question, shown above the filter.
+    pub title: &'a str,
+    /// The hint shown in the filter line while it is empty.
+    pub placeholder: &'a str,
+    /// Everything on offer.
+    pub choices: &'a [Choice<'a>],
+    /// How much colour to use.
+    pub color: ColorChoice,
+}
+
+impl<'a> Request<'a> {
+    /// A request with the usual placeholder and automatic colour.
+    pub fn new(title: &'a str, choices: &'a [Choice<'a>]) -> Self {
+        Self {
+            title,
+            placeholder: "type to filter",
+            choices,
+            color: ColorChoice::Auto,
+        }
+    }
+}
+
+/// How the prompt ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome<'a> {
+    /// The reader picked this.
+    Chose(&'a Choice<'a>),
+    /// The reader left without picking: `Escape`, `Ctrl-C`, or a closed input.
+    Cancelled,
+    /// There was nobody to ask.
+    NotInteractive,
+}
+
+/// Ask, and return what was chosen.
+///
+/// Draws on stderr rather than stdout, so `uf` can be asked a question and
+/// still have its answer piped somewhere: the menu is the conversation, and
+/// the command's output is the result.
+pub fn select<'a>(request: &Request<'a>) -> Outcome<'a> {
+    if !is_interactive() {
+        return Outcome::NotInteractive;
+    }
+    let Ok(raw) = RawMode::enter() else {
+        return Outcome::NotInteractive;
+    };
+
+    let theme = Theme::default();
+    let capabilities = Capabilities::for_stderr(request.color, &TerminalEnv::from_process());
+    let frame = draw::Frame {
+        title: request.title,
+        placeholder: request.placeholder,
+        capabilities,
+        theme: &theme,
+    };
+
+    let mut menu = Menu::new(request.choices);
+    let outcome = run(&mut menu, &frame, &raw);
+
+    // Erase the menu. A chosen command is about to print its own output, and
+    // leaving the picker above it turns the answer into part of the question.
+    clear(&frame, &menu);
+    drop(raw);
+    outcome
+}
+
+/// Read keys and redraw until something ends it.
+fn run<'a>(menu: &mut Menu<'a>, frame: &draw::Frame<'_>, raw: &RawMode) -> Outcome<'a> {
+    let mut drawn = 0usize;
+    let mut buffer = String::with_capacity(1024);
+
+    loop {
+        buffer.clear();
+        if drawn > 0 {
+            // Back to the top of the block, then clear everything below: a
+            // frame that lost rows must not leave the old ones on screen.
+            buffer.push_str(&format!("\x1b[{drawn}A"));
+            buffer.push_str("\x1b[J");
+        }
+        buffer.push_str("\x1b[?25l");
+        draw::frame(menu, frame, &mut buffer);
+        drawn = buffer.matches('\n').count();
+
+        if write(&buffer).is_err() {
+            return Outcome::Cancelled;
+        }
+
+        match read_key(raw) {
+            Ok(None) | Err(_) => return Outcome::Cancelled,
+            Ok(Some(Key::Escape)) => return Outcome::Cancelled,
+            Ok(Some(Key::Enter)) => {
+                // Nothing selected means nothing matches what was typed, and
+                // the frame already says so.
+                if let Some(choice) = menu.selected() {
+                    return Outcome::Chose(choice);
+                }
+            }
+            Ok(Some(Key::Up)) => menu.up(),
+            Ok(Some(Key::Down)) => menu.down(),
+            Ok(Some(Key::Backspace)) => menu.backspace(),
+            Ok(Some(Key::ClearLine)) => menu.clear(),
+            Ok(Some(Key::Char(character))) => menu.push(character),
+            Ok(Some(Key::Other)) => {}
+        }
+    }
+}
+
+/// Erase the block the menu was drawing in.
+fn clear(frame: &draw::Frame<'_>, menu: &Menu<'_>) {
+    let mut buffer = String::new();
+    draw::frame(menu, frame, &mut buffer);
+    let lines = buffer.matches('\n').count();
+    // The cursor is put back by `RawMode`'s drop, which runs whichever way
+    // this returned, so showing it here as well would only be a second copy.
+    let _ = write(&format!("\x1b[{lines}A\x1b[J"));
+}
+
+/// Write to stderr and flush, so a frame appears before the next key is read.
+fn write(text: &str) -> io::Result<()> {
+    let mut stderr = io::stderr();
+    stderr.write_all(text.as_bytes())?;
+    stderr.flush()
+}
+
+/// Whether there is a person at a terminal to ask.
+///
+/// Both streams, not just one. Stdin has to be a terminal or there are no
+/// keystrokes to read; stderr has to be one or the frame is being written into
+/// a file that will end up full of cursor movements.
+fn is_interactive() -> bool {
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        return false;
+    }
+    // `CI` is set by every hosted runner, and a runner that allocates a tty —
+    // several do — would otherwise sit at a prompt until the job times out.
+    if std::env::var_os("CI").is_some() {
+        return false;
+    }
+    !matches!(std::env::var("TERM").as_deref(), Ok("dumb"))
+}

--- a/crates/uf_term/src/prompt/draw.rs
+++ b/crates/uf_term/src/prompt/draw.rs
@@ -1,0 +1,176 @@
+//! Turning a [`Menu`] into the text of one frame.
+//!
+//! Separate from the loop that reads keys so a frame can be asserted on
+//! character by character in a test, which is the only way to be sure a
+//! terminal nobody is watching lines up.
+
+use crate::capability::Capabilities;
+use crate::glyph::Glyphs;
+use crate::style::Style;
+use crate::text::display_width;
+use crate::theme::Theme;
+
+use super::menu::Menu;
+
+/// The mark in front of the highlighted row.
+const POINTER: &str = "❯";
+/// Its ASCII stand-in, one cell wide like the original.
+const POINTER_ASCII: &str = ">";
+
+/// The prompt in front of what has been typed.
+const CARET: &str = "›";
+/// Its ASCII stand-in.
+const CARET_ASCII: &str = ">";
+
+/// Everything a frame needs that is not the menu itself.
+#[derive(Debug, Clone, Copy)]
+pub struct Frame<'a> {
+    /// The question at the top.
+    pub title: &'a str,
+    /// What to type when nothing has been typed.
+    pub placeholder: &'a str,
+    /// How much colour and which glyphs the terminal takes.
+    pub capabilities: Capabilities,
+    /// The palette.
+    pub theme: &'a Theme,
+}
+
+impl Frame<'_> {
+    /// The pointer and caret for this terminal's glyph vocabulary.
+    fn marks(&self) -> (&'static str, &'static str) {
+        match Glyphs::of(self.capabilities.glyphs()).leader {
+            // The Unicode vocabulary is identified by its own leader dot, so
+            // the two never disagree about which set is in use.
+            '·' => (POINTER, CARET),
+            _ => (POINTER_ASCII, CARET_ASCII),
+        }
+    }
+}
+
+/// Draw one frame, appending to `out`.
+///
+/// Every line is written in full and the caller clears from the cursor down
+/// before drawing, so a row that shrinks — a long description replaced by a
+/// short one — leaves nothing of the old row behind.
+pub fn frame(menu: &Menu<'_>, frame: &Frame<'_>, out: &mut String) {
+    let level = frame.capabilities.color();
+    let theme = frame.theme;
+    let (pointer, caret) = frame.marks();
+
+    out.push('\n');
+    push_line(out, |out| {
+        theme.title.paint(level, frame.title, out);
+    });
+
+    // The filter line. The placeholder is dimmed rather than absent so the
+    // line does not change height the moment a reader types into it.
+    push_line(out, |out| {
+        theme.accent.paint(level, caret, out);
+        out.push(' ');
+        if menu.filter().is_empty() {
+            theme.muted.paint(level, frame.placeholder, out);
+        } else {
+            theme.value.paint(level, menu.filter(), out);
+        }
+    });
+    out.push('\n');
+
+    if menu.is_empty() {
+        push_line(out, |out| {
+            theme.muted.paint(level, "nothing matches", out);
+        });
+        return;
+    }
+
+    let width = menu.name_width();
+    let mut group = "";
+    for (choice, highlighted) in menu.visible() {
+        // A heading only where the group changes, and never above the first
+        // row when the menu is unfiltered enough to have only one group.
+        if choice.group != group && !choice.group.is_empty() {
+            group = choice.group;
+            push_line(out, |out| {
+                theme.muted.paint(level, group, out);
+            });
+        }
+        push_row(
+            out,
+            choice.name,
+            choice.about,
+            width,
+            highlighted,
+            pointer,
+            frame,
+        );
+    }
+
+    footer(menu, frame, out);
+}
+
+/// One row: the pointer, the name padded to a column, and the description.
+fn push_row(
+    out: &mut String,
+    name: &str,
+    about: &str,
+    width: usize,
+    highlighted: bool,
+    pointer: &str,
+    frame: &Frame<'_>,
+) {
+    let level = frame.capabilities.color();
+    let theme = frame.theme;
+    push_line(out, |out| {
+        if highlighted {
+            theme.accent.paint(level, pointer, out);
+            out.push(' ');
+            // Bold rather than a reversed background: a reversed row is the
+            // width of the terminal and repaints as a bar every keystroke,
+            // which flickers on a slow connection.
+            Style::new().bold().paint(level, name, out);
+        } else {
+            out.push_str("  ");
+            theme.value.paint(level, name, out);
+        }
+        pad(out, width.saturating_sub(display_width(name)) + 2);
+        theme.muted.paint(level, about, out);
+    });
+}
+
+/// The line under the list: what is off screen, and which keys do what.
+fn footer(menu: &Menu<'_>, frame: &Frame<'_>, out: &mut String) {
+    let level = frame.capabilities.color();
+    let theme = frame.theme;
+    let unicode = frame.marks().0 == POINTER;
+
+    out.push('\n');
+    push_line(out, |out| {
+        let hidden = menu.hidden_below() + menu.hidden_above();
+        if hidden > 0 {
+            theme.muted.paint(level, &format!("{hidden} more · "), out);
+        }
+        let keys = if unicode {
+            "↑↓ move · ⏎ run · esc cancel"
+        } else {
+            "up/down move · enter run · esc cancel"
+        };
+        theme.muted.paint(level, keys, out);
+    });
+}
+
+/// Write one indented line, with everything after it cleared.
+///
+/// `\x1b[K` rather than padding with spaces: it erases to the right edge
+/// whatever the width of the terminal, and costs three bytes instead of one
+/// per column.
+fn push_line(out: &mut String, body: impl FnOnce(&mut String)) {
+    out.push_str("  ");
+    body(out);
+    out.push_str("\x1b[K\n");
+}
+
+/// `count` spaces.
+fn pad(out: &mut String, count: usize) {
+    for _ in 0..count {
+        out.push(' ');
+    }
+}

--- a/crates/uf_term/src/prompt/key.rs
+++ b/crates/uf_term/src/prompt/key.rs
@@ -1,0 +1,148 @@
+//! One keystroke, read from a terminal in raw mode.
+//!
+//! A key is not a byte. An arrow is three bytes, a character outside ASCII is
+//! two to four, and `Escape` is the first byte of most of the sequences it is
+//! not. This module is the whole of that decoding, so the menu above it can be
+//! written against `Key` and tested without a terminal.
+
+use std::io::{self, Read};
+
+use super::raw::RawMode;
+
+/// What the reader pressed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Key {
+    /// Move the selection towards the top of the list.
+    Up,
+    /// Move the selection towards the bottom.
+    Down,
+    /// Take the highlighted item.
+    Enter,
+    /// Leave, taking nothing.
+    Escape,
+    /// Delete the character before the cursor.
+    Backspace,
+    /// Clear the whole filter, which is `Ctrl-U` as it is in a shell.
+    ClearLine,
+    /// A character to add to the filter.
+    Char(char),
+    /// A key with no meaning here.
+    Other,
+}
+
+/// `Ctrl-C`. Not a `Key`: it means "stop", not "leave the menu".
+pub const INTERRUPT: u8 = 0x03;
+
+/// Read one keystroke.
+///
+/// `Ok(None)` means the input ended — a closed terminal, or `Ctrl-D` — which
+/// is the same answer as `Escape` to every caller here but is worth keeping
+/// distinct from "the reader chose to leave".
+pub fn read_key(raw: &RawMode) -> io::Result<Option<Key>> {
+    let Some(first) = read_byte_blocking(raw)? else {
+        return Ok(None);
+    };
+
+    match first {
+        INTERRUPT | 0x04 => Ok(None),
+        b'\r' | b'\n' => Ok(Some(Key::Enter)),
+        0x7f | 0x08 => Ok(Some(Key::Backspace)),
+        0x15 => Ok(Some(Key::ClearLine)),
+        0x1b => escape_sequence(raw),
+        // `Ctrl-N` and `Ctrl-P`, which move in a shell's history and so move
+        // here too. `j` and `k` are deliberately *not* bound: they are letters,
+        // and every letter belongs to the filter.
+        0x0e => Ok(Some(Key::Down)),
+        0x10 => Ok(Some(Key::Up)),
+        byte if byte < 0x20 => Ok(Some(Key::Other)),
+        byte => decode_char(raw, byte),
+    }
+}
+
+/// What followed an `ESC`.
+///
+/// Nothing at all means the reader pressed `Escape` itself, which is why the
+/// terminal is put into its brief mode first — see [`RawMode::brief`].
+fn escape_sequence(raw: &RawMode) -> io::Result<Option<Key>> {
+    raw.brief()?;
+    let next = read_byte(&mut [0u8; 1])?;
+    let key = match next {
+        None => Key::Escape,
+        // `ESC [ A` and `ESC O A`: the second form is what a terminal in
+        // application-cursor mode sends, which several send by default.
+        Some(b'[' | b'O') => match read_byte(&mut [0u8; 1])? {
+            Some(b'A') => Key::Up,
+            Some(b'B') => Key::Down,
+            // An arrow's siblings — Home, End, Page Up — arrive as `ESC [ 1 ~`
+            // and friends. Their trailing bytes are drained so they do not
+            // arrive later as stray characters in the filter.
+            Some(byte) if byte.is_ascii_digit() => {
+                drain_until_tilde()?;
+                Key::Other
+            }
+            _ => Key::Other,
+        },
+        Some(_) => Key::Other,
+    };
+    raw.blocking()?;
+    Ok(Some(key))
+}
+
+/// Swallow the rest of a `ESC [ <digits> ~` sequence.
+fn drain_until_tilde() -> io::Result<()> {
+    /// A sequence longer than this is not one a terminal sent.
+    const BUDGET: usize = 8;
+
+    for _ in 0..BUDGET {
+        match read_byte(&mut [0u8; 1])? {
+            None | Some(b'~') => return Ok(()),
+            Some(_) => {}
+        }
+    }
+    Ok(())
+}
+
+/// Finish a UTF-8 character whose first byte has already been read.
+///
+/// The filter is text, and a reader typing `テ` should see `テ` rather than
+/// three replacement characters. The continuation bytes arrive together, so
+/// this never has to wait.
+fn decode_char(raw: &RawMode, first: u8) -> io::Result<Option<Key>> {
+    let extra = match first {
+        0x00..=0x7f => 0,
+        0xc0..=0xdf => 1,
+        0xe0..=0xef => 2,
+        0xf0..=0xf7 => 3,
+        // A continuation byte with no lead, which is not text.
+        _ => return Ok(Some(Key::Other)),
+    };
+
+    let mut bytes = [first, 0, 0, 0];
+    for slot in bytes.iter_mut().take(extra + 1).skip(1) {
+        let Some(byte) = read_byte_blocking(raw)? else {
+            return Ok(Some(Key::Other));
+        };
+        *slot = byte;
+    }
+
+    match std::str::from_utf8(&bytes[..=extra]) {
+        Ok(text) => Ok(text.chars().next().map(Key::Char)),
+        Err(_) => Ok(Some(Key::Other)),
+    }
+}
+
+/// Read one byte, waiting for it.
+fn read_byte_blocking(raw: &RawMode) -> io::Result<Option<u8>> {
+    raw.blocking()?;
+    read_byte(&mut [0u8; 1])
+}
+
+/// Read one byte in whatever mode the terminal is currently in.
+fn read_byte(buffer: &mut [u8; 1]) -> io::Result<Option<u8>> {
+    match io::stdin().read(buffer) {
+        Ok(0) => Ok(None),
+        Ok(_) => Ok(Some(buffer[0])),
+        Err(error) if error.kind() == io::ErrorKind::Interrupted => Ok(None),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/uf_term/src/prompt/menu.rs
+++ b/crates/uf_term/src/prompt/menu.rs
@@ -1,0 +1,233 @@
+//! The menu's state: what is showing, what is highlighted, and why.
+//!
+//! Every function here is pure. The terminal is somebody else's problem — this
+//! decides what a frame should contain given what has been typed, and it is
+//! the part worth testing, because filtering and scrolling are where a picker
+//! is wrong in ways a screenshot does not show.
+
+use crate::text::display_width;
+
+/// One thing a reader can choose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Choice<'a> {
+    /// What running it looks like: `build`, `run test:lib`.
+    pub name: &'a str,
+    /// One line saying what it does.
+    pub about: &'a str,
+    /// The heading this belongs under, or `""` for none.
+    pub group: &'a str,
+}
+
+impl<'a> Choice<'a> {
+    /// A choice with a name and a description.
+    pub const fn new(name: &'a str, about: &'a str) -> Self {
+        Self {
+            name,
+            about,
+            group: "",
+        }
+    }
+
+    /// The same, under a heading.
+    pub const fn grouped(name: &'a str, about: &'a str, group: &'a str) -> Self {
+        Self { name, about, group }
+    }
+}
+
+/// How many rows of the list are on screen at once.
+///
+/// Ten because a menu taller than that scrolls off a small terminal and stops
+/// being a menu, and because a list you cannot see the end of is one you filter
+/// rather than scroll.
+pub const VISIBLE: usize = 10;
+
+/// What the reader has done so far.
+#[derive(Debug, Clone)]
+pub struct Menu<'a> {
+    /// Everything on offer, in the order it was given.
+    choices: &'a [Choice<'a>],
+    /// What has been typed.
+    filter: String,
+    /// Index into [`Self::matches`], not into `choices`.
+    cursor: usize,
+    /// First visible row, also an index into [`Self::matches`].
+    offset: usize,
+    /// Indices into `choices`, in the order they should be shown.
+    matches: Vec<usize>,
+}
+
+impl<'a> Menu<'a> {
+    /// A menu showing everything, with the first item highlighted.
+    pub fn new(choices: &'a [Choice<'a>]) -> Self {
+        let mut menu = Self {
+            choices,
+            filter: String::new(),
+            cursor: 0,
+            offset: 0,
+            matches: Vec::with_capacity(choices.len()),
+        };
+        menu.refilter();
+        menu
+    }
+
+    /// What has been typed so far.
+    pub fn filter(&self) -> &str {
+        &self.filter
+    }
+
+    /// Whether anything matches what has been typed.
+    pub fn is_empty(&self) -> bool {
+        self.matches.is_empty()
+    }
+
+    /// The highlighted choice, if there is one.
+    pub fn selected(&self) -> Option<&'a Choice<'a>> {
+        self.matches.get(self.cursor).map(|at| &self.choices[*at])
+    }
+
+    /// The rows to draw, top to bottom, each with whether it is highlighted.
+    pub fn visible(&self) -> impl Iterator<Item = (&'a Choice<'a>, bool)> + '_ {
+        self.matches
+            .iter()
+            .enumerate()
+            .skip(self.offset)
+            .take(VISIBLE)
+            .map(move |(at, index)| (&self.choices[*index], at == self.cursor))
+    }
+
+    /// How many matches there are, and how many are off screen below.
+    pub fn hidden_below(&self) -> usize {
+        self.matches.len().saturating_sub(self.offset + VISIBLE)
+    }
+
+    /// How many matches are off screen above.
+    pub fn hidden_above(&self) -> usize {
+        self.offset
+    }
+
+    /// Move the highlight up, wrapping to the bottom.
+    ///
+    /// Wrapping rather than stopping: the item a reader wants is as often the
+    /// last as the first, and pressing up once to reach it is what every menu
+    /// with a `↑` on screen does.
+    pub fn up(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
+        self.cursor = match self.cursor {
+            0 => self.matches.len() - 1,
+            at => at - 1,
+        };
+        self.scroll_to_cursor();
+    }
+
+    /// Move the highlight down, wrapping to the top.
+    pub fn down(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
+        self.cursor = (self.cursor + 1) % self.matches.len();
+        self.scroll_to_cursor();
+    }
+
+    /// Add a character to the filter.
+    pub fn push(&mut self, character: char) {
+        self.filter.push(character);
+        self.refilter();
+    }
+
+    /// Remove the last character of the filter.
+    pub fn backspace(&mut self) {
+        self.filter.pop();
+        self.refilter();
+    }
+
+    /// Empty the filter.
+    pub fn clear(&mut self) {
+        self.filter.clear();
+        self.refilter();
+    }
+
+    /// The widest name among the matches, for the description column.
+    ///
+    /// Measured over what is *visible* rather than over everything: a filter
+    /// that leaves three short names should not indent them past a long name
+    /// that is no longer on screen.
+    pub fn name_width(&self) -> usize {
+        self.visible()
+            .map(|(choice, _)| display_width(choice.name))
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Recompute the matches, and keep the highlight somewhere sensible.
+    ///
+    /// The highlight goes back to the top on every keystroke, which is what a
+    /// reader typing a filter expects: the best match is first, and leaving the
+    /// highlight where it was would select whatever happened to fall under it.
+    fn refilter(&mut self) {
+        self.matches.clear();
+        let mut scored: Vec<(u32, usize)> = self
+            .choices
+            .iter()
+            .enumerate()
+            .filter_map(|(at, choice)| score(choice, &self.filter).map(|rank| (rank, at)))
+            .collect();
+        // Stable by rank, then by the order they were declared: a menu whose
+        // items move around between keystrokes is one a reader stops trusting.
+        scored.sort_by_key(|(rank, at)| (*rank, *at));
+        self.matches.extend(scored.into_iter().map(|(_, at)| at));
+        self.cursor = 0;
+        self.offset = 0;
+    }
+
+    /// Scroll the window so the highlight is inside it.
+    fn scroll_to_cursor(&mut self) {
+        if self.cursor < self.offset {
+            self.offset = self.cursor;
+        } else if self.cursor >= self.offset + VISIBLE {
+            self.offset = self.cursor + 1 - VISIBLE;
+        }
+    }
+}
+
+/// How well `choice` matches `filter`, lower being better; `None` for no match.
+///
+/// Four tiers, and they are in the order a reader means them. A name that
+/// *starts* with what was typed is what they were reaching for; a name that
+/// merely contains it is a near miss; a description match is a guess at what
+/// they meant; and a subsequence match — `bld` for `build` — is the last
+/// resort, because it matches almost everything if allowed to rank higher.
+fn score(choice: &Choice<'_>, filter: &str) -> Option<u32> {
+    if filter.is_empty() {
+        return Some(0);
+    }
+    let filter = filter.to_lowercase();
+    let name = choice.name.to_lowercase();
+
+    if name.starts_with(&filter) {
+        return Some(0);
+    }
+    if name.contains(&filter) {
+        return Some(1);
+    }
+    if choice.about.to_lowercase().contains(&filter) {
+        return Some(2);
+    }
+    is_subsequence(&name, &filter).then_some(3)
+}
+
+/// Whether every character of `needle` appears in `haystack`, in order.
+fn is_subsequence(haystack: &str, needle: &str) -> bool {
+    let mut wanted = needle.chars();
+    let mut next = wanted.next();
+    for character in haystack.chars() {
+        if Some(character) == next {
+            next = wanted.next();
+            if next.is_none() {
+                return true;
+            }
+        }
+    }
+    next.is_none()
+}

--- a/crates/uf_term/src/prompt/raw.rs
+++ b/crates/uf_term/src/prompt/raw.rs
@@ -1,0 +1,98 @@
+//! Raw mode, and putting the terminal back the way it was found.
+//!
+//! A menu needs every keystroke as it happens: no line buffering, and no echo
+//! of the arrow keys as `^[[A`. That is a terminal *mode*, not something a
+//! program can ask for per read.
+//!
+//! It is set here by running `stty`, and the reason is a constraint this crate
+//! chose: `uf_term` has no third-party dependencies, and `tcsetattr` needs
+//! either `libc` or a hand-written `struct termios` whose layout differs
+//! between macOS and Linux — a thing that goes wrong silently and only on the
+//! platform nobody tested. `stty` is POSIX, is on every machine that has a
+//! shell, and takes about a millisecond. A menu opens once.
+//!
+//! The saved settings come from `stty -g`, which prints them in a form `stty`
+//! itself accepts. Restoring is therefore exact rather than a guess at what
+//! the terminal probably had: a program that leaves a terminal in raw mode
+//! leaves the user typing into a shell that does not echo, which they can only
+//! fix by closing the window.
+
+use std::io::{self, Write};
+use std::process::{Command, Stdio};
+
+/// Raw mode for as long as this value lives.
+///
+/// Restoring on drop rather than at the end of the menu, because the ways out
+/// of a menu are many — a chosen item, an escape, a `?` that fails to write —
+/// and every one of them has to put the terminal back. A `Drop` covers the
+/// early return that has not been written yet, which is the one that will
+/// otherwise be forgotten.
+#[derive(Debug)]
+pub struct RawMode {
+    /// What `stty -g` reported before anything was changed.
+    saved: String,
+}
+
+impl RawMode {
+    /// Put the terminal into raw mode, remembering how to undo it.
+    ///
+    /// Fails when there is no terminal to change, which is the same condition
+    /// that means no menu should have been opened.
+    pub fn enter() -> io::Result<Self> {
+        let saved = stty(&["-g"])?;
+        let saved = saved.trim().to_owned();
+        if saved.is_empty() {
+            return Err(io::Error::other("stty -g reported nothing"));
+        }
+        // `-echo` as well as `raw`: `raw` alone still echoes, and an arrow key
+        // would print `^[[A` into the middle of the menu it is scrolling.
+        stty(&["raw", "-echo"])?;
+        Ok(Self { saved })
+    }
+
+    /// Wait for a byte rather than returning immediately when none is ready.
+    ///
+    /// The mode a key read wants: one byte, however long that takes.
+    pub fn blocking(&self) -> io::Result<()> {
+        stty(&["min", "1", "time", "0"]).map(drop)
+    }
+
+    /// Return after a tenth of a second whether or not a byte arrived.
+    ///
+    /// This exists for exactly one ambiguity. `Escape` is one byte, and so is
+    /// the start of every arrow key — the terminal sends `ESC [ A` for "up".
+    /// Reading the byte after an `ESC` while blocking means a reader who
+    /// pressed `Escape` and nothing else waits forever, and the menu looks
+    /// frozen. A tenth of a second is far longer than the gap inside a real
+    /// escape sequence and far shorter than a person notices.
+    pub fn brief(&self) -> io::Result<()> {
+        stty(&["min", "0", "time", "1"]).map(drop)
+    }
+}
+
+impl Drop for RawMode {
+    fn drop(&mut self) {
+        let _ = stty(&[self.saved.as_str()]);
+        // The cursor is hidden while a menu is drawing; leaving it hidden is
+        // the other way to hand back a terminal that looks broken.
+        let mut stderr = io::stderr();
+        let _ = stderr.write_all(b"\x1b[?25h");
+        let _ = stderr.flush();
+    }
+}
+
+/// Run `stty` against the controlling terminal and return what it printed.
+///
+/// `stdin` is inherited deliberately: `stty` acts on the terminal attached to
+/// its own standard input, and that is the terminal the reader is typing at.
+fn stty(args: &[&str]) -> io::Result<String> {
+    let output = Command::new("stty")
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stderr(Stdio::null())
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!("stty {} failed", args.join(" "))));
+    }
+    String::from_utf8(output.stdout).map_err(io::Error::other)
+}

--- a/crates/uf_term/src/prompt/tests.rs
+++ b/crates/uf_term/src/prompt/tests.rs
@@ -1,0 +1,372 @@
+//! The menu's logic, which is filtering and scrolling.
+//!
+//! Nothing here opens a terminal. The two things a picker gets wrong are which
+//! rows it shows and which one is highlighted, and both are decided by pure
+//! functions on purpose so they can be asserted rather than looked at.
+
+use crate::capability::{Capabilities, ColorChoice, GlyphSet, TerminalEnv, Tty};
+use crate::theme::Theme;
+
+use super::draw;
+use super::menu::{Choice, Menu, VISIBLE};
+
+const CHOICES: &[Choice<'static>] = &[
+    Choice::new("build", "Build the project for production"),
+    Choice::new("check", "Lint the project, then type check it with Flow"),
+    Choice::new("dev", "Start the development server"),
+    Choice::new("fmt", "Format every file uf understands"),
+    Choice::new("lint", "Lint the project"),
+    Choice::new("test", "Run the test suite"),
+];
+
+fn names<'a>(menu: &Menu<'a>) -> Vec<&'a str> {
+    menu.visible().map(|(choice, _)| choice.name).collect()
+}
+
+fn highlighted<'a>(menu: &Menu<'a>) -> Option<&'a str> {
+    menu.selected().map(|choice| choice.name)
+}
+
+#[test]
+fn everything_shows_before_anything_is_typed() {
+    let menu = Menu::new(CHOICES);
+
+    assert_eq!(names(&menu).len(), CHOICES.len());
+    assert_eq!(highlighted(&menu), Some("build"));
+}
+
+#[test]
+fn a_prefix_of_a_name_ranks_above_a_name_that_merely_contains_it() {
+    // "lint" is `lint`'s whole name and the tail of nothing else here, but
+    // `check`'s description contains it. The name has to come first.
+    let mut menu = Menu::new(CHOICES);
+    for character in "lint".chars() {
+        menu.push(character);
+    }
+
+    assert_eq!(names(&menu), vec!["lint", "check"]);
+    assert_eq!(highlighted(&menu), Some("lint"));
+}
+
+#[test]
+fn a_description_match_is_offered_when_no_name_matches() {
+    let mut menu = Menu::new(CHOICES);
+    for character in "server".chars() {
+        menu.push(character);
+    }
+
+    assert_eq!(names(&menu), vec!["dev"]);
+}
+
+#[test]
+fn a_subsequence_is_the_last_resort_rather_than_the_first() {
+    // `bld` is not a prefix, not a substring, and in no description. It is in
+    // `build` as a subsequence, and that is the only reason to offer it.
+    let mut menu = Menu::new(CHOICES);
+    for character in "bld".chars() {
+        menu.push(character);
+    }
+
+    assert_eq!(names(&menu), vec!["build"]);
+}
+
+#[test]
+fn filtering_is_case_insensitive() {
+    let mut menu = Menu::new(CHOICES);
+    for character in "BUILD".chars() {
+        menu.push(character);
+    }
+
+    assert_eq!(names(&menu), vec!["build"]);
+}
+
+#[test]
+fn a_filter_that_matches_nothing_says_so_rather_than_showing_everything() {
+    let mut menu = Menu::new(CHOICES);
+    for character in "zzz".chars() {
+        menu.push(character);
+    }
+
+    assert!(menu.is_empty());
+    assert_eq!(highlighted(&menu), None);
+}
+
+#[test]
+fn backspace_puts_back_what_it_took() {
+    let mut menu = Menu::new(CHOICES);
+    for character in "buildx".chars() {
+        menu.push(character);
+    }
+    assert!(menu.is_empty());
+
+    menu.backspace();
+
+    assert_eq!(names(&menu), vec!["build"]);
+}
+
+#[test]
+fn clearing_the_filter_shows_everything_again() {
+    let mut menu = Menu::new(CHOICES);
+    for character in "dev".chars() {
+        menu.push(character);
+    }
+    menu.clear();
+
+    assert_eq!(names(&menu).len(), CHOICES.len());
+    assert_eq!(menu.filter(), "");
+}
+
+#[test]
+fn the_highlight_returns_to_the_top_on_every_keystroke() {
+    // Otherwise the row under the highlight changes meaning as the list is
+    // filtered, and Enter runs whatever happened to land there.
+    let mut menu = Menu::new(CHOICES);
+    menu.down();
+    menu.down();
+    assert_eq!(highlighted(&menu), Some("dev"));
+
+    menu.push('t');
+
+    assert_eq!(highlighted(&menu), Some("test"));
+}
+
+#[test]
+fn moving_up_from_the_top_wraps_to_the_bottom() {
+    let mut menu = Menu::new(CHOICES);
+
+    menu.up();
+
+    assert_eq!(highlighted(&menu), Some("test"));
+}
+
+#[test]
+fn moving_down_from_the_bottom_wraps_to_the_top() {
+    let mut menu = Menu::new(CHOICES);
+    for _ in 0..CHOICES.len() - 1 {
+        menu.down();
+    }
+    assert_eq!(highlighted(&menu), Some("test"));
+
+    menu.down();
+
+    assert_eq!(highlighted(&menu), Some("build"));
+}
+
+#[test]
+fn moving_in_an_empty_menu_does_nothing_rather_than_panicking() {
+    let mut menu = Menu::new(CHOICES);
+    for character in "zzz".chars() {
+        menu.push(character);
+    }
+
+    menu.up();
+    menu.down();
+
+    assert_eq!(highlighted(&menu), None);
+}
+
+/// Enough choices to need scrolling, named so their order is obvious.
+fn many() -> Vec<Choice<'static>> {
+    const NAMES: [&str; 14] = [
+        "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "b0", "b1", "b2", "b3",
+    ];
+    NAMES.iter().map(|name| Choice::new(name, "")).collect()
+}
+
+#[test]
+fn a_long_list_shows_a_window_rather_than_all_of_it() {
+    let choices = many();
+    let menu = Menu::new(&choices);
+
+    assert_eq!(names(&menu).len(), VISIBLE);
+    assert_eq!(menu.hidden_below(), choices.len() - VISIBLE);
+    assert_eq!(menu.hidden_above(), 0);
+}
+
+#[test]
+fn the_window_follows_the_highlight_down() {
+    let choices = many();
+    let mut menu = Menu::new(&choices);
+    for _ in 0..VISIBLE {
+        menu.down();
+    }
+
+    assert_eq!(highlighted(&menu), Some("b0"));
+    assert!(names(&menu).contains(&"b0"), "{:?}", names(&menu));
+    assert_eq!(menu.hidden_above(), 1);
+}
+
+#[test]
+fn wrapping_to_the_bottom_scrolls_the_window_to_it() {
+    let choices = many();
+    let mut menu = Menu::new(&choices);
+
+    menu.up();
+
+    assert_eq!(highlighted(&menu), Some("b3"));
+    assert!(names(&menu).contains(&"b3"));
+    assert_eq!(menu.hidden_below(), 0);
+}
+
+#[test]
+fn the_description_column_is_measured_over_what_is_visible() {
+    // A filter that leaves only short names must not keep indenting them past
+    // a long name that is no longer on screen.
+    const WIDE: &[Choice<'static>] = &[
+        Choice::new("a-very-long-command-name", "long"),
+        Choice::new("fmt", "short"),
+    ];
+    let mut menu = Menu::new(WIDE);
+    assert_eq!(menu.name_width(), "a-very-long-command-name".len());
+
+    for character in "fmt".chars() {
+        menu.push(character);
+    }
+
+    assert_eq!(menu.name_width(), 3);
+}
+
+fn plain_frame(theme: &Theme) -> draw::Frame<'_> {
+    draw::Frame {
+        title: "What would you like to run?",
+        placeholder: "type to filter",
+        capabilities: Capabilities::detect(
+            ColorChoice::Never,
+            Tty::Interactive,
+            &TerminalEnv::default(),
+        ),
+        theme,
+    }
+}
+
+/// The name column of every row in a drawn frame, in order.
+///
+/// Reading the rows rather than searching the whole frame for a name, because
+/// a name also appears inside a description — `check`'s own says "type check"
+/// — and counting those would assert the wrong thing.
+fn drawn_names(out: &str) -> Vec<String> {
+    out.lines()
+        .filter_map(|line| line.strip_suffix("\x1b[K"))
+        .filter_map(|line| line.strip_prefix("  "))
+        .filter_map(|line| {
+            line.strip_prefix("\u{276f} ")
+                .or_else(|| line.strip_prefix("  "))
+        })
+        .filter_map(|line| line.split_whitespace().next())
+        .map(str::to_owned)
+        .collect()
+}
+
+#[test]
+fn a_frame_names_every_visible_choice_once() {
+    let theme = Theme::default();
+    let menu = Menu::new(CHOICES);
+    let mut out = String::new();
+
+    draw::frame(&menu, &plain_frame(&theme), &mut out);
+
+    let drawn = drawn_names(&out);
+    let expected: Vec<String> = CHOICES
+        .iter()
+        .map(|choice| choice.name.to_owned())
+        .collect();
+    assert_eq!(drawn, expected, "{out:?}");
+}
+
+#[test]
+fn a_frame_marks_exactly_one_row() {
+    let theme = Theme::default();
+    let mut menu = Menu::new(CHOICES);
+    menu.down();
+    let mut out = String::new();
+
+    draw::frame(&menu, &plain_frame(&theme), &mut out);
+
+    let marked: Vec<&str> = out
+        .lines()
+        .filter(|line| line.starts_with("  \u{276f} "))
+        .collect();
+    assert_eq!(marked.len(), 1, "{out:?}");
+    assert!(marked[0].contains("check"), "{out:?}");
+}
+
+#[test]
+fn a_frame_at_colour_never_contains_no_escape_byte_but_the_line_clears() {
+    // The clear is a control sequence rather than a colour, and it is what
+    // keeps a shrinking frame from leaving its old rows behind — so it stays
+    // even when nothing is being coloured.
+    let theme = Theme::default();
+    let menu = Menu::new(CHOICES);
+    let mut out = String::new();
+
+    draw::frame(&menu, &plain_frame(&theme), &mut out);
+
+    for sequence in out.split("\x1b[K") {
+        assert!(!sequence.contains('\x1b'), "unexpected escape in {out:?}");
+    }
+}
+
+#[test]
+fn a_frame_says_how_many_are_off_screen() {
+    let theme = Theme::default();
+    let choices = many();
+    let menu = Menu::new(&choices);
+    let mut out = String::new();
+
+    draw::frame(&menu, &plain_frame(&theme), &mut out);
+
+    assert!(out.contains("4 more"), "{out}");
+}
+
+#[test]
+fn a_frame_with_nothing_matching_says_so() {
+    let theme = Theme::default();
+    let mut menu = Menu::new(CHOICES);
+    for character in "zzz".chars() {
+        menu.push(character);
+    }
+    let mut out = String::new();
+
+    draw::frame(&menu, &plain_frame(&theme), &mut out);
+
+    assert!(out.contains("nothing matches"), "{out}");
+    assert!(out.contains("zzz"), "the filter is still shown: {out}");
+}
+
+#[test]
+fn an_ascii_terminal_gets_ascii_marks() {
+    let theme = Theme::default();
+    let menu = Menu::new(CHOICES);
+    let mut frame = plain_frame(&theme);
+    // A locale that is not UTF-8, which is what picks the ASCII vocabulary.
+    let env = TerminalEnv {
+        locale: Some("C".to_owned()),
+        ..TerminalEnv::default()
+    };
+    frame.capabilities = Capabilities::detect(ColorChoice::Never, Tty::Interactive, &env);
+    assert_eq!(frame.capabilities.glyphs(), GlyphSet::Ascii);
+    let mut out = String::new();
+
+    draw::frame(&menu, &frame, &mut out);
+
+    assert!(!out.contains('❯'), "{out}");
+    assert!(!out.contains('↑'), "{out}");
+    assert!(out.contains("enter run"), "{out}");
+}
+
+#[test]
+fn a_group_heading_is_written_once_per_group() {
+    const GROUPED: &[Choice<'static>] = &[
+        Choice::grouped("build", "", "commands"),
+        Choice::grouped("test", "", "commands"),
+        Choice::grouped("run ci", "", "tasks"),
+    ];
+    let theme = Theme::default();
+    let menu = Menu::new(GROUPED);
+    let mut out = String::new();
+
+    draw::frame(&menu, &plain_frame(&theme), &mut out);
+
+    assert_eq!(out.matches("commands").count(), 1, "{out}");
+    assert_eq!(out.matches("tasks").count(), 1, "{out}");
+}

--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -32,6 +32,109 @@ uf_paint() {
   fi
 }
 
+# Unicode marks, unless the locale says the terminal cannot render them.
+#
+# Mirrors `detect_glyphs` in `crates/uf_term/src/capability.rs`, down to
+# treating an unset locale as UTF-8: it is the common case on macOS and in CI
+# images that render it correctly, so it is not a downgrade signal. The marks
+# themselves are `Status::glyph`'s — the installer and the binary it installs
+# should not disagree about what a tick looks like.
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+  "") uf_tick="✓" uf_cross="✗" ;;
+  *[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*) uf_tick="✓" uf_cross="✗" ;;
+  *) uf_tick="+" uf_cross="x" ;;
+esac
+if [ "${TERM:-}" = "dumb" ] || [ -n "${NO_COLOR:-}" ]; then
+  uf_tick="+"
+  uf_cross="x"
+fi
+
+# `$HOME` written as `~`, because a home directory is most of the width of an
+# install path and none of the information in it.
+#
+# For prose only. A `~` inside the double quotes of an `export PATH=…` does not
+# expand — the shell only expands it unquoted, and at the start of a word — so
+# a line printed for the reader to paste uses `uf_home_var` instead.
+uf_tilde() {
+  case "$1" in
+    "$HOME"/*) printf '~%s' "${1#"$HOME"}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# The same path with a literal `$HOME`, for a line the reader will paste.
+#
+# Written into single quotes here so this script does not expand it: the point
+# is that the *reader's* shell does, in whatever profile they paste it into.
+uf_home_var() {
+  case "$1" in
+    "$HOME"/*) printf '$HOME%s' "${1#"$HOME"}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# `label   value`, with the label dim and the column fixed.
+#
+# The width is 9 because `version` is the longest label here and a fixed column
+# is what lets the eye run down the values rather than hunting for where each
+# one starts.
+uf_field() {
+  if [ -z "$uf_colour" ]; then
+    printf '  %-9s%s\n' "$1" "$2" >&2
+  else
+    printf '  \033[2m%-9s\033[0m%s\n' "$1" "$2" >&2
+  fi
+}
+
+# `✓ verb      what`, one line per thing that happened.
+#
+# Past tense, and the verb first: the reader is skimming for what was done, and
+# every line beginning with the same prefix — `uf installer:`, as these lines
+# used to — puts fourteen identical characters in front of the only part that
+# differs.
+uf_step() {
+  if [ -z "$uf_colour" ]; then
+    printf '  %s %-11s%s\n' "$uf_tick" "$1" "$2" >&2
+  else
+    printf '  \033[38;2;53;214;246m%s\033[0m \033[2m%-11s\033[0m%s\n' \
+      "$uf_tick" "$1" "$2" >&2
+  fi
+}
+
+# A note that is not a step and not a failure.
+uf_note() {
+  if [ -z "$uf_colour" ]; then
+    printf '  %s\n' "$1" >&2
+  else
+    printf '  \033[2m%s\033[0m\n' "$1" >&2
+  fi
+}
+
+# Say what went wrong, say what to do about it, and stop.
+#
+# Everything after the first argument is a hint line, and that is why this is
+# one function rather than a pair of `echo`s: an installer that reports a
+# failure without saying what would fix it has told the reader only that they
+# are stuck.
+uf_fail() {
+  message="$1"
+  shift
+  printf '\n' >&2
+  if [ -z "$uf_colour" ]; then
+    printf '  %s %s\n' "$uf_cross" "$message" >&2
+    for hint in "$@"; do
+      [ -n "$hint" ] && printf '    %s\n' "$hint" >&2
+    done
+  else
+    printf '  \033[38;2;255;93;93m%s\033[0m %s\n' "$uf_cross" "$message" >&2
+    for hint in "$@"; do
+      [ -n "$hint" ] && printf '    \033[2m%s\033[0m\n' "$hint" >&2
+    done
+  fi
+  printf '\n' >&2
+  exit 1
+}
+
 # Which inline-image protocol this terminal speaks, if any.
 #
 # There is no way to ask it. Both protocols have a query form, but the answer
@@ -335,14 +438,9 @@ uf_brand() {
   fi
 }
 
-uf_step() {
-  printf 'uf installer: %s\n' "$1" >&2
-}
-
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
-    echo "uf installer: missing required command: $1" >&2
-    exit 1
+    uf_fail "$1 is not installed" "the installer needs curl, tar, mktemp and uname"
   fi
 }
 
@@ -356,23 +454,16 @@ uf_brand
 case "$(uname -s)" in
   Darwin) os="apple-darwin" ;;
   Linux) os="unknown-linux-gnu" ;;
-  *)
-    echo "uf installer: unsupported OS: $(uname -s)" >&2
-    exit 1
-    ;;
+  *) uf_fail "no build for $(uname -s)" "uf ships macOS and Linux binaries" ;;
 esac
 
 case "$(uname -m)" in
   arm64 | aarch64) arch="aarch64" ;;
   x86_64 | amd64) arch="x86_64" ;;
-  *)
-    echo "uf installer: unsupported architecture: $(uname -m)" >&2
-    exit 1
-    ;;
+  *) uf_fail "no build for $(uname -m)" "uf ships aarch64 and x86_64 binaries" ;;
 esac
 
 target="${arch}-${os}"
-uf_step "target ${target}"
 
 case "$requested_version" in
   uf@*) requested_version="${requested_version#uf@}" ;;
@@ -403,9 +494,8 @@ if [ -n "$release_base" ]; then
   if [ "$requested_version" = "latest" ]; then
     if ! version="$(curl -fsSL "${channel_url}/VERSION" | tr -d '[:space:]')" \
       || [ -z "$version" ]; then
-      echo "uf installer: could not resolve the latest version from ${channel_url}/VERSION" >&2
-      echo "uf installer: set UF_VERSION to install a specific release" >&2
-      exit 1
+      uf_fail "no version at ${channel_url}/VERSION" \
+        "set UF_VERSION to install a specific release"
     fi
   fi
 elif [ "$requested_version" = "latest" ]; then
@@ -414,20 +504,26 @@ elif [ "$requested_version" = "latest" ]; then
     && [ -n "$version" ]; then
     channel_url="$stable_url"
   else
-    uf_step "no stable release yet, taking the newest prerelease"
+    prerelease="yes"
     tag="$(newest_prerelease_tag)"
     version="${tag#uf@}"
     if [ -z "$version" ]; then
-      echo "uf installer: could not resolve a release for ${repo}" >&2
-      echo "uf installer: set UF_VERSION to install a specific release" >&2
-      exit 1
+      uf_fail "no release found for ${repo}" \
+        "set UF_VERSION to install a specific release"
     fi
     channel_url="https://github.com/${repo}/releases/download/uf@${version}"
   fi
 else
   channel_url="https://github.com/${repo}/releases/download/uf@${requested_version}"
 fi
-uf_step "version ${version}"
+
+uf_field "target" "$target"
+if [ -n "${prerelease:-}" ]; then
+  uf_field "version" "${version}  (prerelease — no stable release yet)"
+else
+  uf_field "version" "$version"
+fi
+printf '\n' >&2
 
 archive="uf-${target}.tar.gz"
 archive_url="${channel_url}/${archive}"
@@ -439,9 +535,21 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-uf_step "downloading ${archive}"
-curl -fsSL "$archive_url" -o "${tmp_dir}/${archive}"
-curl -fsSL "$checksum_url" -o "${tmp_dir}/${archive}.sha256"
+# Fetch, keeping curl's own diagnosis for the hint line rather than letting it
+# print ahead of ours. "404" and "could not resolve host" are different problems
+# with different fixes, and a formatted failure that swallowed the difference
+# would be prettier and less useful.
+uf_fetch() {
+  if ! curl -fsSL "$1" -o "$2" 2>"${tmp_dir}/curl.err"; then
+    uf_fail "$3" "$(tr -d '\r' <"${tmp_dir}/curl.err" | tail -1)" "$1"
+  fi
+}
+
+uf_fetch "$archive_url" "${tmp_dir}/${archive}" \
+  "could not download ${archive}"
+uf_fetch "$checksum_url" "${tmp_dir}/${archive}.sha256" \
+  "could not download the checksum for ${archive}"
+uf_step "downloaded" "$archive"
 
 expected="$(awk '{print $1}' "${tmp_dir}/${archive}.sha256")"
 if command -v sha256sum >/dev/null 2>&1; then
@@ -449,44 +557,64 @@ if command -v sha256sum >/dev/null 2>&1; then
 elif command -v shasum >/dev/null 2>&1; then
   actual="$(shasum -a 256 "${tmp_dir}/${archive}" | awk '{print $1}')"
 else
-  echo "uf installer: missing sha256sum or shasum" >&2
-  exit 1
+  uf_fail "no sha256sum or shasum" "one of them is needed to verify the download"
 fi
 
 if [ "$actual" != "$expected" ]; then
-  echo "uf installer: checksum mismatch for ${archive}" >&2
-  echo "expected: $expected" >&2
-  echo "actual:   $actual" >&2
-  exit 1
+  uf_fail "checksum mismatch for ${archive}" \
+    "expected ${expected}, got ${actual} — do not run this binary"
 fi
-uf_step "checksum verified"
 
 # Refuse an archive that would write outside the runtime directory. The
 # checksum only proves the archive matches what the same host advertised, so it
 # does not bound where the members land.
 if tar -tzf "${tmp_dir}/${archive}" | grep -Eq '^/|(^|/)\.\.(/|$)'; then
-  echo "uf installer: ${archive} contains paths outside the archive root" >&2
-  exit 1
+  uf_fail "${archive} writes outside its own directory" \
+    "the archive is not one uf published — do not unpack it"
 fi
+# The first twelve characters, the way git shows a commit. The full digest is
+# 64 characters of noise to a reader who cannot check it by eye, and it pushed
+# every other line's value out of the column.
+uf_step "verified" "sha256 $(printf '%.12s' "$expected")"
 
 runtime_dir="${install_root}/runtimes/uf@${version}"
 mkdir -p "$runtime_dir" "$bin_dir"
 tar -xzf "${tmp_dir}/${archive}" -C "$runtime_dir"
-uf_step "installed runtime ${runtime_dir}"
+uf_step "unpacked" "$(uf_tilde "$runtime_dir")"
 
 for name in uf ufr ufx; do
   if [ ! -x "${runtime_dir}/bin/${name}" ]; then
-    echo "uf installer: archive did not contain bin/${name}" >&2
-    exit 1
+    uf_fail "the archive has no bin/${name}" \
+      "this build is incomplete — please report it"
   fi
   ln -sfn "${runtime_dir}/bin/${name}" "${bin_dir}/${name}"
 done
-uf_step "linked uf, ufr, ufx into ${bin_dir}"
+uf_step "linked" "uf, ufr, ufx into $(uf_tilde "$bin_dir")"
 
-echo "uf ${version} installed to ${runtime_dir}" >&2
+printf '\n' >&2
+if [ -z "$uf_colour" ]; then
+  printf '  uf %s is ready.\n' "$version" >&2
+else
+  printf '  \033[1muf %s\033[0m is ready.\n' "$version" >&2
+fi
+
 case ":$PATH:" in
-  *":${bin_dir}:"*) ;;
+  *":${bin_dir}:"*)
+    printf '\n' >&2
+    uf_note "Run \`uf\` to begin."
+    ;;
   *)
-    echo "uf installer: add ${bin_dir} to PATH to use uf from new shells" >&2
+    # Not a failure: uf is installed and works by full path. It is one line of
+    # shell profile away from working by name, and printing the line is more
+    # use than telling the reader that a directory is missing from PATH.
+    printf '\n' >&2
+    uf_note "$(uf_tilde "$bin_dir") is not on your PATH. Add it:"
+    printf '\n' >&2
+    if [ -z "$uf_colour" ]; then
+      printf '    export PATH="%s:$PATH"\n' "$(uf_home_var "$bin_dir")" >&2
+    else
+      printf '    \033[1mexport PATH="%s:$PATH"\033[0m\n' "$(uf_home_var "$bin_dir")" >&2
+    fi
     ;;
 esac
+printf '\n' >&2

--- a/tools/release/test-install.sh
+++ b/tools/release/test-install.sh
@@ -175,7 +175,7 @@ printf 'evil\n' > "${evil}/VERSION"
 if run_installer evil UF_VERSION=evil >"${work}/evil.log" 2>&1; then
   fail "an archive with escaping members was installed"
 fi
-grep -q "paths outside the archive root" "${work}/evil.log" \
+grep -q "writes outside its own directory" "${work}/evil.log" \
   || fail "escaping archive was rejected, but not by the path guard:
 $(cat "${work}/evil.log")"
 [ -e "${work}/escaped" ] && fail "evil: a member escaped the extraction root"


### PR DESCRIPTION
Stacked on #119 — review that one first; this PR's diff is the two commits
on top of it.

### `uf` on its own is a menu

It printed the help: twenty commands, each a name and a sentence, and then
a prompt for the reader to type one of the names they had just read.
Someone who runs `uf` with no arguments is not looking for documentation —
they are deciding what to do next.

```
  What would you like to run?
  › doc

  tasks
  ❯ run docs:build  UF_BIN=./target/release/uf tools/docs/build…
    run docs:dev    ./target/release/uf dev#docs

  ↑↓ move · ⏎ run · esc cancel
```

The project's own tasks are on it beside the commands, each showing what it
will actually run. Commands that **require** an argument are not: choosing
one would parse and then be rejected for what it did not get, and a menu
entry that does not work is worse than a list. A `help` row goes to the full
thing, and two tests hold the menu to what the parser accepts.

**Nothing that reads uf's output has to know this exists.** A pipeline, a CI
job, a `dumb` terminal and `uf --help` all get exactly what they got before
— and so does `uf --cwd elsewhere`, since a menu built for one directory
should not run a command in another.

`uf_term` documents having no third-party dependencies and this does not add
one. Raw mode is `stty`, whose `-g` form round-trips the exact settings, so
the terminal is handed back byte-identical rather than reset to a guess —
verified: every termios flag matches afterwards but `PENDIN`, which the
kernel owns. The menu's logic (filtering, ranking, scrolling, the frame
itself) is pure and has 30 tests; only the key loop touches a terminal.

Also `incremental = false` for dev builds: the cache had reached 10 GB and
its six largest entries were vendored Flow crates that change only on an
upstream sync. `CARGO_INCREMENTAL=1` brings it back.

### The installer stops saying its own name

Every line began with `uf installer:`, immediately under a logo that had
just said the same thing in colour — fourteen identical characters in front
of the only part of each line that differed.

```
  target   aarch64-apple-darwin
  version  0.0.0-alpha.2

  ✓ downloaded uf-aarch64-apple-darwin.tar.gz
  ✓ verified   sha256 37b3afc197b1
  ✓ unpacked   ~/.local/share/uf/runtimes/uf@0.0.0-alpha.2
  ✓ linked     uf, ufr, ufx into ~/.local/bin

  uf 0.0.0-alpha.2 is ready.
```

Two things there were wrong rather than merely plain:

- The PATH hint printed `export PATH="~/.local/bin:$PATH"`. A `~` inside
  double quotes does not expand — **the line a reader was told to paste did
  not work.** It prints `$HOME` now.
- The marks did not fall back to ASCII on a non-UTF-8 locale, which is what
  `detect_glyphs` does for the binary the installer is installing.

A failure now says what would fix it, and keeps curl's own diagnosis instead
of letting it print above ours: a 404 and an unresolvable host are different
problems.

---

`cargo test -p uf_term -p uf_cli` green (16 suites) · `uf test#library` 427
passed · `cargo fmt --check` clean · `tools/release/test-install.sh` all six
cases pass · verified by driving a real pty: menu draws, filters, runs, and
restores the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791115492&installation_model_id=422833&pr_number=120&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F120&signature=e077be4f054521be1a36913a497858bcfc5d09b7f0996daf64a632163f2e0075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->