### PR TITLE
fix(fmt): JSX that runs out at end of input is refused

### DIFF
--- a/crates/uf_fmt/src/flow/mod.rs
+++ b/crates/uf_fmt/src/flow/mod.rs
@@ -16,12 +16,14 @@ pub mod text;
 
 use thiserror::Error;
 use uf_config::FmtConfig;
-use uf_flow::{ParseFailure, Parsed};
+use uf_flow::ast::{expression::ExpressionInner as E, jsx};
+use uf_flow::{Loc, ParseFailure, Parsed};
 use uf_infra::Bump;
 
 use crate::doc::Docs;
 use crate::doc::printer::{PrintOptions, print};
 use comments::Comments;
+use node::{NodeRef, Program};
 use print::{Options, Printer};
 use text::SourceText;
 
@@ -68,6 +70,18 @@ pub fn format(source: &str, config: &FmtConfig) -> Result<String, FlowFormatErro
     }
 
     let text = SourceText::new(source);
+
+    // The parser recovers some truncated JSX without reporting it, and a
+    // recovered tree is missing the closing tag it invented.
+    if let Some(opening) = unterminated_jsx(&parsed.program) {
+        let name = text.slice(text.span(opening.name.loc()));
+        return Err(FlowFormatError::Syntax {
+            line: u32::try_from(opening.loc.start.line).unwrap_or(0),
+            column: u32::try_from(opening.loc.start.column).unwrap_or(0),
+            message: format!("Unexpected end of input, expected the closing tag `</{name}>`"),
+        });
+    }
+
     let comments = Comments::attach(&parsed.program, &text);
     let arena = Bump::with_capacity(source.len() * 4 + 4096);
     let docs = Docs::new(&arena);
@@ -92,4 +106,48 @@ pub fn format(source: &str, config: &FmtConfig) -> Result<String, FlowFormatErro
         },
         group_count,
     ))
+}
+
+/// The opening tag of the first JSX element whose closing tag never arrived.
+///
+/// Flow's port recovers a truncated element by closing it for the author,
+/// and for one shape of truncation — end of input, no trailing newline — it
+/// reports no diagnostic while doing so. `format` would then print the
+/// recovered tree, which no longer contains a `</div>`, and the output does
+/// not parse. Both halves of that break a guarantee `guarantees.rs` states
+/// outright: invalid syntax is refused rather than rewritten, and the output
+/// parses. See ubugeeei-prod/uf#128.
+///
+/// The check is exact rather than heuristic. An element with no closing tag
+/// and no `/>` is not something anyone can write; the grammar has no such
+/// production, so the only way to hold one is to have recovered it. Elements
+/// that really are self-closing carry `self_closing`, and they are the
+/// common case, so the distinction has to be made on that flag rather than
+/// on `closing_element` alone — which is `None` for both.
+///
+/// One walk of the tree, no allocation past the child buffer, and only on
+/// sources that reached the printer. It stops at the first one found:
+/// refusing names a position, and a list of positions in a file that will
+/// not be written is noise.
+fn unterminated_jsx(program: &Program) -> Option<&jsx::Opening<Loc, Loc>> {
+    let mut stack = vec![NodeRef::Program(program)];
+    let mut children: Vec<NodeRef<'_>> = Vec::new();
+
+    while let Some(node) = stack.pop() {
+        if let NodeRef::Expression(expression) = node
+            && let E::JSXElement { inner, .. } = &**expression
+            && inner.closing_element.is_none()
+            && !inner.opening_element.self_closing
+        {
+            return Some(&inner.opening_element);
+        }
+        children.clear();
+        node.children(&mut children);
+        // Reversed, so the stack hands them back in source order and the
+        // position reported is the first one in the file rather than an
+        // arbitrary one.
+        stack.extend(children.iter().rev().copied());
+    }
+
+    None
 }

--- a/crates/uf_fmt/tests/guarantees.rs
+++ b/crates/uf_fmt/tests/guarantees.rs
@@ -271,6 +271,65 @@ fn invalid_syntax_is_refused() {
     }
 }
 
+/// JSX that runs out at end of input is refused, not closed for the author.
+///
+/// ubugeeei-prod/uf#128. Flow's port recovers a truncated element by
+/// inventing the closing tag, and for this shape — end of input with no
+/// trailing newline — it reports no diagnostic while doing so. The printer
+/// then wrote out a tree with no `</div>` in it, breaking both of the
+/// guarantees above it in this file at once.
+///
+/// The same sources *with* a trailing newline are refused by the parser and
+/// always were, which is why `invalid_syntax_is_refused` did not catch this:
+/// every entry in that list ends in one.
+#[test]
+fn jsx_truncated_at_end_of_input_is_refused() {
+    for source in [
+        // The 58 bytes from the issue.
+        "const el = <div className=\"a\" data-testid='b'>text {value}",
+        // The same without attributes, and nested.
+        "const el = <div>text {value}",
+        "const el = <a><b>{x}",
+        // Truncated after a complete child element.
+        "const el = <ul><li /></ul",
+        // Inside a function body, so the element is not the last thing the
+        // parser sees.
+        "const f = () => <div>{x}",
+    ] {
+        let error = format_source(source, &FmtConfig::default())
+            .expect_err(&format!("{source:?} must be refused"));
+        assert!(
+            matches!(error, FormatError::Flow(_)),
+            "{source:?} gave {error:?}"
+        );
+    }
+}
+
+/// Self-closing elements are not truncated ones.
+///
+/// The check behind {@link jsx_truncated_at_end_of_input_is_refused} reads
+/// "no closing tag", and `<br />` has no closing tag either — the tree
+/// stores `None` for both. Telling them apart is the whole difficulty, so
+/// the case that must keep working gets a test of its own rather than
+/// relying on the corpus to notice.
+#[test]
+fn self_closing_jsx_still_formats() {
+    for source in [
+        "const el = <br />;\n",
+        "const el = <Foo bar={1} />;\n",
+        "const el = <div><br /><hr /></div>;\n",
+        "const el = <Foo.Bar.Baz />;\n",
+        "const el = <svg:rect />;\n",
+        "const el = <></>;\n",
+        "const el = <>{x}</>;\n",
+        // No trailing newline, which is the axis the bug turned on.
+        "const el = <br />;",
+    ] {
+        format_source(source, &FmtConfig::default())
+            .unwrap_or_else(|error| panic!("{source:?} must format: {error:?}"));
+    }
+}
+
 /// Nesting past the parser's ceiling is a typed error rather than a stack
 /// overflow, which is the failure mode this whole design exists to avoid.
 #[test]

--- a/crates/uf_fmt/tests/known_bugs.rs
+++ b/crates/uf_fmt/tests/known_bugs.rs
@@ -9,11 +9,15 @@
 //! cargo test -p uf_fmt --test known_bugs -- --ignored
 //! ```
 //!
-//! When one is fixed, delete the `#[ignore]`. When all three are, delete the
-//! file — its job is to be empty.
+//! When one is fixed, its reproduction moves to the test file that owns
+//! the guarantee it broke and the entry here goes. When the last one does,
+//! this file goes with it — its job is to be empty.
 //!
-//! Each was found by `upstream_corpus.rs`, running the formatter over React,
-//! Metro, Relay and React Native.
+//! Each was found by `upstream_corpus.rs`, running the formatter over the
+//! third-party Flow in `tests/fixtures/git`.
+//!
+//! Gone from here: #128, unterminated JSX at end of input, now
+//! `jsx_truncated_at_end_of_input_is_refused` in `guarantees.rs`.
 
 use std::time::{Duration, Instant};
 
@@ -87,34 +91,4 @@ fn comment_types_stay_comments() {
         output.contains("/*: string */"),
         "the annotations stopped being comments:\n{output}"
     );
-}
-
-/// ubugeeei-prod/uf#128 — unterminated JSX at EOF is formatted, not refused.
-///
-/// Fifty-eight bytes, no trailing newline. `flow::format` refuses anything
-/// the parser reports a diagnostic for and the parser reports none, so the
-/// printer runs and drops the `</div>`; the output does not parse. The same
-/// source *with* a trailing newline is refused correctly, so the difference
-/// is where EOF falls rather than the JSX.
-///
-/// Breaks two of the guarantees `guarantees.rs` states outright: invalid
-/// syntax is refused rather than rewritten, and the output parses.
-#[test]
-#[ignore = "ubugeeei-prod/uf#128"]
-fn unterminated_jsx_at_eof_is_refused() {
-    let source = "const el = <div className=\"a\" data-testid='b'>text {value}";
-
-    let Ok(result) = format_source(source, &FmtConfig::default()) else {
-        // Refused, which is the correct outcome.
-        return;
-    };
-
-    // Accepted. Then the least it can do is produce something that parses.
-    format_source(&result.output, &FmtConfig::default()).unwrap_or_else(|error| {
-        panic!(
-            "formatted invalid syntax into output that does not parse: {error}\n\
-             --- out\n{}",
-            result.output
-        )
-    });
 }


### PR DESCRIPTION
Closes #128.

Fifty-eight bytes with no trailing newline:

```
const el = <div className="a" data-testid='b'>text {value}
```

`uf fmt` accepted it and wrote back a `<div>` with no `</div>`, which does not
parse. Two of the guarantees `guarantees.rs` states outright, broken by one
input: invalid syntax is refused rather than rewritten, and the output parses.

### Why the existing check did not fire

`flow::format` already refuses anything the parser reports a diagnostic for.
The parser reports none here — it recovers the element by closing it for the
author, and for this one shape (end of input, no trailing newline) it does so
silently. The same source *with* a newline is refused, and every entry in
`invalid_syntax_is_refused` ends in one, which is why none of them caught it.

### The check

On the tree rather than on the diagnostics. An element with no closing tag and
no `/>` has no production in the grammar; the only way to hold one is to have
recovered it.

That is exact rather than heuristic, but it has to read
`opening_element.self_closing` — `closing_element` is `None` for `<br />` too,
and `<br />` is the common case. `self_closing_jsx_still_formats` is the test
that fails if the distinction is ever collapsed back to
`closing_element.is_none()`.

One walk of the tree, only on sources that already parsed, stopping at the
first element found.

```
$ uf fmt jsx.js
syntax error at 1:11: Unexpected end of input, expected the closing tag `</div>`
```

### Tests

The reproduction moves from `known_bugs.rs` to `guarantees.rs`, beside the
guarantee it broke, with four more truncation shapes around it — nested,
truncated after a complete child, and inside an arrow body so the element is
not the last thing the parser sees.

Verified against the whole formatter corpus: no module in React, Metro, Relay
or React Native is refused that was not refused before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791198343&installation_model_id=422833&pr_number=132&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F132&signature=816ea5b9190ba05b8f2f4f4fd28f85c6a1d53e3299bd6bf151e5af9de88f9f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The formatter now rejects truncated, non-self-closing JSX with a clear syntax error instead of producing potentially incorrect output.
  * Self-closing JSX elements continue to format successfully across supported forms.

* **Tests**
  * Added coverage for truncated JSX at end of input and valid self-closing JSX scenarios.
  * Updated known-bug tracking to reflect the new regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->