### PR TITLE
style: reformat the packages the spread-parentheses fix changed

### DIFF
--- a/packages/fetch/internal/client.js
+++ b/packages/fetch/internal/client.js
@@ -136,7 +136,7 @@ const IDEMPOTENT = new Set(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"]);
  * application talks to more than one.
  */
 export function createFetch(config?: FetchConfig): FetchClient {
-  const settings = { ...DEFAULTS, ...config ?? {} };
+  const settings = { ...DEFAULTS, ...(config ?? {}) };
 
   const raw = async (path: string, options?: RequestOptions<mixed>): Promise<Response> =>
     send(settings, path, options ?? {});
@@ -152,7 +152,7 @@ export function createFetch(config?: FetchConfig): FetchClient {
       createFetch({
         ...settings,
         ...extra,
-        headers: { ...settings.headers ?? {}, ...extra.headers ?? {} },
+        headers: { ...(settings.headers ?? {}), ...(extra.headers ?? {}) },
       }),
   };
 }
@@ -214,8 +214,8 @@ function requestInit(
   signal: AbortSignal,
 ): RequestOptions<mixed> {
   const headers: { [string]: string } = {
-    ...settings.headers ?? {},
-    ...options.headers ?? {},
+    ...(settings.headers ?? {}),
+    ...(options.headers ?? {}),
   };
 
   let body = options.body;

--- a/packages/graphql/index.js
+++ b/packages/graphql/index.js
@@ -89,7 +89,7 @@ function fetchOperation(options: EnvironmentOptions) {
       method: "POST",
       headers: {
         accept: "application/graphql-response+json, application/json",
-        ...options.headers ?? {},
+        ...(options.headers ?? {}),
       },
       body: {
         query: request.text,

--- a/packages/hooks/internal/browser.js
+++ b/packages/hooks/internal/browser.js
@@ -87,7 +87,7 @@ export function useOnline(serverValue: boolean = true): boolean {
 
   return useSyncExternalStore(
     subscribe,
-    () => (inBrowser() ? windowOf().navigator?.onLine ?? true : serverValue),
+    () => (inBrowser() ? (windowOf().navigator?.onLine ?? true) : serverValue),
     () => serverValue,
   );
 }

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -404,8 +404,8 @@ async function resolveMetadata(
     const { title, description } = page.frontmatter;
     merged = {
       ...merged,
-      ...title != null ? { title } : {},
-      ...description != null ? { description } : {},
+      ...(title != null ? { title } : {}),
+      ...(description != null ? { description } : {}),
     };
   }
   if (page.metadata != null) {

--- a/packages/test/internal/registry.js
+++ b/packages/test/internal/registry.js
@@ -221,7 +221,7 @@ function formatRow(name: string, row: mixed): string {
   return name.replace(ROW_TOKEN, (token) => {
     const value = values[index];
     index += 1;
-    return token === "%j" ? JSON.stringify(value) ?? "undefined" : String(value);
+    return token === "%j" ? (JSON.stringify(value) ?? "undefined") : String(value);
   });
 }
 

--- a/packages/ui/internal/dialog.js
+++ b/packages/ui/internal/dialog.js
@@ -119,7 +119,7 @@ export component DialogContent(children: React.Node, ...rest: { readonly [string
     // The first thing worth acting on, not the first thing in the document —
     // and the dialog itself if it contains nothing focusable, so focus is
     // inside it either way.
-    const target = content == null ? null : focusable(content)[0] ?? content;
+    const target = content == null ? null : (focusable(content)[0] ?? content);
     target?.focus();
 
     return () => {

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -124,7 +124,7 @@ async function viteConfig(config, mode) {
   // read this and does not need to: an option added to Vite tomorrow works in
   // a uf project tomorrow, rather than after a uf release that names it.
   return withProjectConfig(generated, {
-    ...config.vite ?? {},
+    ...(config.vite ?? {}),
     plugins: [...(config.vite?.plugins ?? []), ...userPlugins],
   });
 }

--- a/tests/library/hooks.test.js
+++ b/tests/library/hooks.test.js
@@ -170,7 +170,7 @@ describe("useAsync", () => {
       const { error, pending } = useAsync(async () => {
         throw new Error("nope");
       }, []);
-      return <output>{pending ? "pending" : error?.message ?? "none"}</output>;
+      return <output>{pending ? "pending" : (error?.message ?? "none")}</output>;
     }
     render(<Probe />);
     await waitFor(() => {


### PR DESCRIPTION
**`main` is red, and this is the fix.**

ubugeeei-prod/uf#160 taught the printer that a spread and a `??` inside a
conditional keep their parentheses. Eight of this repository's own modules are
written that way, so `uf run fmt:check` — uf formatting uf — failed on the
merge commit and has been failing every branch cut from it since:

```
error: 8 files need formatting
  - packages/fetch/internal/client.js
  - packages/graphql/index.js
  - packages/hooks/internal/browser.js
  - packages/router/internal/runtime.js
  - packages/test/internal/registry.js
  - packages/ui/internal/dialog.js
  - packages/vite/driver.js
  - tests/library/hooks.test.js
```

The change is the output of `uf fmt` and nothing else — twelve lines, all of
one of the two shapes:

```diff
-  const settings = { ...DEFAULTS, ...config ?? {} };
+  const settings = { ...DEFAULTS, ...(config ?? {}) };
-    return token === "%j" ? JSON.stringify(value) ?? "undefined" : String(value);
+    return token === "%j" ? (JSON.stringify(value) ?? "undefined") : String(value);
```

A printer change that reformats the repository is the ordinary case, and the
reformatting belongs in the same commit as the change. #160 did not get it, so
this is the catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791216651&installation_model_id=422833&pr_number=182&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F182&signature=fbf359fc2bede3a64a7981b8cd3504fabe302b2093540a8b4c986108187b23a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->