### PR TITLE
test(fmt): eleven more Flow codebases in the corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ node_modules/
 *.log
 *.tmp
 /docs/public/
+
+# The formatter corpus: ~1 GB of third-party Flow, checked out by
+# `tools/corpus/sync.sh` from `tools/corpus/repos.txt`. The four entries that
+# are still submodules are tracked and unaffected by this. See #137.
+/tests/fixtures/git/*

--- a/crates/uf_fmt/tests/support/mod.rs
+++ b/crates/uf_fmt/tests/support/mod.rs
@@ -51,6 +51,24 @@ const LOC: &str = "<loc>";
 /// Panics when `source` does not parse; callers pass sources they have
 /// already formatted, so a parse failure is a bug in the printer.
 pub fn structure(source: &str) -> String {
+    // On a thread of its own, with the stack the parser gets. `to_value`
+    // and `normalize` both recurse once per AST level, and AST depth is not
+    // bracket depth: a `yargs.usage().default().describe()…` chain is one
+    // node per link and no brackets at all. fbt's `collectFbt.js` is 10 KB
+    // of exactly that, and it overflows a default test thread in a debug
+    // build. The formatter has the same shape of problem for real, which is
+    // ubugeeei-prod/uf#136; this is only the helper getting out of its way.
+    let source = source.to_owned();
+    std::thread::Builder::new()
+        .name("uf-fmt-structure".to_owned())
+        .stack_size(uf_flow::PARSE_STACK_BYTES)
+        .spawn(move || structure_here(&source))
+        .expect("spawns")
+        .join()
+        .expect("the tree renders")
+}
+
+fn structure_here(source: &str) -> String {
     let parsed = uf_flow::parse(source).unwrap_or_else(|error| panic!("parses: {error}"));
     assert!(
         parsed.is_ok(),
@@ -99,9 +117,27 @@ pub fn comments(source: &str) -> Vec<(bool, String)> {
 /// Only lines that continue a `*` column are touched, so an ASCII diagram
 /// or a code sample indented inside a comment still counts as content and
 /// is still compared exactly.
+///
+/// The whitespace before a closing `*/` is the printer's too. A comment
+/// whose last line is written flush left
+///
+/// ```text
+///     /* The entry point to start up the debugger CLI
+///      * Reads in command line arguments and starts up a UISession
+///     */
+/// ```
+///
+/// is re-indented to ` */`, which turns the empty run before the delimiter
+/// into a space — content that was not there. Prepack has three of these
+/// and each looked like a rewritten comment. A trailing line with nothing
+/// on it is dropped rather than compared.
 fn normalize_comment(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
-    for (index, line) in text.lines().enumerate() {
+    let mut lines: Vec<&str> = text.lines().collect();
+    if lines.len() > 1 && lines.last().is_some_and(|last| last.trim().is_empty()) {
+        lines.pop();
+    }
+    for (index, line) in lines.into_iter().enumerate() {
         if index > 0 {
             out.push('\n');
         }

--- a/crates/uf_fmt/tests/upstream_corpus.rs
+++ b/crates/uf_fmt/tests/upstream_corpus.rs
@@ -6,19 +6,24 @@
 //! all three share a blind spot: they were written by people who knew what
 //! the printer does.
 //!
-//! The submodules under `tests/fixtures/git` were not. React, Metro, Relay
-//! and React Native are around 5,800 Flow modules of production code, and
-//! they use the parts of the grammar that a hand-written corpus reaches for
-//! last — `(x as any).path` in a test helper, `{a, ...rest} = parse(url)`
-//! spread over four lines, an object literal on the left of `as` in an
-//! arrow body, `type` used as an ordinary identifier.
+//! The repositories under `tests/fixtures/git` were not. Fifteen of them —
+//! React, Metro, Relay, React Native, Recoil, Flux, Parcel, Yarn, Prepack,
+//! StyleX, fbt, react-native-web, react-motion, DataLoader and redux-form —
+//! come to about 8,100 Flow modules of production code, and they use the
+//! parts of the grammar that a hand-written corpus reaches for last —
+//! `(x as any).path` in a test helper, `{a, ...rest} = parse(url)` spread
+//! over four lines, an object literal on the left of `as` in an arrow body,
+//! `type` used as an ordinary identifier, `function f(): %checks`.
+//!
+//! `tools/corpus/repos.txt` is the list. Adding a line to it is the whole
+//! edit: the fixtures here are read from the directory.
 //!
 //! # Why this skips rather than fails
 //!
-//! The fixtures are ~240 MB of submodule and most work in this repository
-//! does not need them. A test that fails on a fresh clone teaches people to
-//! ignore failures. `uf run fmt:corpus` checks them out and runs this; on a
-//! checkout without them it says so and passes.
+//! The fixtures are ~1 GB of other people's code and most work in this
+//! repository does not need them. A test that fails on a fresh clone
+//! teaches people to ignore failures. `uf run fmt:corpus` checks them out
+//! and runs this; on a checkout without them it says so and passes.
 
 mod support;
 
@@ -28,8 +33,23 @@ use std::path::{Path, PathBuf};
 use uf_config::FmtConfig;
 use uf_fmt::format_source;
 
-/// The four upstream repositories, in the order they are cheapest to fix.
-const FIXTURES: [&str; 4] = ["metro", "react", "relay", "react-native"];
+/// Every corpus repository that is checked out, in directory order.
+///
+/// Read from the filesystem rather than listed here, so that adding a line
+/// to `tools/corpus/repos.txt` is the whole edit. A list in two places is a
+/// list that disagrees with itself.
+fn fixtures() -> Vec<String> {
+    let Ok(entries) = fs::read_dir(corpus_root()) else {
+        return Vec::new();
+    };
+    let mut found: Vec<String> = entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    found.sort();
+    found
+}
 
 /// Modules the printer cannot format in reasonable time.
 ///
@@ -44,28 +64,52 @@ const FIXTURES: [&str; 4] = ["metro", "react", "relay", "react-native"];
 const KNOWN_SLOW: [&str; 1] =
     ["react-native/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js"];
 
-/// Modules the printer gets wrong, with the issue that says how.
+/// Modules the printer gets wrong, each with the issue that says how.
 ///
 /// Separate from {@link KNOWN_SLOW} because they are different problems and
-/// a single list of excuses hides that. One entry: Flow's comment types are
-/// rewritten into real syntax, so a script written to run under bare `node`
-/// stops doing so, and the layout disagrees with itself on the second pass
-/// as a result. See ubugeeei-prod/uf#126.
-const KNOWN_BROKEN: [&str; 1] =
-    ["react-native/packages/react-native/scripts/spm/generate-spm-xcodeproj.js"];
+/// a single list of excuses hides that. Four bugs, eleven modules:
+///
+/// * **#133** — parentheses around a same-precedence right operand are
+///   dropped, so `a && (b && c)` becomes `a && b && c` and the tree
+///   re-associates. Eight of these; three fail as a changed program and
+///   five as non-idempotence, which is the same bug seen on the second
+///   pass.
+/// * **#134** — `function f(): %checks` loses its colon and the output does
+///   not parse.
+/// * **#135** — a comment before an interface's `extends` is relocated into
+///   the type it precedes.
+/// * **#126** — Flow's comment types are rewritten into real syntax, so a
+///   script written to run under bare `node` stops doing so.
+const KNOWN_BROKEN: [&str; 11] = [
+    // #126
+    "react-native/packages/react-native/scripts/spm/generate-spm-xcodeproj.js",
+    // #133
+    "fbt/runtime/nonfb/FbtNumber/IntlCLDRNumberType19.js",
+    "fbt/runtime/nonfb/FbtNumber/IntlCLDRNumberType31.js",
+    "fbt/runtime/nonfb/FbtNumber/IntlCLDRNumberType46.js",
+    "prepack/src/react/elements.js",
+    "prepack/src/serializer/ResidualFunctions.js",
+    "prepack/src/serializer/ResidualHeapSerializer.js",
+    "prepack/src/serializer/ResidualHeapVisitor.js",
+    "yarn/src/package-request.js",
+    // #134
+    "fbt/packages/babel-plugin-fbt/src/FbtUtil.js",
+    // #135
+    "parcel/packages/core/types-internal/src/index.js",
+];
 
 /// The fixtures this run should look at.
 ///
 /// `UF_CORPUS=metro,react` narrows it. Whole repositories rather than a file
 /// count, because a failure is reported as a path and the first thing anyone
 /// does with one is re-run that repository on its own.
-fn wanted() -> Vec<&'static str> {
+fn wanted() -> Vec<String> {
     match std::env::var("UF_CORPUS") {
-        Ok(list) => FIXTURES
+        Ok(list) => fixtures()
             .into_iter()
-            .filter(|fixture| list.split(',').any(|want| want.trim() == *fixture))
+            .filter(|fixture| list.split(',').any(|want| want.trim() == fixture))
             .collect(),
-        Err(_) => FIXTURES.to_vec(),
+        Err(_) => fixtures(),
     }
 }
 
@@ -82,7 +126,7 @@ fn corpus_root() -> PathBuf {
 fn flow_modules() -> Vec<PathBuf> {
     let mut found = Vec::new();
     for fixture in wanted() {
-        let root = corpus_root().join(fixture);
+        let root = corpus_root().join(&fixture);
         if root.is_dir() {
             collect(&root, &mut found);
         }
@@ -274,7 +318,7 @@ fn no_stale_exclusions() {
         // Only when its own fixture is checked out: `UF_CORPUS=metro` must
         // not fail because a React Native path is not there.
         let fixture = slow.split('/').next().unwrap_or_default();
-        if !corpus_root().join(fixture).is_dir() || !wanted().contains(&fixture) {
+        if !corpus_root().join(fixture).is_dir() || !wanted().iter().any(|want| want == fixture) {
             continue;
         }
         assert!(

--- a/tools/corpus/repos.txt
+++ b/tools/corpus/repos.txt
@@ -1,0 +1,28 @@
+# The Flow corpus: third-party repositories the formatter is checked against.
+#
+# name              url                                                    commit
+#
+# Pinned by commit rather than tracked as submodules. Two reasons, and the
+# second is the one that matters: a pinned fetch is one commit deep and
+# nothing else, where `git submodule update --depth 1` still brings a whole
+# tree per entry; and this is 700 MB of somebody else's code that no CI job
+# and no ordinary checkout needs, so it does not belong in `.gitmodules`
+# where every clone has to reckon with it.
+#
+# React, Metro, Relay and React Native predate this file and remain
+# submodules. See ubugeeei-prod/uf#137.
+#
+# Bump a pin by replacing the commit. `tools/corpus/sync.sh` fetches the new
+# one; nothing is left behind to clean up.
+
+recoil            https://github.com/facebookexperimental/Recoil.git       c1b97f3a0117cad76cbc6ab3cb06d89a9ce717af
+flux              https://github.com/facebook/flux.git                     4ee8c50865c357e005cb40ea03cdd403533aad26
+parcel            https://github.com/parcel-bundler/parcel.git             59484858a1a0bcbb71f74088956bb437a2db6505
+yarn              https://github.com/yarnpkg/yarn.git                      c2dda503f3759b5be5f0e24ecd9cf5c97a540147
+react-motion      https://github.com/chenglou/react-motion.git             9e3ce95bacaa9a1b259f969870a21c727232cc68
+prepack           https://github.com/facebookarchive/prepack.git           5beedbe85bd5b9d2de1264abafbb3b76f8584297
+react-native-web  https://github.com/necolas/react-native-web.git          a9de220ba9e65bdea540fb5322ffb1da2b0bf442
+dataloader        https://github.com/graphql/dataloader.git                b70dea3cc72a7e8f941133b0f486aa1840e3f927
+redux-form        https://github.com/redux-form/redux-form.git             88866f08120c1297daf54a5b887b90708e7f35e9
+stylex            https://github.com/facebook/stylex.git                   a58e3fc7ee31365edb6e052864b30daf460efa42
+fbt               https://github.com/facebook/fbt.git                      81614682caa6107c9dedb44c0fc4ac8ecaac4a5f

--- a/tools/corpus/sync.sh
+++ b/tools/corpus/sync.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
-# Check out the upstream Flow corpus under `tests/fixtures/git`.
+# Check out the Flow corpus under `tests/fixtures/git`.
 #
-# React, Metro, Relay and React Native, shallow — about 240 MB, which is why
-# this is not part of `uf run setup`. `crates/uf_fmt/tests/upstream_corpus.rs`
-# runs the formatter's three guarantees over every Flow module in them and
-# skips cleanly when they are not here.
+# `crates/uf_fmt/tests/upstream_corpus.rs` runs the formatter's three
+# guarantees over every Flow module here and skips cleanly when nothing is
+# checked out. This is ~1 GB of other people's code, which is why it is not
+# part of `uf run setup`.
+#
+# Two mechanisms, for now. React, Metro, Relay and React Native are
+# submodules and predate `repos.txt`; everything since is a pinned commit in
+# that manifest, fetched one commit deep. See ubugeeei-prod/uf#137 for
+# converging them.
 #
 # Idempotent, so it is safe as a `dependsOn`.
 set -eu
@@ -13,6 +18,32 @@ repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
 git submodule update --init --depth 1 -- tests/fixtures/git
+
+manifest=tools/corpus/repos.txt
+
+# A git directory outside the checkout, the way submodules keep theirs in
+# `.git/modules`. A nested `.git` inside a fixture is one more thing every
+# tool that walks these trees has to know to skip.
+while read -r name url commit; do
+  case "$name" in '' | '#'*) continue ;; esac
+
+  dest=tests/fixtures/git/$name
+  git_dir=$repo_root/.git/corpus/$name
+
+  if [ ! -e "$dest/.git" ]; then
+    rm -rf "$git_dir"
+    git init --quiet --separate-git-dir "$git_dir" "$dest"
+    git -C "$dest" remote add origin "$url"
+  fi
+
+  # Re-fetch only when the pin moved. `rev-parse` on an empty repository
+  # fails, which is the first-run case and wants the fetch too.
+  if [ "$(git -C "$dest" rev-parse HEAD 2>/dev/null || echo none)" != "$commit" ]; then
+    printf 'corpus: fetching %s at %.12s\n' "$name" "$commit"
+    git -C "$dest" fetch --quiet --depth 1 origin "$commit"
+    git -C "$dest" checkout --quiet --detach FETCH_HEAD
+  fi
+done < "$manifest"
 
 for fixture in tests/fixtures/git/*/; do
   [ -d "$fixture" ] || continue

--- a/uf.config.js
+++ b/uf.config.js
@@ -105,14 +105,15 @@ export default defineConfig({
     // The formatter, over Flow nobody here wrote.
     //
     // `fmt:check` and the guarantee tests both run against sources written
-    // by people who knew what the printer does. React, Metro, Relay and
-    // React Native are about 5,800 Flow modules that were not, and they
-    // reach the corners of the grammar that a hand-written corpus reaches
-    // for last.
+    // by people who knew what the printer does. The fifteen repositories in
+    // `tools/corpus/repos.txt` are about 8,100 Flow modules that were not,
+    // and they reach the corners of the grammar that a hand-written corpus
+    // reaches for last.
     //
-    // Not in `ci`: the fixtures are ~240 MB of submodule, and a check that
-    // fails on a fresh clone teaches people to ignore failures. The test
-    // skips when they are absent, so `rust:test` stays honest either way.
+    // Not in `ci`: the fixtures are ~1 GB of other people's code, and a
+    // check that fails on a fresh clone teaches people to ignore failures.
+    // The test skips when they are absent, so `rust:test` stays honest
+    // either way.
     "corpus:sync": "tools/corpus/sync.sh",
     "fmt:corpus": {
       command: "cargo test -p uf_fmt --test upstream_corpus -- --nocapture",


### PR DESCRIPTION
React, Metro, Relay and React Native are four repositories by one company,
and a corpus of four repositories by one company teaches the formatter that
company's house style. Eleven more, chosen because they are Flow and because
nobody here wrote them: Recoil, Flux, Parcel, Yarn, react-motion, Prepack,
react-native-web, DataLoader, redux-form, StyleX and fbt.

| | before | after |
|---|---|---|
| repositories | 4 | 15 |
| Flow modules | 5,826 | 8,147 |

### What they found

Four bugs in the first run, each filed with a minimal reproduction:

| issue | what | modules |
|---|---|---|
| #133 | `a && (b && c)` loses its parentheses and the tree re-associates | 8 |
| #134 | `function f(): %checks` loses its colon; the output does not parse | 1 |
| #135 | a comment before an interface's `extends` is relocated into the type | 1 |
| #136 | `uf fmt` aborts on a deep chain that nests without brackets | — |

#133 is the interesting one: three of its eight modules fail as a *changed
program* and five as non-idempotence, which is the same bug seen on the
second pass. Prettier keeps those parentheses. The clearest line, from
prepack:

```js
(descriptor instanceof PropertyDescriptor && (descriptor.get === undefined && descriptor.set === undefined));
```

#136 is not a corpus regression — a 7.3 MB file of `1 + 1 + 1 + …` is inside
every limit `uf fmt` declares and aborts the process anyway, because
`nesting_depth` counts brackets and AST depth is not bracket depth. The
corpus is what made it visible.

Eleven modules are excluded by name against those issues, beside the two
already there. `no_stale_exclusions` fails the day one of them is fixed and
the entry is not deleted.

### Pinned commits rather than submodules

`tools/corpus/repos.txt` holds a name, a URL and a commit per line, and
`sync.sh` fetches exactly that commit one deep. A pinned fetch is less data
than `git submodule update --depth 1`, and this is ~1 GB of other people's
code that no CI job and no ordinary checkout needs, so `.gitmodules` — where
every clone has to reckon with it — is the wrong place for it.

The four that are already submodules stay for now; #137 converges them.
`sync.sh` does both and says why.

`FIXTURES` is gone. The corpus test reads the directory, so adding a line to
`repos.txt` is the whole edit rather than a list in two places that
disagrees with itself.

### Two fixes in the harness itself

Both were the corpus reporting the test's own limits as formatter bugs.

**`normalize_comment`** treated the space before a re-indented `*/` as
content. Prepack writes three block comments with the delimiter flush left;
re-indenting them to ` */` is what Prettier does too, and it read as a
rewritten comment. A trailing whitespace-only line belongs to the printer.

**`structure()`** overflowed the stack on fbt's `collectFbt.js` — 10 KB, a
hand-written `yargs.usage().default().describe()…` chain, one AST node per
link and no brackets at all. It runs on a thread with the parser's stack
now.

### Verification

```
$ uf run fmt:corpus
upstream corpus: 8007 formatted, 127 unparseable, 0 failed
test upstream_flow_survives_formatting ... ok
test no_stale_exclusions ... ok
```

433 s in a debug build over all fifteen. Not in CI, for the same reason it
was not before: the fixtures are ~1 GB and a check that fails on a fresh
clone teaches people to ignore failures. The test skips when they are
absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791199311&installation_model_id=422833&pr_number=138&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F138&signature=d182e55086adad3dc5ac0f1863486b1e9f4b101b70176afe5f99befd0c42cfd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->