### PR TITLE
fix(fmt): a contextual keyword at the start of a statement keeps its parens

### DIFF
--- a/crates/uf_fmt/src/flow/print/parens.rs
+++ b/crates/uf_fmt/src/flow/print/parens.rs
@@ -162,6 +162,22 @@ pub fn left_side(expression: &Expression) -> Option<&Expression> {
     }
 }
 
+/// Identifiers that begin a declaration when they begin a statement.
+///
+/// Every one of them is an ordinary identifier anywhere else, which is why
+/// the check has to be about position rather than spelling.
+const STATEMENT_KEYWORDS: [&str; 9] = [
+    "await",
+    "component",
+    "declare",
+    "hook",
+    "interface",
+    "let",
+    "module",
+    "type",
+    "using",
+];
+
 /// Whether the first token of `expression` is one `forbidden` rejects:
 /// Prettier's `startsWithNoLookaheadToken`.
 pub fn starts_with_no_lookahead_token(
@@ -420,27 +436,48 @@ impl<'a> Printer<'a> {
             return false;
         };
 
-        // A bare identifier never needs parentheses, except a few reserved
-        // spellings at the start of a statement.
+        // A bare identifier never needs parentheses, except when it is one
+        // of Flow's contextual keywords, it is the first token of an
+        // expression statement, and the token after it is another
+        // identifier.
+        //
+        // `type` is an ordinary name — `obj.type`, `{type: 'x'}` — right up
+        // until it opens a statement *and is followed by a name*, where the
+        // parser commits to a type alias and wants a `=`. So this, from
+        // React's devtools:
+        //
+        //     (type) as empty;
+        //
+        // stops parsing the moment the parentheses are dropped.
+        //
+        // The `as` is the whole reason it can happen. Every other way an
+        // expression continues — `hook.renderers`, `type(x)`, `let = 1` —
+        // puts punctuation after the identifier, and the parser gives up on
+        // the declaration and reads an expression. `as`, `as const` and
+        // `satisfies` are the only operators spelled as identifiers, so
+        // they are the only ones that can be mistaken for the name in
+        // `type Name = …`.
+        //
+        // Asking only "is it leftmost" was too broad and CI caught it:
+        // `hook.renderers.forEach(…)` in this repository's own
+        // `refresh-runtime.js` became `(hook).renderers.forEach(…)`.
+        //
+        // `role == Role::Statement` is excluded for the opposite reason:
+        // the identifier is the whole statement, `type;` is unambiguous,
+        // and parenthesizing it would be noise.
         if let E::Identifier { inner, .. } = &**expression {
-            let name: &str = &inner.name;
-            if role == Role::Statement
+            return STATEMENT_KEYWORDS.contains(&&*inner.name)
                 && matches!(
-                    name,
-                    "await"
-                        | "interface"
-                        | "module"
-                        | "using"
-                        | "yield"
-                        | "let"
-                        | "component"
-                        | "hook"
-                        | "type"
+                    parent,
+                    NodeRef::Expression(parent)
+                        if matches!(
+                            &**parent,
+                            E::AsExpression { .. }
+                                | E::AsConstExpression { .. }
+                                | E::TSSatisfies { .. }
+                        )
                 )
-            {
-                return false;
-            }
-            return false;
+                && self.is_leftmost_of_expression_statement();
         }
 
         // Rules keyed on the parent.

--- a/crates/uf_fmt/tests/guarantees.rs
+++ b/crates/uf_fmt/tests/guarantees.rs
@@ -165,6 +165,51 @@ const CORPUS: &[&str] = &[
     "const chain = (a?.b)();\n",
 ];
 
+/// Flow's contextual keywords, at the start of a statement and everywhere
+/// else.
+///
+/// Not in {@link CORPUS}: that list is fuzzed by
+/// `no_mutated_input_panics`, and adding an entry reshuffles which mutation
+/// every other entry gets. A regression test should not decide what an
+/// unrelated fuzzer does.
+#[test]
+fn a_contextual_keyword_is_parenthesized_only_where_it_has_to_be() {
+    // Needs them: the parser commits to a type alias and wants a `=`.
+    // React's devtools writes the first.
+    for source in [
+        "(type) as empty;\n",
+        "(component) as empty;\n",
+        "(interface) as empty;\n",
+        "(hook) as const;\n",
+    ] {
+        let output = format_source(source, &FmtConfig::default())
+            .unwrap_or_else(|error| panic!("{source:?} formats: {error}"))
+            .output;
+        assert_eq!(output, source, "lost the parentheses it needs");
+    }
+
+    // Does not: every one of these puts punctuation after the identifier,
+    // so the parser gives up on the declaration and reads an expression.
+    // An earlier version of the rule asked only whether the identifier was
+    // the first token, and turned the first of these into
+    // `(hook).renderers.forEach(…)` — in this repository's own
+    // `refresh-runtime.js`.
+    for source in [
+        "hook.renderers.forEach((injected, id) => injected.id === id);\n",
+        "type(argument);\n",
+        "component[0] = 1;\n",
+        "type;\n",
+    ] {
+        let output = format_source(source, &FmtConfig::default())
+            .unwrap_or_else(|error| panic!("{source:?} formats: {error}"))
+            .output;
+        assert!(
+            !output.starts_with('('),
+            "grew parentheses it does not need:\n{output}"
+        );
+    }
+}
+
 #[test]
 fn the_corpus_is_idempotent_under_every_configuration() {
     for config in configurations() {
@@ -301,8 +346,13 @@ fn no_mutated_input_panics() {
         // The result may be an error; what matters is that it returns.
         let outcome = format_source(&mutated, &config);
         if let Ok(result) = outcome {
-            let again = format_source(&result.output, &config)
-                .unwrap_or_else(|error| panic!("seed {seed}: reformat failed: {error}"));
+            let again = format_source(&result.output, &config).unwrap_or_else(|error| {
+                panic!(
+                    "seed {seed}: reformat failed: {error}\n\
+                     --- in\n{mutated:?}\n--- out\n{:?}",
+                    result.output
+                )
+            });
             similar_asserts::assert_eq!(
                 result.output,
                 again.output,


### PR DESCRIPTION
React's devtools writes this:

    (type) as empty;

`uf fmt` printed `type as empty;`, which does not parse: `type` at the start
of a statement, followed by a name, makes the parser commit to a type alias
and want a `=`.

The rule was already in `needs_parens`, listing exactly these identifiers —
`type`, `component`, `hook`, `interface`, `let`, and the rest — under a
comment saying "except a few reserved spellings at the start of a statement".
Both arms returned `false`, so the exception never fired, and the condition
was the wrong way round besides: it asked whether the identifier *is* the
statement, which is the one case that needs no parentheses. `type;` on its
own is unambiguous; `(type) as empty;` is not.

## And why "at the start" is not enough

The first version of this asked only whether the identifier was the leftmost
token, and CI caught what that costs:

    hook.renderers.forEach(…)   ->   (hook).renderers.forEach(…)

in this repository's own `packages/vite/internal/refresh-runtime.js`.

`as` is the whole reason the ambiguity exists. Every other way an expression
continues — `hook.renderers`, `type(x)`, `component[0]` — puts punctuation
after the identifier, and the parser gives up on the declaration and reads
an expression. `as`, `as const` and `satisfies` are the only operators
spelled as identifiers, so they are the only ones that can be mistaken for
the name in `type Name = …`. The rule now asks for that parent too.

Found by formatting React and React Native — five modules across the two,
and the only reason anyone would ever meet it.

The regression test is its own `#[test]` rather than four more entries in
`CORPUS`, because `CORPUS` is also the fuzzer's input: adding to it changes
which mutation every other entry gets, and doing that from a test about
parentheses surfaced an unrelated bug (#128) in a pull request that had
nothing to do with it. That fuzzer's panic also prints the input and the
output now, rather than a seed nobody can replay by hand.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)