### PR TITLE
fix(cli): uf --version names uf, not the crate

### DIFF
--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -23,8 +23,15 @@ use uf_term::ColorChoice;
 use crate::cli::{ColorOption, Commands};
 use crate::ui::{OutputMode, Ui};
 
+// The root parser. A `///` comment here would become clap's `long_about` and
+// print in `uf --help`, so this one is deliberately not one.
+//
+// `name = "uf"` because clap otherwise takes the *crate* name, and
+// `uf --version` — the first thing anyone runs after installing — answered
+// `uf_cli 0.0.0-alpha.2`, naming something no user has heard of. The usage
+// line still comes from `argv[0]`, so `ufr --help` keeps saying `ufr`.
 #[derive(Debug, Parser)]
-#[command(version, about = "Unified Toolchain for Flow (React)")]
+#[command(name = "uf", version, about = "Unified Toolchain for Flow (React)")]
 struct Cli {
     /// Run as if uf had been started in DIR instead of the current directory.
     #[arg(long, global = true, value_name = "DIR")]

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -567,7 +567,7 @@ fn selecting_no_formatter_leaves_non_flow_files_alone() {
 
 #[test]
 fn alias_binaries_print_the_root_version() {
-    for name in ["ufr", "ufx"] {
+    for name in ["uf", "ufr", "ufx"] {
         let output = binary(name).arg("--version").output().unwrap();
 
         assert!(
@@ -580,7 +580,20 @@ fn alias_binaries_print_the_root_version() {
             stdout.contains(env!("CARGO_PKG_VERSION")),
             "{name} should expose the installed uf version, got {stdout:?}"
         );
+        // The product, not the crate. clap names the command after the crate
+        // unless it is told otherwise, and `uf --version` — the first thing
+        // anyone runs after installing — answered `uf_cli 0.0.0-alpha.2`.
+        assert!(
+            stdout.starts_with("uf "),
+            "{name} --version should name the command, got {stdout:?}"
+        );
+        assert!(!stdout.contains("uf_cli"), "{name}: {stdout:?}");
     }
+
+    // And the aliases still say what they are in their usage line, which
+    // comes from `argv[0]` rather than from the name.
+    let usage = String::from_utf8(binary("ufr").arg("--help").output().unwrap().stdout).unwrap();
+    assert!(usage.contains("Usage: ufr run"), "{usage}");
 }
 
 #[test]


### PR DESCRIPTION
```
$ uf --version
uf_cli 0.0.0-alpha.2
```

clap names a command after its crate unless told otherwise, and the crate is
`uf_cli`. That string is the first thing anyone sees after installing —
`tools/release/test-install.sh` runs `uf --version` as the proof the release
works — and it names something no user has heard of and cannot type.

```
$ uf --version
uf 0.0.0-alpha.2
```

`ufr` and `ufx` share the parser, so they say the same. That is what
`alias_binaries_print_the_root_version` already wanted: they are aliases for
`uf run` and `uf exec`, and the version they report is uf's.

Their usage lines are unaffected, because those come from `argv[0]` rather
than from the name:

```
$ ufr --help
Usage: ufr run [OPTIONS] [SCRIPT] [ARGS]...
$ ufx --help
Usage: ufx exec [OPTIONS] <PACKAGE> [ARGS]...
```

The comment above the derive is deliberately not a doc comment: clap turns one
into `long_about` and prints it in `uf --help`, which is how the first draft of
this change put a paragraph about clap into the toolchain's front page.

### Test

`alias_binaries_print_the_root_version` grows `uf` itself and two assertions —
that the output starts with `uf ` and never contains `uf_cli` — plus a check
that `ufr --help` still says `ufr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219245&installation_model_id=422833&pr_number=193&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F193&signature=3b9ad5f7363a3969051fd7bb2db3613d1e38c498a2a80c78713da4ae67809b21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->