### PR TITLE
fix(fmt): a comment before `extends` stays where it was written

### DIFF
--- a/crates/uf_fmt/src/flow/comments.rs
+++ b/crates/uf_fmt/src/flow/comments.rs
@@ -870,7 +870,15 @@ impl<'a> Attacher<'a, '_> {
                     &inner.id,
                     inner.tparams.as_ref(),
                     NodeRef::ObjectType(&inner.body.0, &inner.body.1),
-                    None,
+                    // `declare class C extends B` has no node for the
+                    // `extends` clause — its children are spliced into the
+                    // declaration's, so `B` arrives as a bare identifier and
+                    // there is no `InterfaceExtends` key to compare against
+                    // the way an interface gives one. The first child that is
+                    // neither the name nor its type parameters is the head of
+                    // the heritage; the body is handled before this is used,
+                    // so a declaration with no heritage cannot reach it.
+                    self.first_child_after_name(enclosing, &inner.id, inner.tparams.as_ref()),
                     inner.mixins.first().map(NodeRef::InterfaceExtends),
                 ),
                 statement::StatementInner::DeclareInterface { inner, .. }
@@ -888,14 +896,15 @@ impl<'a> Attacher<'a, '_> {
         let Some(following) = context.following else {
             return false;
         };
-        if following.key() == body.key() {
-            self.add_block_first(body, context);
-            return true;
-        }
         let id_or_tparams = |node: NodeRef<'a>| {
             NodeRef::Identifier(id).key() == node.key()
                 || tparams.is_some_and(|tparams| NodeRef::TypeParams(tparams).key() == node.key())
         };
+
+        if following.key() == body.key() {
+            self.add_block_first(body, context);
+            return true;
+        }
         for (first, marker) in [
             (extends_first, Marker::Extends),
             (mixins_first, Marker::Mixins),
@@ -913,6 +922,27 @@ impl<'a> Attacher<'a, '_> {
             }
         }
         false
+    }
+
+    /// The first child of `node` that is neither `id` nor `tparams`.
+    ///
+    /// For a declaration whose heritage clause is not a node of its own, and
+    /// so gives nothing to compare a key against. See the `DeclareClass` arm
+    /// of [`handle_class`](Self::handle_class).
+    fn first_child_after_name(
+        &self,
+        node: NodeRef<'a>,
+        id: &'a ast::Identifier<uf_flow::Loc, uf_flow::Loc>,
+        tparams: Option<&'a types::TypeParams<uf_flow::Loc, uf_flow::Loc>>,
+    ) -> Option<NodeRef<'a>> {
+        self.sorted_children(node)
+            .into_iter()
+            .map(|(_, child)| child)
+            .find(|child| {
+                NodeRef::Identifier(id).key() != child.key()
+                    && !tparams
+                        .is_some_and(|tparams| NodeRef::TypeParams(tparams).key() == child.key())
+            })
     }
 
     fn handle_method_name(&mut self, context: Context<'a>) -> bool {

--- a/crates/uf_fmt/src/flow/print/class.rs
+++ b/crates/uf_fmt/src/flow/print/class.rs
@@ -612,15 +612,26 @@ impl<'a> Printer<'a> {
                 self.join(separator, printed),
             ]));
         }
-        let group_mode = heritage.len() > 1;
+        // More than one clause needs the group to lay them out. So does a
+        // trailing comment on the class name, for a different reason: a line
+        // comment ends the line it is on, and without a group there is no
+        // line before `extends` for it to end. See ubugeeei-prod/uf#135.
+        let group_mode = heritage.len() > 1
+            || self.has_comment_placed(NodeRef::Identifier(&class.id).key(), Placement::Trailing);
         if group_mode {
             let clauses: Vec<Doc<'a>> = heritage
                 .into_iter()
                 .map(|clause| self.concat([&LINE, self.group(clause)]))
                 .collect();
             let id = self.docs.group_id();
+            // The head goes inside the group, as Prettier has it. A trailing
+            // line comment on the class name breaks the group it is *in*, and
+            // the line it has to end is the one before `extends` — which is
+            // in this group. Left outside, the break propagated past it to
+            // the statement and the heritage stayed on one line.
+            let head = self.docs.concat_vec(std::mem::take(&mut parts));
             parts.push(self.docs.group_with(
-                self.indent(self.docs.concat_vec(clauses)),
+                self.concat([head, self.indent(self.docs.concat_vec(clauses))]),
                 false,
                 Some(id),
             ));

--- a/crates/uf_fmt/src/flow/print/types.rs
+++ b/crates/uf_fmt/src/flow/print/types.rs
@@ -273,7 +273,11 @@ impl<'a> Printer<'a> {
             T::Component { inner, .. } => self.print_component_type(inner, key),
             T::Object { inner, .. } => self.print_object_type(inner, NodeRef::Type(ty), false),
             T::Interface { inner, .. } => {
-                let extends = self.print_interface_extends_list(&inner.extends, key);
+                // An `interface { … }` type has no name, so the only thing
+                // that can make its heritage start a line is having more
+                // than one target.
+                let group_mode = inner.extends.len() > 1;
+                let extends = self.print_interface_extends_list(&inner.extends, key, group_mode);
                 let body = self.print_object_type(
                     &inner.body.1,
                     NodeRef::ObjectType(&inner.body.0, &inner.body.1),
@@ -1227,7 +1231,7 @@ impl<'a> Printer<'a> {
                 matches!(generic.id, types::generic::Identifier::Qualified(_))
                     && generic.targs.is_none()
             });
-        let extends = self.print_interface_extends_list(&interface.extends, key);
+        let extends = self.print_interface_extends_list(&interface.extends, key, group_mode);
         if group_mode && !interface.extends.is_empty() {
             let id = self.docs.group_id();
             let head = self.docs.concat_vec(std::mem::take(&mut parts));
@@ -1249,10 +1253,17 @@ impl<'a> Printer<'a> {
     }
 
     /// ` extends A, B`, or nothing.
+    ///
+    /// `group_mode` is Prettier's `shouldPrintHeritageClauses`, and it is
+    /// what decides whether the clause can start a new line. With it, a
+    /// single target is `line` then a group; without it, a literal space —
+    /// a line outside a group always breaks, so the two cases are not the
+    /// same doc with a different verdict.
     fn print_interface_extends_list(
         &mut self,
         extends: &'a [(Loc, types::Generic<Loc, Loc>)],
         key: NodeKey,
+        group_mode: bool,
     ) -> Doc<'a> {
         if extends.is_empty() {
             return self.s("");
@@ -1276,7 +1287,15 @@ impl<'a> Printer<'a> {
             ]);
         }
         let list = self.join(separator, printed);
-        self.concat([self.s(" extends "), dangling.unwrap_or(self.s("")), list])
+        let clause = self.concat([self.s("extends "), dangling.unwrap_or(self.s("")), list]);
+        if group_mode {
+            // A line, so a trailing line comment on the interface name has
+            // one to end. Without this the comment was a line suffix with no
+            // line before the body, and it came out after the `{` — five
+            // levels from where it was written. See ubugeeei-prod/uf#135.
+            return self.concat([&LINE, self.group(clause)]);
+        }
+        self.concat([self.s(" "), clause])
     }
 
     /// One `extends` target of an interface or declared class.

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
@@ -1,0 +1,56 @@
+// @flow
+
+// A comment between a name and its `extends` stays where it was written.
+// It used to be moved into the type that followed it, which for an
+// `eslint-disable-next-line` means it stops suppressing what it was written
+// to suppress. See ubugeeei-prod/uf#135.
+export interface AssetSymbols // eslint-disable-next-line no-undef
+  extends Iterable<[Symbol, {| local: Symbol, loc: ?SourceLocation, meta?: ?Meta |}]> {
+  hasExportSymbol(exportSymbol: Symbol): boolean;
+}
+
+interface Plain // why
+  extends Base {
+  m(): boolean;
+}
+
+interface WithArgs // why
+  extends Base<Element> {
+  m(): boolean;
+}
+
+// A block comment is not a line comment: it does not end the line, so the
+// header stays on one.
+interface Inline /* why */ extends Base {
+  m(): boolean;
+}
+
+// No comment at all: still one line.
+interface Quiet extends Base {
+  m(): boolean;
+}
+
+// More than one target is the other thing that makes the heritage start a
+// line. A long one is not here: uf and the hermes plugin disagree about
+// whether the first target joins `extends`, which is ubugeeei-prod/uf#143
+// and nothing to do with comments.
+interface Several extends Base, Other {
+  m(): boolean;
+}
+
+declare class Declared // why
+  extends Base
+{
+  m(): boolean;
+}
+
+declare class DeclaredQuiet extends Base {
+  m(): boolean;
+}
+
+declare class DeclaredMixed // why
+  extends Base
+  mixins Mixin
+{
+  m(): boolean;
+}

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.js
@@ -1,0 +1,53 @@
+// @flow
+
+// A comment between a name and its `extends` stays where it was written.
+// It used to be moved into the type that followed it, which for an
+// `eslint-disable-next-line` means it stops suppressing what it was written
+// to suppress. See ubugeeei-prod/uf#135.
+export interface AssetSymbols // eslint-disable-next-line no-undef
+  extends Iterable<[Symbol, {| local: Symbol, loc: ?SourceLocation, meta?: ?Meta |}]> {
+  hasExportSymbol(exportSymbol: Symbol): boolean;
+}
+
+interface Plain // why
+  extends Base {
+  m(): boolean;
+}
+
+interface WithArgs // why
+  extends Base<Element> {
+  m(): boolean;
+}
+
+// A block comment is not a line comment: it does not end the line, so the
+// header stays on one.
+interface Inline /* why */ extends Base {
+  m(): boolean;
+}
+
+// No comment at all: still one line.
+interface Quiet extends Base {
+  m(): boolean;
+}
+
+// More than one target is the other thing that makes the heritage start a
+// line. A long one is not here: uf and the hermes plugin disagree about
+// whether the first target joins `extends`, which is ubugeeei-prod/uf#143
+// and nothing to do with comments.
+interface Several extends Base, Other {
+  m(): boolean;
+}
+
+declare class Declared // why
+  extends Base {
+  m(): boolean;
+}
+
+declare class DeclaredQuiet extends Base {
+  m(): boolean;
+}
+
+declare class DeclaredMixed // why
+  extends Base mixins Mixin {
+  m(): boolean;
+}

--- a/crates/uf_fmt/tests/upstream_corpus.rs
+++ b/crates/uf_fmt/tests/upstream_corpus.rs
@@ -76,11 +76,9 @@ const KNOWN_SLOW: [&str; 1] =
 ///   pass.
 /// * **#134** — `function f(): %checks` loses its colon and the output does
 ///   not parse.
-/// * **#135** — a comment before an interface's `extends` is relocated into
-///   the type it precedes.
 /// * **#126** — Flow's comment types are rewritten into real syntax, so a
 ///   script written to run under bare `node` stops doing so.
-const KNOWN_BROKEN: [&str; 11] = [
+const KNOWN_BROKEN: [&str; 10] = [
     // #126
     "react-native/packages/react-native/scripts/spm/generate-spm-xcodeproj.js",
     // #133
@@ -94,8 +92,6 @@ const KNOWN_BROKEN: [&str; 11] = [
     "yarn/src/package-request.js",
     // #134
     "fbt/packages/babel-plugin-fbt/src/FbtUtil.js",
-    // #135
-    "parcel/packages/core/types-internal/src/index.js",
 ];
 
 /// The fixtures this run should look at.


### PR DESCRIPTION
Closes #135.

```js
export interface AssetSymbols // eslint-disable-next-line no-undef
  extends Iterable<[Symbol, {| local: Symbol, meta?: ?Meta |}]> {
```

came back as

```js
export interface AssetSymbols extends Iterable<[Symbol, {| local:  // eslint-disable-next-line no-undef
        Symbol, meta?: ?Meta |}]> {
```

The comment moved five levels down the tree. A directive that moves stops
suppressing what it was written to suppress and starts suppressing something
else — `$FlowFixMe` and `$FlowExpectedError` have the same shape — and the
comment multiset is satisfied either way, so nothing today would have caught
the relocation. The corpus caught the non-idempotence it caused instead.

### Two causes, one per declaration kind

**Interfaces.** The comment was attached correctly, as a trailing comment of
the name. `print_interface_extends_list` then wrote a literal `" extends "`,
so there was no line for a trailing *line* comment to end and it came out as a
line suffix, flushed after the `{`.

Prettier's `printHeritageClauses` emits `[line, group(["extends ", …])]` when
its `shouldPrintHeritageClauses` holds and `[" ", …]` when it does not — two
docs rather than one doc with a different verdict, because a line outside a
group always breaks. uf had only the second. That flag is what uf already
calls `group_mode`, so it is now passed down.

**`declare class`.** Two things, and the first is why the second was
invisible:

1. `handle_class` matched the heritage clause by node key, and
   `declare class C extends B` has no node for its `extends` — the children
   are spliced into the declaration's, so a plain `B` arrives as a bare
   identifier and `extends_first` was `None`. The comment fell through to the
   body.
2. With that fixed the comment attaches, and `group_mode` had to learn about
   it — and the head had to move *inside* the heritage group. A trailing line
   comment breaks the group it is in, and the line it has to end is the one
   before `extends`. Left outside, the break propagated past that group and
   the heritage stayed on one line.

### Tests

```sh
prettier --parser hermes --plugin prettier-plugin-hermes-parser \
  --print-width 100 crates/uf_fmt/tests/fixtures/heritage_comments.js
```

Byte-identical. Line comment and block comment, with and without type
arguments, on `interface` and on `declare class`, with `mixins`, and the quiet
cases that must stay on one line.

Not in it: a long multi-target `extends`, where uf agrees with
`--parser flow` and not with the hermes plugin. That is #143, it predates this
change, and the fixture says so where the case would have been.

`parcel/packages/core/types-internal/src/index.js` comes out of
`KNOWN_BROKEN`:

```
upstream corpus: 8109 formatted, 11 unparseable, 0 failed
test upstream_flow_survives_formatting ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791202120&installation_model_id=422833&pr_number=144&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F144&signature=927f3d85674020563bee1bff1d58e00bf11b7e6bc45d801b536a9148ad1524f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved formatting of Flow `extends` and `mixins` clauses when comments appear between a type name and its heritage clause.
  - Preserved line comments in their original position, keeping related directives effective.
  - Applied consistent line-breaking behavior to interfaces and declared classes, including multiple heritage targets and generic types.
  - Kept block-comment formatting on the same line where appropriate.

- **Tests**
  - Added coverage for heritage-clause comments, declared classes, interfaces, and mixins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->