### PR TITLE
fix(release): ask npm what it can do, not what number it is

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,11 @@ jobs:
       # resolves to nothing. No network, so it belongs here rather than in the
       # pre-tag check alone.
       - run: ./target/release/uf run release:closure
+      # And that the one command the release bootstrap depends on still runs.
+      # It is invoked by hand, once, by one person, so a mistake in it costs a
+      # round trip and blocks a release — it has cost three. Stubs, so this
+      # needs no npm session and no network.
+      - run: ./target/release/uf run release:trust:test
 
   upstream-integrations:
     name: Upstream Integrations

--- a/tools/release/bootstrap-publish.sh
+++ b/tools/release/bootstrap-publish.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env sh
+# Publish, once, the names the registry does not have yet.
+#
+# `npm trust` binds a name the registry already has. It cannot create one:
+#
+#   npm error code E404
+#   npm error 404 Not Found - POST .../@uniflowed%2fcore/trust
+#
+# So the first publish of a *new* name cannot go over OIDC, because there is
+# nothing to bind the workflow to. It has to come from a person, once, and
+# then `tools/release/trust-npm.sh` binds it and every release after that is
+# the workflow's. `uf.config.js` calls this `publish.firstPublish.localBootstrap`.
+#
+#   npm login
+#   tools/release/bootstrap-publish.sh
+#
+# It publishes only what is missing. A name that is already on the registry is
+# left alone whatever version it is at — moving an existing package to a new
+# version is the release workflow's job, not this one's.
+#
+# Every publish is shown before anything is sent, and nothing is sent without
+# an answer. `--yes` skips the question for a non-interactive run.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+assume_yes=false
+for argument in "$@"; do
+  case "$argument" in
+    -y | --yes) assume_yes=true ;;
+    *) echo "bootstrap-publish: unknown option: $argument" >&2; exit 2 ;;
+  esac
+done
+
+command -v npm >/dev/null 2>&1 || { echo "bootstrap-publish: missing npm" >&2; exit 1; }
+who="$(npm whoami 2>/dev/null || true)"
+if [ -z "$who" ]; then
+  echo "bootstrap-publish: not logged in. Run 'npm login' first." >&2
+  exit 1
+fi
+
+list="tools/release/published-packages.txt"
+version="$(node -p "require('./packages/core/package.json').version")"
+
+# The dist-tag a prerelease goes to, so `latest` is not moved by one. The same
+# rule `publish.yml` applies, because a bootstrap that tagged differently would
+# leave the two halves of a release disagreeing.
+tag=latest
+case "$version" in
+  *-alpha*) tag=alpha ;;
+  *-beta*) tag=beta ;;
+  *-rc*) tag=rc ;;
+esac
+
+missing=""
+for package in $(grep -vE '^[[:space:]]*(#|$)' "$list"); do
+  name="@uniflowed/${package}"
+  if npm view "$name" name >/dev/null 2>&1; then
+    printf '  on npm      %s\n' "$name"
+  else
+    printf '  to publish  %s@%s  (--tag %s)\n' "$name" "$version" "$tag"
+    missing="${missing} ${package}"
+  fi
+done
+
+if [ -z "$missing" ]; then
+  echo
+  echo "bootstrap-publish: every name is on the registry; nothing to do."
+  exit 0
+fi
+
+count="$(printf '%s' "$missing" | wc -w | tr -d ' ')"
+cat <<MESSAGE
+
+${count} package(s) have never been published, as ${who}.
+
+This is the one step that cannot go over OIDC, and it cannot be undone: npm
+does not free a name that has been published. Everything after it is the
+publish workflow's.
+MESSAGE
+
+if [ "$assume_yes" != true ]; then
+  printf 'Publish them? [y/N] '
+  read -r answer
+  case "$answer" in
+    y | Y | yes | YES) ;;
+    *) echo "bootstrap-publish: nothing was published."; exit 1 ;;
+  esac
+fi
+
+# A dry run of every one before any real one, so a package that cannot be
+# packed stops this before half the names are out.
+for package in $missing; do
+  ( cd "packages/${package}" && npm publish --access public --tag "$tag" --dry-run >/dev/null ) \
+    || { echo "bootstrap-publish: @uniflowed/${package} would not publish" >&2; exit 1; }
+done
+echo "bootstrap-publish: all ${count} pack cleanly"
+
+published=0
+for package in $missing; do
+  name="@uniflowed/${package}"
+  echo "bootstrap-publish: publishing ${name}@${version}"
+  ( cd "packages/${package}" && npm publish --access public --tag "$tag" )
+  published=$((published + 1))
+done
+
+cat <<MESSAGE
+
+bootstrap-publish: ${published} published.
+
+Now bind them to the workflow, so every release after this one is the
+workflow's and no token exists anywhere:
+
+  tools/release/trust-npm.sh
+MESSAGE

--- a/tools/release/test-trust-npm.sh
+++ b/tools/release/test-trust-npm.sh
@@ -101,6 +101,10 @@ if [ "$flavour" = strict ] && [ -z "$permission" ]; then
 fi
 [ -n "$dry" ] && exit 0
 case "$flavour" in
+  unpublished)
+    echo "npm error code E404" >&2
+    echo "npm error 404 Not Found - POST https://registry.npmjs.org/-/package/${package}/trust" >&2
+    exit 1 ;;
   existing | conflicting)
     echo "npm error code E409" >&2
     echo "npm error 409 Conflict - a trusted publisher configuration that a token could also match already exists for this package" >&2
@@ -154,7 +158,27 @@ grep -q "npm trust revoke" "${work}/conflicting.log" \
 $(cat "${work}/conflicting.log")"
 pass "a configuration pointing somewhere else fails and names the fix"
 
-# 5. An npm without the subcommand stops, binds nothing, and says what to do.
+# 5. A name the registry does not have answers E404. `npm trust` binds a name
+#    the registry already has; it cannot create one. That is a different job,
+#    named, rather than the end of this one.
+if run unpublished; then
+  fail "unpublished: E404 should end in a non-zero exit:
+$(cat "${work}/unpublished.log")"
+fi
+grep -q "is not on the registry yet" "${work}/unpublished.log" \
+  || fail "unpublished: it did not say which names:
+$(cat "${work}/unpublished.log")"
+grep -q "bootstrap-publish.sh" "${work}/unpublished.log" \
+  || fail "unpublished: it did not name the way out:
+$(cat "${work}/unpublished.log")"
+# All of them, not the first one: `set -eu` used to stop on the first.
+missing="$(grep -c 'is not on the registry yet' "${work}/unpublished.log")"
+[ "$missing" = "$names" ] \
+  || fail "unpublished: reported ${missing} of ${names}, so it stopped early:
+$(cat "${work}/unpublished.log")"
+pass "every unpublished name is reported, and the bootstrap is named"
+
+# 6. An npm without the subcommand stops, binds nothing, and says what to do.
 if run ancient; then
   fail "ancient: the script should have stopped:
 $(cat "${work}/ancient.log")"

--- a/tools/release/test-trust-npm.sh
+++ b/tools/release/test-trust-npm.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# `trust-npm.sh` against npms that behave differently, without touching npm.
+#
+# This script is the whole of the release bootstrap and it is run by hand,
+# once, by one person, on one machine — so every mistake in it costs a round
+# trip and blocks a release. It has cost three:
+#
+#   * it passed `--allow-publish`, which one npm requires and another rejects
+#     as an unknown flag;
+#   * a guard was added that built its own argument list, so the guard passed
+#     while the bind it guarded could not run;
+#   * the shared argument list then passed `"${2:-}"`, an empty positional
+#     that only the real bind hits because the dry run always has one:
+#     `npm error Unknown positional argument:`.
+#
+# Each was a shape of `npm trust github` that no stub was strict enough to
+# see. The stubs here parse their arguments the way npm does and refuse
+# anything they were not given, which is what makes them worth running.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+script="tools/release/trust-npm.sh"
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-trust-npm.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+names="$(grep -cvE '^[[:space:]]*(#|$)' tools/release/published-packages.txt)"
+
+fail() {
+  echo "test-trust-npm: FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+# An npm that parses like npm: named flags take their values, an unknown flag
+# is an error, and a second positional — or an empty one — is an error.
+#
+# $1 names the flavour: `permissive` accepts `--allow-publish`, `strict`
+# requires it, `ancient` has no such subcommand.
+make_npm() {
+  flavour="$1"
+  mkdir -p "${work}/${flavour}"
+  cat > "${work}/${flavour}/npm" <<EOF
+#!/bin/sh
+flavour="${flavour}"
+EOF
+  cat >> "${work}/${flavour}/npm" <<'EOF'
+case "$1" in
+  --version) echo "11.99.0"; exit 0 ;;
+  whoami) echo "tester"; exit 0 ;;
+  trust) ;;
+  *) exit 0 ;;
+esac
+shift
+[ "${1:-}" = "github" ] || { echo "npm error Unknown subcommand: ${1:-}" >&2; exit 1; }
+shift
+if [ "${1:-}" = "--help" ]; then
+  case "$flavour" in
+    ancient) echo "npm trust github [package]" ;;
+    strict)  echo "  --file (required)"; echo "  --repository|--repo"
+             echo "  --allow-publish"; echo "  --allow-stage-publish" ;;
+    *)       echo "  --file (required)"; echo "  --repository|--repo" ;;
+  esac
+  exit 0
+fi
+[ "${1:-}" = "list" ] && exit 1
+package=""; file=""; repository=""; permission=""; dry=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --file) file="${2:-}"; shift 2 ;;
+    --repository|--repo) repository="${2:-}"; shift 2 ;;
+    --allow-publish|--allow-stage-publish)
+      case "$flavour" in
+        permissive) echo "npm error Unknown flag: $1" >&2; exit 1 ;;
+        *) permission="$1"; shift ;;
+      esac ;;
+    --yes|-y) shift ;;
+    --dry-run) dry=1; shift ;;
+    --*) echo "npm error Unknown flag: $1" >&2; exit 1 ;;
+    "") echo "npm error Unknown positional argument: " >&2; exit 1 ;;
+    *) if [ -z "$package" ]; then package="$1"; shift
+       else echo "npm error Unknown positional argument: $1" >&2; exit 1; fi ;;
+  esac
+done
+[ -n "$package" ] || { echo "npm error a package is required" >&2; exit 1; }
+[ -n "$file" ] || { echo "npm error --file is required" >&2; exit 1; }
+[ -n "$repository" ] || { echo "npm error --repository is required" >&2; exit 1; }
+if [ "$flavour" = strict ] && [ -z "$permission" ]; then
+  echo "npm error At least one permission flag is required (--allow-publish, --allow-stage-publish)" >&2
+  exit 1
+fi
+[ -n "$dry" ] && exit 0
+echo "bound $package"
+EOF
+  chmod +x "${work}/${flavour}/npm"
+}
+
+run() {
+  make_npm "$1"
+  PATH="${work}/$1:$PATH" sh "$script" >"${work}/$1.log" 2>&1
+}
+
+# 1 and 2. Both flag sets bind every name. The script asks the help which one
+#          this npm speaks rather than assuming either.
+for flavour in strict permissive; do
+  run "$flavour" || fail "${flavour}: the script failed:
+$(cat "${work}/${flavour}.log")"
+  bound="$(grep -c '^bound ' "${work}/${flavour}.log" || true)"
+  [ "$bound" = "$names" ] \
+    || fail "${flavour}: bound ${bound} of ${names}:
+$(cat "${work}/${flavour}.log")"
+  pass "${flavour} npm binds all ${names} names"
+done
+
+# 3. An npm without the subcommand stops, binds nothing, and says what to do.
+if run ancient; then
+  fail "ancient: the script should have stopped:
+$(cat "${work}/ancient.log")"
+fi
+grep -q '^bound ' "${work}/ancient.log" && fail "ancient: it bound something"
+grep -q 'npm install -g npm@' "${work}/ancient.log" \
+  || fail "ancient: no upgrade instruction:
+$(cat "${work}/ancient.log")"
+pass "an npm without the subcommand stops and names the upgrade"
+
+echo "test-trust-npm: ok"

--- a/tools/release/test-trust-npm.sh
+++ b/tools/release/test-trust-npm.sh
@@ -56,18 +56,24 @@ case "$1" in
   *) exit 0 ;;
 esac
 shift
+if [ "${1:-}" = "list" ]; then
+  case "$flavour" in
+    conflicting) echo "  file: some-other.yml"; echo "  repository: someone/else"; exit 0 ;;
+    existing) echo "  file: publish.yml"; echo "  repository: ubugeeei-prod/uf"; exit 0 ;;
+    *) exit 1 ;;
+  esac
+fi
 [ "${1:-}" = "github" ] || { echo "npm error Unknown subcommand: ${1:-}" >&2; exit 1; }
 shift
 if [ "${1:-}" = "--help" ]; then
   case "$flavour" in
     ancient) echo "npm trust github [package]" ;;
-    strict)  echo "  --file (required)"; echo "  --repository|--repo"
+    permissive) echo "  --file (required)"; echo "  --repository|--repo" ;;
+    *)       echo "  --file (required)"; echo "  --repository|--repo"
              echo "  --allow-publish"; echo "  --allow-stage-publish" ;;
-    *)       echo "  --file (required)"; echo "  --repository|--repo" ;;
   esac
   exit 0
 fi
-[ "${1:-}" = "list" ] && exit 1
 package=""; file=""; repository=""; permission=""; dry=""
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -94,6 +100,12 @@ if [ "$flavour" = strict ] && [ -z "$permission" ]; then
   exit 1
 fi
 [ -n "$dry" ] && exit 0
+case "$flavour" in
+  existing | conflicting)
+    echo "npm error code E409" >&2
+    echo "npm error 409 Conflict - a trusted publisher configuration that a token could also match already exists for this package" >&2
+    exit 1 ;;
+esac
 echo "bound $package"
 EOF
   chmod +x "${work}/${flavour}/npm"
@@ -109,19 +121,45 @@ run() {
 for flavour in strict permissive; do
   run "$flavour" || fail "${flavour}: the script failed:
 $(cat "${work}/${flavour}.log")"
-  bound="$(grep -c '^bound ' "${work}/${flavour}.log" || true)"
+  # The script's own line, not the stub's: the stub's output goes into the
+  # file the script captures so it can tell E409 from a real failure.
+  bound="$(grep -c '^trust-npm: bound ' "${work}/${flavour}.log" || true)"
   [ "$bound" = "$names" ] \
     || fail "${flavour}: bound ${bound} of ${names}:
 $(cat "${work}/${flavour}.log")"
   pass "${flavour} npm binds all ${names} names"
 done
 
-# 3. An npm without the subcommand stops, binds nothing, and says what to do.
+# 3. A name that already has this repository's configuration answers E409,
+#    which is "already done" and not a failure. `set -eu` used to stop the
+#    whole run on the first one.
+run existing || fail "existing: E409 should not stop the run:
+$(cat "${work}/existing.log")"
+grep -q "already points at publish.yml" "${work}/existing.log" \
+  || fail "existing: it did not say the configuration is the right one:
+$(cat "${work}/existing.log")"
+grep -q "0 bound, ${names} already configured" "${work}/existing.log" \
+  || fail "existing: wrong summary:
+$(cat "${work}/existing.log")"
+pass "a name that is already configured for this workflow is reported, not fatal"
+
+# 4. And one whose configuration names something else is a problem, because a
+#    publish from this repository will be refused for it.
+if run conflicting; then
+  fail "conflicting: a configuration for another workflow should fail:
+$(cat "${work}/conflicting.log")"
+fi
+grep -q "npm trust revoke" "${work}/conflicting.log" \
+  || fail "conflicting: no way out was named:
+$(cat "${work}/conflicting.log")"
+pass "a configuration pointing somewhere else fails and names the fix"
+
+# 5. An npm without the subcommand stops, binds nothing, and says what to do.
 if run ancient; then
   fail "ancient: the script should have stopped:
 $(cat "${work}/ancient.log")"
 fi
-grep -q '^bound ' "${work}/ancient.log" && fail "ancient: it bound something"
+grep -q '^trust-npm: bound ' "${work}/ancient.log" && fail "ancient: it bound something"
 grep -q 'npm install -g npm@' "${work}/ancient.log" \
   || fail "ancient: no upgrade instruction:
 $(cat "${work}/ancient.log")"

--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -93,14 +93,24 @@ fi
 # One argument list, used by the dry run and by every real bind, so the check
 # and the thing it checks cannot drift.
 #
+# `shift` then `"$@"`, so a call with no extra arguments passes none. Writing
+# it as `"${2:-}"` passes an *empty* argument instead, which npm reads as a
+# positional it does not have:
+#
+#   npm error Unknown positional argument:
+#
+# and which only the real bind hits, because the dry run always has one.
+#
 # shellcheck disable=SC2086 # deliberate: $permission is one flag or nothing
 trust() {
-  npm trust github "$1" \
+  package="$1"
+  shift
+  npm trust github "$package" \
     --file "$workflow" \
     --repository "$repository" \
     $permission \
     --yes \
-    "${2:-}"
+    "$@"
 }
 
 # One dry run before the first real one.

--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -49,12 +49,18 @@ if ! npm trust github --help 2>&1 | grep -q -- '--repository'; then
 trust-npm: this npm does not have \`npm trust github --file --repository\`.
 
   npm --version   ${npm_version}
+  node --version  $(node --version 2>/dev/null || echo unknown)
 
 That subcommand is how a package name is bound to this repository's publish
 workflow, and it is the whole of the release bootstrap. Upgrade npm and run
 this again:
 
   npm install -g npm@latest
+
+If that answers EBADENGINE, npm's latest wants a newer node than this one.
+The last npm 11 has the subcommand and asks only for node >= 22.9.0:
+
+  npm install -g npm@11.11.0
 MESSAGE
   exit 1
 fi

--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -31,10 +31,33 @@ repository="${UF_TRUST_REPOSITORY:-ubugeeei-prod/uf}"
 workflow="${UF_TRUST_WORKFLOW:-publish.yml}"
 
 command -v npm >/dev/null 2>&1 || { echo "trust-npm: missing npm" >&2; exit 1; }
-case "$(npm --version)" in
-  1[1-9].* | [2-9][0-9].*) ;;
-  *) echo "trust-npm: npm 11 or newer is required for \`npm trust\`" >&2; exit 1 ;;
-esac
+npm_version="$(npm --version 2>/dev/null || echo unknown)"
+
+# Ask npm what it can do rather than what number it is.
+#
+# `npm trust github` and its `--file`/`--repository` arrived partway through
+# npm 11, so a major-version gate lets through an npm that has `trust` and not
+# the arguments this script passes — and npm does not fail on an argument it
+# does not know, it *warns* and carries on with the value as a positional:
+#
+#   npm warn "publish.yml" is being parsed as a normal command line argument.
+#   npm warn Unknown cli config "--file".
+#
+# which is a run that looks like it worked and bound nothing.
+if ! npm trust github --help 2>&1 | grep -q -- '--repository'; then
+  cat >&2 <<MESSAGE
+trust-npm: this npm does not have \`npm trust github --file --repository\`.
+
+  npm --version   ${npm_version}
+
+That subcommand is how a package name is bound to this repository's publish
+workflow, and it is the whole of the release bootstrap. Upgrade npm and run
+this again:
+
+  npm install -g npm@latest
+MESSAGE
+  exit 1
+fi
 
 who="$(npm whoami 2>/dev/null || true)"
 if [ -z "$who" ]; then
@@ -56,15 +79,19 @@ first="$(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.txt | he
 #
 #   npm error code EUSAGE
 #   npm error Unknown flag: --allow-publish
+# Both streams: npm puts some failures on stdout, and a guard that reports
+# half of them is a guard that reports warnings and hides the error.
 errors="$(mktemp "${TMPDIR:-/tmp}/trust-npm.XXXXXX")"
 trap 'rm -f "$errors"' EXIT INT TERM
 if ! npm trust github "@uniflowed/${first}" \
   --file "$workflow" \
   --repository "$repository" \
   --yes \
-  --dry-run >/dev/null 2>"$errors"; then
+  --dry-run >"$errors" 2>&1; then
   echo "trust-npm: npm rejected the arguments this script passes:" >&2
-  cat "$errors" >&2
+  grep -v '^npm warn Unknown user config' <"$errors" >&2 || cat "$errors" >&2
+  echo >&2
+  echo "trust-npm: npm --version ${npm_version}" >&2
   exit 1
 fi
 

--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -74,30 +74,51 @@ echo "trust-npm: configuring as ${who}, for ${repository} (${workflow})"
 
 first="$(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.txt | head -1)"
 
+# What this npm calls "may publish".
+#
+# The flag set moves between npm releases and it has moved in both directions:
+# the npm this script was written against required `--allow-publish`, npm
+# 11.11.0 rejects it as an unknown flag, and a newer one requires it again —
+#
+#   npm error At least one permission flag is required
+#             (--allow-publish, --allow-stage-publish)
+#
+# so it is asked for rather than assumed. A version number would not answer
+# this; the help does.
+permission=""
+if npm trust github --help 2>&1 | grep -q -- '--allow-publish'; then
+  permission="--allow-publish"
+fi
+
+# One argument list, used by the dry run and by every real bind, so the check
+# and the thing it checks cannot drift.
+#
+# shellcheck disable=SC2086 # deliberate: $permission is one flag or nothing
+trust() {
+  npm trust github "$1" \
+    --file "$workflow" \
+    --repository "$repository" \
+    $permission \
+    --yes \
+    "${2:-}"
+}
+
 # One dry run before the first real one.
 #
 # `--dry-run` needs no session and writes nothing; it parses the arguments and
-# prints what it would do. It is the only thing that would have caught
-# `--allow-publish` — a flag `npm trust github` does not have — which sat in
-# this script from the day it was written and would have stopped it on the
-# first package, `set -eu`, with the release still blocked and the reason
-# reading like an npm outage:
+# prints what it would do. It is what catches a flag this npm does not take,
+# before `set -eu` stops the script on the first package with the release
+# still blocked and the reason reading like an npm outage.
 #
-#   npm error code EUSAGE
-#   npm error Unknown flag: --allow-publish
-# Both streams: npm puts some failures on stdout, and a guard that reports
-# half of them is a guard that reports warnings and hides the error.
+# Both streams, because npm puts some failures on stdout and a guard that
+# reports half of them reports the warnings and hides the error.
 errors="$(mktemp "${TMPDIR:-/tmp}/trust-npm.XXXXXX")"
 trap 'rm -f "$errors"' EXIT INT TERM
-if ! npm trust github "@uniflowed/${first}" \
-  --file "$workflow" \
-  --repository "$repository" \
-  --yes \
-  --dry-run >"$errors" 2>&1; then
+if ! trust "@uniflowed/${first}" --dry-run >"$errors" 2>&1; then
   echo "trust-npm: npm rejected the arguments this script passes:" >&2
   grep -v '^npm warn Unknown user config' <"$errors" >&2 || cat "$errors" >&2
   echo >&2
-  echo "trust-npm: npm --version ${npm_version}" >&2
+  echo "trust-npm: npm --version ${npm_version}, permission flag '${permission:-none}'" >&2
   exit 1
 fi
 
@@ -112,10 +133,7 @@ for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.
     continue
   fi
   echo "trust-npm: binding ${name}"
-  npm trust github "$name" \
-    --file "$workflow" \
-    --repository "$repository" \
-    --yes
+  trust "$name"
 done
 
 echo

--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -12,12 +12,14 @@
 # Have the second factor to hand: this is interactive, once per run, and it is
 # why no workflow and no agent can do it.
 #
-# `npm trust` configures a name that has never been published, which is what
-# makes this the whole bootstrap — the first release goes out over OIDC like
-# every one after it, and nobody has to publish by hand to create the package
-# first. (The npm documentation still describes the older flow, where the
-# package had to exist and the binding was a web form; `npm trust` landed in
-# npm 11 and supersedes it.)
+# `npm trust` binds a name the registry already has. It cannot create one:
+#
+#   npm error code E404
+#   npm error 404 Not Found - POST .../@uniflowed%2fcore/trust
+#
+# so a name that has never been published has to be published once before it
+# can be bound. That is what `tools/release/bootstrap-publish.sh` is for, and
+# this script says which names need it rather than stopping on the first.
 #
 # Safe to re-run. A name that is already bound is skipped when `npm trust list`
 # can read it, and re-bound harmlessly when it cannot — which is the usual
@@ -135,6 +137,7 @@ fi
 bound=0
 existing=0
 mismatched=""
+unpublished=""
 
 # `npm trust list` needs the same session *and* a one-time password, so on a
 # session that has not been through 2FA it returns nothing and every name is
@@ -155,9 +158,16 @@ for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.
     bound=$((bound + 1))
     continue
   fi
+  # A name the registry does not have cannot be bound, and that is a
+  # different job rather than a failure of this one.
+  if grep -q 'E404' "$errors"; then
+    echo "trust-npm: ${name} is not on the registry yet"
+    unpublished="${unpublished} ${package}"
+    continue
+  fi
   if ! grep -q 'E409' "$errors"; then
     echo "trust-npm: ${name} could not be bound:" >&2
-    cat "$errors" >&2
+    grep -v '^npm warn Unknown user config' <"$errors" >&2 || cat "$errors" >&2
     exit 1
   fi
   existing=$((existing + 1))
@@ -171,7 +181,21 @@ for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.
 done
 
 echo
-echo "trust-npm: ${bound} bound, ${existing} already configured"
+echo "trust-npm: ${bound} bound, ${existing} already configured, \
+$(printf '%s' "$unpublished" | wc -w | tr -d ' ') not on the registry"
+if [ -n "$unpublished" ]; then
+  cat >&2 <<MESSAGE
+
+These have never been published, so there is nothing to bind yet:
+${unpublished}
+
+\`npm trust\` binds a name the registry has; it does not create one. Publish
+them once, then run this again:
+
+  tools/release/bootstrap-publish.sh
+
+MESSAGE
+fi
 if [ -n "$mismatched" ]; then
   cat >&2 <<MESSAGE
 
@@ -183,6 +207,9 @@ Revoke the old configuration and run this again:
 
   npm trust revoke <package>
 MESSAGE
+  exit 1
+fi
+if [ -n "$unpublished" ]; then
   exit 1
 fi
 

--- a/tools/release/trust-npm.sh
+++ b/tools/release/trust-npm.sh
@@ -132,19 +132,59 @@ if ! trust "@uniflowed/${first}" --dry-run >"$errors" 2>&1; then
   exit 1
 fi
 
+bound=0
+existing=0
+mismatched=""
+
+# `npm trust list` needs the same session *and* a one-time password, so on a
+# session that has not been through 2FA it returns nothing and every name is
+# attempted. That is fine: a name that already has a configuration answers
+#
+#   npm error code E409
+#   npm error 409 Conflict - a trusted publisher configuration that a token
+#   could also match already exists for this package
+#
+# which is "already done", not a failure — but it is *not* proof that the
+# configuration is this repository's workflow, so the one that says so is
+# asked for and checked. `set -eu` would stop the run on the first of these,
+# which is what it did.
 for package in $(grep -vE '^[[:space:]]*(#|$)' tools/release/published-packages.txt); do
   name="@uniflowed/${package}"
-  # `npm trust list` needs the same session *and* a one-time password, so on a
-  # session that has not been through 2FA it returns nothing and every name is
-  # attempted. Attempting one that is already bound is not an error — npm says
-  # so and moves on — so this is a shortcut, not a guard.
-  if npm trust list "$name" 2>/dev/null | grep -q "file: ${workflow}"; then
-    echo "trust-npm: ${name} is already bound to ${workflow}"
+  if trust "$name" >"$errors" 2>&1; then
+    echo "trust-npm: bound ${name}"
+    bound=$((bound + 1))
     continue
   fi
-  echo "trust-npm: binding ${name}"
-  trust "$name"
+  if ! grep -q 'E409' "$errors"; then
+    echo "trust-npm: ${name} could not be bound:" >&2
+    cat "$errors" >&2
+    exit 1
+  fi
+  existing=$((existing + 1))
+  if npm trust list "$name" 2>/dev/null | grep -q "$workflow"; then
+    echo "trust-npm: ${name} already points at ${workflow}"
+  else
+    echo "trust-npm: ${name} already has a configuration, and it is not ${workflow}:"
+    npm trust list "$name" 2>&1 | sed 's/^/    /'
+    mismatched="${mismatched} ${name}"
+  fi
 done
+
+echo
+echo "trust-npm: ${bound} bound, ${existing} already configured"
+if [ -n "$mismatched" ]; then
+  cat >&2 <<MESSAGE
+
+These already had a trusted publisher and it does not name ${workflow}:
+${mismatched}
+
+A publish from this repository's workflow will be refused for each of them.
+Revoke the old configuration and run this again:
+
+  npm trust revoke <package>
+MESSAGE
+  exit 1
+fi
 
 echo
 echo "Done. A 'uf@*' tag now publishes these over OIDC, with no token anywhere."

--- a/uf.config.js
+++ b/uf.config.js
@@ -158,6 +158,10 @@ export default defineConfig({
     // published resolves to nothing. No network, so `ci` runs it.
     "release:closure": "tools/release/verify-npm.sh --closure-only",
     "install:test": "tools/release/test-install.sh",
+    // The bootstrap is run by hand, once, by one person, and every mistake
+    // in it costs a round trip and blocks a release. It has cost three, each
+    // a shape of `npm trust github` that no test was strict enough to see.
+    "release:trust:test": "tools/release/test-trust-npm.sh",
     "release:manifest": "tools/release/build-manifest.sh",
     "release:package": "tools/release/package-binaries.sh",
     "release:bump": "tools/release/bump-version.sh",

--- a/uf.config.js
+++ b/uf.config.js
@@ -162,6 +162,10 @@ export default defineConfig({
     // in it costs a round trip and blocks a release. It has cost three, each
     // a shape of `npm trust github` that no test was strict enough to see.
     "release:trust:test": "tools/release/test-trust-npm.sh",
+    // `npm trust` binds a name the registry already has and cannot create
+    // one, so a name that has never been published is published once by a
+    // person and is the workflow's from then on.
+    "release:bootstrap": "tools/release/bootstrap-publish.sh",
     "release:manifest": "tools/release/build-manifest.sh",
     "release:package": "tools/release/package-binaries.sh",
     "release:bump": "tools/release/bump-version.sh",


### PR DESCRIPTION
Run against a real npm, the guard added in ubugeeei-prod/uf#188 fired and
reported only this:

```
trust-npm: npm rejected the arguments this script passes:
npm warn "publish.yml" is being parsed as a normal command line argument.
npm warn "ubugeeei-prod/uf" is being parsed as a normal command line argument.
npm warn Unknown cli config "--file".
npm warn Unknown cli config "--repository".
```

Two things were wrong.

### The version gate is too loose

`npm trust github` and its `--file` and `--repository` arrived partway through
npm 11; the gate only asked for npm 11. And an npm that has `trust` without
those arguments **does not fail on them** — npm warns about a flag it does not
know and carries on with the value as a positional. So the run looks like it
worked and binds nothing.

It is a feature probe now: `npm trust github --help` has to mention
`--repository`. It reports the version rather than leaving it to be guessed:

```
trust-npm: this npm does not have `npm trust github --file --repository`.

  npm --version   11.6.2

That subcommand is how a package name is bound to this repository's publish
workflow, and it is the whole of the release bootstrap. Upgrade npm and run
this again:

  npm install -g npm@latest
```

### The guard threw away stdout

`>/dev/null 2>"$errors"` kept the warnings and discarded the error underneath
them, which is why the report above is three warnings and no reason. Both
streams are kept now, and npm's version is printed after them, because that is
what the next question is going to be.

### Checked

Against a stub npm both ways: one that answers `--help` without `--repository`
stops with the upgrade message and binds nothing; one that answers with it
reaches the loop and binds all seventeen names.

Context in ubugeeei-prod/uf#130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791220153&installation_model_id=422833&pr_number=194&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F194&signature=5e8180522e89fd6afe721c58bd34d5b9b5e18031842e898e2fe42b2046b9c6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->