### PR TITLE
fix(test): the test runner brings the loader it is started with

### DIFF
--- a/crates/uf_lib/tests/package_surface.rs
+++ b/crates/uf_lib/tests/package_surface.rs
@@ -1318,3 +1318,45 @@ fn declared_uniflowed_dependencies(manifest: &Value) -> BTreeSet<String> {
     }
     declared
 }
+
+/// A package uf loads into the host on another's behalf is a dependency of
+/// the package that needs it.
+///
+/// [`every_uniflowed_import_is_declared`] reads `import` statements, and this
+/// dependency is not written as one. `uf test` starts the Capability JS Host
+/// with `--import @uniflowed/host/register` (`--preload` on Bun): the loader
+/// reaches the process as a command-line argument that
+/// `crates/uf_cli/src/commands/test.rs` builds, resolved out of the project's
+/// own `node_modules`, and no module under `packages/test` mentions it.
+///
+/// So nothing tied the runner to the loader, and a project that installed
+/// `@uniflowed/test` got a runner that could not run:
+///
+/// ```text
+/// $ uf create app react demo && cd demo && uf install
+/// $ uf test
+/// error: `@uniflowed/host` is not installed for …/demo; add it to the
+/// project's dependencies and run the package manager (`uf install`)
+/// ```
+///
+/// The template is not the place to fix that. A project depends on the test
+/// runner; which loader that runner needs is the runner's business, and
+/// every project that ever declares `@uniflowed/test` would otherwise have to
+/// know to name it too.
+#[test]
+fn a_loader_uf_injects_is_declared_by_the_package_that_needs_it() {
+    // Package -> what `uf` loads into the host for it. One entry today, from
+    // the single `installed_package` call in `commands/test.rs` that is not
+    // the package the user asked for. Add a line when a command grows another.
+    const INJECTED: &[(&str, &str)] = &[("test", "@uniflowed/host")];
+
+    for (package, loader) in INJECTED {
+        let relative = Utf8PathBuf::from(package).join("package.json");
+        let declared = declared_uniflowed_dependencies(&manifest(&relative));
+        assert!(
+            declared.contains(*loader),
+            "uf loads {loader} into the host for @uniflowed/{package}, which does not \
+             declare it — a project that installs the package does not get the loader"
+        );
+    }
+}

--- a/crates/uf_project/src/template.rs
+++ b/crates/uf_project/src/template.rs
@@ -58,6 +58,14 @@ fn app_package_json(name: &str) -> String {
     )
 }
 
+/// The manifest `uf create lib` writes.
+///
+/// It names the test runner and not the loader the runner is started with.
+/// `@uniflowed/test` depends on `@uniflowed/host`, so a project that says it
+/// wants to run tests gets what running them takes; naming the loader here
+/// as well made every scaffolded library carry a dependency it never imports,
+/// and — until the first release that sends `@uniflowed/host` — one that
+/// `uf install` could not resolve at all.
 fn lib_package_json(name: &str) -> String {
     format!(
         r#"{{
@@ -68,7 +76,6 @@ fn lib_package_json(name: &str) -> String {
   }},
   "devDependencies": {{
     "@uniflowed/config": "latest",
-    "@uniflowed/host": "latest",
     "@uniflowed/test": "latest"
   }}
 }}

--- a/crates/uf_project/src/tests.rs
+++ b/crates/uf_project/src/tests.rs
@@ -79,6 +79,12 @@ fn creates_flow_library_template() {
 
     assert!(index.contains("opaque type UniflowedId"));
     assert!(!package.contains(r#""scripts""#));
+
+    // The runner, not the loader it is started with. `@uniflowed/test`
+    // depends on `@uniflowed/host`, so naming the loader here too would put a
+    // package a scaffolded library never imports into its manifest.
+    assert!(package.contains(r#""@uniflowed/test""#));
+    assert!(!package.contains("@uniflowed/host"));
 }
 
 #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -4672,7 +4672,10 @@
     "packages/test": {
       "name": "@uniflowed/test",
       "version": "0.0.0-alpha.2",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@uniflowed/host": "0.0.0-alpha.2"
+      }
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
@@ -4697,7 +4700,8 @@
       "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.2"
+        "@uniflowed/react": "0.0.0-alpha.2",
+        "@uniflowed/validator": "0.0.0-alpha.2"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4742,7 +4746,6 @@
       "version": "0.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.2",
         "@uniflowed/react": "0.0.0-alpha.2"
       }
     }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -19,5 +19,8 @@
     "index.js",
     "worker.js",
     "internal"
-  ]
+  ],
+  "dependencies": {
+    "@uniflowed/host": "0.0.0-alpha.2"
+  }
 }


### PR DESCRIPTION
`uf test` starts a Capability JS Host that cannot read Flow until the loader is
registered — `node --import @uniflowed/host/register …`, built in
[`crates/uf_cli/src/commands/test.rs:169`](https://github.com/ubugeeei-prod/uf/blob/main/crates/uf_cli/src/commands/test.rs#L169)
and resolved out of the project's own `node_modules`.

Nothing recorded that dependency. `@uniflowed/test` declared none at all, and
because the loader reaches the process as a *command-line argument* rather than
an `import`, `every_uniflowed_import_is_declared` could not see it either. A
project that installed the runner got a runner that could not run:

```
$ uf create app react demo && cd demo && npm install
$ uf test
error: `@uniflowed/host` is not installed for …/demo; add it to the project's
dependencies and run the package manager (`uf install`)
```

The app template only ever had the loader by accident, through
`@uniflowed/vite` — and the published `@uniflowed/vite@0.0.0-alpha.1` does not
declare it, so the accident does not hold. The library template named
`@uniflowed/host` directly, which is worse: that name has never reached npm, so
`uf create lib` scaffolded a project whose first `uf install` was an `E404`.

So the edge goes where it belongs: **`@uniflowed/test` depends on
`@uniflowed/host`**, and the library template stops naming a package it never
imports.

### Evidence

Same tarballs built from this tree, same scaffold, one line of difference in the
runner's manifest. The project declares `@uniflowed/config` and
`@uniflowed/test` and nothing else, so npm resolves the loader only if the
runner asks for it:

| | `node_modules/@uniflowed` | `uf test` |
| --- | --- | --- |
| before | `config test` | `error: @uniflowed/host is not installed` |
| after | `config host test` | `✓ 1 passed, 0 failed in 675.8ms` |

### Test

`a_loader_uf_injects_is_declared_by_the_package_that_needs_it`, in
`crates/uf_lib/tests/package_surface.rs`, beside the import-based check it
complements. On the manifest as it is on `main`:

```
uf loads @uniflowed/host into the host for @uniflowed/test, which does not
declare it — a project that installs the package does not get the loader
```

### Also in here

`package-lock.json` picks up two entries that had already drifted from
`packages/ui` and `packages/web`; that is what `npm install --package-lock-only`
produces and hand-keeping them stale would be worse. Nothing checks that the
lockfile matches the workspace manifests — filed separately.

### Not fixed here

`@uniflowed/host` is still not on npm, so `uf test` in a scaffolded project
starts working at the first release that sends it. Five of the seventeen names
in `tools/release/published-packages.txt` are on the registry; the rest are
ubugeeei-prod/uf#130 and ubugeeei-prod/uf#142, and the publish job is blocked on
one `npm login && tools/release/trust-npm.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791213084&installation_model_id=422833&pr_number=168&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F168&signature=28a26d391aca00d9c2b033a2ec4c232ceecb78945393ebca527e28cd31d2c01e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->