### PR TITLE
fix(fmt): an interface's `extends` keeps its first target

### DIFF
--- a/crates/uf_fmt/src/flow/print/types.rs
+++ b/crates/uf_fmt/src/flow/print/types.rs
@@ -276,14 +276,20 @@ impl<'a> Printer<'a> {
                 // An `interface { … }` type has no name, so the only thing
                 // that can make its heritage start a line is having more
                 // than one target.
-                let group_mode = inner.extends.len() > 1;
-                let extends = self.print_interface_extends_list(&inner.extends, key, group_mode);
+                let extends = self.print_interface_extends_list(&inner.extends, key);
                 let body = self.print_object_type(
                     &inner.body.1,
                     NodeRef::ObjectType(&inner.body.0, &inner.body.1),
                     true,
                 );
-                self.concat([self.s("interface"), extends, self.s(" "), body])
+                // An `interface { … }` type has no name to hang a comment
+                // on, so heritage is the only thing that can make it group.
+                let head = if inner.extends.is_empty() {
+                    self.s("interface")
+                } else {
+                    self.group(self.indent(self.concat([self.s("interface"), extends])))
+                };
+                self.concat([head, self.s(" "), body])
             }
             T::Array { inner, .. } => {
                 let argument = self.print_type(&inner.argument);
@@ -1223,23 +1229,24 @@ impl<'a> Printer<'a> {
         parts.push(self.s(" "));
         parts.push(id);
         parts.push(self.print_optional_type_params(interface.tparams.as_ref()));
-        let group_mode = self.has_comment_placed(
-            NodeRef::Identifier(&interface.id).key(),
-            Placement::Trailing,
-        ) || interface.extends.len() > 1
-            || interface.extends.first().is_some_and(|(_, generic)| {
-                matches!(generic.id, types::generic::Identifier::Qualified(_))
-                    && generic.targs.is_none()
-            });
-        let extends = self.print_interface_extends_list(&interface.extends, key, group_mode);
-        if group_mode && !interface.extends.is_empty() {
-            let id = self.docs.group_id();
+        // Any heritage at all, or a trailing comment on the name. That is
+        // the hermes plugin's condition, and the hermes plugin is what every
+        // expectation in `tests/fixtures` is generated with — Prettier's own
+        // estree printer answers this differently, and the two disagree
+        // about a long `extends` list. See ubugeeei-prod/uf#143.
+        let group_mode = !interface.extends.is_empty()
+            || self.has_comment_placed(
+                NodeRef::Identifier(&interface.id).key(),
+                Placement::Trailing,
+            );
+        let extends = self.print_interface_extends_list(&interface.extends, key);
+        if group_mode {
             let head = self.docs.concat_vec(std::mem::take(&mut parts));
-            parts.push(self.docs.group_with(
-                self.concat([head, self.indent(extends)]),
-                false,
-                Some(id),
-            ));
+            // The head is indented *with* the clause rather than beside it.
+            // `interface Several` stays whole — the space after `interface`
+            // is a space and not a line — and what the indent reaches is the
+            // line before `extends`.
+            parts.push(self.group(self.indent(self.concat([head, extends]))));
         } else {
             parts.push(extends);
         }
@@ -1254,16 +1261,19 @@ impl<'a> Printer<'a> {
 
     /// ` extends A, B`, or nothing.
     ///
-    /// `group_mode` is Prettier's `shouldPrintHeritageClauses`, and it is
-    /// what decides whether the clause can start a new line. With it, a
-    /// single target is `line` then a group; without it, a literal space —
-    /// a line outside a group always breaks, so the two cases are not the
-    /// same doc with a different verdict.
+    /// One target and several are the same doc but for where the indent
+    /// goes: `extends ` keeps its first target, and only the ones after it
+    /// are indented under it.
+    ///
+    /// ```text
+    /// interface Several
+    ///   extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+    ///     BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB {
+    /// ```
     fn print_interface_extends_list(
         &mut self,
         extends: &'a [(Loc, types::Generic<Loc, Loc>)],
         key: NodeKey,
-        group_mode: bool,
     ) -> Doc<'a> {
         if extends.is_empty() {
             return self.s("");
@@ -1275,27 +1285,22 @@ impl<'a> Printer<'a> {
         let dangling =
             self.print_dangling_comments(key, crate::flow::comments::Marker::Extends, false);
         let separator = self.concat([self.s(","), &LINE]);
-        if extends.len() > 1 {
-            let list = self.join(separator, printed);
-            return self.concat([
-                &LINE,
-                dangling.map_or(self.s(""), |dangling| {
-                    self.concat([dangling, &crate::doc::HARDLINE])
-                }),
-                self.s("extends"),
-                self.group(self.indent(self.concat([&LINE, list]))),
-            ]);
-        }
         let list = self.join(separator, printed);
-        let clause = self.concat([self.s("extends "), dangling.unwrap_or(self.s("")), list]);
-        if group_mode {
-            // A line, so a trailing line comment on the interface name has
-            // one to end. Without this the comment was a line suffix with no
-            // line before the body, and it came out after the `{` — five
-            // levels from where it was written. See ubugeeei-prod/uf#135.
-            return self.concat([&LINE, self.group(clause)]);
-        }
-        self.concat([self.s(" "), clause])
+        let targets = if extends.len() > 1 {
+            self.indent(list)
+        } else {
+            list
+        };
+        // A line rather than a space, so a trailing line comment on the name
+        // has one to end. Without it the comment was a line suffix with
+        // nothing before the body to flush at, and it came out after the `{`
+        // — five levels from where it was written. See ubugeeei-prod/uf#135.
+        self.concat([
+            &LINE,
+            dangling.unwrap_or(self.s("")),
+            self.s("extends "),
+            targets,
+        ])
     }
 
     /// One `extends` target of an interface or declared class.

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
@@ -31,12 +31,28 @@ interface Quiet extends Base {
 }
 
 // More than one target is the other thing that makes the heritage start a
-// line. A long one is not here: uf and the hermes plugin disagree about
-// whether the first target joins `extends`, which is ubugeeei-prod/uf#143
-// and nothing to do with comments.
+// line. `extends ` keeps its first target and the rest indent under it.
 interface Several extends Base, Other {
   m(): boolean;
 }
+
+interface SeveralLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
+    CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC {
+  m(): boolean;
+}
+
+interface OneLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {
+  m(): boolean;
+}
+
+// An `interface { … }` *type* groups on its heritage too, having no name to
+// hang a comment on. Its members are not in this fixture: uf separates them
+// with `;` where the hermes plugin uses `,`, which is ubugeeei-prod/uf#151
+// and nothing to do with heritage.
+type Anonymous = interface extends Base {};
 
 declare class Declared // why
   extends Base

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.js
@@ -31,12 +31,28 @@ interface Quiet extends Base {
 }
 
 // More than one target is the other thing that makes the heritage start a
-// line. A long one is not here: uf and the hermes plugin disagree about
-// whether the first target joins `extends`, which is ubugeeei-prod/uf#143
-// and nothing to do with comments.
+// line. `extends ` keeps its first target and the rest indent under it.
 interface Several extends Base, Other {
   m(): boolean;
 }
+
+interface SeveralLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
+    CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC {
+  m(): boolean;
+}
+
+interface OneLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {
+  m(): boolean;
+}
+
+// An `interface { … }` *type* groups on its heritage too, having no name to
+// hang a comment on. Its members are not in this fixture: uf separates them
+// with `;` where the hermes plugin uses `,`, which is ubugeeei-prod/uf#151
+// and nothing to do with heritage.
+type Anonymous = interface extends Base {};
 
 declare class Declared // why
   extends Base {


### PR DESCRIPTION
Closes #143. **Stacked on #144** — the diff shows both until that merges.

```js
interface Several
  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
    CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC {
```

is what `prettier --parser hermes --plugin prettier-plugin-hermes-parser`
returns for that input. uf put `extends` on a line of its own and the first
target under it.

### Both are Prettier

`prettier --parser flow` agrees with uf. The hermes plugin has its own
`printInterface` that does not: it keeps `"extends "` with its first target and
indents only the ones after it, and it groups on *any* heritage where the
estree printer asks for more than one target or a trailing comment.

The plugin is the one that counts here. `crates/uf_fmt/tests/fixtures.rs` says
every expectation in that directory is generated with it, so it is what
"Prettier compatible" is measured against in this crate.

### The change

The clause is one doc for both counts, differing only in where the indent goes,
and `group_mode` becomes the plugin's condition. The head moves inside the
indent with it — `interface Several` stays whole because the space after
`interface` is a space and not a line, and what the indent reaches is the line
before `extends`.

An `interface { … }` *type* has no name to hang a comment on, so heritage is
the only thing that can make it group; it goes through the same clause now.

### Tests

`heritage_comments.js` gets the long cases back — they were removed with a
comment pointing at this issue — and gains a single long target and an
anonymous interface type. Byte-identical to the plugin.

Not in it: that anonymous type's *members*. uf separates them with `;` where
the plugin uses `,`, which is #151 and nothing to do with heritage. The case is
there with an empty body so the separator is not silently wrong.

```
upstream corpus: 8110 formatted, 10 unparseable, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791206599&installation_model_id=422833&pr_number=152&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F152&signature=b15d49f2f034d97737a0d4edb7e3295d118058a688d02ae715790f2a0d503c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->