### PR TITLE
fix(fmt): an object's spread of an await keeps its parentheses too

### DIFF
--- a/crates/uf_fmt/src/flow/print/parens.rs
+++ b/crates/uf_fmt/src/flow/print/parens.rs
@@ -696,7 +696,12 @@ impl<'a> Printer<'a> {
                     }
                     Some(E::Conditional { .. }) => role == Role::Test,
                     Some(E::Binary { .. }) => true,
-                    _ => matches!(parent, NodeRef::Spread(_) | NodeRef::JsxSpreadAttribute(_)),
+                    // The third place this had been spelled out rather than
+                    // asked. `{ ...(await x) }` is an `ObjectProperty` and
+                    // `[...(await x)]` is a `Spread`, so naming only the
+                    // second dropped the parentheses from the first while the
+                    // array beside it kept them. See ubugeeei-prod/uf#159.
+                    _ => is_spread_argument(parent),
                 }
             }
             E::StringLiteral { .. } => {

--- a/crates/uf_fmt/tests/fixtures/spread_parens.expected.js
+++ b/crates/uf_fmt/tests/fixtures/spread_parens.expected.js
@@ -11,6 +11,19 @@ const objectAnd = { ...(a && b) };
 const objectNullish = { ...(a ?? b) };
 const objectSequence = { ...(a, b) };
 
+// `await` and `yield` are the same shape once more, and were the third place
+// the question was answered by naming node kinds rather than asking.
+async function awaited() {
+  const objectAwait = { ...(await resolveConfig(name)), filepath: name };
+  const arrayAwait = [...(await load()), 1];
+  const callAwait = merge(...(await load()));
+  const memberAwait = { ...(await load()).entries, filepath: name };
+}
+function* yielded() {
+  const objectYield = { ...(yield next()), done: false };
+  const arrayYield = [...(yield next()), 1];
+}
+
 // Nothing is added where nothing was needed.
 const objectMember = { ...a.b };
 const objectCall = { ...f() };

--- a/crates/uf_fmt/tests/fixtures/spread_parens.js
+++ b/crates/uf_fmt/tests/fixtures/spread_parens.js
@@ -11,6 +11,19 @@ const objectAnd = { ...(a && b) };
 const objectNullish = { ...(a ?? b) };
 const objectSequence = { ...(a, b) };
 
+// `await` and `yield` are the same shape once more, and were the third place
+// the question was answered by naming node kinds rather than asking.
+async function awaited() {
+  const objectAwait = { ...(await resolveConfig(name)), filepath: name };
+  const arrayAwait = [...(await load()), 1];
+  const callAwait = merge(...(await load()));
+  const memberAwait = { ...(await load()).entries, filepath: name };
+}
+function* yielded() {
+  const objectYield = { ...(yield next()), done: false };
+  const arrayYield = [...(yield next()), 1];
+}
+
 // Nothing is added where nothing was needed.
 const objectMember = { ...a.b };
 const objectCall = { ...f() };

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -412,7 +412,7 @@ async function resolveMetadata(
     merged = { ...merged, ...page.metadata };
   }
   if (typeof page.generateMetadata === "function") {
-    merged = { ...merged, ...await page.generateMetadata(args) };
+    merged = { ...merged, ...(await page.generateMetadata(args)) };
   }
   return merged;
 }


### PR DESCRIPTION
ubugeeei-prod/uf#159 found this question answered by naming node kinds in two
places and replaced both with `is_spread_argument`. There was a third, in the
arm for `await` and `yield`:

```rust
_ => matches!(parent, NodeRef::Spread(_) | NodeRef::JsxSpreadAttribute(_)),
```

So the array kept its parentheses and the object beside it lost them:

```diff
-const a = { ...await resolveConfig(name), filepath: name };
+const a = { ...(await resolveConfig(name)), filepath: name };
 const i = [...(await load()), 1];
```

An object's spread is an `ObjectProperty::SpreadProperty`; an array's is a
`Spread`. Same shape, one arm along. It asks the predicate now.

### Where it was found

`metro/scripts/support/generateBabelFlowLibraryDefinitions.js`, while reading
its diff against Prettier for ubugeeei-prod/uf#179 — the two lines are eight
apart in that file, and fixing the first left the second visible.

### Tests

`spread_parens.js` gains the `await` and `yield` cases in object, array, call
and member position, beside the ones it already had. On `main`:

```
fixture spread_parens expected output is not a fixed point
assertion failed: fixture spread_parens formatted wrong
```

Corpus unchanged: `8110 formatted, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791216498&installation_model_id=422833&pr_number=181&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F181&signature=e6571aef903a5f91d50323b9c10f47ca34415447f74b6bf62ac898959ddb402b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->