### PR TITLE
fix(fmt): a comment type stays a comment

### DIFF
--- a/crates/uf_fmt/src/flow/print/types.rs
+++ b/crates/uf_fmt/src/flow/print/types.rs
@@ -951,22 +951,58 @@ impl<'a> Printer<'a> {
         }
     }
 
-    /// `: T`, with the annotation node's comments.
+    /// `: T`, or `/*: T */` when that is how it was written, with the
+    /// annotation node's comments.
     pub fn print_type_annotation(
         &mut self,
         annotation: &'a types::Annotation<Loc, Loc>,
     ) -> Doc<'a> {
         let node = NodeRef::Annotation(annotation);
         let has_leading = self.has_comment_placed(node.key(), Placement::Leading);
-        let printed = self.print_node(node, |p| {
-            let ty = p.print_type(&annotation.annotation);
-            p.concat([p.s(": "), ty])
+        let comment_form = self.comment_type_source(&annotation.loc);
+        let printed = self.print_node(node, |p| match comment_form {
+            Some(raw) => p.replace_end_of_line(raw),
+            None => {
+                let ty = p.print_type(&annotation.annotation);
+                p.concat([p.s(": "), ty])
+            }
         });
-        if has_leading {
+        if has_leading || comment_form.is_some() {
             self.concat([self.s(" "), printed])
         } else {
             printed
         }
+    }
+
+    /// The source of an annotation written as one of Flow's comment types,
+    /// `/*` to `*/`, or [`None`] when it was written as ordinary syntax.
+    ///
+    /// Flow's parser lexes `/*: string */` as an ordinary annotation and the
+    /// tree records nothing to say where it came from — but the *location*
+    /// does: an annotation written in a comment starts at the `/*` rather
+    /// than at the `:`. That is exact, and it is where Prettier decides the
+    /// same thing.
+    ///
+    /// The bytes come back untouched, which is also what Prettier does:
+    /// `/*: {[string]: string} */` keeps its spacing where a real annotation
+    /// would be re-printed as `{ [string]: string }`. Reformatting inside the
+    /// comment would be a second, quieter way of the same bug — the text is a
+    /// comment to every tool that is not Flow.
+    ///
+    /// Preserving the form at all matters because it is the whole point of
+    /// the syntax: a file can carry annotations *and* run under bare `node`.
+    /// React Native has a build script that does, and after `uf fmt` it
+    /// needed a compiler. See ubugeeei-prod/uf#126.
+    fn comment_type_source(&self, loc: &Loc) -> Option<&'a str> {
+        let span = self.text.span(loc);
+        let source = self.text.text();
+        if !source.get(span.start..)?.starts_with("/*") {
+            return None;
+        }
+        // The location stops before the closing delimiter. A block comment
+        // does not nest, so the next `*/` is this one's.
+        let close = source.get(span.end..)?.find("*/")? + span.end + 2;
+        source.get(span.start..close)
     }
 
     /// `<T, U>` on a declaration, or nothing.

--- a/crates/uf_fmt/tests/fixtures/comment_types.expected.js
+++ b/crates/uf_fmt/tests/fixtures/comment_types.expected.js
@@ -1,0 +1,31 @@
+// @flow
+
+// Flow's comment types: annotations that a file can carry and still run
+// under bare `node`. Normalising them away is not a layout decision, it is a
+// file that needed no build step and now needs one. See ubugeeei-prod/uf#126.
+
+function greet(name /*: string */) /*: string */ {
+  return "hi " + name;
+}
+
+const total /*: number */ = 1;
+const plain: number = 2;
+
+function mixed(a /*: string */, b: number, c /*: ?Array<string> */) {
+  return a;
+}
+
+class Holder {
+  field /*: string */ = "x";
+  method(x /*: number */) /*: void */ {}
+}
+
+const arrow = (x /*: number */) /*: number */ => x;
+
+// The bytes come back untouched, spacing included. A real annotation would be
+// re-printed as `{ [string]: string }`; inside the comment it is text.
+const table /*: {[string]: string} */ = {};
+const wide /*: Array<{product: string, packagePath: string, packageName: string}> */ = [];
+
+// Ordinary annotations next to them are still normalised.
+const spaced: { [string]: string } = {};

--- a/crates/uf_fmt/tests/fixtures/comment_types.js
+++ b/crates/uf_fmt/tests/fixtures/comment_types.js
@@ -1,0 +1,31 @@
+// @flow
+
+// Flow's comment types: annotations that a file can carry and still run
+// under bare `node`. Normalising them away is not a layout decision, it is a
+// file that needed no build step and now needs one. See ubugeeei-prod/uf#126.
+
+function greet(name /*: string */) /*: string */ {
+  return "hi " + name;
+}
+
+const total /*: number */ = 1;
+const plain: number = 2;
+
+function mixed(a /*: string */, b: number, c /*: ?Array<string> */) {
+  return a;
+}
+
+class Holder {
+  field /*: string */ = "x";
+  method(x /*: number */) /*: void */ {}
+}
+
+const arrow = (x /*: number */) /*: number */ => x;
+
+// The bytes come back untouched, spacing included. A real annotation would be
+// re-printed as `{ [string]: string }`; inside the comment it is text.
+const table /*: {[string]: string} */ = {};
+const wide /*: Array<{product: string, packagePath: string, packageName: string}> */ = [];
+
+// Ordinary annotations next to them are still normalised.
+const spaced: {[string]: string} = {};

--- a/crates/uf_fmt/tests/known_bugs.rs
+++ b/crates/uf_fmt/tests/known_bugs.rs
@@ -18,30 +18,46 @@
 //!
 //! Gone from here: #128, unterminated JSX at end of input, and #125,
 //! exponential call arguments — both now in `guarantees.rs`, beside the
-//! guarantee each broke.
+//! guarantee each broke. #126 has shrunk to its declaration half; its
+//! annotation half is `comment_types.js` in the fixture directory.
 
 use uf_config::FmtConfig;
 use uf_fmt::format_source;
 
-/// ubugeeei-prod/uf#126 — comment types are rewritten into real syntax.
+/// ubugeeei-prod/uf#126 — a `/*:: … */` declaration block is rewritten.
 ///
-/// Flow's comment types exist so that a file can carry annotations *and*
-/// run without a build step. React Native's `scripts/spm` has such a file
-/// and `node` runs it directly; after `uf fmt` it needs a compiler.
+/// The annotation half of that issue is fixed: `/*: string */` survives, and
+/// `comment_types.js` in the fixture directory pins it against Prettier.
+/// What is left is the *declaration* form, where a whole statement lives
+/// inside the comment:
 ///
-/// The corpus caught it as non-idempotence — the signature measures
-/// differently once the annotations stop being comments — which is a
-/// symptom. Fixing the layout alone would leave a formatter that quietly
-/// requires a toolchain.
+/// ```text
+/// /*:: import type { SpmGraph } from './spm-types'; */
+/// /*:: type PbxEntry = { uuid: string }; */
+/// ```
+///
+/// The parser hands those back as ordinary statements — their locations sit
+/// inside the comment, which is how the annotation form is detected, but a
+/// run of them shares one `/*::` and one `*/` and the printer has no notion
+/// of that yet.
+///
+/// React Native's `scripts/spm/generate-spm-xcodeproj.js` is the module: it
+/// is idempotent and keeps its tree now, so it is out of `KNOWN_BROKEN`, and
+/// `node` still cannot run what comes out.
 #[test]
 #[ignore = "ubugeeei-prod/uf#126"]
-fn comment_types_stay_comments() {
+fn comment_type_declarations_stay_comments() {
     let source = concat!(
         "// @flow\n",
         "\n",
-        "function greet(name /*: string */) /*: string */ {\n",
-        "  return 'hi ' + name;\n",
-        "}\n",
+        "/*:: type Named = { name: string }; */\n",
+        "\n",
+        "/*::\n",
+        "type Pair = { a: string, b: string };\n",
+        "type Triple = { a: string, b: string, c: string };\n",
+        "*/\n",
+        "\n",
+        "const x = 1;\n",
     );
 
     let output = format_source(source, &FmtConfig::default())
@@ -49,7 +65,11 @@ fn comment_types_stay_comments() {
         .output;
 
     assert!(
-        output.contains("/*: string */"),
-        "the annotations stopped being comments:\n{output}"
+        output.contains("/*:: type Named"),
+        "the declaration stopped being a comment:\n{output}"
+    );
+    assert!(
+        output.contains("/*::\ntype Pair"),
+        "the block stopped being a comment:\n{output}"
     );
 }

--- a/crates/uf_fmt/tests/upstream_corpus.rs
+++ b/crates/uf_fmt/tests/upstream_corpus.rs
@@ -66,7 +66,7 @@ const KNOWN_SLOW: [&str; 0] = [];
 /// Modules the printer gets wrong, each with the issue that says how.
 ///
 /// Separate from {@link KNOWN_SLOW} because they are different problems and
-/// a single list of excuses hides that. Four bugs, eleven modules:
+/// a single list of excuses hides that. Two bugs, nine modules:
 ///
 /// * **#133** — parentheses around a same-precedence right operand are
 ///   dropped, so `a && (b && c)` becomes `a && b && c` and the tree
@@ -75,11 +75,7 @@ const KNOWN_SLOW: [&str; 0] = [];
 ///   pass.
 /// * **#134** — `function f(): %checks` loses its colon and the output does
 ///   not parse.
-/// * **#126** — Flow's comment types are rewritten into real syntax, so a
-///   script written to run under bare `node` stops doing so.
-const KNOWN_BROKEN: [&str; 10] = [
-    // #126
-    "react-native/packages/react-native/scripts/spm/generate-spm-xcodeproj.js",
+const KNOWN_BROKEN: [&str; 9] = [
     // #133
     "fbt/runtime/nonfb/FbtNumber/IntlCLDRNumberType19.js",
     "fbt/runtime/nonfb/FbtNumber/IntlCLDRNumberType31.js",


### PR DESCRIPTION
Part of #126.

```js
function greet(name /*: string */) /*: string */ {
```

came back as

```js
function greet(name: string): string {
```

which is the same program to Flow and a different one to Node. Comment types
exist so a file can carry annotations *and* run without a build step. React
Native has one that `node` runs directly —
`scripts/spm/generate-spm-xcodeproj.js` — and after `uf fmt` it needed a
compiler.

### How it is detected

Flow's parser lexes `/*: string */` as an ordinary annotation and the tree
records nothing to say where it came from. The *location* does: an annotation
written in a comment starts at the `/*` rather than at the `:`. That is exact
rather than a guess at the source text, and it is where Prettier decides the
same thing.

### The bytes come back untouched

Which is also what Prettier does:

```js
const table /*: {[string]: string} */ = {};   // unchanged
const spaced: {[string]: string} = {};        // → { [string]: string }
```

Reformatting inside the comment would be a second, quieter version of the same
bug. The text is a comment to every tool that is not Flow, and the one that is
does not mind the spacing.

### What is left

The *declaration* form, where a whole statement lives in the comment:

```js
/*:: import type { SpmGraph } from './spm-types'; */
/*::
type Pair = { a: string, b: string };
*/
```

A run of those shares one `/*::` and one `*/`, and the printer has no notion of
that yet. `known_bugs.rs` narrows to it, still `#[ignore]`d against #126.

The React Native module comes out of `KNOWN_BROKEN` regardless: it parses, it
is idempotent, and it keeps its tree and comments — 8,109 formatted, 0 failed.
What it still does not do is run under `node`, which is why #126 stays open.

### Tests

```sh
prettier --parser hermes --plugin prettier-plugin-hermes-parser \
  --print-width 100 crates/uf_fmt/tests/fixtures/comment_types.js
```

Byte-identical. Parameters, returns, variables, class fields, methods, arrows,
the untouched-spacing cases, and an ordinary annotation beside them that is
still normalised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791204847&installation_model_id=422833&pr_number=148&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F148&signature=dfe119b0cc83148ea8250f10bf0f080400006b7445be2e184768b5a669a7350b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->