### PR TITLE
fix(packages): declare the validator @uniflowed/ui imports

### DIFF
--- a/crates/uf_lib/tests/package_surface.rs
+++ b/crates/uf_lib/tests/package_surface.rs
@@ -9,7 +9,8 @@
 //! - every module opens with the `// @flow` pragma,
 //! - every `exports` subpath resolves and every shipped module is reachable,
 //! - every shipped `package.json` declares `"sideEffects": false`,
-//! - the Rust registry in `uf_lib` and the shipped subpaths agree.
+//! - the Rust registry in `uf_lib` and the shipped subpaths agree,
+//! - every `@uniflowed/*` a package imports is declared in its manifest.
 //!
 //! One package is exempt from the Flow rules: `@uniflowed/vite` is executed
 //! by the JavaScript host *before* any transform exists — it is how the
@@ -1242,4 +1243,78 @@ fn every_advertised_module_resolves_to_a_package() {
         unresolvable.len(),
         unresolvable.join("\n")
     );
+}
+
+/// Every `@uniflowed/*` a package imports is declared in its manifest.
+///
+/// An undeclared dependency resolves inside this workspace, where every
+/// sibling is a directory away, and not for anyone who installs the package
+/// from npm. `@uniflowed/ui` imported `@uniflowed/validator` for a type and
+/// declared nothing, so a consumer running `uf check` could not resolve
+/// `Schema`. See ubugeeei-prod/uf#146.
+///
+/// Type-only imports count: a published package whose types do not resolve
+/// is a package whose types do not resolve.
+///
+/// {@link module_specifiers} is what makes this checkable rather than a
+/// search of the text, and the difference matters here. `packages/vite`
+/// builds application code in a template literal:
+///
+/// ```text
+/// return `import { hydrate } from "@uniflowed/router/client";
+/// ```
+///
+/// `@uniflowed/vite` does not import `@uniflowed/router` — the app it
+/// generates does, and that app declares it. `packages/react` names
+/// `@uniflowed/react` in a comment. A search reports both and is wrong about
+/// both.
+#[test]
+fn every_uniflowed_import_is_declared() {
+    let mut undeclared: Vec<String> = Vec::new();
+
+    for module in shipped_modules() {
+        let Some(package) = module.iter().next() else {
+            continue;
+        };
+        let manifest = manifest(&Utf8PathBuf::from(package).join("package.json"));
+        let name = manifest["name"].as_str().unwrap_or_default();
+        let declared = declared_uniflowed_dependencies(&manifest);
+
+        for specifier in module_specifiers(&read(&module)) {
+            if !specifier.starts_with("@uniflowed/") {
+                continue;
+            }
+            // A package may name itself: `exports` makes that resolve, and
+            // it is how one of its own subpaths is spelled from inside.
+            let target = specifier.split('/').take(2).collect::<Vec<_>>().join("/");
+            if target == name || declared.contains(&target) {
+                continue;
+            }
+            undeclared.push(format!("{name} imports {specifier} in {module}"));
+        }
+    }
+
+    undeclared.sort();
+    undeclared.dedup();
+    assert!(
+        undeclared.is_empty(),
+        "packages import @uniflowed/* they do not declare:\n  {}",
+        undeclared.join("\n  ")
+    );
+}
+
+/// The `@uniflowed/*` names a manifest declares, of any kind.
+fn declared_uniflowed_dependencies(manifest: &Value) -> BTreeSet<String> {
+    let mut declared = BTreeSet::new();
+    for key in ["dependencies", "peerDependencies", "optionalDependencies"] {
+        let Some(Value::Object(map)) = manifest.get(key) else {
+            continue;
+        };
+        declared.extend(
+            map.keys()
+                .filter(|name| name.starts_with("@uniflowed/"))
+                .cloned(),
+        );
+    }
+    declared
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.2"
+    "@uniflowed/react": "0.0.0-alpha.2",
+    "@uniflowed/validator": "0.0.0-alpha.2"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -39,4 +39,5 @@ server
 stylex
 test
 ui
+validator
 vite


### PR DESCRIPTION
Closes #146.

`packages/ui/form/types.js`:

```js
import type { Schema } from "@uniflowed/validator";
```

`packages/ui/package.json` declared `@uniflowed/react` and nothing else, and
`validator` was not on the publish list. So a consumer who installs
`@uniflowed/ui` and runs `uf check` cannot resolve `Schema`.

It is a type import, so nothing fails at runtime and nothing here noticed: the
workspace resolves `@uniflowed/validator` from `packages/`, which a consumer
does not have.

Both halves are fixed — the declaration, and `validator` on the list, which
makes it one more name for #130 to bind.

### The check

`every_uniflowed_import_is_declared`, over every module under `packages/`.

It reuses `module_specifiers`, and that is what makes it checkable rather than
a search of the text. `packages/vite` builds application code inside a template
literal:

```js
return `import { hydrate } from "@uniflowed/router/client";
```

`@uniflowed/vite` does not import `@uniflowed/router` — the app it generates
does, and that app declares it. `packages/react` names `@uniflowed/react` in a
comment. A search reports both and is wrong about both; the scanner keeps a
template literal's delimiters and drops comments, so neither is seen.

One violation in 44 packages, and it is the real one:

```
packages import @uniflowed/* they do not declare:
  @uniflowed/ui imports @uniflowed/validator in ui/form/types.js
```

A package naming itself is allowed: `exports` makes that resolve, and it is how
one of its own subpaths is spelled from inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791206204&installation_model_id=422833&pr_number=150&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F150&signature=a5037dc7d46fe70364aac49c0cb4d3fbfb24cb3c3f41916f5c9fd1e03bf9aff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->