### PR TITLE
fix(pm): a submodule is not one of this project's packages

### DIFF
--- a/crates/uf_pm/src/lib.rs
+++ b/crates/uf_pm/src/lib.rs
@@ -316,14 +316,45 @@ struct PackageStoreEntry<'a> {
 
 fn discover_package_manifests(root: &Utf8Path) -> Result<Vec<Utf8PathBuf>, PackageManagerError> {
     let mut manifests = Vec::new();
-    visit_package_dirs(root, root, &mut manifests)?;
+    let submodules = submodule_paths(root);
+    visit_package_dirs(root, root, &submodules, &mut manifests)?;
     manifests.sort();
     Ok(manifests)
+}
+
+/// The paths `.gitmodules` lists, relative to `root`.
+///
+/// A submodule is somebody else's repository that happens to be checked out
+/// inside this one, and its `package.json` is not one of this project's
+/// packages: it must not be locked, and its `scripts` are not this project
+/// breaking the no-scripts rule.
+///
+/// This was already wrong before anything made it visible. `upstream/flow`
+/// is Meta's repository and its manifest was being locked as a workspace
+/// package; it went unnoticed only because that manifest happens to declare
+/// no scripts. Checking out a fixture that does declare some — React Native,
+/// Metro — turned it into `uf install` refusing to run at all.
+///
+/// Parsed by hand rather than with a git library, because it is four lines
+/// of `key = value` and a dependency on libgit2 to read them would be the
+/// larger cost. An unreadable or absent file means no submodules, which is
+/// the right answer for a checkout that has none.
+fn submodule_paths(root: &Utf8Path) -> Vec<Utf8PathBuf> {
+    let Ok(source) = fs::read_to_string(root.join(".gitmodules")) else {
+        return Vec::new();
+    };
+    source
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("path"))
+        .filter_map(|rest| rest.trim_start().strip_prefix('='))
+        .map(|value| Utf8PathBuf::from(value.trim()))
+        .collect()
 }
 
 fn visit_package_dirs(
     root: &Utf8Path,
     dir: &Utf8Path,
+    submodules: &[Utf8PathBuf],
     manifests: &mut Vec<Utf8PathBuf>,
 ) -> Result<(), PackageManagerError> {
     let entries = fs::read_dir(dir).map_err(|source| PackageManagerError::Read {
@@ -349,10 +380,10 @@ fn visit_package_dirs(
             })?;
 
         if file_type.is_dir() {
-            if should_skip_dir(root, &path) {
+            if should_skip_dir(root, &path, submodules) {
                 continue;
             }
-            visit_package_dirs(root, &path, manifests)?;
+            visit_package_dirs(root, &path, submodules, manifests)?;
         } else if file_type.is_file() && path.file_name() == Some("package.json") {
             manifests.push(path);
         }
@@ -361,15 +392,19 @@ fn visit_package_dirs(
     Ok(())
 }
 
-fn should_skip_dir(root: &Utf8Path, path: &Utf8Path) -> bool {
+fn should_skip_dir(root: &Utf8Path, path: &Utf8Path, submodules: &[Utf8PathBuf]) -> bool {
     let name = path.file_name().unwrap_or_default();
-    matches!(
+    if matches!(
         name,
         ".git" | ".uf" | "dist" | "node_modules" | "target" | "__uf_vrt__"
-    ) || path
-        .strip_prefix(root)
-        .map(|relative| relative.as_str().starts_with("tools/fuzz/target"))
-        .unwrap_or(false)
+    ) {
+        return true;
+    }
+    let Ok(relative) = path.strip_prefix(root) else {
+        return false;
+    };
+    relative.as_str().starts_with("tools/fuzz/target")
+        || submodules.iter().any(|submodule| relative == submodule)
 }
 
 fn lock_manifest(

--- a/crates/uf_pm/src/tests.rs
+++ b/crates/uf_pm/src/tests.rs
@@ -150,3 +150,74 @@ fn install_still_detects_the_native_resolver_afterwards() {
         }
     );
 }
+
+/// A submodule is somebody else's repository, not one of this project's
+/// packages.
+///
+/// This repository has had `upstream/flow` — Meta's Flow — since the
+/// beginning, and its manifest was being locked as a workspace package. It
+/// went unnoticed because that one happens to declare no scripts; a fixture
+/// that does, such as Metro, turned it into `uf install` refusing to run at
+/// all.
+#[test]
+fn a_submodule_is_not_one_of_the_project_s_packages() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::write(
+        root.join("package.json"),
+        r#"{ "name": "demo", "version": "1.0.0" }"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join(".gitmodules"),
+        "[submodule \"vendored\"]\n\tpath = vendor/thing\n\turl = https://example.test/thing\n",
+    )
+    .unwrap();
+
+    let vendored = root.join("vendor/thing");
+    fs::create_dir_all(&vendored).unwrap();
+    // A manifest that would be refused if it were ours.
+    fs::write(
+        vendored.join("package.json"),
+        r#"{ "name": "thing", "version": "2.0.0", "scripts": { "build": "make" } }"#,
+    )
+    .unwrap();
+
+    let report = install_workspace(&root, &UniflowedConfig::default()).unwrap();
+
+    let names: Vec<&str> = report
+        .packages
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect();
+    assert_eq!(names, ["demo"], "the submodule was locked as a package");
+}
+
+#[test]
+fn a_directory_that_merely_looks_like_a_submodule_is_still_ours() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::write(
+        root.join("package.json"),
+        r#"{ "name": "demo", "version": "1.0.0" }"#,
+    )
+    .unwrap();
+    // No `.gitmodules`, so nothing is skipped.
+    let nested = root.join("packages/core");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(
+        nested.join("package.json"),
+        r#"{ "name": "@demo/core", "version": "1.0.0" }"#,
+    )
+    .unwrap();
+
+    let report = install_workspace(&root, &UniflowedConfig::default()).unwrap();
+
+    let mut names: Vec<&str> = report
+        .packages
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect();
+    names.sort_unstable();
+    assert_eq!(names, ["@demo/core", "demo"]);
+}


### PR DESCRIPTION
`uf install` walks the tree for `package.json` files and skips a fixed list
of directory names. `upstream/flow` is not on it, so Meta's Flow repository
was being locked as one of this project's workspace packages.

That has been true since the submodule was added and went unnoticed for one
reason: Flow's manifest happens to declare no `scripts`. Checking out a
second submodule that does declare some — Metro — turns it into `uf install`
refusing to run at all:

    error: package manifest tests/fixtures/git/metro/package.json declares
    scripts; use uf tasks in uf.config.js

Which is the right error about the wrong manifest. The no-scripts rule is
about what *this* project ships; a vendored repository is somebody else's,
and neither its scripts nor its version belong in `uf.lock`.

`.gitmodules` already says exactly which directories those are, so
`discover_package_manifests` reads it once and skips them. Parsed by hand —
four lines of `key = value`, against a dependency on libgit2 to read them —
and an absent file means no submodules, which is the right answer for a
checkout that has none.

Two tests: a submodule whose manifest declares scripts is ignored, and a
nested package in a checkout with no `.gitmodules` is still found.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175108&installation_model_id=422833&pr_number=124&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F124&signature=ae4ba04eba1cac243d6ba5c4a886d34402565e52c47eda8ffb0acc9f4e8f36a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->