### PR TITLE
fix(fmt): a tuple type ending in a spread keeps its trailing comma

### DIFF
--- a/crates/uf_fmt/src/flow/print/array.rs
+++ b/crates/uf_fmt/src/flow/print/array.rs
@@ -191,15 +191,15 @@ impl<'a> Printer<'a> {
             };
         }
 
+        // Only a *pattern's* rest: `const [a, ...rest,] = xs` is a syntax
+        // error, so nothing may follow it. A spread anywhere else is an
+        // ordinary last element and takes the comma like one — `[...a, ...b,]`
+        // in an array literal, and `[...[number, number],]` in a tuple type,
+        // which is how StyleX writes `Matrix3d`'s sixteen arguments.
         let last_is_rest = matches!(
             elements.last(),
             Some(Element::Node(NodeRef::PatternRest(_)))
-        ) || matches!(
-            elements.last(),
-            Some(Element::Node(NodeRef::TupleElement(
-                types::tuple::Element::SpreadElement { .. }
-            )))
-        ) || matches!(elements.last(), Some(Element::Node(NodeRef::Spread(_))) if false);
+        );
         let can_have_trailing_comma = !last_is_rest && !inexact;
         let last_is_hole = matches!(elements.last(), Some(Element::Hole));
         let group_id = self.docs.group_id();

--- a/crates/uf_fmt/tests/fixtures/spread_trailing_commas.expected.js
+++ b/crates/uf_fmt/tests/fixtures/spread_trailing_commas.expected.js
@@ -1,0 +1,38 @@
+// @flow
+// A spread as the last element takes the trailing comma; a pattern's rest
+// cannot, because nothing may follow it.
+
+type Matrix3d = [
+  ...[number, number, number, number],
+  ...[number, number, number, number],
+  ...[number, number, number, number],
+  ...[number, number, number, number],
+];
+
+type Head = [number, ...Rest];
+
+const collected = [
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+  ...ccccccccccccccc,
+];
+
+call(
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+  ...ccccccccccccccc,
+);
+
+const [
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+  ...ccccccccccccccc
+] = source;
+
+function withRest(
+  aaaaaaaaaaaaaaaaaaaaaaaaaaa: number,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: number,
+  ...rest: Args
+) {}
+
+type Inexact = { a: number, ... };

--- a/crates/uf_fmt/tests/fixtures/spread_trailing_commas.js
+++ b/crates/uf_fmt/tests/fixtures/spread_trailing_commas.js
@@ -1,0 +1,38 @@
+// @flow
+// A spread as the last element takes the trailing comma; a pattern's rest
+// cannot, because nothing may follow it.
+
+type Matrix3d = [
+  ...[number, number, number, number],
+  ...[number, number, number, number],
+  ...[number, number, number, number],
+  ...[number, number, number, number],
+];
+
+type Head = [number, ...Rest];
+
+const collected = [
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+  ...ccccccccccccccc,
+];
+
+call(
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+  ...ccccccccccccccc,
+);
+
+const [
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+  ...ccccccccccccccc
+] = source;
+
+function withRest(
+  aaaaaaaaaaaaaaaaaaaaaaaaaaa: number,
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: number,
+  ...rest: Args
+) {}
+
+type Inexact = { a: number, ... };


### PR DESCRIPTION
Fixes ubugeeei-prod/uf#175.

Only an array *pattern's* rest may not be followed by a comma —
`const [a, ...rest,] = xs` is a syntax error. A spread anywhere else is an
ordinary last element and takes one:

```diff
 type Matrix3d = [
   ...[number, number, number, number],
-  ...[number, number, number, number]
+  ...[number, number, number, number],
 ];
```

The tuple case had been grouped with the pattern case. Its third clause was

```rust
|| matches!(elements.last(), Some(Element::Node(NodeRef::Spread(_))) if false)
```

— dead, and evidently written to record that an array literal's spread does
*not* suppress the comma. That is a sentence now rather than an unreachable
pattern.

### Where it was found

The corpus, against `prettier --parser hermes --plugin
prettier-plugin-hermes-parser --print-width 100`:
`stylex/packages/style-value-parser/src/css-types/transform-function.js`,
which spells `Matrix3d`'s sixteen arguments as four spreads. It is the only
module in the corpus that hits it, and it is byte-identical to Prettier now.

### Tests

`spread_trailing_commas.js` / `.expected.js` pins both directions — a tuple
spread, an array-literal spread, a call argument spread and a rest parameter
take the comma; an array pattern's rest and an inexact object type do not. On
`main`:

```
fixture spread_trailing_commas expected output is not a fixed point
```

Corpus unchanged: `8110 formatted, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791215623&installation_model_id=422833&pr_number=176&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F176&signature=6f6f0bd997ba214a4272b57405dec565ce8fdd755cb5bced740dc478a6facf41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->