### PR TITLE
fix(fmt): a right-nested logical chain lays out like a left-nested one

### DIFF
--- a/crates/uf_fmt/src/flow/print/binary.rs
+++ b/crates/uf_fmt/src/flow/print/binary.rs
@@ -9,7 +9,8 @@ use uf_flow::ast::{expression, statement};
 
 use super::Printer;
 use super::parens::{
-    binaryish_operator, is_binaryish, is_call_like, is_jsx, is_member, same, should_flatten,
+    binaryish_operator, is_binaryish, is_call_like, is_jsx, is_member,
+    logical_in_logical_needs_parens, same, should_flatten,
 };
 use crate::doc::{Doc, DocKind, LINE};
 use crate::flow::comments::Placement;
@@ -17,14 +18,26 @@ use crate::flow::node::{Expression, NodeRef};
 
 /// Whether a logical expression's right side is an object, array or JSX
 /// that should hug the operator rather than break after it.
+///
+/// The right side here is the *last operand of the chain*, which is not
+/// `inner.right` when the source parenthesized to the right: `a && (b && {})`
+/// prints as `a && b && {}`, and what hugs the operator is the object. See
+/// {@link flattens_into_parent}.
 pub fn should_inline_logical_expression(expression: &Expression) -> bool {
     let expression::ExpressionInner::Logical { inner, .. } = &**expression else {
         return false;
     };
-    match &*inner.right {
+    let mut right = &inner.right;
+    while flattens_into_parent(expression, right) {
+        let expression::ExpressionInner::Logical { inner, .. } = &**right else {
+            break;
+        };
+        right = &inner.right;
+    }
+    match &**right {
         expression::ExpressionInner::Object { inner: object, .. } => !object.properties.is_empty(),
         expression::ExpressionInner::Array { inner: array, .. } => !array.elements.is_empty(),
-        _ => is_jsx(&inner.right),
+        _ => is_jsx(right),
     }
 }
 
@@ -35,6 +48,42 @@ fn operands(expression: &Expression) -> Option<(&Expression, &Expression)> {
         expression::ExpressionInner::Logical { inner, .. } => Some((&inner.left, &inner.right)),
         _ => None,
     }
+}
+
+/// Whether `right` joins its parent's chain instead of printing as a group
+/// of its own.
+///
+/// Prettier flattens the left spine only, and says why: `1 + 2 - 3` parses
+/// as `((1 + 2) - 3)`, so the left is where the rest of the expression is,
+/// and anything on the right had a different precedence and deserves its own
+/// group.
+///
+/// That reasoning holds for every tree built from source without
+/// parentheses, and `a && (b && c)` is the case it does not cover. The
+/// parentheses are redundant — see
+/// [`logical_in_logical_needs_parens`](super::parens::logical_in_logical_needs_parens)
+/// — so they are not printed, and what comes out is `a && b && c`. Reading
+/// that back gives a *left*-nested tree, which lays out as one chain. Unless
+/// the right-nested one lays out the same way, `uf fmt` twice is not
+/// `uf fmt` once:
+///
+/// ```text
+/// - descriptor.get === undefined && descriptor.set === undefined;
+/// + descriptor.get === undefined &&
+/// +   descriptor.set === undefined;
+/// ```
+///
+/// The condition is the paren rule, not a second copy of it: an operand
+/// that keeps its parentheses — `a + (b + c)`, `a && (b || c)` — is a group,
+/// exactly as before. See ubugeeei-prod/uf#133.
+fn flattens_into_parent(expression: &Expression, right: &Expression) -> bool {
+    let expression::ExpressionInner::Logical { inner: parent, .. } = &**expression else {
+        return false;
+    };
+    let expression::ExpressionInner::Logical { inner: child, .. } = &**right else {
+        return false;
+    };
+    !logical_in_logical_needs_parens(&parent.operator, &child.operator)
 }
 
 /// Whether two expressions are both binary or both logical.
@@ -146,8 +195,13 @@ impl<'a> Printer<'a> {
 
         let (left, right) = operands(expression).expect("binaryish");
         let operator = binaryish_operator(expression).unwrap_or("");
-        let same_precedence_sub_expression =
-            is_binaryish(left) && should_flatten(operator, binaryish_operator(left).unwrap_or(""));
+        // "Is there another link of the same precedence in this chain?" —
+        // Prettier asks it of the left because a chain written without
+        // parentheses is left-nested. A flattened right is the same chain
+        // read from the other end, and answers the same question.
+        let same_precedence_sub_expression = (is_binaryish(left)
+            && should_flatten(operator, binaryish_operator(left).unwrap_or("")))
+            || flattens_into_parent(expression, right);
 
         if should_not_indent
             || (should_inline_logical_expression(expression) && !same_precedence_sub_expression)
@@ -221,11 +275,31 @@ impl<'a> Printer<'a> {
         }
 
         let should_inline = should_inline_logical_expression(expression);
-        let printed_right = self.print_expression(right);
-        let right_doc = if should_inline {
-            self.concat([self.s(operator), self.s(" "), printed_right])
-        } else {
-            self.concat([self.s(operator), &LINE, printed_right])
+        // A right operand that prints without parentheses continues this
+        // chain rather than starting a group. Its parts are spliced in, so
+        // the operands break together or not at all — and the hug of a
+        // trailing object is decided by the innermost link, which is where
+        // that object actually sits.
+        let flattened_right = flattens_into_parent(expression, right).then(|| {
+            let node = NodeRef::Expression(right);
+            self.ancestors.push(node);
+            let parts = self.binaryish_parts(right, true, is_inside_parenthesis);
+            self.ancestors.pop();
+            parts
+        });
+        let right_doc = match &flattened_right {
+            Some(parts) => {
+                let tail = self.docs.concat(parts.iter().copied());
+                self.concat([self.s(operator), &LINE, tail])
+            }
+            None => {
+                let printed_right = self.print_expression(right);
+                if should_inline {
+                    self.concat([self.s(operator), self.s(" "), printed_right])
+                } else {
+                    self.concat([self.s(operator), &LINE, printed_right])
+                }
+            }
         };
 
         // If there's only a single binary expression, we want to create a

--- a/crates/uf_fmt/src/flow/print/parens.rs
+++ b/crates/uf_fmt/src/flow/print/parens.rs
@@ -315,6 +315,26 @@ pub fn binaryish_operator(expression: &Expression) -> Option<&'static str> {
     }
 }
 
+/// Whether a logical expression inside another one keeps its parentheses.
+///
+/// `a && b || c` is printed `(a && b) || c`: a logical operator inside a
+/// different one is always parenthesized, however the precedences fall. The
+/// same operator on either side needs nothing — `&&`, `||` and `??` each
+/// give the same value and short-circuit at the same operand however they
+/// associate, and Prettier drops the parentheses too.
+///
+/// Dropping them has a consequence for layout, and
+/// [`binaryish_parts`](super::Printer::print_binaryish) is the other caller
+/// of this function for that reason: an operand printed without parentheses
+/// has to lay out as part of its parent's chain, or the second pass reads
+/// the flat text back as a left-nested tree and disagrees with the first.
+pub fn logical_in_logical_needs_parens(
+    parent: &expression::LogicalOperator,
+    child: &expression::LogicalOperator,
+) -> bool {
+    std::mem::discriminant(parent) != std::mem::discriminant(child)
+}
+
 /// The spelling of a logical operator.
 pub fn logical_operator(operator: &expression::LogicalOperator) -> &'static str {
     match operator {
@@ -882,12 +902,11 @@ impl<'a> Printer<'a> {
                 inner: parent_logical,
                 ..
             } => {
-                // `a && b || c` is printed `(a && b) || c`: a logical
-                // operator inside a different one is always parenthesized,
-                // however the precedences fall.
                 if let E::Logical { inner, .. } = &**expression {
-                    return std::mem::discriminant(&parent_logical.operator)
-                        != std::mem::discriminant(&inner.operator);
+                    return logical_in_logical_needs_parens(
+                        &parent_logical.operator,
+                        &inner.operator,
+                    );
                 }
                 self.binaryish_in_binaryish(
                     expression,

--- a/crates/uf_fmt/tests/fixtures/logical_chains.expected.js
+++ b/crates/uf_fmt/tests/fixtures/logical_chains.expected.js
@@ -1,0 +1,72 @@
+// @flow
+
+// A chain the source wrote right-nested. The parentheses are redundant for
+// `&&`, `||` and `??`, so they are not printed, and what is left has to lay
+// out as one chain — see ubugeeei-prod/uf#133.
+const rightNested =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  cccccccccccccccccccccccccccccccccc;
+const leftNested =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  cccccccccccccccccccccccccccccccccc;
+const flat =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  cccccccccccccccccccccccccccccccccc;
+
+const orRight =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ||
+  ccccccccccccccccccccccccccc;
+const nullishRight =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?? bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ?? ccccccccccccccccccc;
+
+// Short enough to stay on one line, whichever way it was written.
+const short = a && b && c;
+const shortOr = a || b || c;
+const shortNullish = a ?? b ?? c;
+
+// Mixed operators keep their parentheses and their group.
+const mixed =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
+  (b || c);
+const mixedLeft = (a && b) || c;
+const mixedOther = a || (b && c);
+
+// Arithmetic and bitwise are not associative to the formatter: the
+// parentheses stay, and so does the group.
+const plus =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+  (b + c);
+const times =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa * (b * c);
+const bitOr =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | (b | c);
+
+// The shape prepack writes, which is where this was found.
+const found =
+  descriptor instanceof PropertyDescriptor &&
+  descriptor.get === undefined &&
+  descriptor.set === undefined;
+
+// A right operand that is an object still hugs the operator.
+const inlined = someCondition &&
+  anotherConditionThatIsQuiteLong && { key: value, other: thing, third: item };
+
+if (
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  cccccccccccccccccccccccccccccccc
+) {
+  run();
+}
+
+function returnsIt() {
+  return (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+    cccccccccccccccccccccccccccccc
+  );
+}

--- a/crates/uf_fmt/tests/fixtures/logical_chains.js
+++ b/crates/uf_fmt/tests/fixtures/logical_chains.js
@@ -1,0 +1,44 @@
+// @flow
+
+// A chain the source wrote right-nested. The parentheses are redundant for
+// `&&`, `||` and `??`, so they are not printed, and what is left has to lay
+// out as one chain — see ubugeeei-prod/uf#133.
+const rightNested =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccccccccccc);
+const leftNested =
+  (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) && cccccccccccccccccccccccccccccccccc;
+const flat =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccccccccccc;
+
+const orRight = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa || (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || ccccccccccccccccccccccccccc);
+const nullishRight = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?? (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ?? ccccccccccccccccccc);
+
+// Short enough to stay on one line, whichever way it was written.
+const short = a && (b && c);
+const shortOr = a || (b || c);
+const shortNullish = a ?? (b ?? c);
+
+// Mixed operators keep their parentheses and their group.
+const mixed = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && (b || c);
+const mixedLeft = (a && b) || c;
+const mixedOther = a || (b && c);
+
+// Arithmetic and bitwise are not associative to the formatter: the
+// parentheses stay, and so does the group.
+const plus = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + (b + c);
+const times = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa * (b * c);
+const bitOr = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | (b | c);
+
+// The shape prepack writes, which is where this was found.
+const found = (descriptor instanceof PropertyDescriptor && (descriptor.get === undefined && descriptor.set === undefined));
+
+// A right operand that is an object still hugs the operator.
+const inlined = someCondition && (anotherConditionThatIsQuiteLong && { key: value, other: thing, third: item });
+
+if (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccccccccc)) {
+  run();
+}
+
+function returnsIt() {
+  return aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccccccc);
+}

--- a/crates/uf_fmt/tests/support/mod.rs
+++ b/crates/uf_fmt/tests/support/mod.rs
@@ -18,6 +18,13 @@
 //! * **trailing commas** — the printer decides those from the layout.
 //! * **regex flags** — reordered, so they are compared as a sorted set.
 //! * **empty statements** — a lone `;` is dropped, as Prettier drops it.
+//! * **the shape of a logical chain** — `a && (b && c)` prints as
+//!   `a && b && c`, because the parentheses are redundant and Prettier drops
+//!   them too. `&&`, `||` and `??` each evaluate the same operands in the
+//!   same order and short-circuit at the same one however they associate, so
+//!   a chain of one operator is compared as the flat sequence of its
+//!   operands. Only those three: `(a + b) + c` and `a + (b + c)` differ for
+//!   strings and for floats, and Prettier keeps those parentheses.
 //! * **quoted property keys** — `{ "a": 1 }` is the same property as
 //!   `{ a: 1 }`, and the printer drops quotes it does not need.
 //! * **a redundant specifier alias** — `export {x as x}` is `export {x}`,
@@ -150,6 +157,20 @@ fn normalize(value: Value) -> Value {
             // literal is one — carries the container inline rather than
             // under a `comments` key.
             Value::Null
+        }
+        Value::Object(fields) if is_logical(&fields) => {
+            // A chain of one logical operator, as the flat list of its
+            // operands. `a && (b && c)` and `(a && b) && c` are the same
+            // program and print the same, so they compare equal here.
+            let mut operator = String::new();
+            let mut operands = Vec::new();
+            flatten_logical(Value::Object(fields), &mut operator, &mut operands);
+            let mut chain = Map::new();
+            chain.insert("operator".to_owned(), Value::String(operator));
+            chain.insert("operands".to_owned(), Value::Array(operands));
+            let mut out = Map::new();
+            out.insert("LogicalChain".to_owned(), Value::Object(chain));
+            Value::Object(out)
         }
         Value::Object(fields) => {
             // `export {x as x}` and `export {x}` are the same specifier, and
@@ -366,4 +387,54 @@ fn clean_jsx_text(text: &str) -> String {
         }
     }
     kept.join(" ")
+}
+
+/// Whether a serialized node is a `Logical`.
+fn is_logical(fields: &Map<String, Value>) -> bool {
+    fields.len() == 1 && fields.contains_key("Logical")
+}
+
+/// The operator and operands of a logical chain, normalised.
+///
+/// Recurses through both sides for as long as the operator is the same, so
+/// `a && (b && c)`, `(a && b) && c` and `a && b && c` all reduce to
+/// `And [a, b, c]`. A different operator ends the chain and is normalised as
+/// an operand in its own right, which keeps `a && (b || c)` distinct from
+/// `(a && b) || c`.
+fn flatten_logical(value: Value, operator: &mut String, operands: &mut Vec<Value>) {
+    let Value::Object(fields) = value else {
+        operands.push(normalize(value));
+        return;
+    };
+    if !is_logical(&fields) {
+        operands.push(normalize(Value::Object(fields)));
+        return;
+    }
+    let Some(Value::Object(node)) = fields.get("Logical") else {
+        operands.push(normalize(Value::Object(fields)));
+        return;
+    };
+    let here = match node.get("inner").and_then(|inner| inner.get("operator")) {
+        Some(Value::String(name)) => name.clone(),
+        _ => {
+            operands.push(normalize(Value::Object(fields)));
+            return;
+        }
+    };
+    if operator.is_empty() {
+        *operator = here;
+    } else if *operator != here {
+        operands.push(normalize(Value::Object(fields)));
+        return;
+    }
+    let Some(Value::Object(inner)) = node.get("inner") else {
+        operands.push(normalize(Value::Object(fields)));
+        return;
+    };
+    for side in ["left", "right"] {
+        match inner.get(side) {
+            Some(value) => flatten_logical(value.clone(), operator, operands),
+            None => operands.push(Value::Null),
+        }
+    }
 }


### PR DESCRIPTION
Closes #133.

```js
const found =
  descriptor instanceof PropertyDescriptor &&
  descriptor.get === undefined && descriptor.set === undefined;
```

Prettier puts all three operands on their own lines. uf kept the last two
together — and then the second pass, which reads that text back as a
left-nested chain, laid it out Prettier's way. So `uf fmt` twice was not
`uf fmt` once.

### Why the left spine only was not enough

`printBinaryishExpressions` flattens the left spine, and Prettier says why:
`1 + 2 - 3` parses as `((1 + 2) - 3)`, so the left is where the rest of the
expression lives and anything on the right had a different precedence and
deserves its own group.

That holds for every tree built from source without parentheses.
`a && (b && c)` is the case it does not cover: for `&&`, `||` and `??` the
parentheses are redundant, they are not printed, and the operands then have
to break together or the two passes disagree.

A right operand that prints *without* parentheses is now spliced into its
parent's parts. The condition is the parenthesization rule itself — extracted
as `logical_in_logical_needs_parens`, with both callers on it — rather than a
second copy of it that can drift. An operand that keeps its parentheses,
`a + (b + c)` or `a && (b || c)` or `a | (b | c)`, is still a group of its
own and is unchanged.

Two decisions upstream of the layout had to follow the same reading. Both
were found by the fixture rather than reasoned out in advance:

* `should_inline_logical_expression` asks whether the right side is an object
  that should hug the operator. The right side of the *chain* is its last
  operand, which is not `inner.right` when the source parenthesized to the
  right — `a && (b && {…})` hugs the object.
* `same_precedence_sub_expression` asks whether there is another link of the
  same precedence. A flattened right is one, read from the other end.

### The tree does change, and here that is allowed

Dropping the parentheses re-associates: `Logical(And, a, Logical(And, b, c))`
becomes `Logical(And, Logical(And, a, b), c)`, and `structure()` called that a
changed program.

For `&&`, `||` and `??` it is not one. The same operands are evaluated in the
same order and the chain short-circuits at the same one however it
associates. So a chain of a single logical operator is compared as the flat
list of its operands.

Only those three. `(a + b) + c` and `a + (b + c)` differ for strings and for
floats, Prettier keeps those parentheses, and nothing about `+` moves.

### Tests

A new fixture pair, with the expectation generated the way every fixture in
that directory is:

```sh
prettier --parser hermes --plugin prettier-plugin-hermes-parser \
  --print-width 100 crates/uf_fmt/tests/fixtures/logical_chains.js
```

Byte-identical to Prettier. It covers all three nestings for `&&`, the same
for `||` and `??`, the short forms that stay on one line, mixed operators,
`+` `*` and `|` keeping their parentheses, a trailing object that hugs, `if`
and `return` heads, and the prepack line that found this.

The eight corpus modules this unblocks come out of `KNOWN_BROKEN` in a
follow-up, once #138 has put them there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791200199&installation_model_id=422833&pr_number=139&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F139&signature=8f2903b03f9354948944367e56aff767bde140fb9bcf6091e5eb14e5ba9f2e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->