### PR TITLE
feat(release): uf release writes the changelog for the version it cuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+## uf@0.0.0-alpha.3
+
+_2026-09-05_
+
+### Added
+
+- **explain**: say who does the work for every command that delegates (#167)
+- **web**: the primitives a page is built from, and three rules that were wrong (#119)
+- **test**: a clock a test controls, and the namespace `uft` (#115)
+- **cli**: add Flow API docs command (#121)
+- **test**: snapshots, and the discipline that makes them a test (#118)
+- **test**: the matchers that stand in for a value instead of being one (#114)
+- **relay**: Relay, re-exported by name — and the environment nobody should rewrite (#110)
+- **server**: the request a server function is inside (#109)
+- **stylex**: the compiler was written and nothing ever called it (#108)
+- **check**: the platform globals, and a mark drawn at its own proportions (#107)
+- **cli**: completion that knows this project, and errors that name the fix (#101)
+
+### Fixed
+
+- **fmt**: an object's spread keeps its parentheses (#160)
+- **project**: a file that cannot be read does not stop the project (#165)
+- **fmt**: a comment type declaration stays a comment (#154)
+- **fmt**: a comment after a class's type parameters ends its line too (#156)
+- **fmt**: a comment type stays a comment (#148)
+- **fmt**: refuse a chain that nests without brackets (#149)
+- **fmt**: a comment before `extends` stays where it was written (#144)
+- **fmt**: a right-nested logical chain lays out like a left-nested one (#139)
+- **packages**: declare the validator @uniflowed/ui imports (#150)
+- **fmt**: an inferred predicate keeps the colon it stands after (#140)
+- **fmt**: JSX that runs out at end of input is refused (#132)
+- **vite**: decide a Flow keyword by the line, not by the token (#123)
+- **pm**: a submodule is not one of this project's packages (#124)
+- **fmt**: a contextual keyword at the start of a statement keeps its parens (#122)
+- **core**: the root entry point re-exported two files that were never written (#95)
+
+### Performance
+
+- **fmt**: print each call argument once (#145)
+
+### Documentation
+
+- say that formatter fixtures are data (#158)
+- everything after one bootstrap line is a `uf` command (#116)
+- what closing each red line would take, and the failure none of them prevent (#102)
+
+### Internal
+
+- reformat the packages the spread-parentheses fix changed (#182)
+- **release**: read back what actually reached npm (#147)
+- **upstream**: pin React, Relay and React Native beside Flow (#141)
+- **fmt**: eleven more Flow codebases in the corpus (#138)
+- **fmt**: keep the reproductions for three filed bugs in the repository (#129)
+- **fmt**: the formatter's guarantees, over Flow nobody here wrote (#127)
+- **release**: see a half-sent release before tagging, not during (#117)
+- **publish**: drop a preflight that could never pass (#94)
+
+### Other
+
+- rename (#131)
+- Add ubugeeei Redundancy Guide for uf project
+- Four fixes: a replaceable formatter, three wrong lint rules, star re-exports, and a bundler `uf test` never loaded (#112)

--- a/crates/uf_cli/src/changelog.rs
+++ b/crates/uf_cli/src/changelog.rs
@@ -1,0 +1,366 @@
+//! The changelog section a release writes.
+//!
+//! `uf release` had no answer to "what is in this one". `release.yml` asked
+//! GitHub for `--generate-notes`, which is a list of pull request titles in
+//! merge order — the same information, sorted by when somebody happened to
+//! press the button, and readable only on the release page.
+//!
+//! This turns the same commits into a section of `CHANGELOG.md`: grouped by
+//! what the change *is*, in the repository, where the next person looks.
+//!
+//! The grouping is Conventional Commits, which this repository already
+//! writes — every commit between `uf@0.0.0-alpha.2` and today parses. A
+//! subject that does not is kept rather than dropped: a changelog that
+//! silently omits a change is worse than one with an untidy line in it.
+
+/// One commit, as the changelog cares about it.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Entry<'a> {
+    /// `feat`, `fix`, … or [`None`] when the subject is not conventional.
+    kind: Option<&'a str>,
+    /// The `(scope)`, when there is one.
+    scope: Option<&'a str>,
+    /// Whether the subject was marked `!` as a breaking change.
+    breaking: bool,
+    /// Everything after the `: `.
+    summary: &'a str,
+}
+
+/// The headings a section can have, in the order they are printed.
+///
+/// Ordered by what a reader is looking for rather than alphabetically:
+/// what broke, what is new, what was fixed, what got faster, then the work
+/// that does not change the product. A heading with nothing under it is not
+/// printed at all.
+const GROUPS: &[(&str, &[&str])] = &[
+    ("Added", &["feat"]),
+    ("Fixed", &["fix"]),
+    ("Performance", &["perf"]),
+    ("Documentation", &["docs"]),
+    (
+        "Internal",
+        &["build", "chore", "ci", "refactor", "style", "test"],
+    ),
+];
+
+/// Read `type(scope)!: summary`.
+///
+/// Anything else comes back as a summary with no type, which puts it under
+/// "Other" rather than dropping it.
+pub(crate) fn parse(subject: &str) -> Entry<'_> {
+    let subject = subject.trim();
+    let Some((head, summary)) = subject.split_once(": ") else {
+        return Entry {
+            kind: None,
+            scope: None,
+            breaking: false,
+            summary: subject,
+        };
+    };
+    // A `: ` inside prose is not a type separator. A type is one word, with
+    // an optional parenthesised scope, and nothing else.
+    let (head, breaking) = head
+        .strip_suffix('!')
+        .map_or((head, false), |head| (head, true));
+    let (kind, scope) = match head.split_once('(') {
+        Some((kind, rest)) => match rest.strip_suffix(')') {
+            Some(scope) => (kind, Some(scope)),
+            None => {
+                return Entry {
+                    kind: None,
+                    scope: None,
+                    breaking: false,
+                    summary: subject,
+                };
+            }
+        },
+        None => (head, None),
+    };
+    // Only the types this file knows how to file. Anything else is prose
+    // that happens to have a colon in it — `note: a thing: and another` — and
+    // reading it as a type would eat the word and put the rest under a
+    // heading nobody chose.
+    if !GROUPS.iter().any(|(_, kinds)| kinds.contains(&kind)) {
+        return Entry {
+            kind: None,
+            scope: None,
+            breaking: false,
+            summary: subject,
+        };
+    }
+    Entry {
+        kind: Some(kind),
+        scope,
+        breaking,
+        summary,
+    }
+}
+
+/// The `## uf@<version>` section for `subjects`, newest commit first.
+///
+/// `date` is passed in rather than read from the clock so the output is a
+/// function of its inputs and the tests can say what they expect.
+pub(crate) fn section(tag: &str, date: &str, subjects: &[String]) -> String {
+    let entries: Vec<Entry<'_>> = subjects.iter().map(|subject| parse(subject)).collect();
+
+    let mut out = format!("## {tag}\n\n_{date}_\n");
+
+    let breaking: Vec<&Entry<'_>> = entries.iter().filter(|entry| entry.breaking).collect();
+    if !breaking.is_empty() {
+        out.push_str("\n### Breaking\n\n");
+        for entry in breaking {
+            out.push_str(&line(entry));
+        }
+    }
+
+    for (heading, kinds) in GROUPS {
+        let group: Vec<&Entry<'_>> = entries
+            .iter()
+            .filter(|entry| !entry.breaking)
+            .filter(|entry| entry.kind.is_some_and(|kind| kinds.contains(&kind)))
+            .collect();
+        if group.is_empty() {
+            continue;
+        }
+        out.push_str(&format!("\n### {heading}\n\n"));
+        for entry in group {
+            out.push_str(&line(entry));
+        }
+    }
+
+    let other: Vec<&Entry<'_>> = entries
+        .iter()
+        .filter(|entry| !entry.breaking)
+        .filter(|entry| entry.kind.is_none())
+        .collect();
+    if !other.is_empty() {
+        out.push_str("\n### Other\n\n");
+        for entry in other {
+            out.push_str(&line(entry));
+        }
+    }
+
+    out
+}
+
+/// One bullet: the scope in bold when there is one, then the summary.
+fn line(entry: &Entry<'_>) -> String {
+    match entry.scope {
+        Some(scope) => format!("- **{scope}**: {}\n", entry.summary),
+        None => format!("- {}\n", entry.summary),
+    }
+}
+
+/// `section` written into `existing`, under the file's title.
+///
+/// The newest release goes directly under the title, so the file reads
+/// newest-first and nobody has to scroll past a year of history to see what
+/// shipped today.
+///
+/// A section for the same tag is *replaced*, not stacked. `uf release alpha`
+/// is run more than once while a release is being prepared — a commit lands,
+/// the changelog is regenerated — and a file that grew a second
+/// `## uf@0.0.0-alpha.3` every time would be a file nobody trusted.
+pub(crate) fn prepend(existing: Option<&str>, section: &str) -> String {
+    const TITLE: &str = "# Changelog\n";
+    let heading = section.lines().next().unwrap_or_default();
+    let Some(existing) = existing else {
+        return format!("{TITLE}\n{section}");
+    };
+    // A file that does not start with the title is somebody else's, and the
+    // section goes on top of it whole rather than into the middle of it.
+    let rest = existing.strip_prefix(TITLE).unwrap_or(existing);
+    let rest = without_section(rest, heading);
+    let rest = rest.trim_start_matches('\n');
+    if rest.is_empty() {
+        return format!("{TITLE}\n{section}");
+    }
+    format!("{TITLE}\n{section}\n{rest}")
+}
+
+/// `body` with the `## …` section headed by `heading` removed.
+///
+/// A section runs from its heading to the next `## ` at the start of a line,
+/// or to the end of the file.
+fn without_section<'a>(body: &'a str, heading: &str) -> std::borrow::Cow<'a, str> {
+    if heading.is_empty() {
+        return std::borrow::Cow::Borrowed(body);
+    }
+    let mut out = String::new();
+    let mut skipping = false;
+    for line in body.split_inclusive('\n') {
+        if line.trim_end() == heading {
+            skipping = true;
+            continue;
+        }
+        if skipping {
+            if line.starts_with("## ") {
+                skipping = false;
+            } else {
+                continue;
+            }
+        }
+        out.push_str(line);
+    }
+    if out.len() == body.len() {
+        return std::borrow::Cow::Borrowed(body);
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_conventional_subject_is_read_apart() {
+        let entry = parse("fix(fmt): an object's spread keeps its parentheses (#160)");
+        assert_eq!(entry.kind, Some("fix"));
+        assert_eq!(entry.scope, Some("fmt"));
+        assert!(!entry.breaking);
+        assert_eq!(
+            entry.summary,
+            "an object's spread keeps its parentheses (#160)"
+        );
+
+        let entry = parse("docs: say that formatter fixtures are data (#158)");
+        assert_eq!(entry.kind, Some("docs"));
+        assert_eq!(entry.scope, None);
+
+        let entry = parse("feat(cli)!: `uf run` takes the task name first");
+        assert_eq!(entry.kind, Some("feat"));
+        assert!(entry.breaking);
+    }
+
+    /// A subject that is not conventional is kept, not dropped.
+    #[test]
+    fn an_unconventional_subject_keeps_its_whole_text() {
+        for subject in [
+            "rename (#131)",
+            "Merge branch 'main'",
+            "note: this is prose: with a colon in it",
+            "FIX(fmt): shouting is not a type",
+            "(fmt): a scope with no type",
+        ] {
+            let entry = parse(subject);
+            assert_eq!(entry.kind, None, "{subject}");
+            assert_eq!(entry.summary, subject, "{subject}");
+        }
+    }
+
+    #[test]
+    fn a_section_groups_by_what_the_change_is() {
+        let subjects: Vec<String> = [
+            "feat(explain): say who does the work (#167)",
+            "fix(fmt): an object's spread keeps its parentheses (#160)",
+            "fix(project): a file that cannot be read does not stop it (#165)",
+            "perf(fmt): print each call argument once (#145)",
+            "docs: say that formatter fixtures are data (#158)",
+            "test(fmt): eleven more Flow codebases in the corpus (#138)",
+            "style: reformat the packages (#182)",
+            "rename (#131)",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+
+        let section = section("uf@0.0.0-alpha.3", "2026-09-06", &subjects);
+
+        similar_asserts::assert_eq!(
+            section,
+            "\
+## uf@0.0.0-alpha.3
+
+_2026-09-06_
+
+### Added
+
+- **explain**: say who does the work (#167)
+
+### Fixed
+
+- **fmt**: an object's spread keeps its parentheses (#160)
+- **project**: a file that cannot be read does not stop it (#165)
+
+### Performance
+
+- **fmt**: print each call argument once (#145)
+
+### Documentation
+
+- say that formatter fixtures are data (#158)
+
+### Internal
+
+- **fmt**: eleven more Flow codebases in the corpus (#138)
+- reformat the packages (#182)
+
+### Other
+
+- rename (#131)
+"
+        );
+    }
+
+    /// A heading with nothing under it is not printed, and a breaking change
+    /// goes first whatever its type.
+    #[test]
+    fn empty_headings_are_absent_and_breaking_changes_lead() {
+        let subjects: Vec<String> = ["fix(pm)!: the lockfile format changed".to_owned()].to_vec();
+
+        let section = section("uf@1.0.0", "2026-09-06", &subjects);
+
+        similar_asserts::assert_eq!(
+            section,
+            "## uf@1.0.0\n\n_2026-09-06_\n\n### Breaking\n\n- **pm**: the lockfile format changed\n"
+        );
+        assert!(!section.contains("### Fixed"));
+    }
+
+    /// Cutting the same release twice replaces its section rather than
+    /// stacking a second one.
+    #[test]
+    fn regenerating_a_section_replaces_it() {
+        let first = prepend(
+            None,
+            "## uf@0.0.0-alpha.3\n\n_2026-09-06_\n\n### Fixed\n\n- one\n",
+        );
+        let older = prepend(
+            Some(&first),
+            "## uf@0.0.0-alpha.4\n\n_2026-09-07_\n\n- new\n",
+        );
+        let again = prepend(
+            Some(&older),
+            "## uf@0.0.0-alpha.3\n\n_2026-09-06_\n\n### Fixed\n\n- one\n- two\n",
+        );
+
+        assert_eq!(again.matches("## uf@0.0.0-alpha.3").count(), 1, "{again}");
+        assert!(again.contains("- two"), "{again}");
+        assert!(again.contains("## uf@0.0.0-alpha.4"), "{again}");
+    }
+
+    #[test]
+    fn a_new_section_goes_under_the_title() {
+        let first = prepend(None, "## uf@0.0.0-alpha.3\n\n_2026-09-06_\n");
+        assert_eq!(
+            first,
+            "# Changelog\n\n## uf@0.0.0-alpha.3\n\n_2026-09-06_\n"
+        );
+
+        let second = prepend(Some(&first), "## uf@0.0.0-alpha.4\n\n_2026-09-07_\n");
+        similar_asserts::assert_eq!(
+            second,
+            "\
+# Changelog
+
+## uf@0.0.0-alpha.4
+
+_2026-09-07_
+
+## uf@0.0.0-alpha.3
+
+_2026-09-06_
+"
+        );
+    }
+}

--- a/crates/uf_cli/src/commands/release.rs
+++ b/crates/uf_cli/src/commands/release.rs
@@ -3,7 +3,7 @@
 use std::fs;
 
 use anyhow::{Context, Result, anyhow, bail};
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde_json::json;
 use uf_config::load_config;
 use uf_prepare::default_plan;
@@ -135,6 +135,7 @@ pub(crate) fn release(cwd: &Utf8Path, ui: &mut Ui, bump: ReleaseBump) -> Result<
     let tag = format!("{}{}", resolved.config.release.tag_prefix, next_version);
     let state_dir = resolved.root.join(".uf");
     fs::create_dir_all(&state_dir).with_context(|| format!("failed to create {state_dir}"))?;
+    let changelog = write_changelog(&resolved.root, &tag, &resolved.config.release.tag_prefix)?;
     let manifest = state_dir.join("release.json");
     write_json_file(
         &manifest,
@@ -147,6 +148,8 @@ pub(crate) fn release(cwd: &Utf8Path, ui: &mut Ui, bump: ReleaseBump) -> Result<
             "command": resolved.config.release.command.as_str(),
             "publish": resolved.config.release.publish,
             "trustedTrigger": resolved.config.publish.trusted_publish.trigger,
+            "changelog": changelog.as_ref().map(Changelog::path),
+            "changes": changelog.as_ref().map_or(0, |written| written.changes),
         }),
     )?;
 
@@ -154,7 +157,18 @@ pub(crate) fn release(cwd: &Utf8Path, ui: &mut Ui, bump: ReleaseBump) -> Result<
     let command = resolved.config.release.command.to_string();
     let trigger = format!("{:?}", resolved.config.publish.trusted_publish.trigger);
     let manifest_path = manifest.to_string();
-    let summary = format!("release {tag} planned");
+    let changelog_path = changelog.as_ref().map(Changelog::path);
+    let changelog_row = changelog_path
+        .as_deref()
+        .map(|path| KeyValue::toned("changelog", path, Tone::Path));
+    let summary = match &changelog {
+        Some(written) => format!(
+            "release {tag} planned, {} change{} written to the changelog",
+            written.changes,
+            if written.changes == 1 { "" } else { "s" }
+        ),
+        None => format!("release {tag} planned"),
+    };
 
     ui.render(|renderer, out| {
         renderer.banner(out, "uf release", Some(&tag));
@@ -173,10 +187,106 @@ pub(crate) fn release(cwd: &Utf8Path, ui: &mut Ui, bump: ReleaseBump) -> Result<
                 KeyValue::toned("manifest", &manifest_path, Tone::Path),
             ],
         );
+        if let Some(entry) = &changelog_row {
+            renderer.key_values(out, 2, &[entry.clone()]);
+        }
         renderer.blank(out);
         renderer.status(out, Status::Success, &summary);
     });
     Ok(())
+}
+
+/// A changelog section written to disk.
+struct Changelog {
+    /// Where it was written.
+    file: Utf8PathBuf,
+    /// How many commits it describes.
+    changes: usize,
+}
+
+impl Changelog {
+    fn path(&self) -> String {
+        self.file.to_string()
+    }
+}
+
+/// Write the section for `tag` to `CHANGELOG.md`, from the commits since the
+/// last release tag.
+///
+/// [`None`] when there is no git history to read — an exported source tree, a
+/// directory that is not a repository. A release plan is still worth writing
+/// there; a missing changelog is not a reason to refuse to cut a release, and
+/// saying so is better than an error that stops the command.
+fn write_changelog(root: &Utf8Path, tag: &str, tag_prefix: &str) -> Result<Option<Changelog>> {
+    let Some(subjects) = commit_subjects(root, tag_prefix)? else {
+        return Ok(None);
+    };
+    if subjects.is_empty() {
+        return Ok(None);
+    }
+    // The date of the commit being released rather than the wall clock: a
+    // changelog regenerated next week should say the same thing, and there is
+    // no date crate in this binary to read a clock with anyway.
+    let date = git(root, &["log", "-1", "--format=%cs"])
+        .map(|date| date.trim().to_owned())
+        .filter(|date| !date.is_empty())
+        .unwrap_or_else(|| String::from("unreleased"));
+    let section = crate::changelog::section(tag, &date, &subjects);
+    let file = root.join("CHANGELOG.md");
+    let existing = fs::read_to_string(&file).ok();
+    let contents = crate::changelog::prepend(existing.as_deref(), &section);
+    fs::write(&file, contents).with_context(|| format!("failed to write {file}"))?;
+    Ok(Some(Changelog {
+        file,
+        changes: subjects.len(),
+    }))
+}
+
+/// The subjects of every commit since the last `<prefix>*` tag, newest first.
+///
+/// Merges are left out: a merge commit's subject says which branch was
+/// merged, which is a fact about this repository's history rather than about
+/// what changed.
+fn commit_subjects(root: &Utf8Path, tag_prefix: &str) -> Result<Option<Vec<String>>> {
+    let previous = git(
+        root,
+        &[
+            "describe",
+            "--tags",
+            "--abbrev=0",
+            "--match",
+            &format!("{tag_prefix}*"),
+        ],
+    );
+    let range = match previous {
+        Some(previous) if !previous.trim().is_empty() => format!("{}..HEAD", previous.trim()),
+        // No release yet: everything that has ever been committed.
+        _ => String::from("HEAD"),
+    };
+    let Some(log) = git(root, &["log", "--no-merges", "--format=%s", &range]) else {
+        return Ok(None);
+    };
+    Ok(Some(
+        log.lines()
+            .map(str::trim)
+            .filter(|subject| !subject.is_empty())
+            .map(str::to_owned)
+            .collect(),
+    ))
+}
+
+/// Run `git` in `root`, or [`None`] when it is not there or says no.
+fn git(root: &Utf8Path, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root.as_str())
+        .args(args)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 fn bump_semver(version: &str, bump: ReleaseBump) -> Result<String> {

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -5,6 +5,7 @@
 //! primitives it draws with live in `uf_term`.
 
 mod brand;
+mod changelog;
 mod cli;
 mod commands;
 mod menu;

--- a/crates/uf_cli/tests/workflow.rs
+++ b/crates/uf_cli/tests/workflow.rs
@@ -291,3 +291,127 @@ fn an_undefined_task_reports_an_error_on_stderr() {
     assert!(stderr.contains("error: task \"nope\" is not defined"));
     assert_plain(&stderr);
 }
+
+/// `uf release` writes the changelog for the version it is cutting.
+///
+/// The tag alone is a version number; the changelog is what is in it. Before
+/// this, the only answer to "what changed" was `gh release --generate-notes`,
+/// which is pull request titles in merge order, on the release page, not in
+/// the repository.
+///
+/// A real repository with real tags, because the interesting parts are the
+/// range (`<last tag>..HEAD`) and the grouping, and neither exists without
+/// history to read.
+#[test]
+fn release_writes_the_changelog_for_the_version_it_cuts() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let git = |args: &[&str]| {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "uf")
+            .env("GIT_AUTHOR_EMAIL", "uf@example.com")
+            .env("GIT_COMMITTER_NAME", "uf")
+            .env("GIT_COMMITTER_EMAIL", "uf@example.com")
+            .output()
+            .expect("git runs");
+        assert!(
+            status.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+    };
+
+    git(&["init", "--quiet", "--initial-branch", "main"]);
+    fs::write(root.join("a.txt"), "one\n").unwrap();
+    git(&["add", "-A"]);
+    git(&["commit", "--quiet", "-m", "feat(cli): the first thing"]);
+    git(&["tag", "uf@0.0.0-alpha.2"]);
+
+    for (file, subject) in [
+        ("b.txt", "fix(fmt): a spread keeps its parentheses"),
+        ("c.txt", "docs: say what it does"),
+        ("d.txt", "rename"),
+    ] {
+        fs::write(root.join(file), "x\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "--quiet", "-m", subject]);
+    }
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(root)
+        .args(["release", "alpha"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("changelog"), "{stdout}");
+    assert!(
+        stdout.contains("3 changes written to the changelog"),
+        "{stdout}"
+    );
+    assert_plain(&stdout);
+
+    let changelog = fs::read_to_string(root.join("CHANGELOG.md")).unwrap();
+    assert!(changelog.starts_with("# Changelog\n"), "{changelog}");
+    // Since the tag, and not before it: the `feat` is in `uf@0.0.0-alpha.2`.
+    assert!(!changelog.contains("the first thing"), "{changelog}");
+    assert!(changelog.contains("### Fixed"), "{changelog}");
+    assert!(
+        changelog.contains("- **fmt**: a spread keeps its parentheses"),
+        "{changelog}"
+    );
+    assert!(changelog.contains("### Documentation"), "{changelog}");
+    assert!(changelog.contains("- say what it does"), "{changelog}");
+    // A subject that is not conventional is kept rather than dropped.
+    assert!(changelog.contains("### Other"), "{changelog}");
+    assert!(changelog.contains("- rename"), "{changelog}");
+    assert!(!changelog.contains("### Added"), "{changelog}");
+
+    // Cutting the same release again replaces the section rather than
+    // stacking a second one.
+    let again = uf()
+        .arg("--cwd")
+        .arg(root)
+        .args(["release", "alpha"])
+        .output()
+        .unwrap();
+    assert!(again.status.success());
+    let twice = fs::read_to_string(root.join("CHANGELOG.md")).unwrap();
+    similar_asserts::assert_eq!(twice, changelog);
+}
+
+/// A directory with no git history still gets a release plan.
+///
+/// `uf release` is not only run inside this repository, and a missing
+/// changelog is not a reason to refuse to cut a release.
+#[test]
+fn release_without_a_repository_still_writes_its_plan() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["release", "alpha"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("planned"), "{stdout}");
+    assert!(!stdout.contains("changelog"), "{stdout}");
+    assert!(!dir.path().join("CHANGELOG.md").exists());
+    assert!(dir.path().join(".uf/release.json").exists());
+}


### PR DESCRIPTION
Half of the P4 roadmap item *"Wire `uf release alpha` to changelog generation
and tag push"*. The changelog half.

`uf release alpha` computed a version, wrote `.uf/release.json`, and had no
answer to "what is in this one". The only answer anywhere was
`gh release --generate-notes` in `release.yml` — pull request titles in merge
order, on the release page, not in the repository.

```
$ uf release alpha

  bump             Alpha
  next version     0.0.0-alpha.3
  tag              uf@0.0.0-alpha.3
  manifest         …/.uf/release.json
  changelog        …/CHANGELOG.md

✓ release uf@0.0.0-alpha.3 planned, 41 changes written to the changelog
```

```markdown
# Changelog

## uf@0.0.0-alpha.3

_2026-09-05_

### Added

- **explain**: say who does the work for every command that delegates (#167)
…

### Fixed

- **fmt**: an object's spread keeps its parentheses (#160)
…

### Other

- rename (#131)
```

The grouping is Conventional Commits, which this repository already writes —
every commit between `uf@0.0.0-alpha.2` and today parses. A subject that does
not is kept under **Other** rather than dropped: a changelog that silently
omits a change is worse than one with an untidy line in it. Only the types the
file knows are read as types, so `note: prose: with a colon` stays prose.

### Three things it deliberately does not do

* **It does not push the tag.** That is the other half of the roadmap item and
  it belongs in its own change, because it should refuse to push while
  `tools/release/preflight.sh` says the release would be half-sent — which it
  does say today, per ubugeeei-prod/uf#130.
* **It does not read a clock.** The date is `git log -1 --format=%cs`, the date
  of the commit being released, so regenerating the file next week says the
  same thing. It also keeps a date crate out of the binary.
* **It does not stack.** Cutting the same release twice replaces that section.
  `uf release alpha` gets run repeatedly while a release is being prepared, and
  a file that grew a second `## uf@0.0.0-alpha.3` every time would be a file
  nobody trusted. Pinned by running the command twice and comparing the file.

### Tests

* Six unit tests over the pure parts — parsing, grouping, empty headings,
  breaking changes leading, replacing a section, prepending under the title.
* `release_writes_the_changelog_for_the_version_it_cuts` builds a real
  repository with a real `uf@*` tag and four commits, and checks the range is
  `<tag>..HEAD`, the grouping, that an unconventional subject survives, that an
  empty heading is absent, and that a second run changes nothing.
* `release_without_a_repository_still_writes_its_plan` — `uf release` is not
  only run inside this repository, and a missing changelog is not a reason to
  refuse to cut a release.

`CHANGELOG.md` in this diff is that output for the release being prepared. The
tag is not pushed, and cannot be until the npm bindings in
ubugeeei-prod/uf#130 exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791217982&installation_model_id=422833&pr_number=187&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F187&signature=14f0307681e3968b1ad7ad74997eb1dd9dfc02434424db2309e5332cd442e9fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->