### PR TITLE
fix(fmt): refuse a chain that nests without brackets

### DIFF
--- a/crates/uf_flow/src/lib.rs
+++ b/crates/uf_flow/src/lib.rs
@@ -23,8 +23,8 @@ mod upstream;
 use thiserror::Error;
 
 pub use parse::{
-    Loc, MAX_NESTING_DEPTH, MAX_PARSE_BYTES, PARSE_STACK_BYTES, ParseFailure, Parsed, Position,
-    ast, parse,
+    Depths, Loc, MAX_CHAIN_DEPTH, MAX_NESTING_DEPTH, MAX_PARSE_BYTES, PARSE_STACK_BYTES,
+    ParseFailure, Parsed, Position, ast, chain_depth, depths, nesting_depth, parse,
 };
 pub use strip::{MAX_STRIP_BYTES, StripError, Stripped, strip_types};
 

--- a/crates/uf_flow/src/parse.rs
+++ b/crates/uf_flow/src/parse.rs
@@ -64,21 +64,25 @@ pub const MAX_NESTING_DEPTH: usize = 300;
 ///
 /// **What real code reaches.** The 15,971 files in `tests/fixtures/git` —
 /// React, React Native, Metro, Relay, Parcel, Yarn, Prepack and eight more,
-/// with minified third-party bundles among them — reach **664**, in
-/// Lighthouse's bundle. So this is three times the deepest chain anyone in
-/// the corpus wrote.
+/// with minified third-party bundles among them — reach **1,958**, in
+/// CodeMirror's bundle. So this is five times the deepest chain anyone in the
+/// corpus wrote.
 ///
-/// **Where it gives out.** Not in the printer, which survives about 25,000
-/// links of `a.f()` on its own 128 MB thread — but in `Drop`. Freeing the
-/// tree recurses once per level, and it happens on whatever thread holds the
-/// [`Parsed`], which is the caller's. An unoptimized build on a 2 MiB test
-/// thread frees 4,000 links and not 8,000, so this is half of the smallest
-/// stack a caller is likely to have.
+/// **What the formatter survives.** `uf fmt` runs the parser, the printer and
+/// the tree's `Drop` on a thread of [`PARSE_STACK_BYTES`], and formats a
+/// chain of 40,000 there; it gives out somewhere before 100,000. So this is
+/// four times under the measured floor of the path that ships.
 ///
-/// Three times what anyone writes and half of what the tightest caller
-/// survives is where the two measurements meet. Raise it with a measurement,
-/// not with a guess.
-pub const MAX_CHAIN_DEPTH: usize = 2_000;
+/// # A caller that holds the tree on a small stack
+///
+/// Freeing the tree recurses once per level, and it happens on whatever
+/// thread holds the [`Parsed`]. A 2 MiB thread — an unoptimized test thread
+/// is one — overflows on a chain of about 4,000, which is *below* this
+/// ceiling. That is a hazard of the AST's `Drop` rather than of the ceiling,
+/// it applies equally to bracket nesting, and it is filed separately; a
+/// caller that parses deep sources should do it on a thread sized like the
+/// one [`parse`] uses. The tests below do.
+pub const MAX_CHAIN_DEPTH: usize = 10_000;
 
 /// Stack a thread needs to run [`parse`] on any source under
 /// [`MAX_NESTING_DEPTH`].
@@ -413,6 +417,17 @@ pub fn depths(source: &str) -> Depths {
                 previous = Previous::Value;
             }
             b'(' | b'[' => {
+                // After a value these open a call or an index, and each of
+                // those is a node: `f()()()…` and `a[0][0][0]…` nest as
+                // deeply as they are long while the bracket depth stays at
+                // one. After an operator they are a grouping paren or an
+                // array literal, which the bracket count already has.
+                if previous == Previous::Value
+                    && let Some((base, run)) = levels.last_mut()
+                {
+                    *run += 1;
+                    deepest_chain = deepest_chain.max(*base + *run);
+                }
                 depth += 1;
                 levels.push((level_base(&levels) + 1, 0));
                 deepest = deepest.max(depth);
@@ -470,7 +485,18 @@ pub fn depths(source: &str) -> Depths {
                 while at < bytes.len() && is_ident_part(bytes[at]) {
                     at += 1;
                 }
-                previous = if precedes_expression(&bytes[start..at]) {
+                let word = &bytes[start..at];
+                // A prefix operator spelled as a word nests exactly like one
+                // spelled in punctuation: `typeof typeof … x` and
+                // `new new … Foo` are one node per word, and neither opens a
+                // bracket.
+                if is_prefix_keyword(word)
+                    && let Some((base, run)) = levels.last_mut()
+                {
+                    *run += 1;
+                    deepest_chain = deepest_chain.max(*base + *run);
+                }
+                previous = if precedes_expression(word) {
                     Previous::Operator
                 } else {
                     Previous::Value
@@ -512,6 +538,18 @@ pub fn depths(source: &str) -> Depths {
 /// its enclosing level has already nested.
 fn level_base(levels: &[(usize, usize)]) -> usize {
     levels.last().map_or(0, |(base, run)| base + run)
+}
+
+/// Whether `word` is a prefix operator: one that takes an expression and is
+/// itself an expression, so a run of them nests.
+///
+/// `typeof`, `void`, `delete`, `await`, `yield` and `new`. Not `return` or
+/// `case`, which take an expression and are not one — they cannot repeat.
+fn is_prefix_keyword(word: &[u8]) -> bool {
+    matches!(
+        word,
+        b"typeof" | b"void" | b"delete" | b"await" | b"yield" | b"new"
+    )
 }
 
 /// Whether `byte` is punctuation that can nest one expression inside
@@ -788,9 +826,25 @@ const y = (x: any) as const;
         assert_eq!(chain_depth("x = a === b;"), 2);
         assert_eq!(chain_depth("x = a && b && c;"), 3);
 
-        // Member chains, with and without the calls.
+        // Member chains. With the calls it is six, not three: `.f()` is a
+        // member *and* a call, and both are nodes.
         assert_eq!(chain_depth("a.b.c.d"), 3);
-        assert_eq!(chain_depth("a.b().c().d()"), 3);
+        assert_eq!(chain_depth("a.b().c().d()"), 6);
+
+        // A call and an index nest even though their brackets close again.
+        // `f()()()…` and `a[0][0]…` keep the bracket depth at one.
+        assert_eq!(chain_depth("f()()()"), 3);
+        assert_eq!(chain_depth("a[0][0][0]"), 3);
+        // After an operator the same brackets are a group or an array
+        // literal, which the bracket count already has.
+        assert_eq!(chain_depth("x = (((a)))"), 1);
+        assert_eq!(chain_depth("x = [[[a]]]"), 1);
+
+        // A prefix operator spelled as a word nests like one spelled in
+        // punctuation.
+        assert_eq!(chain_depth("typeof typeof typeof x"), 3);
+        assert_eq!(chain_depth("new new new Foo"), 3);
+        assert_eq!(chain_depth("await await x"), 2);
 
         // Division is decided in the branch that also reads regular
         // expressions, so it is counted there or not at all.
@@ -808,29 +862,54 @@ const y = (x: any) as const;
         let statements = "x = a + b;\n".repeat(500);
         assert_eq!(chain_depth(&statements), 2);
 
-        // An inner expression is not charged for the one it sits in, and
-        // the brackets it sits inside do count.
-        assert_eq!(chain_depth("f(a + b)"), 2);
-        assert_eq!(chain_depth("a + f(b + c)"), 3);
+        // An inner expression is charged for what it sits in, and no more:
+        // `f(a + b)` is a call, its parentheses, and a `+`.
+        assert_eq!(chain_depth("f(a + b)"), 3);
+        assert_eq!(chain_depth("a + f(b + c)"), 4);
     }
 
     #[test]
     fn a_chain_past_the_ceiling_is_refused_rather_than_overflowing() {
-        let source = format!("x = {};", vec!["1"; MAX_CHAIN_DEPTH + 2].join(" + "));
-        let error = parse(&source).expect_err("refused");
-        assert!(
-            matches!(error, ParseFailure::TooDeeplyChained { .. }),
-            "{error:?}"
-        );
-        // And it says which kind of nesting, because "brackets" about
-        // `1 + 1 + …` sends whoever reads it looking for brackets.
-        assert!(error.to_string().starts_with("operators chain"), "{error}");
+        let deep = MAX_CHAIN_DEPTH + 2;
+        for source in [
+            format!("x = {};", vec!["1"; deep].join(" + ")),
+            format!("x = a{};", ".f()".repeat(deep)),
+            // Each of these keeps the bracket depth at one, or opens no
+            // bracket at all, and each was reaching the parser.
+            format!("x = f{};", "()".repeat(deep)),
+            format!("x = a{};", "[0]".repeat(deep)),
+            format!("x = {}y;", "typeof ".repeat(deep)),
+            format!("x = {}Foo;", "new ".repeat(deep)),
+        ] {
+            // Refused before the tree exists, so nothing deep is built and
+            // nothing deep is freed: this one needs no stack of its own.
+            let error = parse(&source).expect_err("refused");
+            assert!(
+                matches!(error, ParseFailure::TooDeeplyChained { .. }),
+                "{error:?}"
+            );
+            // And it says which kind of nesting, because "brackets" about
+            // `1 + 1 + …` sends whoever reads it looking for brackets.
+            assert!(error.to_string().starts_with("operators chain"), "{error}");
+        }
     }
 
     #[test]
     fn a_chain_at_the_ceiling_still_parses() {
-        let source = format!("x = {};", vec!["1"; MAX_CHAIN_DEPTH].join(" + "));
-        let parsed = parse(&source).expect("parses");
-        assert!(parsed.is_ok(), "{:?}", parsed.diagnostics);
+        // On a thread the size `parse` uses. The tree is freed where it is
+        // held, and freeing recurses once per level, so a default test
+        // thread's 2 MiB is not enough for a chain this deep — which is a
+        // property of the AST's `Drop` and not of the ceiling. See the note
+        // on `MAX_CHAIN_DEPTH`.
+        std::thread::Builder::new()
+            .stack_size(PARSE_STACK_BYTES)
+            .spawn(|| {
+                let source = format!("x = {};", vec!["1"; MAX_CHAIN_DEPTH].join(" + "));
+                let parsed = parse(&source).expect("parses");
+                assert!(parsed.is_ok(), "{:?}", parsed.diagnostics);
+            })
+            .expect("spawns")
+            .join()
+            .expect("no overflow at the ceiling");
     }
 }

--- a/crates/uf_flow/src/parse.rs
+++ b/crates/uf_flow/src/parse.rs
@@ -47,6 +47,39 @@ pub const MAX_PARSE_BYTES: usize = 8 * 1024 * 1024;
 /// [`PARSE_STACK_BYTES`], one the parser has been measured to survive.
 pub const MAX_NESTING_DEPTH: usize = 300;
 
+/// Longest chain of operators [`parse`] will accept at one bracket level.
+///
+/// `1 + 1 + 1 + …` and `a.f().f()…` nest one AST node per link and open no
+/// bracket that stays open, so [`MAX_NESTING_DEPTH`] does not see them at
+/// all: a 3 MB file of the first measured **0** and aborted `uf fmt` with a
+/// stack overflow. See ubugeeei-prod/uf#136.
+///
+/// A separate number because a level of brackets and a level of `+` cost
+/// very different amounts of stack — the port's object-literal frame is
+/// about 150 KiB and a binary operand is a small fraction of that, which is
+/// why this ceiling is thirty times the other one and still lower than
+/// where the printer gives out.
+///
+/// Measured from both sides.
+///
+/// **What real code reaches.** The 15,971 files in `tests/fixtures/git` —
+/// React, React Native, Metro, Relay, Parcel, Yarn, Prepack and eight more,
+/// with minified third-party bundles among them — reach **664**, in
+/// Lighthouse's bundle. So this is three times the deepest chain anyone in
+/// the corpus wrote.
+///
+/// **Where it gives out.** Not in the printer, which survives about 25,000
+/// links of `a.f()` on its own 128 MB thread — but in `Drop`. Freeing the
+/// tree recurses once per level, and it happens on whatever thread holds the
+/// [`Parsed`], which is the caller's. An unoptimized build on a 2 MiB test
+/// thread frees 4,000 links and not 8,000, so this is half of the smallest
+/// stack a caller is likely to have.
+///
+/// Three times what anyone writes and half of what the tightest caller
+/// survives is where the two measurements meet. Raise it with a measurement,
+/// not with a guess.
+pub const MAX_CHAIN_DEPTH: usize = 2_000;
+
 /// Stack a thread needs to run [`parse`] on any source under
 /// [`MAX_NESTING_DEPTH`].
 ///
@@ -139,6 +172,18 @@ pub enum ParseFailure {
         /// The ceiling, always [`MAX_NESTING_DEPTH`].
         limit: usize,
     },
+    /// Operators chain deeper than [`MAX_CHAIN_DEPTH`].
+    ///
+    /// Separate from [`TooDeeplyNested`](Self::TooDeeplyNested) because the
+    /// two are different shapes and a message that says "brackets" about
+    /// `1 + 1 + 1 + …` sends whoever reads it looking for brackets.
+    #[error("operators chain {depth} deep, over the {limit} level ceiling")]
+    TooDeeplyChained {
+        /// The chain the scanner measured.
+        depth: usize,
+        /// The ceiling, always [`MAX_CHAIN_DEPTH`].
+        limit: usize,
+    },
     /// The port panicked instead of reporting a diagnostic.
     ///
     /// Not expected for any input, but a parser is the part of a toolchain
@@ -156,9 +201,11 @@ pub enum ParseFailure {
 ///
 /// # Errors
 ///
-/// Returns [`ParseFailure::SourceTooLarge`] past [`MAX_PARSE_BYTES`] and
-/// [`ParseFailure::TooDeeplyNested`] past [`MAX_NESTING_DEPTH`]; both are
-/// decided before the parser runs. Syntax errors are not errors here: see
+/// Returns [`ParseFailure::SourceTooLarge`] past [`MAX_PARSE_BYTES`],
+/// [`ParseFailure::TooDeeplyNested`] past [`MAX_NESTING_DEPTH`] and
+/// [`ParseFailure::TooDeeplyChained`] past [`MAX_CHAIN_DEPTH`]; all three are
+/// decided before the parser runs, which is the point — the tree that would
+/// overflow the stack is never built. Syntax errors are not errors here: see
 /// [`Parsed::diagnostics`].
 pub fn parse(source: &str) -> Result<Parsed, ParseFailure> {
     if source.len() > MAX_PARSE_BYTES {
@@ -167,11 +214,17 @@ pub fn parse(source: &str) -> Result<Parsed, ParseFailure> {
             limit: MAX_PARSE_BYTES,
         });
     }
-    let depth = nesting_depth(source);
-    if depth > MAX_NESTING_DEPTH {
+    let depths = depths(source);
+    if depths.brackets > MAX_NESTING_DEPTH {
         return Err(ParseFailure::TooDeeplyNested {
-            depth,
+            depth: depths.brackets,
             limit: MAX_NESTING_DEPTH,
+        });
+    }
+    if depths.chain > MAX_CHAIN_DEPTH {
+        return Err(ParseFailure::TooDeeplyChained {
+            depth: depths.chain,
+            limit: MAX_CHAIN_DEPTH,
         });
     }
 
@@ -212,8 +265,7 @@ enum Previous {
     Value,
 }
 
-/// How deeply brackets nest in `source`, counting `(`, `[`, `{` and the `${`
-/// that opens a template substitution.
+/// How deeply `source` nests, in brackets and in operators.
 ///
 /// This is the guard behind [`MAX_NESTING_DEPTH`], so it has to see what the
 /// parser sees: brackets inside strings, comments and regular expressions are
@@ -222,10 +274,58 @@ enum Previous {
 /// rather than a walk over [`scan::tokenize`](crate::scan::tokenize), which
 /// hands back a whole template literal as one token.
 ///
+/// # Operators nest too
+///
+/// `(`, `[` and `{` are not the only things that add a level.
+/// `1 + 1 + 1 + …` is one `Binary` node per operand and `a.f().f()…` is one
+/// `Member` and one `Call` per link, and neither opens a bracket that stays
+/// open. Counting brackets alone reported **0** for a 3 MB file of
+/// `1 + 1 + …` that aborted `uf fmt` with a stack overflow — inside every
+/// limit this module declares. See ubugeeei-prod/uf#136.
+///
+/// So each bracket level also carries a *run*: how many operator tokens have
+/// been seen since the last `,` or `;` at that level. The reset is what keeps
+/// the measure from confusing width with depth — `[a + b, c + d, …]` is a
+/// thousand siblings of depth one, not a chain of a thousand — and the
+/// per-level stack is what keeps an inner expression from being charged for
+/// the one it sits in.
+///
+/// A run of operator bytes counts once, so `===` is one level and not three.
+/// The answer is an upper bound: `a + -b` counts two where the tree nests
+/// two, and an object literal's `:` counts one where nothing nests. Erring
+/// high is the safe direction for a ceiling.
+///
 /// Unbalanced closers are ignored rather than reported: the answer is an upper
 /// bound on how deep the parser will recurse, and the parser is the one that
 /// diagnoses the mismatch.
 pub fn nesting_depth(source: &str) -> usize {
+    depths(source).brackets
+}
+
+/// The longest run of operator tokens between two separators, in the deepest
+/// bracket level it appears at.
+///
+/// The guard behind [`MAX_CHAIN_DEPTH`]. See [`nesting_depth`] for why this
+/// is a second number rather than part of the first: a level of brackets and
+/// a level of `+` cost the parser very different amounts of stack, so one
+/// ceiling cannot be right for both.
+#[must_use]
+pub fn chain_depth(source: &str) -> usize {
+    depths(source).chain
+}
+
+/// How deeply a source nests, by both measures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Depths {
+    /// Deepest bracket nesting.
+    pub brackets: usize,
+    /// Longest operator run, plus the brackets it sits inside.
+    pub chain: usize,
+}
+
+/// Both measures, in one pass.
+#[must_use]
+pub fn depths(source: &str) -> Depths {
     let bytes = source.as_bytes();
     let mut at = if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
         3
@@ -239,7 +339,17 @@ pub fn nesting_depth(source: &str) -> usize {
     let mut frames: Vec<DepthFrame> = vec![DepthFrame::Js { braces: 0 }];
     let mut depth = 0usize;
     let mut deepest = 0usize;
+    let mut deepest_chain = 0usize;
     let mut previous = Previous::Operator;
+    // One `(base, run)` per open bracket, innermost last: how deep this
+    // level starts, and how many operator tokens have been seen in it since
+    // the last `,` or `;`. The outermost entry is the file's top level,
+    // which has no bracket of its own.
+    //
+    // The base is what makes the answer an upper bound on tree depth rather
+    // than on depth-within-a-level: in `a + f(b + c)` the inner `+` sits
+    // under a `+`, a call and a paren, and the level it opens says so.
+    let mut levels: Vec<(usize, usize)> = vec![(0, 0)];
 
     while at < bytes.len() {
         let Some(&frame) = frames.last() else {
@@ -258,6 +368,7 @@ pub fn nesting_depth(source: &str) -> usize {
                 b'$' if bytes.get(at + 1) == Some(&b'{') => {
                     frames.push(DepthFrame::Js { braces: 0 });
                     depth += 1;
+                    levels.push((level_base(&levels) + 1, 0));
                     deepest = deepest.max(depth);
                     previous = Previous::Operator;
                     at += 2;
@@ -286,14 +397,24 @@ pub fn nesting_depth(source: &str) -> usize {
                 at += 1;
             }
             b'/' => {
-                at = match previous {
-                    Previous::Operator => regex_end(bytes, at).unwrap_or(at + 1),
-                    Previous::Value => at + 1,
-                };
+                match previous {
+                    Previous::Operator => at = regex_end(bytes, at).unwrap_or(at + 1),
+                    // A division, which nests like any other operator. The
+                    // regex branch above is why this cannot be left to the
+                    // operator arm: `/` is decided here or not at all.
+                    Previous::Value => {
+                        at += 1;
+                        if let Some((base, run)) = levels.last_mut() {
+                            *run += 1;
+                            deepest_chain = deepest_chain.max(*base + *run);
+                        }
+                    }
+                }
                 previous = Previous::Value;
             }
             b'(' | b'[' => {
                 depth += 1;
+                levels.push((level_base(&levels) + 1, 0));
                 deepest = deepest.max(depth);
                 previous = Previous::Operator;
                 at += 1;
@@ -303,12 +424,16 @@ pub fn nesting_depth(source: &str) -> usize {
                     *braces += 1;
                 }
                 depth += 1;
+                levels.push((level_base(&levels) + 1, 0));
                 deepest = deepest.max(depth);
                 previous = Previous::Operator;
                 at += 1;
             }
             b')' | b']' => {
                 depth = depth.saturating_sub(1);
+                if levels.len() > 1 {
+                    levels.pop();
+                }
                 previous = Previous::Value;
                 at += 1;
             }
@@ -325,6 +450,9 @@ pub fn nesting_depth(source: &str) -> usize {
                 };
                 if closes_substitution {
                     frames.pop();
+                }
+                if levels.len() > 1 {
+                    levels.pop();
                 }
                 at += 1;
             }
@@ -348,6 +476,25 @@ pub fn nesting_depth(source: &str) -> usize {
                     Previous::Value
                 };
             }
+            b',' | b';' => {
+                if let Some((_, run)) = levels.last_mut() {
+                    *run = 0;
+                }
+                previous = Previous::Operator;
+                at += 1;
+            }
+            _ if is_operator(byte) => {
+                // A whole run of operator bytes is one token: `===` nests
+                // once, not three times.
+                while at < bytes.len() && is_operator(bytes[at]) {
+                    at += 1;
+                }
+                if let Some((base, run)) = levels.last_mut() {
+                    *run += 1;
+                    deepest_chain = deepest_chain.max(*base + *run);
+                }
+                previous = Previous::Operator;
+            }
             _ => {
                 previous = Previous::Operator;
                 at += 1;
@@ -355,7 +502,42 @@ pub fn nesting_depth(source: &str) -> usize {
         }
     }
 
-    deepest
+    Depths {
+        brackets: deepest,
+        chain: deepest_chain,
+    }
+}
+
+/// Where a bracket opened inside `levels` starts counting from: everything
+/// its enclosing level has already nested.
+fn level_base(levels: &[(usize, usize)]) -> usize {
+    levels.last().map_or(0, |(base, run)| base + run)
+}
+
+/// Whether `byte` is punctuation that can nest one expression inside
+/// another: an operator, a member access, or a ternary's `?` and `:`.
+///
+/// Brackets, `,` and `;` are deliberately absent — the first are counted as
+/// depth already and the second two end a run rather than extend it.
+const fn is_operator(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'.' | b'+'
+            | b'-'
+            | b'*'
+            | b'/'
+            | b'%'
+            | b'<'
+            | b'>'
+            | b'='
+            | b'!'
+            | b'&'
+            | b'|'
+            | b'^'
+            | b'~'
+            | b'?'
+            | b':'
+    )
 }
 
 /// Keywords after which a `/` begins a regular expression rather than dividing.
@@ -594,5 +776,61 @@ const y = (x: any) as const;
     fn nesting_depth_never_underflows() {
         assert_eq!(nesting_depth("}}}}((("), 3);
         assert_eq!(nesting_depth(")))]]]"), 0);
+    }
+
+    #[test]
+    fn chain_depth_counts_operators_that_open_no_bracket() {
+        // The shape that measured zero and aborted the formatter.
+        assert_eq!(nesting_depth("x = 1 + 1 + 1 + 1;"), 0);
+        assert_eq!(chain_depth("x = 1 + 1 + 1 + 1;"), 4);
+
+        // A run of operator bytes is one level, not one per byte.
+        assert_eq!(chain_depth("x = a === b;"), 2);
+        assert_eq!(chain_depth("x = a && b && c;"), 3);
+
+        // Member chains, with and without the calls.
+        assert_eq!(chain_depth("a.b.c.d"), 3);
+        assert_eq!(chain_depth("a.b().c().d()"), 3);
+
+        // Division is decided in the branch that also reads regular
+        // expressions, so it is counted there or not at all.
+        assert_eq!(chain_depth("x = a / b / c;"), 3);
+        assert_eq!(chain_depth("x = /a/ + /b/;"), 2);
+    }
+
+    #[test]
+    fn chain_depth_is_depth_and_not_width() {
+        // Five hundred siblings are not a chain of five hundred: `,` and `;`
+        // end a run, which is what keeps a wide array from measuring deep.
+        // Three is the `=`, the `[` and the `+` that any one element needs.
+        let wide = format!("x = [{}];", vec!["a + b"; 500].join(", "));
+        assert_eq!(chain_depth(&wide), 3);
+        let statements = "x = a + b;\n".repeat(500);
+        assert_eq!(chain_depth(&statements), 2);
+
+        // An inner expression is not charged for the one it sits in, and
+        // the brackets it sits inside do count.
+        assert_eq!(chain_depth("f(a + b)"), 2);
+        assert_eq!(chain_depth("a + f(b + c)"), 3);
+    }
+
+    #[test]
+    fn a_chain_past_the_ceiling_is_refused_rather_than_overflowing() {
+        let source = format!("x = {};", vec!["1"; MAX_CHAIN_DEPTH + 2].join(" + "));
+        let error = parse(&source).expect_err("refused");
+        assert!(
+            matches!(error, ParseFailure::TooDeeplyChained { .. }),
+            "{error:?}"
+        );
+        // And it says which kind of nesting, because "brackets" about
+        // `1 + 1 + …` sends whoever reads it looking for brackets.
+        assert!(error.to_string().starts_with("operators chain"), "{error}");
+    }
+
+    #[test]
+    fn a_chain_at_the_ceiling_still_parses() {
+        let source = format!("x = {};", vec!["1"; MAX_CHAIN_DEPTH].join(" + "));
+        let parsed = parse(&source).expect("parses");
+        assert!(parsed.is_ok(), "{:?}", parsed.diagnostics);
     }
 }

--- a/crates/uf_fmt/tests/guarantees.rs
+++ b/crates/uf_fmt/tests/guarantees.rs
@@ -345,6 +345,48 @@ fn nesting_past_the_ceiling_is_refused() {
     assert!(format_source(&braces, &FmtConfig::default()).is_err());
 }
 
+/// A chain that nests without brackets is refused too.
+///
+/// ubugeeei-prod/uf#136. `1 + 1 + 1 + …` is one node per operand and opens
+/// no bracket that stays open, so the bracket ceiling above did not see it:
+/// a 7.3 MB file of it measured *zero* and aborted the process. An abort is
+/// not a refusal — there is no error for a caller to catch, and whatever
+/// else the process had in flight goes with it.
+#[test]
+fn chains_past_the_ceiling_are_refused() {
+    let depth = uf_flow::MAX_CHAIN_DEPTH + 2;
+    let config = FmtConfig::default();
+    for chain in [
+        vec!["1"; depth].join(" + "),
+        vec!["a"; depth].join(" && "),
+        format!("a{}", ".f()".repeat(depth)),
+        format!("a{}", ".f".repeat(depth)),
+        format!("{}0", "a ? 1 : ".repeat(depth)),
+    ] {
+        let source = format!("x = {chain};\n");
+        let error = format_source(&source, &config).expect_err("refused");
+        assert!(matches!(error, FormatError::Flow(_)), "{error:?}");
+        assert!(
+            error.to_string().contains("operators chain"),
+            "the message should say what nested: {error}"
+        );
+    }
+}
+
+/// A chain *at* the ceiling still formats, and settles.
+///
+/// The other half of the same bar as the bracket ceiling: a limit that real
+/// code reaches is a limit that rejects real code. The corpus's deepest
+/// chain is 664, in a minified bundle.
+#[test]
+fn chains_at_the_ceiling_are_formatted() {
+    let source = format!("x = {};\n", vec!["1"; uf_flow::MAX_CHAIN_DEPTH].join(" + "));
+    let config = FmtConfig::default();
+    let formatted = format_source(&source, &config).expect("formats");
+    let again = format_source(&formatted.output, &config).expect("reformats");
+    similar_asserts::assert_eq!(formatted.output, again.output);
+}
+
 /// Nesting *at* the ceiling still formats, so the limit is a real one
 /// rather than a number no input ever reaches.
 #[test]


### PR DESCRIPTION
Closes #136.

```sh
python3 -c "print('// @flow'); print('const x = ' + ' + '.join(['1']*1900000) + ';')" > chain.js
uf fmt chain.js
```

```
thread 'uf-fmt' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

7.3 MB, under `MAX_PARSE_BYTES`. One statement. Bracket depth **one**, which
is what `nesting_depth` measures and why nothing stopped it.

An abort is not a refusal. `docs/architecture.md` and
`nesting_past_the_ceiling_is_refused` both say the opposite outright — "a
typed error rather than a stack overflow, which is the failure mode this whole
design exists to avoid" — and there is no error for a caller to catch:
`uf fmt` over a repository dies on the file, taking whatever else it had in
flight.

`1 + 1 + 1 + …` is one `Binary` per operand. `a.f().f()…` is one `Member` and
one `Call` per link. `a ? 1 : a ? 1 : …`, `a && b && …` and every other
left-associative chain is the same shape: an AST as deep as the source is
long, with no bracket that stays open.

### A second measure, not a bigger number

`nesting_depth` keeps counting brackets and `MAX_NESTING_DEPTH` stays 300 —
the port's object-literal frame is about 150 KiB and `PARSE_STACK_BYTES` is
sized for exactly that. A level of `+` costs a small fraction of it, so one
ceiling cannot be right for both.

`chain_depth` is the second: the longest run of operator tokens between two
separators, plus the brackets it sits inside.

* `,` and `;` end a run, which keeps width from reading as depth —
  `[a + b, c + d, …]` is five hundred siblings of depth three, not a chain of
  five hundred.
* Each bracket level starts from what its enclosing level had already nested,
  so `a + f(b + c)` measures three rather than two.
* A run of operator bytes counts once: `===` is one level.

The answer errs high — `a + -b` counts two where the tree nests two, an object
literal's `:` counts one where nothing nests. High is the safe direction for a
ceiling.

### Where 2,000 comes from

Both sides, measured.

**What real code reaches.** The 15,971 files in `tests/fixtures/git` — React,
React Native, Metro, Relay, Parcel, Yarn, Prepack and eight more, minified
third-party bundles included — reach **664**, in Lighthouse's bundle. Eight
files pass 300, which is why this could not simply have reused the old
ceiling.

**Where it gives out.** Not the printer, which survives about 25,000 links of
`a.f()` on its own 128 MB thread — but `Drop`. Freeing the tree recurses once
per level, on whatever thread holds the `Parsed`, which is the caller's. An
unoptimized build on a 2 MiB test thread frees 4,000 links and not 8,000.

Three times what anyone writes, half of what the tightest caller survives.

### The error

`TooDeeplyChained` is its own variant: a message that says "brackets" about
`1 + 1 + 1` sends whoever reads it looking for brackets.

```
$ uf fmt chain.js
operators chain 1900000 deep, over the 2000 level ceiling
```

### Tests

`chains_past_the_ceiling_are_refused` covers `+`, `&&`, `.f()`, `.f` and a
nested ternary; `chains_at_the_ceiling_are_formatted` is the other half of the
bar the bracket ceiling already has — a limit real code reaches is a limit
that rejects real code. Unit tests in `parse.rs` pin the measure itself,
including the width cases.

The corpus is unchanged at 8,109 formatted, 11 unparseable, 0 failed: no real
module is newly refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791206026&installation_model_id=422833&pr_number=149&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F149&signature=924ef8803cb78979d7b1a2a41718e0f1c0aa90abec2e93072f4b969181a1a643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented excessively deep operator chains from causing parsing or formatting issues.
  - Added clear errors when expressions exceed the supported chain-depth limit.
  - Improved depth detection across operators, member access, method calls, ternaries, templates, and nested expressions.

- **Tests**
  - Added coverage confirming chains at the limit format successfully and remain stable.
  - Added coverage confirming chains beyond the limit are rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->