### PR TITLE
build(upstream): pin React, Relay and React Native beside Flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,28 @@ jobs:
       # manifest that does not parse is a package that cannot be installed.
       - run: ./target/release/uf run manifests
 
+  upstream-integrations:
+    name: Upstream Integrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # React's compiler crates, Relay's compiler crates, React Native's codegen
+      # and Libraries. Nothing compiles against them yet, so this job is the
+      # only thing that would notice a pin that has been force-pushed away or a
+      # directory upstream moved. `sync.sh` fails on a missing subtree.
+      - run: tools/upstream/sync.sh --integrations
+      - name: The crates the manifest promises
+        run: |
+          set -eu
+          test -d upstream/react/compiler/crates/react_compiler_validation
+          test -d upstream/relay/compiler/crates/graphql-ir
+          test -d upstream/react-native/packages/react-native-codegen
+          test -d upstream/react-native/packages/react-native/Libraries
+          echo "upstream integrations: every promised subtree is present"
+
   upstream-flow:
     name: Upstream Flow
     needs: toolchain

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ node_modules/
 # `tools/corpus/sync.sh` from `tools/corpus/repos.txt`. The four entries that
 # are still submodules are tracked and unaffected by this. See #137.
 /tests/fixtures/git/*
+
+# Upstream integration sources, fetched on request by
+# `tools/upstream/sync.sh --integrations` from `tools/upstream/repos.txt`.
+# `upstream/flow` is a submodule and is tracked; ignore rules do not apply to it.
+/upstream/*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,42 @@ needing `tools/upstream/sync.sh` before cargo will parse the workspace at all,
 and the `include_str!` paths reaching outside `rust_port`. The trade is that the
 built code and the readable checkout stop being the same bytes by construction.
 
+## Other Upstream Sources
+
+`upstream/flow` is a submodule because it is a cargo path dependency: the
+workspace does not resolve without it, so `tools/upstream/sync.sh` materializes
+it on every checkout and in every CI job.
+
+Three more upstream repositories are pinned by commit in
+`tools/upstream/repos.txt` and fetched on request:
+
+```sh
+tools/upstream/sync.sh --integrations   # uf run upstream:sync:integrations
+```
+
+They are not submodules, and they are not fetched by default, for one reason:
+**nothing in the cargo graph depends on them yet**, and `sync.sh` runs in every
+CI job. Vendoring them into that path would slow every job to hold source that
+nothing compiles.
+
+Each is filtered to the subtrees uf reads, which is about 45 MB of roughly a
+gigabyte.
+
+| Pinned source | What it is | What uf does today |
+| --- | --- | --- |
+| `upstream/react` — `compiler/crates` | The React Compiler's official Rust port: `react_compiler_validation`, `react_compiler_hir`, `react_compiler_inference` and nine more. | `uf_react_compiler` implements the *syntax-mode* checks itself, over Flow's AST. It is honest about being a subset — see its module docs for the three checks it leaves out rather than approximates — but `@uniflowed/react-compiler` already advertises `implementation: "official-rust"`, and this is the source that makes that true. |
+| `upstream/relay` — `compiler/crates` | Relay's compiler, in Rust: `graphql-syntax`, `graphql-ir`, `relay-transforms`, and 44 others. | `@uniflowed/relay` re-exports the JavaScript Relay runtime and shells out to the published `relay-compiler`. Artifact generation is the hot path the redundancy guide says must be native. |
+| `upstream/react-native` — `packages/react-native-codegen`, `packages/react-native/Libraries` | React Native's codegen and its Flow-typed JavaScript libraries. | `@uniflowed/react-native` is a declaration module. The codegen is what turns a Flow spec into native bindings, and the Libraries are the Flow types a React Native app is written against. |
+
+The pins are the four repositories' `main` as of the commit that added this
+section. Bumping one is a line in `repos.txt`; `sync.sh` fetches the new commit
+and nothing is left behind.
+
+The "Upstream Integrations" CI job fetches all three and checks the subtrees
+are where the manifest says. That is the whole of what it asserts: a pin that
+has been force-pushed away, or a directory that upstream moved, fails there
+rather than the next time someone tries to build against it.
+
 ## Flow To JavaScript
 
 Every host runs JavaScript, and `uf` projects are Flow. `uf_transform` is the

--- a/tools/upstream/repos.txt
+++ b/tools/upstream/repos.txt
@@ -1,0 +1,18 @@
+# Upstream sources uf integrates with, pinned by commit.
+#
+#   name | url | commit | sparse subtrees
+#
+# `upstream/flow` is not here. It is a submodule and it has to stay one: it is
+# a *path dependency* in `Cargo.toml`, so cargo will not resolve the workspace
+# without it, and `tools/upstream/sync.sh` materializes it before anything else
+# on every checkout and in every CI job.
+#
+# Nothing in the cargo graph depends on the repositories below yet, so they are
+# fetched on request — `tools/upstream/sync.sh --integrations` — rather than in
+# every job. What each is for, and what uf does today instead, is in
+# docs/architecture.md; keeping that honest is the point of listing them here
+# rather than quietly vendoring them.
+
+react | https://github.com/facebook/react.git | f1f7ed2ac267a21dd2e3e67c4a606b9cf56e360b | compiler/crates compiler/Cargo.toml compiler/Cargo.lock
+relay | https://github.com/facebook/relay.git | 52c26aed65a496182f2fa978f9911db5be4f652d | compiler/crates compiler/Cargo.toml compiler/Cargo.lock
+react-native | https://github.com/facebook/react-native.git | 8cfde6d0834baf27cc14efff45bf853434acb3aa | packages/react-native-codegen packages/react-native/Libraries

--- a/tools/upstream/sync.sh
+++ b/tools/upstream/sync.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
-# Materialize the `upstream/flow` submodule cheaply.
+# Materialize the upstream sources uf builds against.
+#
+# Without arguments: `upstream/flow`, which every cargo invocation needs.
+# With `--integrations`: also the repositories in `tools/upstream/repos.txt`,
+# which nothing in the cargo graph depends on yet.
 #
 # `uf_flow`'s `upstream-parser` feature builds against Meta's official Flow Rust
 # port, which is not published to crates.io. The submodule tracks the whole Flow
@@ -53,3 +57,51 @@ if [ ! -d "$submodule_path/tslib" ]; then
 fi
 
 printf 'upstream/flow ready at %s\n' "$(git -C "$submodule_path" rev-parse --short HEAD)"
+
+# The rest of `upstream/` is pinned by commit in `tools/upstream/repos.txt`
+# rather than tracked as submodules, for the reason that file gives: nothing in
+# the cargo graph depends on them, and this script runs in every CI job.
+#
+# `--integrations` fetches them. Each is filtered to the subtrees uf actually
+# reads — React's compiler crates, Relay's compiler crates, React Native's
+# codegen and Libraries — because the three repositories together are about a
+# gigabyte and uf reads perhaps eighty megabytes of it.
+[ "${1:-}" = "--integrations" ] || exit 0
+
+manifest=tools/upstream/repos.txt
+
+while IFS='|' read -r name url commit subtrees; do
+  name=$(echo "$name" | tr -d '[:space:]')
+  case "$name" in '' | '#'*) continue ;; esac
+  url=$(echo "$url" | tr -d '[:space:]')
+  commit=$(echo "$commit" | tr -d '[:space:]')
+  subtrees=$(echo "$subtrees" | sed 's/^ *//; s/ *$//')
+
+  dest=upstream/$name
+  git_dir=$repo_root/.git/upstream/$name
+
+  if [ ! -e "$dest/.git" ]; then
+    rm -rf "$git_dir"
+    mkdir -p "$(dirname "$git_dir")"
+    git init --quiet --separate-git-dir "$git_dir" "$dest"
+    git -C "$dest" remote add origin "$url"
+    git -C "$dest" config core.sparseCheckout true
+  fi
+
+  if [ "$(git -C "$dest" rev-parse HEAD 2>/dev/null || echo none)" != "$commit" ]; then
+    printf 'upstream: fetching %s at %.12s\n' "$name" "$commit"
+    git -C "$dest" fetch --quiet --depth 1 --filter=blob:none origin "$commit"
+    # shellcheck disable=SC2086 # deliberate word splitting: one argument per subtree
+    git -C "$dest" sparse-checkout set $subtrees
+    git -C "$dest" checkout --quiet --detach "$commit"
+  fi
+
+  for subtree in $subtrees; do
+    if [ ! -e "$dest/$subtree" ]; then
+      echo "upstream sync failed: $dest/$subtree is missing" >&2
+      exit 1
+    fi
+  done
+
+  printf 'upstream/%s ready at %s\n' "$name" "$(git -C "$dest" rev-parse --short HEAD)"
+done < "$manifest"

--- a/uf.config.js
+++ b/uf.config.js
@@ -47,6 +47,12 @@ export default defineConfig({
     // until the submodule is checked out, and `uf run` needs a built `uf`.
     // One command breaks that circle, and it is in CONTRIBUTING.md.
     "upstream:sync": "tools/upstream/sync.sh",
+    // React's compiler crates, Relay's compiler crates, and React Native's
+    // codegen and Libraries — pinned in `tools/upstream/repos.txt`, fetched on
+    // request rather than in every job because nothing in the cargo graph
+    // depends on them yet. docs/architecture.md says what each is for and what
+    // uf does instead today.
+    "upstream:sync:integrations": "tools/upstream/sync.sh --integrations",
     setup: {
       command: "echo 'ready: run `uf run ci` to check everything'",
       dependsOn: ["upstream:sync", "build"],


### PR DESCRIPTION
The redundancy guide says to integrate upstream Rust implementations and,
where a suitable crate is not published, to use pinned upstream source through
submodules — naming `facebook/flow` and `react/react`. Only Flow was here.

Three more, pinned by commit in `tools/upstream/repos.txt`:

| Pinned source | What it is | What uf does today |
| --- | --- | --- |
| `upstream/react` — `compiler/crates` | The React Compiler's official Rust port: `react_compiler_validation`, `react_compiler_hir`, `react_compiler_inference` and nine more. | `uf_react_compiler` implements the syntax-mode checks itself over Flow's AST, and its module docs are honest about the three it leaves out rather than approximates. But `@uniflowed/react-compiler` already advertises `implementation: "official-rust"`, and this is the source that makes that true. |
| `upstream/relay` — `compiler/crates` | Relay's compiler in Rust: `graphql-syntax`, `graphql-ir`, `relay-transforms` and 44 others. | uf shells out to the published JavaScript `relay-compiler`. Artifact generation is exactly the repeated, repository-wide work the guide says belongs in Rust. |
| `upstream/react-native` — `packages/react-native-codegen`, `packages/react-native/Libraries` | The codegen that turns a Flow spec into native bindings, and the Flow types an app is written against. | `@uniflowed/react-native` is a declaration module. |

### Fetched on request, not in every job

`upstream/flow` is a submodule and has to stay one: it is a cargo *path
dependency*, so the workspace does not resolve without it, and `sync.sh`
materializes it in every CI job.

Nothing in the cargo graph depends on these three yet. Putting them in
`.gitmodules` would make every job in the repository pay for source that
nothing compiles, so they are a manifest and a flag instead:

```sh
tools/upstream/sync.sh --integrations   # uf run upstream:sync:integrations
```

Each is filtered to the subtrees uf reads — `--filter=blob:none` plus a sparse
checkout — which comes to 45 MB of roughly a gigabyte:

```
upstream/flow ready at 81b0c2a3d
upstream/react ready at f1f7ed2
upstream/relay ready at 52c26ae
upstream/react-native ready at 8cfde6d

28M  upstream/flow/     3.2M upstream/react/
28M  upstream/relay/     14M upstream/react-native/
```

The default path — no flag — is byte-for-byte what it was, so no existing job
gets slower. Re-running is a no-op; changing a pin re-fetches and leaves
nothing behind.

### What holds them honest

A new **Upstream Integrations** job fetches all three and checks that the four
subtrees the manifest promises are where it says. Nothing compiles against
them, so without it a force-pushed pin or a directory upstream moved would be
discovered by whoever next tried to build against it.

`docs/architecture.md` gains a section recording what each is for **and what
uf does instead today** — the part that keeps a vendored directory from
reading as a capability the project already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791200960&installation_model_id=422833&pr_number=141&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F141&signature=3e5adbb96a6cb31c885090fa330d560f80fe4bddaa61dbdce6cca48a776071df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->