### PR TITLE
fix(create): a scaffolded app passes uf's own linter

### DIFF
--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -1000,6 +1000,37 @@ fn creating_a_library_suggests_running_its_tests() {
     assert!(stdout.contains("3. uf test"));
 }
 
+/// A scaffolded project passes uf's own linter.
+///
+/// It did not. `uf create app react` wrote `export default component Page()`
+/// and `export default component Counter()`, and uf's own
+/// `react/no-default-export-component` warned about both — "framework routes
+/// are wired by name; export components with a named export" — on the very
+/// first command a new project runs. The layout in the same template already
+/// used a named export, and `@uniflowed/router` documents the named `Page` as
+/// what `uf create` scaffolds, so the two files were the odd ones out.
+///
+/// A starter that trips the toolchain's own rules teaches the rules are
+/// noise.
+#[test]
+fn a_scaffolded_project_lints_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = dir.path().join("app");
+    create_app(&app);
+
+    let output = uf().arg("--cwd").arg(&app).arg("lint").output().unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "uf lint on a new project:\n{stdout}{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("no problems"), "{stdout}");
+    assert!(stdout.contains("warnings       0"), "{stdout}");
+    assert!(stdout.contains("errors         0"), "{stdout}");
+}
+
 #[test]
 fn creating_over_an_existing_project_reports_the_conflict_on_stderr() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/uf_project/src/template.rs
+++ b/crates/uf_project/src/template.rs
@@ -147,7 +147,7 @@ fn app_page() -> String {
     r#"// @flow
 import * as React from "@uniflowed/react";
 
-import Counter from "./Counter.js";
+import { Counter } from "./Counter.js";
 
 /// The states this page can be in. An enum rather than a union of strings so
 /// the `match` below is exhaustive: adding a member here stops compiling until
@@ -166,7 +166,7 @@ component Headline(mood: Mood) {
   return <h1>Flow {tone}</h1>;
 }
 
-export default component Page() {
+export component Page() {
   return (
     <main>
       <Headline mood={Mood.Calm} />
@@ -191,7 +191,7 @@ import { useCounter } from "./useCounter.js";
 
 /// A component declaration: Flow reads the parameter list as the props, so
 /// there is no separate props type to keep in step with the signature.
-export default component Counter(initial: number) {
+export component Counter(initial: number) {
   const [count, increment] = useCounter(initial);
 
   return (


### PR DESCRIPTION
Fixes ubugeeei-prod/uf#185.

The first command a new project runs reported two warnings, and they were uf's
own rule about uf's own template:

```
$ uf create app react demo && cd demo && uf lint

  warning[react/no-default-export-component]: framework routes are wired by
  name; export components with a named export
   --> app/_uf.page.js:23:1
  23 │ export default component Page() {

! 2 warnings
```

Three things in the repository already agreed with the rule and not with the
template:

* `app/_uf.layout.js`, in the same template, writes `export component Layout(…)`.
* `@uniflowed/router`'s runtime says so in a comment — *"its default export, or
  the named `Page` that `uf create` scaffolds"* — which the template did not.
* The rule itself, which uf ships on by default.

So the page and the counter export by name, and the page imports `{ Counter }`.

### Nothing downstream changes

The router resolves `module.default ?? module.Page`. Checked by scaffolding,
installing and building, then reading the prerendered HTML:

```html
<main><h1>Flow at native speed</h1><p>Edit <code>app/_uf.page.js</code>…</p><button type="button">count: 0</button></main>
```

and `uf lint` on the new scaffold:

```
  files checked  9
  errors         0
  warnings       0

✓ no problems
```

### Test

`a_scaffolded_project_lints_clean` scaffolds and lints — the shape of the bug
rather than the shape of the fix, so it will catch the next template that trips
a rule too. On `main` it reports the two warnings above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791217280&installation_model_id=422833&pr_number=186&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F186&signature=0995d5272533797e9aa1ff0f11d0b3b266e8f6793a24a275f9843c9bc62f500e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->