### PR TITLE
fix(installer): the download goes where TMPDIR says

### DIFF
--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -529,7 +529,14 @@ archive="uf-${target}.tar.gz"
 archive_url="${channel_url}/${archive}"
 checksum_url="${archive_url}.sha256"
 
-tmp_dir="$(mktemp -d)"
+# With a template, so `TMPDIR` is honoured. BSD `mktemp -d` given no template
+# ignores it and uses the system directory, which is not where a reader who
+# set `TMPDIR` asked for their downloads to land — a restricted CI image, a
+# sandbox, a container whose default temp is read-only. The same trap is
+# written down in `tools/release/verify-npm.sh`, which is where this was
+# noticed: an installer that fails here fails with `mkdtemp failed`, which
+# names neither the cause nor the fix.
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/uf-install.XXXXXX")"
 cleanup() {
   rm -rf "$tmp_dir"
 }

--- a/tools/release/test-install.sh
+++ b/tools/release/test-install.sh
@@ -51,7 +51,8 @@ target="$(rustc -vV | awk -F': ' '/^host:/ { print $2 }')"
 archive="uf-${target}.tar.gz"
 [ -f "${release_dir}/${archive}" ] || fail "missing ${release_dir}/${archive}"
 
-work="$(mktemp -d)"
+# See `install.sh`: without a template, BSD `mktemp -d` ignores `TMPDIR`.
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-install.XXXXXX")"
 server_pid=""
 cleanup() {
   [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
@@ -136,7 +137,32 @@ $(cat "${work}/reinstall.log")"
 "${work}/pinned/bin/uf" --version >/dev/null || fail "reinstall: uf stopped working"
 pass "reinstalling over an existing runtime is idempotent"
 
-# 4. A tampered archive must be rejected, not installed.
+# 4. A `TMPDIR` the caller set is where the download goes.
+#
+#    Pointed at a directory that does not exist, an installer that honours it
+#    stops and one that ignores it carries on using the system temp — so this
+#    is the case that tells the two apart. Honouring it is the point: BSD
+#    `mktemp -d` given no template uses the system directory whatever
+#    `TMPDIR` says, and on a machine whose system temp is not writable — a
+#    sandbox, a container, a locked-down CI image — that is an install that
+#    fails with `mkdtemp failed` and names neither cause nor fix.
+if run_installer tmpdir TMPDIR="${work}/not-a-directory" >"${work}/tmpdir.log" 2>&1; then
+  fail "TMPDIR was ignored: the installer used the system temp instead
+$(cat "${work}/tmpdir.log")"
+fi
+if [ -e "${work}/tmpdir/bin/uf" ]; then
+  fail "TMPDIR: a failed install left a binary behind"
+fi
+
+#    And with one that does exist, it installs.
+mkdir -p "${work}/scratch"
+run_installer tmpdir2 TMPDIR="${work}/scratch" >"${work}/tmpdir2.log" 2>&1 \
+  || fail "installing with TMPDIR set failed:
+$(cat "${work}/tmpdir2.log")"
+[ -x "${work}/tmpdir2/bin/uf" ] || fail "TMPDIR: uf was not linked"
+pass "a caller's TMPDIR is used, and a bad one stops the install"
+
+# 5. A tampered archive must be rejected, not installed.
 tampered="${site}/tampered"
 mkdir -p "$tampered"
 cp "${site}/${version}/${archive}.sha256" "${site}/${version}/VERSION" "$tampered/"
@@ -150,7 +176,7 @@ $(cat "${work}/tampered.log")"
 [ -e "${work}/tampered/bin/uf" ] && fail "tampered: uf was linked anyway"
 pass "a tampered archive fails the checksum and installs nothing"
 
-# 5. An archive whose members escape the extraction root must be rejected even
+# 6. An archive whose members escape the extraction root must be rejected even
 #    though its checksum is honest — the same host serves both.
 evil="${site}/evil"
 mkdir -p "$evil"
@@ -181,7 +207,7 @@ $(cat "${work}/evil.log")"
 [ -e "${work}/escaped" ] && fail "evil: a member escaped the extraction root"
 pass "an archive with members outside the root is rejected"
 
-# 6. A version that does not exist must fail loudly rather than leave a broken
+# 7. A version that does not exist must fail loudly rather than leave a broken
 #    install behind.
 if run_installer missing UF_VERSION=99.99.99 >"${work}/missing.log" 2>&1; then
   fail "a nonexistent version reported success"


### PR DESCRIPTION
Fixes ubugeeei-prod/uf#191.

`curl -fsSL https://setup.uniflowed.dev | sh` fails on a machine whose system
temp directory is not writable, and fails like this:

```
  target   aarch64-apple-darwin
  version  0.0.0-alpha.2  (prerelease — no stable release yet)

mktemp: mkdtemp failed on /var/folders/…/tmp.WC7zFqHuKe: Operation not permitted
```

Setting `TMPDIR` does not help, because BSD `mktemp -d` given no template
ignores it and uses the system directory anyway.

```diff
-tmp_dir="$(mktemp -d)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/uf-install.XXXXXX")"
```

The same trap is already written down two directories away, in
`tools/release/verify-npm.sh`, which is where it was recognised.

### Evidence

With the template, the **published** `uf@0.0.0-alpha.2` installs from
setup.uniflowed.dev into a sandbox with no writable system temp:

```
  ✓ downloaded uf-aarch64-apple-darwin.tar.gz
  ✓ verified   sha256 362036f709d7
  ✓ unpacked   …/runtimes/uf@0.0.0-alpha.2
  ✓ linked     uf, ufr, ufx

  uf 0.0.0-alpha.2 is ready.
```

and the binary it linked runs:

```
$ uf --version
uf_cli 0.0.0-alpha.2
$ uf create app react demo
✓ created 8 files
```

### Test

`test-install.sh` grows the case that tells the two behaviours apart: pointed
at a `TMPDIR` that does not exist, an installer that honours it stops, and one
that ignores it carries on using the system temp. It checks the ordinary
direction too — a `TMPDIR` that does exist installs — because a guard that
only asserts a failure is a guard that passes when nothing works.

`test-install.sh`'s own `mktemp -d` had the same shape and is fixed with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219091&installation_model_id=422833&pr_number=192&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F192&signature=c121b61118292bb2edc6be2abf4cc8c3dd5c73e7721e249f06fa0c573a9936be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->