### PR TITLE
fix(release): trust-npm.sh passes a flag npm does not have

### DIFF
--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -8,6 +8,10 @@
 #   npm login
 #   tools/release/trust-npm.sh
 #
+# Binding a name is an account change, so npm asks for a one-time password.
+# Have the second factor to hand: this is interactive, once per run, and it is
+# why no workflow and no agent can do it.
+#
 # `npm trust` configures a name that has never been published, which is what
 # makes this the whole bootstrap — the first release goes out over OIDC like
 # every one after it, and nobody has to publish by hand to create the package
@@ -15,7 +19,9 @@
 # package had to exist and the binding was a web form; `npm trust` landed in
 # npm 11 and supersedes it.)
 #
-# Idempotent: a package that is already bound is reported and left alone.
+# Safe to re-run. A name that is already bound is skipped when `npm trust list`
+# can read it, and re-bound harmlessly when it cannot — which is the usual
+# case, because that read needs the one-time password too.
 set -eu
 
 repo_root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
@@ -37,8 +43,37 @@ if [ -z "$who" ]; then
 fi
 echo "trust-npm: configuring as ${who}, for ${repository} (${workflow})"
 
+first="$(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.txt | head -1)"
+
+# One dry run before the first real one.
+#
+# `--dry-run` needs no session and writes nothing; it parses the arguments and
+# prints what it would do. It is the only thing that would have caught
+# `--allow-publish` — a flag `npm trust github` does not have — which sat in
+# this script from the day it was written and would have stopped it on the
+# first package, `set -eu`, with the release still blocked and the reason
+# reading like an npm outage:
+#
+#   npm error code EUSAGE
+#   npm error Unknown flag: --allow-publish
+errors="$(mktemp "${TMPDIR:-/tmp}/trust-npm.XXXXXX")"
+trap 'rm -f "$errors"' EXIT INT TERM
+if ! npm trust github "@uniflowed/${first}" \
+  --file "$workflow" \
+  --repository "$repository" \
+  --yes \
+  --dry-run >/dev/null 2>"$errors"; then
+  echo "trust-npm: npm rejected the arguments this script passes:" >&2
+  cat "$errors" >&2
+  exit 1
+fi
+
 for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.txt); do
   name="@uniflowed/${package}"
+  # `npm trust list` needs the same session *and* a one-time password, so on a
+  # session that has not been through 2FA it returns nothing and every name is
+  # attempted. Attempting one that is already bound is not an error — npm says
+  # so and moves on — so this is a shortcut, not a guard.
   if npm trust list "$name" 2>/dev/null | grep -q "file: ${workflow}"; then
     echo "trust-npm: ${name} is already bound to ${workflow}"
     continue
@@ -47,7 +82,6 @@ for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.
   npm trust github "$name" \
     --file "$workflow" \
     --repository "$repository" \
-    --allow-publish \
     --yes
 done
 


### PR DESCRIPTION
**The one command standing between this repository and a release does not run.**

```
$ npm trust github @uniflowed/config --file publish.yml \
    --repository ubugeeei-prod/uf --allow-publish --yes --dry-run
npm error code EUSAGE
npm error Unknown flag: --allow-publish
```

`npm trust github` takes `--file`, `--repository`, `--environment`,
`--dry-run`, `--json`, `--registry` and `--yes`. There is no `--allow-publish`,
and there never was. `tools/release/trust-npm.sh` is `set -eu`, so it would
have stopped on the first name — release still blocked, reason reading like an
npm outage.

Without the flag, the same command reaches the real work:

```
Establishing trust between @uniflowed/config package and GitHub Actions
Anyone with GitHub repository write access can publish to @uniflowed/config
Two-factor authentication is required for this operation

package: @uniflowed/config
file: publish.yml
repository: ubugeeei-prod/uf
```

### The guard

One `--dry-run` before the first real bind. It needs no session and writes
nothing — it parses the arguments and says what it would do — and it is the
only thing that would have caught this. It reports what npm said rather than
dying to `set -e`:

```
trust-npm: npm rejected the arguments this script passes:
npm error code EUSAGE
npm error Unknown flag: --nope
```

Checked both ways against a stub `npm`: the old script stops after
`binding @uniflowed/config`, the new one binds all seventeen, and the guard
fires when a flag is rejected.

### Two comments that were also wrong

* *"Idempotent: a package that is already bound is reported and left alone."*
  `npm trust list` needs the one-time password too, so on a session that has
  not been through 2FA it returns nothing and every name is attempted.
  Re-binding is harmless — the check is a shortcut, not a guard — and the
  comment now says that.
* The header said `npm login` and stopped there. Binding a name is an account
  change, so npm asks for a **second factor**. That is why no workflow and no
  agent can do it, and it belongs in the instructions rather than in the
  surprise.

Context in ubugeeei-prod/uf#130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791218331&installation_model_id=422833&pr_number=188&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F188&signature=5ce4abf8446274d3ec06e79bf429e588e959c217ec8d293b52548de3a9f7cdc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->