### PR TITLE
ci(release): read back what actually reached npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,12 @@ jobs:
       # Every package manifest, not just one: there are 44 of them now, and a
       # manifest that does not parse is a package that cannot be installed.
       - run: ./target/release/uf run manifests
+      # And that the set that goes to npm is closed under its own
+      # dependencies. `@uniflowed/stylex` depends on `@uniflowed/core`, so a
+      # release that sends one without the other publishes a package that
+      # resolves to nothing. No network, so it belongs here rather than in the
+      # pre-tag check alone.
+      - run: ./target/release/uf run release:closure
 
   upstream-integrations:
     name: Upstream Integrations

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,3 +82,26 @@ jobs:
           for package in $(grep -vE '^\s*(#|$)' tools/release/published-packages.txt); do
             publish "$package"
           done
+
+  verify:
+    name: Verify the npm release
+    needs: npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      # The job above can succeed and leave the registry without the version
+      # it was asked to publish — `uf@0.0.0-alpha.2` had a tag, a GitHub
+      # release and nothing on npm, and nothing between that and a user
+      # noticed. This reads the registry back and installs from it.
+      - name: What actually reached npm
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: tools/release/verify-npm.sh "${REF_NAME#uf@}"

--- a/tools/release/preflight.sh
+++ b/tools/release/preflight.sh
@@ -17,6 +17,12 @@ set -eu
 repo_root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
 cd "$repo_root"
 
+# The closure first, because it needs no network and it is the failure that
+# cannot be fixed by binding a name: a published package whose dependency is
+# not published resolves to nothing.
+tools/release/verify-npm.sh --closure-only
+echo
+
 list="tools/release/published-packages.txt"
 missing=""
 count=0

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -10,6 +10,11 @@
 # package here when it is implemented, not when it is declared. `uf_lib`'s
 # registry is the source of truth for what each one is.
 #
+# It has to be a *closure*: `@uniflowed/stylex` depends on `@uniflowed/core`,
+# so a release that sends one without the other produces a package that
+# resolves to nothing — `ETARGET` on the first thing a user types.
+# `tools/release/verify-npm.sh --closure-only` checks that, and CI runs it.
+#
 # Adding a name here is half the job. `publish.yml` publishes over OIDC, and a
 # name that `npm trust` has not bound to that workflow fails the job *after* the
 # names before it have gone out — so a release is half-sent by adding a package
@@ -20,6 +25,7 @@
 #
 # and run `uf run release:preflight` before tagging to see where things stand.
 config
+core
 fetch
 graphql
 hooks

--- a/tools/release/verify-npm.sh
+++ b/tools/release/verify-npm.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env sh
+# What actually reached npm, checked from the registry rather than from here.
+#
+# `uf@0.0.0-alpha.2` has a git tag and a GitHub release. npm has nothing from
+# it: every run of `publish.yml` has failed, and until this existed nothing
+# between the tag and a user noticed. See ubugeeei-prod/uf#142.
+#
+#   tools/release/verify-npm.sh                 # the version in the tree
+#   tools/release/verify-npm.sh 0.0.0-alpha.3
+#   tools/release/verify-npm.sh --closure-only  # no network
+#
+# Two phases, and the first needs no network:
+#
+#   1. Every `@uniflowed/*` dependency of a published package is itself
+#      published. `@uniflowed/router` depends on `@uniflowed/server`, so a
+#      release that sends one without the other produces a package that
+#      resolves to nothing — `ETARGET` on the first thing a user types.
+#   2. Every listed name is on the registry at this version, and installs
+#      into an empty directory with its dependencies resolved.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+list="tools/release/published-packages.txt"
+closure_only=false
+version=""
+
+for argument in "$@"; do
+  case "$argument" in
+    --closure-only) closure_only=true ;;
+    -*) echo "verify-npm: unknown option: $argument" >&2; exit 2 ;;
+    *) version="$argument" ;;
+  esac
+done
+
+packages="$(grep -vE '^[[:space:]]*(#|$)' "$list")"
+
+if [ -z "$version" ]; then
+  version="$(node -p "require('./packages/core/package.json').version")"
+fi
+
+# ---- 1. The closure ------------------------------------------------------
+
+echo "verify-npm: checking the dependency closure of $list"
+missing_closure=""
+for name in $packages; do
+  manifest="packages/$name/package.json"
+  [ -f "$manifest" ] || { echo "verify-npm: no $manifest" >&2; exit 1; }
+  for dependency in $(node -e "
+    const m = require('./$manifest');
+    const all = { ...m.dependencies, ...m.peerDependencies, ...m.optionalDependencies };
+    for (const key of Object.keys(all)) if (key.startsWith('@uniflowed/')) console.log(key.slice('@uniflowed/'.length));
+  "); do
+    if ! echo "$packages" | grep -qx "$dependency"; then
+      printf '  %-18s depends on @uniflowed/%s, which is not published\n' "$name" "$dependency"
+      missing_closure="$missing_closure $name->$dependency"
+    fi
+  done
+done
+
+if [ -n "$missing_closure" ]; then
+  cat >&2 <<MESSAGE
+
+Not closed:$missing_closure
+
+A package whose dependency is not published resolves to nothing. Either add
+the dependency to $list — and bind it with
+tools/release/trust-npm.sh — or take the dependent out.
+MESSAGE
+  exit 1
+fi
+echo "  every @uniflowed/* dependency is itself published"
+
+if [ "$closure_only" = true ]; then
+  exit 0
+fi
+
+# ---- 2. What the registry has --------------------------------------------
+
+echo
+echo "verify-npm: checking @uniflowed/* at $version on the registry"
+absent=""
+for name in $packages; do
+  url="https://registry.npmjs.org/@uniflowed%2f$name/$version"
+  status="$(curl -fsS -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || echo 000)"
+  if [ "$status" = "200" ]; then
+    printf '  on npm      @uniflowed/%s@%s\n' "$name" "$version"
+  else
+    printf '  MISSING     @uniflowed/%s@%s\n' "$name" "$version"
+    absent="$absent $name"
+  fi
+done
+
+if [ -n "$absent" ]; then
+  cat >&2 <<MESSAGE
+
+Not on the registry at $version:$absent
+
+The tag says this version was released. npm does not have it, so nobody can
+install it. Re-run the publish job once the names are bound; npm is additive,
+so the ones that did go out stay.
+MESSAGE
+  exit 1
+fi
+
+# ---- 3. That they install ------------------------------------------------
+
+echo
+echo "verify-npm: installing them into an empty project"
+# With a template: BSD `mktemp -d` ignores `TMPDIR` without one, and this
+# script is run by hand on macOS as often as by CI on Linux.
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-verify-npm.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+cd "$work"
+npm init -y >/dev/null 2>&1
+
+specifiers=""
+for name in $packages; do
+  specifiers="$specifiers @uniflowed/$name@$version"
+done
+
+# shellcheck disable=SC2086 # deliberate word splitting: one argument per package
+if npm install --no-audit --no-fund $specifiers >"$work/install.log" 2>&1; then
+  echo "  installed $(echo "$packages" | wc -l | tr -d ' ') packages"
+else
+  echo "verify-npm: install failed" >&2
+  tail -20 "$work/install.log" >&2
+  exit 1
+fi
+
+for name in $packages; do
+  entry="$work/node_modules/@uniflowed/$name/package.json"
+  [ -f "$entry" ] || { echo "verify-npm: @uniflowed/$name is not in node_modules" >&2; exit 1; }
+done
+
+cd "$repo_root"
+echo
+echo "verify-npm: @uniflowed/* at $version is on the registry and installs"

--- a/uf.config.js
+++ b/uf.config.js
@@ -150,6 +150,13 @@ export default defineConfig({
     // has not bound fails the publish job *after* the names before it have
     // gone out, which half-sends a release.
     "release:preflight": "tools/release/preflight.sh",
+    // What actually reached npm, read from the registry. `publish.yml` runs
+    // it after publishing, because `uf@0.0.0-alpha.2` had a tag, a GitHub
+    // release and nothing on npm, and nothing noticed. See #142.
+    "release:verify": "tools/release/verify-npm.sh",
+    // The offline half of it: a published package whose dependency is not
+    // published resolves to nothing. No network, so `ci` runs it.
+    "release:closure": "tools/release/verify-npm.sh --closure-only",
     "install:test": "tools/release/test-install.sh",
     "release:manifest": "tools/release/build-manifest.sh",
     "release:package": "tools/release/package-binaries.sh",


### PR DESCRIPTION
Part of #142.

`uf@0.0.0-alpha.2` has a git tag and a GitHub release. npm has nothing from it
— all eight `publish.yml` runs have failed — and between the tag and a user,
nothing noticed:

```
$ npm install @uniflowed/router@0.0.0-alpha.2
npm error notarget No matching version found
```

`tools/release/test-install.sh` does this thoroughly for the binary installer.
There was no equivalent for npm.

### `tools/release/verify-npm.sh`

Three phases:

1. **The closure**, offline. Every `@uniflowed/*` dependency of a published
   package is itself published.
2. **The registry.** Every listed name is there at this version.
3. **An install.** All of them into an empty directory, dependencies resolved.

`publish.yml` runs it on the tag after publishing, the way `release.yml`
already installs the binaries it just built.

### The closure check found something

```
react-testing   depends on @uniflowed/core, which is not published
stylex          depends on @uniflowed/core, which is not published
```

`@uniflowed/core` is where `nativeRuntimeRequired` lives and it was not on the
list at all, so both of those would have published as packages that resolve to
nothing. It is on the list now — one more name for #130 to bind.

The same check refuses the workaround #130 invites. Trimming the list to the
five names bound today:

```
router   depends on @uniflowed/server, which is not published
vite     depends on @uniflowed/host, which is not published
```

so a partial release cannot go out quietly.

### Where each phase runs

Phase 1 needs no network, so `ci` runs it on every push (`uf run
release:closure`) and `preflight.sh` runs it *before* the registry check — it
is the failure that binding a name does not fix.

Verified against a version that is really on npm:

```
$ tools/release/verify-npm.sh 0.0.0-alpha.1
  on npm      @uniflowed/config@0.0.0-alpha.1
  on npm      @uniflowed/react@0.0.0-alpha.1
  on npm      @uniflowed/test@0.0.0-alpha.1
  installed 3 packages
verify-npm: @uniflowed/* at 0.0.0-alpha.1 is on the registry and installs
```

and against the full list, where it reports the eleven names that are not.

### Not covered

A package that *imports* an `@uniflowed/*` it does not declare.
`@uniflowed/ui` does. Reading imports needs a parser rather than a grep —
`packages/vite` has `@uniflowed/router` inside a template literal of generated
application code, and a grep calls that a dependency. That is #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791204037&installation_model_id=422833&pr_number=147&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F147&signature=97916692805c758eeba30eeeca399f676c618647d7707ddd0e13dbe7a14d2c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->