### PR TITLE
docs: say what the formatter does now, not what it did

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Unified Toolchain for Flow (React)
 > - **The build is being moved onto Vite.** The dev server and bundler in this
 >   repository are being deleted as Vite takes over, so `uf dev` and `uf build`
 >   are mid-migration.
-> - **The formatter prints Flow only.** `uf fmt` now formats `.js` from the
->   official parser's syntax tree, matching Prettier; JSON, CSS and
->   TypeScript are not routed to Biome yet.
+> - **The formatter prints Flow itself and delegates the rest.** `uf fmt`
+>   formats `.js` from the official parser's syntax tree, matching Prettier,
+>   and hands JSON, CSS and TypeScript to Biome. Code inside a tagged
+>   template — GraphQL, CSS — is left as written, where Prettier reformats
+>   it.
 > - Commands, config keys and package names may change without notice.
 >
 > Everything below describes where `uf` is going. Treat it as the plan, not as
@@ -181,8 +183,9 @@ enables:
 - editor integration targets for VS Code, Neovim, Emacs, Vim, Helix, Zed, and Cursor
 - formatter defaults to double quotes and semicolons; Flow files are parsed by
   the official Flow Rust parser and printed by uf's own Prettier-compatible
-  printer, checked against Prettier's output by a fixture corpus. Non-Flow files
-  are configured to route to Biome, which is not wired up yet
+  printer, checked against Prettier's output by a fixture corpus and against
+  its own guarantees over ~8,100 modules of third-party Flow. Non-Flow files
+  go to the formatter named by `fmt.nonFlow.formatter`, Biome by default
 
 No Babel, Jest, Yarn, npm scripts, or `.flowconfig` is required for generated
 projects. Flow becomes JavaScript through `uf transform`: the official Flow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,9 +273,11 @@ a *tie*, broken by the whitespace between it and what follows.
 
 **Four guarantees**, each a test rather than an intention:
 
-- **Prettier-compatible.** 27 fixtures under `crates/uf_fmt/tests/fixtures`
+- **Prettier-compatible.** The fixtures under `crates/uf_fmt/tests/fixtures`
   pair an input with the output of `prettier --parser hermes
   --plugin prettier-plugin-hermes-parser`, and are compared byte for byte.
+  With one exception, named below: uf does not format code embedded in a
+  tagged template, so the target is `--embedded-language-formatting=off`.
 - **Idempotent.** `format(format(x)) == format(x)`.
 - **Tree-preserving.** The output re-parses to the same tree as the input,
   compared as JSON with locations, comments, `raw` spellings and the other
@@ -285,8 +287,23 @@ a *tie*, broken by the whitespace between it and what follows.
   unmarked fails the whole run rather than shortening the file.
 - **Total.** Invalid syntax is a typed error and the file is left alone;
   no input panics. The parser recurses, so `uf_flow` refuses sources past
-  8 MiB or 300 levels of bracket nesting *before* parsing, and the work
-  runs on a thread with the stack that ceiling was measured against.
+  8 MiB, 300 levels of bracket nesting, or 10,000 links of an operator
+  chain that nests without brackets *before* parsing, and the work runs on
+  a thread with the stack those ceilings were measured against.
+
+Every one of these but the first is also checked over third-party Flow —
+React, Metro, Relay, React Native, Recoil, Flux, Parcel, Yarn, Prepack,
+StyleX, fbt, react-native-web, react-motion, DataLoader and redux-form,
+about 8,100 modules — by `crates/uf_fmt/tests/upstream_corpus.rs`. That
+corpus is where most of the printer bugs this repository has fixed came
+from: a hand-written fixture is written by somebody who already knows what
+the printer does.
+
+The exception named above is embedded languages. Prettier formats GraphQL,
+CSS and SQL inside a tagged template and re-indents it to the surrounding
+code; uf leaves every template exactly as written. It is Prettier's
+`embeddedLanguageFormatting`, its default is `"auto"`, and uf is compatible
+with `"off"`. See ubugeeei-prod/uf#177.
 
 Parentheses are not in the port's tree, so every pair in the output is
 recomputed from precedence and position. That is what makes the
@@ -295,10 +312,17 @@ printed, one it does not is dropped, and `(a?.b)()` keeps the parentheses
 that end its optional chain because dropping them would change what the
 program does.
 
-Non-Flow files (JSON, CSS, TypeScript) are configured to route to Biome's
-formatters through `fmt.nonFlow.formatter`, but that routing is not
-implemented yet: `uf fmt` still formats `.js` only, and `package.json` is
-read by the linter and never rewritten.
+Non-Flow files (JSON, JSONC, CSS, TypeScript) go to the formatter named by
+`fmt.nonFlow.formatter`, as a subprocess: `uf fmt` collects them, hands them
+to that command, and reports what it did. The default is Biome, resolved
+from the project's `node_modules/.bin` before `PATH` so a project gets the
+version it installed. `"none"` turns it off, and a formatter that is not
+installed is an error that names it rather than a silent skip.
+
+Not linked in, because linking Biome would make uf's release depend on
+Biome's — red line 5. Running the binary a project already has means the
+project upgrades its formatter without waiting for uf, and can name one uf
+has never heard of.
 
 ## Flow And React
 

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -35,8 +35,10 @@
       `prettier --parser hermes` by 27 fixtures; idempotent,
       tree-preserving, comment-preserving and total.
 - [x] Route non-Flow formatter configuration to Biome.
-- [ ] Actually run Biome for `.json`, `.jsonc`, `.css` and `.ts`: the config
-      key exists, the routing does not.
+- [x] Actually run Biome for `.json`, `.jsonc`, `.css` and `.ts`. `uf fmt`
+      collects the non-Flow files and hands them to the command named by
+      `fmt.nonFlow.formatter`, resolved from `node_modules/.bin` before
+      `PATH`.
 - [x] Default formatter settings to double quotes and semicolons.
 - [ ] Add large-project file discovery tests with ignored directories and non-UTF8 guardrails.
 - [ ] Add benchmark gates for config loading, route discovery, lint scanning, and test discovery.


### PR DESCRIPTION
Three claims about the formatter had gone stale, and one was never made.

### Biome is wired up

`docs/architecture.md` said the non-Flow routing "is not implemented yet:
`uf fmt` still formats `.js` only", and the README said JSON, CSS and
TypeScript "are not routed to Biome yet". Run in a directory with a JSON and a
CSS file:

```diff
 --- data.json
-{"b":1,   "a":  [1,2,3]}
+{ "b": 1, "a": [1, 2, 3] }
 --- style.css
-body{color:red;   background:blue}
+body {
+  color: red;
+  background: blue;
+}
```

and without Biome installed:

```
! biome is not installed, so 2 non-Flow files were left alone. Install it,
  or set `fmt.nonFlow.formatter` to "none" in uf.config.js.
```

`docs/issue-roadmap.md`'s box is ticked to match.

### The fixture count was 27 and is 32

A number in prose is a number that rots, so it is gone. What replaced it is
the corpus — the same guarantees over ~8,100 modules of third-party Flow —
which is the stronger claim anyway, and is where most of the printer bugs this
repository has fixed came from.

### `MAX_CHAIN_DEPTH` was missing

The list of ceilings the parser refuses a source at named the byte limit and
the bracket depth but not the chain depth added in ubugeeei-prod/uf#149.

### Embedded languages were never mentioned

Prettier formats GraphQL, CSS and SQL inside a tagged template and re-indents
it to the surrounding code. uf leaves every template exactly as written. So
"Prettier compatible" means `--embedded-language-formatting=off`, and a user
should read that here rather than discover it when their `graphql` templates
stop moving. Filed as ubugeeei-prod/uf#177; this is the half of that issue
which is a paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791215772&installation_model_id=422833&pr_number=178&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F178&signature=46af2025b37525225c5f6ad2f7c6d2db888d5db4d3247ce8f02579182bd2682a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->