### PR TITLE
fix(fmt): a comment after a class's type parameters ends its line too

### DIFF
--- a/crates/uf_fmt/src/flow/print/class.rs
+++ b/crates/uf_fmt/src/flow/print/class.rs
@@ -613,11 +613,19 @@ impl<'a> Printer<'a> {
             ]));
         }
         // More than one clause needs the group to lay them out. So does a
-        // trailing comment on the class name, for a different reason: a line
-        // comment ends the line it is on, and without a group there is no
-        // line before `extends` for it to end. See ubugeeei-prod/uf#135.
+        // trailing comment on the class name — or on its type parameters,
+        // which is the same comment one token later — for a different
+        // reason: a line comment ends the line it is on, and without a group
+        // there is no line before `extends` for it to end. See
+        // ubugeeei-prod/uf#135.
+        let trailing_comment_on =
+            |node: NodeRef<'a>| self.has_comment_placed(node.key(), Placement::Trailing);
         let group_mode = heritage.len() > 1
-            || self.has_comment_placed(NodeRef::Identifier(&class.id).key(), Placement::Trailing);
+            || trailing_comment_on(NodeRef::Identifier(&class.id))
+            || class
+                .tparams
+                .as_ref()
+                .is_some_and(|tparams| trailing_comment_on(NodeRef::TypeParams(tparams)));
         if group_mode {
             let clauses: Vec<Doc<'a>> = heritage
                 .into_iter()

--- a/crates/uf_fmt/src/flow/print/types.rs
+++ b/crates/uf_fmt/src/flow/print/types.rs
@@ -277,10 +277,14 @@ impl<'a> Printer<'a> {
                 // that can make its heritage start a line is having more
                 // than one target.
                 let extends = self.print_interface_extends_list(&inner.extends, key);
+                // An object type, not an interface body. `interface { … }` in
+                // a type position separates its members with `,` and stays on
+                // one line when it fits; the `;` and the line per member
+                // belong to the *declaration*. See ubugeeei-prod/uf#151.
                 let body = self.print_object_type(
                     &inner.body.1,
                     NodeRef::ObjectType(&inner.body.0, &inner.body.1),
-                    true,
+                    false,
                 );
                 // An `interface { … }` type has no name to hang a comment
                 // on, so heritage is the only thing that can make it group.

--- a/crates/uf_fmt/src/flow/print/types.rs
+++ b/crates/uf_fmt/src/flow/print/types.rs
@@ -276,14 +276,20 @@ impl<'a> Printer<'a> {
                 // An `interface { … }` type has no name, so the only thing
                 // that can make its heritage start a line is having more
                 // than one target.
-                let group_mode = inner.extends.len() > 1;
-                let extends = self.print_interface_extends_list(&inner.extends, key, group_mode);
+                let extends = self.print_interface_extends_list(&inner.extends, key);
                 let body = self.print_object_type(
                     &inner.body.1,
                     NodeRef::ObjectType(&inner.body.0, &inner.body.1),
                     true,
                 );
-                self.concat([self.s("interface"), extends, self.s(" "), body])
+                // An `interface { … }` type has no name to hang a comment
+                // on, so heritage is the only thing that can make it group.
+                let head = if inner.extends.is_empty() {
+                    self.s("interface")
+                } else {
+                    self.group(self.indent(self.concat([self.s("interface"), extends])))
+                };
+                self.concat([head, self.s(" "), body])
             }
             T::Array { inner, .. } => {
                 let argument = self.print_type(&inner.argument);
@@ -1223,23 +1229,24 @@ impl<'a> Printer<'a> {
         parts.push(self.s(" "));
         parts.push(id);
         parts.push(self.print_optional_type_params(interface.tparams.as_ref()));
-        let group_mode = self.has_comment_placed(
-            NodeRef::Identifier(&interface.id).key(),
-            Placement::Trailing,
-        ) || interface.extends.len() > 1
-            || interface.extends.first().is_some_and(|(_, generic)| {
-                matches!(generic.id, types::generic::Identifier::Qualified(_))
-                    && generic.targs.is_none()
-            });
-        let extends = self.print_interface_extends_list(&interface.extends, key, group_mode);
-        if group_mode && !interface.extends.is_empty() {
-            let id = self.docs.group_id();
+        // Any heritage at all, or a trailing comment on the name. That is
+        // the hermes plugin's condition, and the hermes plugin is what every
+        // expectation in `tests/fixtures` is generated with — Prettier's own
+        // estree printer answers this differently, and the two disagree
+        // about a long `extends` list. See ubugeeei-prod/uf#143.
+        let group_mode = !interface.extends.is_empty()
+            || self.has_comment_placed(
+                NodeRef::Identifier(&interface.id).key(),
+                Placement::Trailing,
+            );
+        let extends = self.print_interface_extends_list(&interface.extends, key);
+        if group_mode {
             let head = self.docs.concat_vec(std::mem::take(&mut parts));
-            parts.push(self.docs.group_with(
-                self.concat([head, self.indent(extends)]),
-                false,
-                Some(id),
-            ));
+            // The head is indented *with* the clause rather than beside it.
+            // `interface Several` stays whole — the space after `interface`
+            // is a space and not a line — and what the indent reaches is the
+            // line before `extends`.
+            parts.push(self.group(self.indent(self.concat([head, extends]))));
         } else {
             parts.push(extends);
         }
@@ -1254,16 +1261,19 @@ impl<'a> Printer<'a> {
 
     /// ` extends A, B`, or nothing.
     ///
-    /// `group_mode` is Prettier's `shouldPrintHeritageClauses`, and it is
-    /// what decides whether the clause can start a new line. With it, a
-    /// single target is `line` then a group; without it, a literal space —
-    /// a line outside a group always breaks, so the two cases are not the
-    /// same doc with a different verdict.
+    /// One target and several are the same doc but for where the indent
+    /// goes: `extends ` keeps its first target, and only the ones after it
+    /// are indented under it.
+    ///
+    /// ```text
+    /// interface Several
+    ///   extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+    ///     BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB {
+    /// ```
     fn print_interface_extends_list(
         &mut self,
         extends: &'a [(Loc, types::Generic<Loc, Loc>)],
         key: NodeKey,
-        group_mode: bool,
     ) -> Doc<'a> {
         if extends.is_empty() {
             return self.s("");
@@ -1275,27 +1285,22 @@ impl<'a> Printer<'a> {
         let dangling =
             self.print_dangling_comments(key, crate::flow::comments::Marker::Extends, false);
         let separator = self.concat([self.s(","), &LINE]);
-        if extends.len() > 1 {
-            let list = self.join(separator, printed);
-            return self.concat([
-                &LINE,
-                dangling.map_or(self.s(""), |dangling| {
-                    self.concat([dangling, &crate::doc::HARDLINE])
-                }),
-                self.s("extends"),
-                self.group(self.indent(self.concat([&LINE, list]))),
-            ]);
-        }
         let list = self.join(separator, printed);
-        let clause = self.concat([self.s("extends "), dangling.unwrap_or(self.s("")), list]);
-        if group_mode {
-            // A line, so a trailing line comment on the interface name has
-            // one to end. Without this the comment was a line suffix with no
-            // line before the body, and it came out after the `{` — five
-            // levels from where it was written. See ubugeeei-prod/uf#135.
-            return self.concat([&LINE, self.group(clause)]);
-        }
-        self.concat([self.s(" "), clause])
+        let targets = if extends.len() > 1 {
+            self.indent(list)
+        } else {
+            list
+        };
+        // A line rather than a space, so a trailing line comment on the name
+        // has one to end. Without it the comment was a line suffix with
+        // nothing before the body to flush at, and it came out after the `{`
+        // — five levels from where it was written. See ubugeeei-prod/uf#135.
+        self.concat([
+            &LINE,
+            dangling.unwrap_or(self.s("")),
+            self.s("extends "),
+            targets,
+        ])
     }
 
     /// One `extends` target of an interface or declared class.

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
@@ -31,12 +31,28 @@ interface Quiet extends Base {
 }
 
 // More than one target is the other thing that makes the heritage start a
-// line. A long one is not here: uf and the hermes plugin disagree about
-// whether the first target joins `extends`, which is ubugeeei-prod/uf#143
-// and nothing to do with comments.
+// line. `extends ` keeps its first target and the rest indent under it.
 interface Several extends Base, Other {
   m(): boolean;
 }
+
+interface SeveralLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
+    CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC {
+  m(): boolean;
+}
+
+interface OneLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {
+  m(): boolean;
+}
+
+// An `interface { … }` *type* groups on its heritage too, having no name to
+// hang a comment on. Its members are not in this fixture: uf separates them
+// with `;` where the hermes plugin uses `,`, which is ubugeeei-prod/uf#151
+// and nothing to do with heritage.
+type Anonymous = interface extends Base {};
 
 declare class Declared // why
   extends Base

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
@@ -74,6 +74,19 @@ declare class DeclaredQuiet extends Base {
   m(): boolean;
 }
 
+// The comment is one token later here, on the type parameters rather than on
+// the name, and it has the same line to end.
+declare class DeclaredGeneric<T> // why
+  extends Base<T>
+{
+  m(): boolean;
+}
+
+interface Generic<T> // why
+  extends Base<T> {
+  m(): boolean;
+}
+
 declare class DeclaredMixed // why
   extends Base
   mixins Mixin

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.expected.js
@@ -49,10 +49,20 @@ interface OneLong
 }
 
 // An `interface { … }` *type* groups on its heritage too, having no name to
-// hang a comment on. Its members are not in this fixture: uf separates them
-// with `;` where the hermes plugin uses `,`, which is ubugeeei-prod/uf#151
-// and nothing to do with heritage.
-type Anonymous = interface extends Base {};
+// hang a comment on. Its body is an object type: `,` between members, and one
+// line when it fits. The `;` and the line per member belong to the
+// declaration forms below it.
+type Anonymous = interface extends Base { m(): boolean };
+type Members = interface { a: string, b: number };
+type Empty = interface {};
+type Wide = interface extends Base {
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: string,
+  bbbbbbbbbbbbbbbbbbbbbb: number,
+};
+
+declare interface Declared {
+  m(): boolean;
+}
 
 declare class Declared // why
   extends Base

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.js
@@ -70,6 +70,18 @@ declare class DeclaredQuiet extends Base {
   m(): boolean;
 }
 
+// The comment is one token later here, on the type parameters rather than on
+// the name, and it has the same line to end.
+declare class DeclaredGeneric<T> // why
+  extends Base<T> {
+  m(): boolean;
+}
+
+interface Generic<T> // why
+  extends Base<T> {
+  m(): boolean;
+}
+
 declare class DeclaredMixed // why
   extends Base mixins Mixin {
   m(): boolean;

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.js
@@ -49,10 +49,17 @@ interface OneLong
 }
 
 // An `interface { … }` *type* groups on its heritage too, having no name to
-// hang a comment on. Its members are not in this fixture: uf separates them
-// with `;` where the hermes plugin uses `,`, which is ubugeeei-prod/uf#151
-// and nothing to do with heritage.
-type Anonymous = interface extends Base {};
+// hang a comment on. Its body is an object type: `,` between members, and one
+// line when it fits. The `;` and the line per member belong to the
+// declaration forms below it.
+type Anonymous = interface extends Base { m(): boolean };
+type Members = interface { a: string, b: number };
+type Empty = interface {};
+type Wide = interface extends Base { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: string, bbbbbbbbbbbbbbbbbbbbbb: number };
+
+declare interface Declared {
+  m(): boolean;
+}
 
 declare class Declared // why
   extends Base {

--- a/crates/uf_fmt/tests/fixtures/heritage_comments.js
+++ b/crates/uf_fmt/tests/fixtures/heritage_comments.js
@@ -31,12 +31,28 @@ interface Quiet extends Base {
 }
 
 // More than one target is the other thing that makes the heritage start a
-// line. A long one is not here: uf and the hermes plugin disagree about
-// whether the first target joins `extends`, which is ubugeeei-prod/uf#143
-// and nothing to do with comments.
+// line. `extends ` keeps its first target and the rest indent under it.
 interface Several extends Base, Other {
   m(): boolean;
 }
+
+interface SeveralLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
+    CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC {
+  m(): boolean;
+}
+
+interface OneLong
+  extends AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {
+  m(): boolean;
+}
+
+// An `interface { … }` *type* groups on its heritage too, having no name to
+// hang a comment on. Its members are not in this fixture: uf separates them
+// with `;` where the hermes plugin uses `,`, which is ubugeeei-prod/uf#151
+// and nothing to do with heritage.
+type Anonymous = interface extends Base {};
 
 declare class Declared // why
   extends Base {


### PR DESCRIPTION
```js
declare class B<T> // why
  extends Base<T>
```

came back as `declare class B<T> extends Base<T> { // why`.

The comment is the same comment #144 fixed, one token later — on the type
parameters rather than on the name — and `group_mode` only asked about the
name. Found by CodeRabbit on #144.

The interface half needs nothing: #152 replaced that condition with the hermes
plugin's, which groups on any heritage at all, so `interface A<T> // why` was
already right. The fixture covers both anyway, because the two printers have
drifted apart before.

**Stacked on #153** — the diff shows the whole stack until those merge.

```
upstream corpus: 8110 formatted, 10 unparseable, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791208516&installation_model_id=422833&pr_number=156&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F156&signature=782592433b72fb91a10dcf6be3318daadc529b70d4a16f4a22640a39ce55b5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of class and interface heritage clauses when comments appear after names or type parameters.
  * Updated line wrapping and indentation for single- and multiple-target `extends` clauses.
  * Improved formatting for anonymous and declared interfaces, including empty and member-bearing forms.

* **Tests**
  * Added coverage for long heritage clauses, multiple targets, dangling comments, anonymous interfaces, and generic declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->