### PR TITLE
perf(fmt): print each call argument once

### DIFF
--- a/crates/uf_fmt/src/flow/print/assignment.rs
+++ b/crates/uf_fmt/src/flow/print/assignment.rs
@@ -18,7 +18,7 @@ use crate::doc::{Doc, LINE, LINE_SUFFIX_BOUNDARY, can_break, text_of};
 use crate::flow::node::{Expression, NodeRef, Type};
 
 /// How an assignment lays out its two sides.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Layout {
     /// First break after the operator, then the sides are broken
     /// independently on their own lines.
@@ -42,7 +42,7 @@ pub enum Layout {
 /// What Prettier passes down to the print of one child: the layout its
 /// assignment chose, or that it is the hugged first or last argument of a
 /// call.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct PrintArgs {
     /// The layout of the assignment this node is the right side of.
     pub assignment_layout: Option<Layout>,

--- a/crates/uf_fmt/src/flow/print/call.rs
+++ b/crates/uf_fmt/src/flow/print/call.rs
@@ -467,7 +467,40 @@ impl<'a> Printer<'a> {
     }
 
     /// One argument, spread or not.
+    ///
+    /// Memoised. `print_arguments` prints the argument it is considering
+    /// hugging a second time, with different [`PrintArgs`], and every level
+    /// below it does the same — so without this the document is 2^depth and
+    /// nineteen levels of `expect.objectContaining` does not finish. The
+    /// same node printed the same way in the same place is the same
+    /// document, so the second print is a lookup. See ubugeeei-prod/uf#125.
+    ///
+    /// `expansion_bailout` is part of the answer and is replayed with it.
+    /// Nothing reads that flag as an *input* — every reader sets it to
+    /// `false` immediately before the print it is asking about — so a
+    /// cached print restores it rather than merging into it.
     pub fn print_argument(
+        &mut self,
+        argument: &'a expression::ExpressionOrSpread<Loc, Loc>,
+        args: PrintArgs,
+    ) -> Doc<'a> {
+        let key = (
+            argument_node(argument).key(),
+            args,
+            self.ancestors.last().map(|node| node.key()),
+        );
+        if let Some(&(doc, bailed)) = self.argument_docs.get(&key) {
+            self.expansion_bailout = bailed;
+            return doc;
+        }
+        self.expansion_bailout = false;
+        let doc = self.print_argument_uncached(argument, args);
+        let bailed = self.expansion_bailout;
+        self.argument_docs.insert(key, (doc, bailed));
+        doc
+    }
+
+    fn print_argument_uncached(
         &mut self,
         argument: &'a expression::ExpressionOrSpread<Loc, Loc>,
         args: PrintArgs,

--- a/crates/uf_fmt/src/flow/print/mod.rs
+++ b/crates/uf_fmt/src/flow/print/mod.rs
@@ -36,6 +36,7 @@ mod types;
 
 use uf_config::{FmtConfig, QuoteStyle};
 use uf_flow::ast::CommentKind;
+use uf_infra::FxHashMap;
 
 use super::comments::{Comment, Comments, Marker, Placement};
 use super::node::{NodeKey, NodeRef, Program};
@@ -84,7 +85,24 @@ pub struct Printer<'a> {
     /// Set when a hugged call argument turned out to need its own line
     /// breaks: Prettier's `ArgExpansionBailout`, without the exception.
     pub expansion_bailout: bool,
+    /// Arguments already printed, by node, print arguments and parent.
+    ///
+    /// `print_arguments` prints the argument it is considering hugging a
+    /// second time, and so does every level below it, which makes the
+    /// document exponential in the nesting: nineteen levels of
+    /// `expect.objectContaining` is a file React Native writes and `uf fmt`
+    /// did not finish on. See ubugeeei-prod/uf#125.
+    ///
+    /// The same node, printed with the same arguments in the same place, is
+    /// the same document. Keying on the parent as well is not needed for
+    /// that — a node has one parent — but it is free and it says what the
+    /// entry means.
+    pub argument_docs: FxHashMap<ArgumentKey, (Doc<'a>, bool)>,
 }
+
+/// What identifies a printed argument: the node, how it was asked to print,
+/// and where it sat.
+pub type ArgumentKey = (NodeKey, PrintArgs, Option<NodeKey>);
 
 pub use assignment::PrintArgs;
 
@@ -105,6 +123,7 @@ impl<'a> Printer<'a> {
             ancestors: Vec::with_capacity(64),
             program,
             expansion_bailout: false,
+            argument_docs: FxHashMap::default(),
         }
     }
 

--- a/crates/uf_fmt/tests/guarantees.rs
+++ b/crates/uf_fmt/tests/guarantees.rs
@@ -9,6 +9,7 @@ mod support;
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use uf_config::{FmtConfig, QuoteStyle};
 use uf_fmt::{FormatError, format_source};
@@ -355,6 +356,43 @@ fn nesting_at_the_ceiling_is_formatted() {
     assert_eq!(formatted.output.matches('[').count(), depth);
     let again = format_source(&formatted.output, &config).expect("reformats");
     similar_asserts::assert_eq!(formatted.output, again.output);
+}
+
+/// Nesting does not cost exponentially.
+///
+/// ubugeeei-prod/uf#125. `print_arguments` prints the argument it is
+/// considering hugging a second time, and so does every level below it, so
+/// the document was 2^depth: about 4x per level, sixteen seconds at twelve,
+/// and React Native's `react-native-compatibility-check` — nineteen deep —
+/// did not finish at all.
+///
+/// Forty rather than twelve, because twelve is now too fast to distinguish
+/// from nothing and forty is decisive: at 4x per level it would be longer
+/// than the age of the universe.
+#[test]
+fn deep_call_arguments_are_not_exponential() {
+    let mut source = "x".to_owned();
+    for _ in 0..40 {
+        source = format!("expect.objectContaining({{ fault: {source} }})");
+    }
+    let source = format!("// @flow\nconst result = {source};\n");
+
+    let config = FmtConfig::default();
+    let started = Instant::now();
+    let once = format_source(&source, &config).expect("formats").output;
+    let took = started.elapsed();
+
+    assert!(took < Duration::from_secs(2), "forty levels took {took:?}");
+
+    // And the answer is a real one: it settles, and it is still the same
+    // program. A cache that returned the wrong document would be fast.
+    let twice = format_source(&once, &config).expect("reformats").output;
+    similar_asserts::assert_eq!(once, twice);
+    assert_eq!(
+        support::structure(&source),
+        support::structure(&once),
+        "the program changed"
+    );
 }
 
 /// No input panics or hangs. The mutations are deterministic — a fixed

--- a/crates/uf_fmt/tests/known_bugs.rs
+++ b/crates/uf_fmt/tests/known_bugs.rs
@@ -11,56 +11,17 @@
 //!
 //! When one is fixed, its reproduction moves to the test file that owns
 //! the guarantee it broke and the entry here goes. When the last one does,
-//! this file goes with it — its job is to be empty.
+//! this file goes with it — its job is to be empty. One left.
 //!
 //! Each was found by `upstream_corpus.rs`, running the formatter over the
 //! third-party Flow in `tests/fixtures/git`.
 //!
-//! Gone from here: #128, unterminated JSX at end of input, now
-//! `jsx_truncated_at_end_of_input_is_refused` in `guarantees.rs`.
-
-use std::time::{Duration, Instant};
+//! Gone from here: #128, unterminated JSX at end of input, and #125,
+//! exponential call arguments — both now in `guarantees.rs`, beside the
+//! guarantee each broke.
 
 use uf_config::FmtConfig;
 use uf_fmt::format_source;
-
-/// ubugeeei-prod/uf#125 — deeply nested call arguments are exponential.
-///
-/// `print_arguments` prints its interesting child a second time to decide
-/// whether to hug it, so the document is 2^depth. Measured at about 4x per
-/// level and independent of the line width, which is what says it is the
-/// document rather than the measuring:
-///
-/// | depth | time |
-/// |---|---|
-/// | 8 | 0.09s |
-/// | 10 | 1.0s |
-/// | 12 | 16s |
-/// | 14 | killed at 30s |
-///
-/// React Native writes `expect.objectContaining` nineteen deep in
-/// `react-native-compatibility-check`, and `uf fmt` does not finish on it.
-#[test]
-#[ignore = "ubugeeei-prod/uf#125"]
-fn deeply_nested_call_arguments_finish_in_reasonable_time() {
-    // Twelve rather than fourteen: fourteen does not finish, and a test
-    // that hangs is a test people stop running. Twelve takes about sixteen
-    // seconds, which is decisive enough against a two-second bound.
-    let mut source = "x".to_owned();
-    for _ in 0..12 {
-        source = format!("expect.objectContaining({{ fault: {source} }})");
-    }
-    let source = format!("// @flow\nconst result = {source};\n");
-
-    let started = Instant::now();
-    format_source(&source, &FmtConfig::default()).expect("formats");
-    let took = started.elapsed();
-
-    assert!(
-        took < Duration::from_secs(2),
-        "twelve levels took {took:?}; depth 6 takes 0.03s"
-    );
-}
 
 /// ubugeeei-prod/uf#126 — comment types are rewritten into real syntax.
 ///

--- a/crates/uf_fmt/tests/upstream_corpus.rs
+++ b/crates/uf_fmt/tests/upstream_corpus.rs
@@ -53,16 +53,15 @@ fn fixtures() -> Vec<String> {
 
 /// Modules the printer cannot format in reasonable time.
 ///
-/// One file, and it is a performance bug rather than a wrong answer:
-/// `expect.objectContaining({...})` nested nineteen deep, and
-/// `print_arguments` prints its interesting child twice, so the document is
-/// exponential in the nesting. See ubugeeei-prod/uf#125 for the numbers.
+/// Empty, and the goal is that it stays that way. It held
+/// `react-native-compatibility-check`'s `VersionDiffing-test.js` until
+/// ubugeeei-prod/uf#125 was fixed: `expect.objectContaining` nested
+/// nineteen deep, printed twice per level, so the document was 2^depth.
 ///
-/// Named rather than skipped by a heuristic, so that the day the bug is
-/// fixed this list is what fails and gets deleted. `no_stale_exclusions`
-/// keeps it from rotting the other way.
-const KNOWN_SLOW: [&str; 1] =
-    ["react-native/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js"];
+/// Named rather than skipped by a heuristic, so that the day a bug is fixed
+/// this list is what fails and gets deleted. `no_stale_exclusions` keeps it
+/// from rotting the other way.
+const KNOWN_SLOW: [&str; 0] = [];
 
 /// Modules the printer gets wrong, each with the issue that says how.
 ///


### PR DESCRIPTION
Closes #125.

`uf fmt` did not finish on a file React Native ships:
`react-native-compatibility-check`'s `VersionDiffing-test.js` — 68 KB, 1,922
lines, longest line 101 characters, and `expect.objectContaining` nested
nineteen deep.

`print_arguments` prints the argument it is considering hugging a second
time, with different `PrintArgs`, and so does every level below it. The
document is 2^depth — about 4x per level, and independent of the line width,
which is what says it is the document rather than the measuring.

### The fix

The same node, printed the same way in the same place, is the same document.
So the second print is a lookup, and the two branches of the recursion share
their work instead of duplicating it: two prints per node rather than 2^n.

`expansion_bailout` is part of the answer and is replayed with it. Nothing
reads that flag as an *input* — every reader sets it to `false` immediately
before the print it is asking about — so a cached print restores it rather
than merging into it.

### Evidence

Both binaries over the whole 8,120-module corpus, output compared byte for
byte:

```
differing: 1
   react-native/.../VersionDiffing-test.js
```

That one is the file the old binary produces no output for at all:

```
after   real 0.00   1,749 lines
before  real 64.47  killed, 0 bytes
```

Depth is flat rather than 4x per level:

| depth | 6 | 10 | 12 | 14 | 19 | 40 |
|---|---|---|---|---|---|---|
| before | 0.03 s | 1.0 s | 16 s | 30 s+ | — | — |
| after | 0.00 s | 0.00 s | 0.00 s | 0.00 s | 0.00 s | 0.00 s |

The 300 largest ordinary modules, 17 MB, three runs each. The memo pays for
itself where the exponential never bites, because a hugged argument is common
and its second print is now a lookup:

```
before  2.33s  2.27s  2.26s
after   2.24s  2.19s  2.21s
```

Peak RSS on a 255 KB module: 18.7 MB before, 18.9 MB after.

Hardware: M-series macOS, release profile, `upstream/flow` at `81b0c2a3d`.

### Tests

`KNOWN_SLOW` is empty, and the goal is that it stays that way.

The reproduction moves to `guarantees.rs` at depth forty rather than twelve —
twelve is now too fast to tell from nothing, and at 4x per level forty would
be longer than the age of the universe. It asserts the output settles and the
tree survives as well as the time, because a cache that returned the wrong
document would also be fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791203464&installation_model_id=422833&pr_number=145&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F145&signature=0b66252a8fcf08efb5ba7a4c129dd019e89bc8123d7b8c034df159822d8e8c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->