### PR TITLE
fix(fmt): only require itself is kept on one line

### DIFF
--- a/crates/uf_fmt/src/flow/print/call.rs
+++ b/crates/uf_fmt/src/flow/print/call.rs
@@ -334,6 +334,11 @@ impl<'a> Printer<'a> {
 
         // A template literal on its own line, `require("x")`, AMD `define`,
         // and test calls keep their arguments as they are.
+        //
+        // `require` and no more: Prettier lets `require.resolve("…")`,
+        // `require.resolve.paths("…")` and `import.meta.resolve("…")` break
+        // their argument like any other call, and only the bare `require`
+        // stays on one line past the print width.
         let is_template_on_own_line = arguments.len() == 1
             && self.is_template_on_its_own_line(argument_expression(&arguments[0]));
         let parent_expression = match self.parent() {
@@ -341,7 +346,6 @@ impl<'a> Printer<'a> {
             _ => None,
         };
         if is_template_on_own_line
-            || self.is_require_like_call(call)
             || self.is_commonjs_or_amd_call(call)
             || (!optional && is_test_call(expression, parent_expression))
         {
@@ -532,26 +536,6 @@ impl<'a> Printer<'a> {
             && !self
                 .text
                 .has_newline(self.text.span(expression.loc()).start, true)
-    }
-
-    /// `require("x")`, `require.resolve("x")`, `import.meta.resolve("x")`
-    /// with a single string argument.
-    fn is_require_like_call(&self, call: &'a expression::Call<Loc, Loc>) -> bool {
-        let mut name = String::new();
-        if !callee_name(&call.callee, &mut name) {
-            return false;
-        }
-        if !matches!(
-            name.as_str(),
-            "require" | "require.resolve" | "require.resolve.paths" | "import.meta.resolve"
-        ) {
-            return false;
-        }
-        let arguments = &call.arguments.arguments;
-        arguments.len() == 1
-            && !is_spread(&arguments[0])
-            && is_string_literal(argument_expression(&arguments[0]))
-            && !self.has_comment(argument_node(&arguments[0]).key())
     }
 
     fn is_commonjs_or_amd_call(&self, call: &'a expression::Call<Loc, Loc>) -> bool {

--- a/crates/uf_fmt/tests/fixtures/calls.expected.js
+++ b/crates/uf_fmt/tests/fixtures/calls.expected.js
@@ -93,6 +93,17 @@ new Promise((resolve, reject) => {
 });
 require("module");
 const lazy = require("./some/very/long/path/to/a/module/that/does/not/fit/on/one/line/at/all/really.js");
+// Only the bare `require` stays on one line. Everything spelled like it is an
+// ordinary call and breaks its argument.
+const resolved = require.resolve(
+  "./some/very/long/path/to/a/module/that/does/not/fit/on/one/line.js",
+);
+const paths = require.resolve.paths(
+  "./some/very/long/path/to/a/module/that/does/not/fit/on/one.js",
+);
+const url = import.meta.resolve(
+  "./some/very/long/path/to/a/module/that/does/not/fit/on/one/line.js",
+);
 define(["dep"], function (dep) {
   return dep;
 });

--- a/crates/uf_fmt/tests/fixtures/calls.js
+++ b/crates/uf_fmt/tests/fixtures/calls.js
@@ -34,6 +34,11 @@ async function fetching() {
 new Promise((resolve, reject) => { setTimeout(resolve, 100); });
 require("module");
 const lazy = require("./some/very/long/path/to/a/module/that/does/not/fit/on/one/line/at/all/really.js");
+// Only the bare `require` stays on one line. Everything spelled like it is an
+// ordinary call and breaks its argument.
+const resolved = require.resolve("./some/very/long/path/to/a/module/that/does/not/fit/on/one/line.js");
+const paths = require.resolve.paths("./some/very/long/path/to/a/module/that/does/not/fit/on/one.js");
+const url = import.meta.resolve("./some/very/long/path/to/a/module/that/does/not/fit/on/one/line.js");
 define(["dep"], function (dep) { return dep; });
 foo(function () {}, bar);
 foo((x) => {}, bar);


### PR DESCRIPTION
Fixes ubugeeei-prod/uf#179.

`is_require_like_call` matched four names:

```rust
"require" | "require.resolve" | "require.resolve.paths" | "import.meta.resolve"
```

and Prettier keeps only the first on one line. Measured, at
`--print-width 100`:

```js
require("yyyy…yyyy");        // 101 columns, and Prettier leaves it
require.resolve(
  "yyyy…yyyy",
);
require.resolve.paths(
  "yyyy…yyyy",
);
import.meta.resolve(
  "yyyy…yyyy",
);
```

The visible cost was not the long line. With nowhere to break inside the call,
the assignment printer broke after the `=` instead:

```diff
-const babelTraverseFlowDefinitionPath = require.resolve(
-  "../../flow-typed/npm/babel-traverse_v7.x.x.js",
-);
+const babelTraverseFlowDefinitionPath =
+  require.resolve("../../flow-typed/npm/babel-traverse_v7.x.x.js");
```

`is_require_like_call` is deleted rather than shortened: with only `require`
left it said nothing `is_commonjs_or_amd_call` does not already say, whose
`require` arm is a superset — one string argument or several, with no comment
on the first.

### Where it was found

`metro/scripts/support/generateBabelFlowLibraryDefinitions.js`, in the corpus
sweep against Prettier.

### Tests

The three cases join `calls.js`, next to the `require("…")` that must keep
behaving. The fixture fails on `main`:

```
fixture calls expected output is not a fixed point
assertion failed: fixture calls formatted wrong
```

Corpus unchanged: `8110 formatted, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791216313&installation_model_id=422833&pr_number=180&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F180&signature=cda61d03e67d0cf5713863147fa087067d346ed3b558d81139f3983fa688c633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->