### PR TITLE
fix(fmt): an empty block that is not a body keeps its two lines

### DIFF
--- a/crates/uf_fmt/src/flow/print/class.rs
+++ b/crates/uf_fmt/src/flow/print/class.rs
@@ -5,9 +5,9 @@ use uf_flow::Loc;
 use uf_flow::ast::{class, expression, function, statement, types};
 
 use super::Printer;
-use super::statement::EmptyBlock;
 use super::assignment::Rhs;
 use super::parens::is_member;
+use super::statement::EmptyBlock;
 use crate::doc::{Doc, HARDLINE, LINE, SOFTLINE};
 use crate::flow::comments::{Marker, Placement};
 use crate::flow::node::{Class, NodeKey, NodeRef};

--- a/crates/uf_fmt/src/flow/print/class.rs
+++ b/crates/uf_fmt/src/flow/print/class.rs
@@ -5,6 +5,7 @@ use uf_flow::Loc;
 use uf_flow::ast::{class, expression, function, statement, types};
 
 use super::Printer;
+use super::statement::EmptyBlock;
 use super::assignment::Rhs;
 use super::parens::is_member;
 use crate::doc::{Doc, HARDLINE, LINE, SOFTLINE};
@@ -360,7 +361,7 @@ impl<'a> Printer<'a> {
             class::BodyElement::PrivateField(field) => p.print_private_field(field),
             class::BodyElement::StaticBlock(block) => {
                 let key = NodeRef::ClassMember(member).key();
-                let body = p.print_block_body(&block.body, key);
+                let body = p.print_block_body(&block.body, key, EmptyBlock::Collapsed);
                 p.concat([p.s("static "), body])
             }
             class::BodyElement::DeclareMethod(method) => {

--- a/crates/uf_fmt/src/flow/print/function.rs
+++ b/crates/uf_fmt/src/flow/print/function.rs
@@ -11,6 +11,7 @@ use uf_flow::Loc;
 use uf_flow::ast::{expression, function, pattern, statement, types};
 
 use super::Printer;
+use super::statement::EmptyBlock;
 use super::assignment::{Layout, PrintArgs};
 use super::call::{is_test_call, parameter_count};
 use super::parens::{is_binaryish, is_call_like, is_jsx, starts_with_no_lookahead_token};
@@ -82,7 +83,7 @@ impl<'a> Printer<'a> {
         ])));
         match &function.body {
             function::Body::BodyBlock((loc, block)) => {
-                let body = self.print_block(loc, block);
+                let body = self.print_block(loc, block, EmptyBlock::Collapsed);
                 parts.push(self.s(" "));
                 parts.push(body);
             }
@@ -116,7 +117,7 @@ impl<'a> Printer<'a> {
         ];
         match &function.body {
             function::Body::BodyBlock((loc, block)) => {
-                let body = self.print_block(loc, block);
+                let body = self.print_block(loc, block, EmptyBlock::Collapsed);
                 parts.push(self.s(" "));
                 parts.push(body);
             }
@@ -562,7 +563,7 @@ impl<'a> Printer<'a> {
                     break (printed, ArrowBody::Expression(body));
                 }
                 function::Body::BodyBlock((loc, block)) => {
-                    let printed = self.print_block(loc, block);
+                    let printed = self.print_block(loc, block, EmptyBlock::Collapsed);
                     break (printed, ArrowBody::Block);
                 }
             }
@@ -805,7 +806,7 @@ impl<'a> Printer<'a> {
         let renders = self.print_renders_annotation(&component.renders);
         parts.push(self.group(self.concat([parameters, renders])));
         if let Some((loc, body)) = &component.body {
-            let body = self.print_block(loc, body);
+            let body = self.print_block(loc, body, EmptyBlock::Collapsed);
             parts.push(self.s(" "));
             parts.push(body);
         }

--- a/crates/uf_fmt/src/flow/print/function.rs
+++ b/crates/uf_fmt/src/flow/print/function.rs
@@ -11,10 +11,10 @@ use uf_flow::Loc;
 use uf_flow::ast::{expression, function, pattern, statement, types};
 
 use super::Printer;
-use super::statement::EmptyBlock;
 use super::assignment::{Layout, PrintArgs};
 use super::call::{is_test_call, parameter_count};
 use super::parens::{is_binaryish, is_call_like, is_jsx, starts_with_no_lookahead_token};
+use super::statement::EmptyBlock;
 use crate::doc::{Doc, HARDLINE, LINE, SOFTLINE, will_break};
 use crate::flow::comments::Marker;
 use crate::flow::node::{Expression, Function, NodeKey, NodeRef};

--- a/crates/uf_fmt/src/flow/print/module.rs
+++ b/crates/uf_fmt/src/flow/print/module.rs
@@ -4,6 +4,7 @@ use uf_flow::Loc;
 use uf_flow::ast::statement;
 
 use super::Printer;
+use super::statement::EmptyBlock;
 use crate::doc::{Doc, HARDLINE, LINE, SOFTLINE};
 use crate::flow::comments::{Marker, Placement};
 use crate::flow::node::{NodeKey, NodeRef};
@@ -503,7 +504,7 @@ impl<'a> Printer<'a> {
                 self.print_string_node(loc, literal)
             }
         };
-        let body = self.print_block(&module.body.0, &module.body.1);
+        let body = self.print_block(&module.body.0, &module.body.1, EmptyBlock::Open);
         self.concat([self.s("declare module "), id, self.s(" "), body])
     }
 
@@ -520,7 +521,7 @@ impl<'a> Printer<'a> {
             statement::declare_namespace::Id::Global(id)
             | statement::declare_namespace::Id::Local(id) => self.print_identifier(id),
         };
-        let body = self.print_block(&namespace.body.0, &namespace.body.1);
+        let body = self.print_block(&namespace.body.0, &namespace.body.1, EmptyBlock::Open);
         let declare = if namespace.implicit_declare {
             self.s("")
         } else {

--- a/crates/uf_fmt/src/flow/print/statement.rs
+++ b/crates/uf_fmt/src/flow/print/statement.rs
@@ -4,6 +4,34 @@ use uf_flow::Loc;
 use uf_flow::ast::{expression, statement};
 
 use super::Printer;
+
+/// What an empty block prints as.
+///
+/// Prettier decides this from the parent, and the split is between a body
+/// that is *expected* to be empty sometimes and a block whose emptiness is
+/// worth seeing on its own line:
+///
+/// ```js
+/// function noop() {}          // a body that does nothing, said in one line
+/// while (poll()) {}           // a loop whose work is the condition
+/// try {
+/// } catch (error) {}          // the `try` is empty by accident
+/// ```
+///
+/// Which is not a matter of taste: `if (a) {}` reads as a mistake and
+/// `if (a) {\n}` reads as a hole somebody left, and the second is what the
+/// author wrote.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum EmptyBlock {
+    /// `{}` — function, method, arrow, component and static bodies, and the
+    /// bodies of `for (;;)`, `while` and `do … while`. A `catch` too, unless
+    /// the statement also has a `finally`.
+    Collapsed,
+    /// `{` and `}` on two lines — `if`, `else`, `try`, `finally`, `with`,
+    /// `for … in`, `for … of`, a labelled block, a `case` block, a block on
+    /// its own, and a `declare module` or `declare namespace` body.
+    Open,
+}
 use crate::doc::{BREAK_PARENT, Doc, HARDLINE, LINE, SOFTLINE};
 use crate::flow::comments::{Marker, Placement};
 use crate::flow::node::{Expression, NodeRef, Statement};
@@ -39,7 +67,10 @@ impl<'a> Printer<'a> {
         use statement::StatementInner as S;
         let key = NodeRef::Statement(statement).key();
         match &**statement {
-            S::Block { inner, .. } => self.print_block_body(&inner.body, key),
+            S::Block { inner, .. } => {
+                let empty = self.empty_block_of_statement();
+                self.print_block_body(&inner.body, key, empty)
+            }
             S::Break { inner, .. } => {
                 let label = match &inner.label {
                     Some(label) => {
@@ -241,13 +272,13 @@ impl<'a> Printer<'a> {
             }
             S::Switch { inner, .. } => self.print_switch(inner),
             S::Try { inner, .. } => {
-                let block = self.print_block(&inner.block.0, &inner.block.1);
+                let block = self.print_block(&inner.block.0, &inner.block.1, EmptyBlock::Open);
                 let handler = inner.handler.as_ref().map(|handler| {
-                    let printed = self.print_catch_clause(handler);
+                    let printed = self.print_catch_clause(handler, inner.finalizer.is_some());
                     self.concat([self.s(" "), printed])
                 });
                 let finalizer = inner.finalizer.as_ref().map(|(loc, block)| {
-                    let printed = self.print_block(loc, block);
+                    let printed = self.print_block(loc, block, EmptyBlock::Open);
                     self.concat([self.s(" finally "), printed])
                 });
                 self.concat([
@@ -529,12 +560,23 @@ impl<'a> Printer<'a> {
         self.docs.concat_vec(parts)
     }
 
+    /// `catch (error) { … }`.
+    ///
+    /// `has_finally` because an empty handler collapses to `catch {}` only
+    /// when it is the end of the statement. With a `finally` after it the
+    /// three braces line up, and Prettier keeps the handler open so they do.
     fn print_catch_clause(
         &mut self,
         clause: &'a statement::try_::CatchClause<Loc, Loc>,
+        has_finally: bool,
     ) -> Doc<'a> {
+        let empty = if has_finally {
+            EmptyBlock::Open
+        } else {
+            EmptyBlock::Collapsed
+        };
         self.print_node(NodeRef::CatchClause(clause), |p| {
-            let body = p.print_block(&clause.body.0, &clause.body.1);
+            let body = p.print_block(&clause.body.0, &clause.body.1, empty);
             let Some(param) = &clause.param else {
                 return p.concat([p.s("catch "), body]);
             };
@@ -650,22 +692,57 @@ impl<'a> Printer<'a> {
         false
     }
 
-    /// A `{ … }` block that is not itself a statement.
-    pub fn print_block(&mut self, loc: &'a Loc, block: &'a statement::Block<Loc, Loc>) -> Doc<'a> {
-        let node = NodeRef::Block(loc, block);
-        self.print_node(node, |p| p.print_block_body(&block.body, node.key()))
+    /// How an empty block *statement* prints, from what encloses it.
+    ///
+    /// A block statement is the same node whether it is a loop body, an `if`
+    /// branch, a `case` body or a block somebody wrote on its own, so this is
+    /// the one place the parent has to be asked. Everywhere else the caller
+    /// knows what it is printing and says so.
+    ///
+    /// The block is on top of the stack while its statement is being printed,
+    /// so the parent is what is under it.
+    fn empty_block_of_statement(&self) -> EmptyBlock {
+        use statement::StatementInner as S;
+        match self.parent() {
+            // `for … in` and `for … of` are deliberately not here: Prettier
+            // keeps those open and collapses only the three-part `for`.
+            Some(NodeRef::Statement(parent)) => match &**parent {
+                S::For { .. } | S::While { .. } | S::DoWhile { .. } => EmptyBlock::Collapsed,
+                _ => EmptyBlock::Open,
+            },
+            // A `match` arm is a body like a function's, not a branch like an
+            // `if`: `_ => {}` is how an arm says it does nothing.
+            Some(NodeRef::MatchStatementCase(_)) => EmptyBlock::Collapsed,
+            _ => EmptyBlock::Open,
+        }
     }
 
-    /// `{`, the statements, `}`; `{}` when there is nothing to print.
+    /// A `{ … }` block that is not itself a statement.
+    pub fn print_block(
+        &mut self,
+        loc: &'a Loc,
+        block: &'a statement::Block<Loc, Loc>,
+        empty: EmptyBlock,
+    ) -> Doc<'a> {
+        let node = NodeRef::Block(loc, block);
+        self.print_node(node, |p| p.print_block_body(&block.body, node.key(), empty))
+    }
+
+    /// `{`, the statements, `}`; `{}` or `{`/`}` on two lines when there is
+    /// nothing to print, as [`EmptyBlock`] says.
     pub fn print_block_body(
         &mut self,
         body: &'a [Statement],
         key: crate::flow::node::NodeKey,
+        empty: EmptyBlock,
     ) -> Doc<'a> {
         let has_body = body.iter().any(|statement| !is_empty_statement(statement));
         let dangling = self.print_dangling_comments(key, Marker::None, false);
         if !has_body && dangling.is_none() {
-            return self.s("{}");
+            return match empty {
+                EmptyBlock::Collapsed => self.s("{}"),
+                EmptyBlock::Open => self.concat([self.s("{"), &HARDLINE, self.s("}")]),
+            };
         }
         let mut parts = Vec::new();
         if has_body {

--- a/crates/uf_fmt/tests/fixtures/empty_blocks.expected.js
+++ b/crates/uf_fmt/tests/fixtures/empty_blocks.expected.js
@@ -1,0 +1,64 @@
+// @flow
+// Empty blocks. Prettier collapses a body that is expected to be empty
+// sometimes and keeps open a block whose emptiness is worth seeing.
+
+if (a) {
+}
+if (b) {
+} else if (c) {
+  d();
+}
+if (e) {
+} else {
+}
+while (f) {}
+for (;;) {}
+function g() {}
+try {
+} catch (h) {}
+const i = () => {};
+class J {
+  k() {}
+}
+switch (l) {
+}
+try {
+} catch (a) {
+} finally {
+}
+do {} while (b);
+label: {
+}
+{
+}
+if (c) {
+  // only a comment
+}
+class D {
+  static {}
+}
+for (const a in b) {
+}
+for (const c of d) {
+}
+const e = { f() {}, get g() {}, set h(i) {} };
+async function j() {}
+function* k() {}
+const l = async () => {};
+class M {
+  constructor() {}
+  static n() {}
+}
+if (o) {
+}
+with (p) {
+}
+declare module "a" {
+}
+declare namespace b {
+}
+component C() {}
+switch (d) {
+  case 1: {
+  }
+}

--- a/crates/uf_fmt/tests/fixtures/empty_blocks.js
+++ b/crates/uf_fmt/tests/fixtures/empty_blocks.js
@@ -1,0 +1,72 @@
+// @flow
+// Empty blocks. Prettier collapses a body that is expected to be empty
+// sometimes and keeps open a block whose emptiness is worth seeing.
+
+if (a) {
+}
+if (b) {
+} else if (c) {
+  d();
+}
+if (e) {
+} else {
+}
+while (f) {}
+for (;;) {}
+function g() {}
+try {
+} catch (h) {}
+const i = () => {};
+class J {
+  k() {}
+}
+switch (l) {
+}
+try {
+} catch (a) {
+} finally {
+}
+do {
+} while (b);
+label: {
+}
+{
+}
+if (c) {
+  // only a comment
+}
+class D {
+  static {
+  }
+}
+for (const a in b) {
+}
+for (const c of d) {
+}
+const e = { f() {}, get g() {}, set h(i) {} };
+async function j() {
+}
+function* k() {
+}
+const l = async () => {
+};
+class M {
+  constructor() {
+  }
+  static n() {
+  }
+}
+if (o) {
+} 
+with (p) {
+}
+declare module "a" {
+}
+declare namespace b {
+}
+component C() {
+}
+switch (d) {
+  case 1: {
+  }
+}


### PR DESCRIPTION
Fixes ubugeeei-prod/uf#173.

`uf fmt` collapsed every empty block to `{}`. Prettier collapses only the ones
that are a *body*, and leaves open a block whose emptiness is something the
author wrote:

```diff
-if (a) {}
+if (a) {
+}
-if (b) {} else if (c) {
+if (b) {
+} else if (c) {
   d();
 }
-try {} catch (h) {}
+try {
+} catch (h) {}
```

### The rule, measured

`{}` for a function, method, arrow, getter, setter, constructor, generator,
`component` or `static` body; for `for (;;)`, `while` and `do … while`; for a
`match` arm; and for a `catch` that is the end of its statement.

`{` and `}` on two lines for `if`, `else`, `try`, `finally`, `with`,
`for … in`, `for … of`, a labelled block, a `case` block, a block on its own,
and a `declare module` / `declare namespace` body.

`for … in` and `for … of` not collapsing where `for (;;)` does looks arbitrary
and is. The list was derived by running each construct through
`prettier --parser hermes --plugin prettier-plugin-hermes-parser
--print-width 100` rather than from memory, because byte-identical output is
the target and taste is not part of it.

### Shape

An `EmptyBlock` argument rather than a rule buried in the block printer. Every
caller but one knows what it is printing and says so; the one exception is a
block *statement*, which is the same node whether it is a loop body, an `if`
branch, a `case` body or a block somebody wrote on its own, so that is the only
place the parent is consulted.

### Tests

`empty_blocks.js` / `.expected.js` — every parent in the list above, one file,
byte-identical to Prettier. It fails on `main` at the first `if`.

The existing `components_hooks_match_enums` fixture caught the `match` arm: an
arm body is a body, not a branch, and Prettier writes `_ => {}`.

Corpus unchanged (`8110 formatted, 0 failed`), and the two modules this was
found in are now byte-identical to Prettier:

```
prepack/src/utils/reachability.js
react/compiler/…/error.todo-round2_severity_diff.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791215258&installation_model_id=422833&pr_number=174&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F174&signature=d1345675388b21aa643640aba469e85654ddcc0a3c7c42acbe8ecc5a4d54bc82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->