### PR TITLE
fix(doc): document a source at the parser's ceiling without aborting

### DIFF
--- a/crates/uf_doc/src/lib.rs
+++ b/crates/uf_doc/src/lib.rs
@@ -169,6 +169,34 @@ pub enum DocError {
 /// so callers can render them before failing the command.
 pub fn generate(root: &Utf8Path, config: &UniflowedConfig) -> Result<DocReport, DocError> {
     let scan = scan_source_files(root, config)?;
+
+    // On a thread with the stack the parser documents for its ceilings, the
+    // way `uf_fmt` does. Reading a tree recurses once per level and so does
+    // *freeing* it, and the free happens wherever the `Parsed` is held — a
+    // main thread's 8 MiB is not enough for a source at `MAX_CHAIN_DEPTH`,
+    // which `uf fmt` formats without complaint. See ubugeeei-prod/uf#155.
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .name("uf-doc".into())
+            .stack_size(uf_flow::PARSE_STACK_BYTES)
+            .spawn_scoped(scope, || document(scan))
+            .map_err(|source| DocError::Write {
+                path: root.to_path_buf(),
+                source,
+            })?
+            .join()
+            .unwrap_or_else(|_| {
+                Err(DocError::Write {
+                    path: root.to_path_buf(),
+                    source: std::io::Error::other("the documentation worker panicked"),
+                })
+            })
+    })
+}
+
+/// Every documented export in `scan`, with the syntax diagnostics found on
+/// the way and the files that could not be read.
+fn document(scan: uf_project::SourceScan) -> Result<DocReport, DocError> {
     let mut report = DocReport {
         unreadable: scan
             .unreadable
@@ -896,6 +924,36 @@ mod tests {
 
     use super::*;
     use similar_asserts::assert_eq;
+
+    /// A source at the parser's ceiling does not abort the process.
+    ///
+    /// ubugeeei-prod/uf#155. Reading a tree recurses once per level and so
+    /// does freeing it, and the free happens wherever the `Parsed` is held.
+    /// `generate` ran on its caller's thread, so a member-call chain at
+    /// `MAX_CHAIN_DEPTH` — a source `uf fmt` formats without complaint —
+    /// overflowed a main thread's 8 MiB and took the process with it.
+    ///
+    /// This test runs on a *test* thread, 2 MiB, which is smaller still: if
+    /// the work ever moves back onto the caller's stack it fails here first.
+    #[test]
+    fn a_source_at_the_parsers_ceiling_is_documented() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(dir.path()).unwrap();
+        fs::create_dir(root.join("src")).unwrap();
+        // Two chain levels per link — a member and a call — and one more for
+        // the `=`, so this is the deepest source the parser accepts.
+        let chain = ".f()".repeat(uf_flow::MAX_CHAIN_DEPTH / 2 - 1);
+        fs::write(
+            root.join("src/deep.js"),
+            format!("// @flow\n\n/** Deep. */\nexport const deep = a{chain};\n"),
+        )
+        .unwrap();
+
+        let report = generate(root, &UniflowedConfig::default()).unwrap();
+
+        assert_eq!(report.diagnostics, Vec::new());
+        assert_eq!(report.files_scanned, 1);
+    }
 
     #[test]
     fn documents_exported_flow_declarations() {

--- a/crates/uf_doc/src/lib.rs
+++ b/crates/uf_doc/src/lib.rs
@@ -160,6 +160,16 @@ pub enum DocError {
         #[source]
         source: std::io::Error,
     },
+    /// The thread the work runs on could not be started, or did not finish.
+    ///
+    /// Separate from [`DocError::Write`] because nothing was being written:
+    /// reporting "failed to write /some/project" for a thread that would not
+    /// spawn sends whoever reads it to look at a disk that is fine.
+    #[error("the documentation worker {reason}")]
+    Worker {
+        /// What happened to it, as a phrase that finishes the sentence.
+        reason: &'static str,
+    },
 }
 
 /// Generate a documentation report from the project source files.
@@ -180,17 +190,11 @@ pub fn generate(root: &Utf8Path, config: &UniflowedConfig) -> Result<DocReport, 
             .name("uf-doc".into())
             .stack_size(uf_flow::PARSE_STACK_BYTES)
             .spawn_scoped(scope, || document(scan))
-            .map_err(|source| DocError::Write {
-                path: root.to_path_buf(),
-                source,
+            .map_err(|_| DocError::Worker {
+                reason: "could not be started",
             })?
             .join()
-            .unwrap_or_else(|_| {
-                Err(DocError::Write {
-                    path: root.to_path_buf(),
-                    source: std::io::Error::other("the documentation worker panicked"),
-                })
-            })
+            .unwrap_or(Err(DocError::Worker { reason: "panicked" }))
     })
 }
 
@@ -940,14 +944,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = Utf8Path::from_path(dir.path()).unwrap();
         fs::create_dir(root.join("src")).unwrap();
-        // Two chain levels per link — a member and a call — and one more for
-        // the `=`, so this is the deepest source the parser accepts.
-        let chain = ".f()".repeat(uf_flow::MAX_CHAIN_DEPTH / 2 - 1);
-        fs::write(
-            root.join("src/deep.js"),
-            format!("// @flow\n\n/** Deep. */\nexport const deep = a{chain};\n"),
-        )
-        .unwrap();
+        // Two chain levels per link — a member and a call — so `.f()` alone
+        // can only land on an even count. The trailing `.g` is the odd level
+        // that puts this exactly on the ceiling rather than one under it.
+        let chain = format!(
+            "{}{}",
+            ".f()".repeat(uf_flow::MAX_CHAIN_DEPTH / 2 - 1),
+            ".g"
+        );
+        let source = format!("// @flow\n\n/** Deep. */\nexport const deep = a{chain};\n");
+        assert_eq!(
+            uf_flow::depths(&source).chain,
+            uf_flow::MAX_CHAIN_DEPTH,
+            "the fixture has to sit on the ceiling, not near it"
+        );
+        fs::write(root.join("src/deep.js"), source).unwrap();
 
         let report = generate(root, &UniflowedConfig::default()).unwrap();
 

--- a/crates/uf_flow/src/parse.rs
+++ b/crates/uf_flow/src/parse.rs
@@ -199,9 +199,16 @@ pub enum ParseFailure {
 
 /// Parse `source` with the official Flow port and return its syntax tree.
 ///
-/// Run it on a thread with [`PARSE_STACK_BYTES`] of stack: the port recurses
-/// once per level of nesting, and [`MAX_NESTING_DEPTH`] levels do not fit in
-/// a default thread.
+/// # Call this from a thread with [`PARSE_STACK_BYTES`] of stack
+///
+/// Not because parsing needs it — this spawns its own thread for that — but
+/// because *everything the caller then does with the tree* needs it. Reading
+/// it recurses once per level, and so does freeing it, and the free happens
+/// wherever the [`Parsed`] is held. A main thread's 8 MiB is not enough for a
+/// source at [`MAX_CHAIN_DEPTH`], which is inside every limit here.
+///
+/// `uf_fmt` and `uf_doc` both do this. See ubugeeei-prod/uf#155 for the
+/// structural fix that would make it unnecessary.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
Part of #155.

`uf doc` over a file that `uf fmt` formats without complaint takes the process
with it:

```js
export const deep = a.f().f()… ;   // 5,000 links, inside every limit
```

```
fatal runtime error: stack overflow, aborting
```

Reading a tree recurses once per level. So does *freeing* it, and the free
happens wherever the `Parsed` is held — which was `generate`'s caller, the main
thread, 8 MiB. `uf_flow::parse` spawns its own thread to build the tree and
hands it back; the stack it needed does not come with it.

`uf_fmt` has always done this correctly and says why. `uf_doc` now does the
same: the file loop runs on a thread of `PARSE_STACK_BYTES`.

### The test

It runs on an ordinary *test* thread — 2 MiB, smaller than the main thread this
was failing on — so if the work ever moves back onto the caller's stack it
fails there first.

### Why #155 stays open

`parse`'s documentation says the requirement outright now, but it is still a
contract the next caller has to remember, and this is the second caller in two
that got it wrong. The structural fix is for the tree to be freed where it was
built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791209603&installation_model_id=422833&pr_number=161&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F161&signature=de0f7298387055347ec5185e09ccb9e1fe9bf7294aca16ef522a12b5651e13a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Documentation generation now handles deeply nested source files more reliably, preventing process termination at parser depth limits.
  - Errors from documentation processing are reported cleanly instead of causing unexpected worker failures.

- **Documentation**
  - Updated parser guidance to clarify safe handling of deeply nested parsed content and stack requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->