### PR TITLE
refactor(flow): one set of parse options, and the test that keeps it one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,6 +3683,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "thiserror",
+ "uf_flow",
  "uf_infra",
 ]
 

--- a/crates/uf_flow/src/lib.rs
+++ b/crates/uf_flow/src/lib.rs
@@ -23,8 +23,9 @@ mod upstream;
 use thiserror::Error;
 
 pub use parse::{
-    Depths, Loc, MAX_CHAIN_DEPTH, MAX_NESTING_DEPTH, MAX_PARSE_BYTES, PARSE_STACK_BYTES,
-    ParseFailure, Parsed, Position, ast, chain_depth, depths, nesting_depth, parse,
+    Depths, Loc, MAX_CHAIN_DEPTH, MAX_NESTING_DEPTH, MAX_PARSE_BYTES, PARSE_OPTIONS,
+    PARSE_STACK_BYTES, ParseFailure, Parsed, Position, ast, chain_depth, depths, nesting_depth,
+    parse,
 };
 pub use strip::{MAX_STRIP_BYTES, StripError, Stripped, strip_types};
 

--- a/crates/uf_flow/src/parse.rs
+++ b/crates/uf_flow/src/parse.rs
@@ -102,9 +102,24 @@ pub const PARSE_STACK_BYTES: usize = 128 * 1024 * 1024;
 /// Every syntax `uf` ships in templates or lints is on — component and hook
 /// syntax, enums, pattern matching, records, Flow types, and types in
 /// comments. Decorators stay off because generated projects never emit them.
-/// This mirrors the options [`validate_source`](crate::validate_source) uses,
-/// so the formatter and the linter always agree on what parses.
-const UF_PARSE_OPTIONS: ParseOptions = ParseOptions {
+///
+/// # The only copy
+///
+/// Everything in uf that hands source to the Flow parser hands it *this*:
+/// [`parse`], [`validate_source`](crate::validate_source), and the transform
+/// in `uf_transform`, which re-exports it rather than declaring its own. There
+/// were three literals, equal member for member by coincidence, each with a
+/// comment claiming it mirrored one of the others. Nothing checked that, and a
+/// file that parses for the linter and not for the formatter is worse than one
+/// that parses for neither: the linter says the file is fine, the formatter
+/// refuses it, and the reader has no way to tell which is right.
+///
+/// `uf_transform`'s `tests/parse_options.rs` is what keeps it one copy. It
+/// runs the same syntax through all three entry points and requires the same
+/// answer, and it requires every member of [`ParseOptions`] to decide at least
+/// one of those samples — so a member added upstream fails the test until a
+/// sample covers it, rather than drifting unwatched.
+pub const PARSE_OPTIONS: ParseOptions = ParseOptions {
     components: true,
     enums: true,
     pattern_matching: true,
@@ -240,7 +255,7 @@ pub fn parse(source: &str) -> Result<Parsed, ParseFailure> {
     }
 
     let (program, errors) = catch_unwind(AssertUnwindSafe(|| {
-        flow_parser::parse_program_without_file(false, None, Some(UF_PARSE_OPTIONS), Ok(source))
+        flow_parser::parse_program_without_file(false, None, Some(PARSE_OPTIONS), Ok(source))
     }))
     .map_err(|_| ParseFailure::ParserPanicked)?;
 

--- a/crates/uf_flow/src/upstream.rs
+++ b/crates/uf_flow/src/upstream.rs
@@ -4,35 +4,15 @@
 //! enums) natively, so nothing rewrites the source before parsing and every
 //! diagnostic points at the location the user actually wrote.
 
-use flow_parser::ParseOptions;
 use flow_parser::loc::Loc;
 use flow_parser::parse_error::ParseError;
 
+use crate::parse::PARSE_OPTIONS;
 use crate::{FlowError, ParseDiagnostic, ParseOutcome};
-
-/// Parse options aligned with the `uf` project defaults.
-///
-/// Decorators stay off because generated projects never emit them, and every
-/// syntax `uf` ships in templates or lints stays on.
-const UF_PARSE_OPTIONS: ParseOptions = ParseOptions {
-    components: true,
-    enums: true,
-    pattern_matching: true,
-    records: true,
-    esproposal_decorators: false,
-    types: true,
-    ambiguous_types: true,
-    enable_types_in_comments: true,
-    use_strict: false,
-    assert_operator: false,
-    module_ref_prefix: None,
-    ambient: false,
-    allow_return_outside_function: false,
-};
 
 pub(crate) fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
     let (_program, errors): (_, Vec<(Loc, ParseError)>) =
-        flow_parser::parse_program_without_file(false, None, Some(UF_PARSE_OPTIONS), Ok(source));
+        flow_parser::parse_program_without_file(false, None, Some(PARSE_OPTIONS), Ok(source));
 
     Ok(ParseOutcome {
         diagnostics: errors.iter().map(diagnostic_from_error).collect(),

--- a/crates/uf_transform/Cargo.toml
+++ b/crates/uf_transform/Cargo.toml
@@ -24,6 +24,7 @@ rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+uf_flow = { path = "../uf_flow" }
 uf_infra = { path = "../uf_infra" }
 
 [dev-dependencies]

--- a/crates/uf_transform/src/estree.rs
+++ b/crates/uf_transform/src/estree.rs
@@ -11,7 +11,6 @@
 //! columns count code points instead; [`crate::babel`] recomputes them from
 //! the offsets so every position downstream agrees.
 
-use flow_parser::ParseOptions;
 use flow_parser::estree_translator::{self, Config, OffsetStyle};
 use flow_parser::loc::Loc;
 use flow_parser::offset_utils::{OffsetKind, OffsetTable};
@@ -26,26 +25,16 @@ use crate::TransformError;
 /// scan in uf has an explicit ceiling rather than trusting its input.
 pub const MAX_SOURCE_BYTES: usize = 8 * 1024 * 1024;
 
-/// Parse options aligned with the `uf` project defaults.
+/// The parse options every part of uf uses, re-exported from `uf_flow`.
 ///
-/// Every syntax uf documents is on: components, hooks, enums, pattern
-/// matching, records. Decorators stay off because generated projects never
-/// emit them.
-pub const PARSE_OPTIONS: ParseOptions = ParseOptions {
-    components: true,
-    enums: true,
-    pattern_matching: true,
-    records: true,
-    esproposal_decorators: false,
-    types: true,
-    ambiguous_types: true,
-    enable_types_in_comments: true,
-    use_strict: false,
-    assert_operator: false,
-    module_ref_prefix: None,
-    ambient: false,
-    allow_return_outside_function: false,
-};
+/// This crate used to declare its own literal, equal to `uf_flow`'s member for
+/// member and equal only by coincidence: nothing compared them, and a syntax
+/// the transform accepted and the linter did not would have shown up as a
+/// module that lints clean and fails to load. `uf_flow` owns Flow syntax for
+/// uf, and the options are part of what that means.
+///
+/// `tests/parse_options.rs` is what keeps this a re-export.
+pub use uf_flow::PARSE_OPTIONS;
 
 /// Parse `source` and render it as an ESTree `Program`.
 ///

--- a/crates/uf_transform/tests/parse_options.rs
+++ b/crates/uf_transform/tests/parse_options.rs
@@ -1,0 +1,259 @@
+//! One set of parse options, and the two things that keep it one.
+//!
+//! uf hands source to Meta's Flow parser from three places — [`uf_flow::parse`]
+//! for anything that rewrites a module, [`uf_flow::validate_source`] for the
+//! linter's "does this parse", and [`uf_transform::estree::parse`] for the
+//! transform. Each used to carry its own `ParseOptions` literal, equal to the
+//! others member for member, each with a comment saying it mirrored one of
+//! them. Nothing compared them.
+//!
+//! A drift there does not look like a bug in the parser. It looks like a file
+//! that lints clean and will not format, or transforms and will not check —
+//! and the reader has no way to tell which of the two commands is right. So
+//! there is one constant now, and these tests are what stop a second one:
+//!
+//! * [`every_entry_point_parses_the_same_syntax`] runs the samples through all
+//!   three and requires the same answer, which is the property a reader
+//!   actually depends on;
+//! * [`every_option_decides_a_sample`] requires each member of `ParseOptions`
+//!   to change the answer for at least one sample, which is what makes the
+//!   first test complete. Without it a member could be dropped from one copy
+//!   and no sample would notice.
+//!
+//! This test lives in `uf_transform` because it is the crate that can see both
+//! sides.
+
+use flow_parser::ParseOptions;
+
+/// A source, and the option whose value decides what the parser makes of it.
+///
+/// "Decides" and not "decides whether it parses": for most of them the option
+/// is the difference between a tree and a syntax error, but `f<T>(x)` and
+/// `'m#./other'` parse either way and come out as different trees, which is
+/// why [`fingerprint`] compares trees.
+///
+/// The sources are the smallest thing that reaches the option, and
+/// deliberately not idiomatic uf — this `component` takes no props and returns
+/// `null`, because what is under test is the grammar the parser was handed,
+/// not the code anyone would write.
+struct Sample {
+    /// The `ParseOptions` member this source exercises.
+    option: &'static str,
+    /// The source, as a whole module.
+    source: &'static str,
+}
+
+const SAMPLES: &[Sample] = &[
+    Sample {
+        option: "components",
+        source: "component Greeting() { return null; }",
+    },
+    Sample {
+        option: "enums",
+        source: "enum Status { Active, Off }",
+    },
+    Sample {
+        option: "pattern_matching",
+        source: "const chosen = match (value) { 1 => 'one', _ => 'other' };",
+    },
+    Sample {
+        option: "records",
+        source: "const point = Point { x: 1, y: 2 };",
+    },
+    Sample {
+        option: "esproposal_decorators",
+        source: "@decorate class Thing {}",
+    },
+    Sample {
+        option: "types",
+        source: "const count: number = 1;",
+    },
+    Sample {
+        option: "ambiguous_types",
+        source: "const named = identity<string>(value);",
+    },
+    Sample {
+        option: "enable_types_in_comments",
+        source: "const count /*: number */ = 1;",
+    },
+    Sample {
+        option: "use_strict",
+        source: "var permissions = 0755;",
+    },
+    Sample {
+        option: "assert_operator",
+        source: "const definitely = maybe!;",
+    },
+    Sample {
+        option: "module_ref_prefix",
+        source: "const other = 'm#./other';",
+    },
+    Sample {
+        option: "ambient",
+        source: "function signatureOnly(): void;",
+    },
+    Sample {
+        option: "allow_return_outside_function",
+        source: "return 1;",
+    },
+];
+
+/// What the parser makes of `source` under `options`: its errors and its tree.
+///
+/// Not "does it parse": several of these options change the *shape* of a tree
+/// the parser accepts either way. `ambiguous_types` decides whether `f<T>(x)`
+/// is a parameterized call or two comparisons, and `module_ref_prefix` decides
+/// whether a string is a string or a module reference — both parse with the
+/// option off, and a test that only asked whether they parsed would report
+/// that neither option does anything.
+fn fingerprint(options: &ParseOptions, source: &str) -> String {
+    let (program, errors) =
+        flow_parser::parse_program_without_file(false, None, Some(options.clone()), Ok(source));
+    format!("{errors:?}\n{program:?}")
+}
+
+/// The same source through every entry point uf has, and the same answer.
+#[test]
+fn every_entry_point_parses_the_same_syntax() {
+    for sample in SAMPLES {
+        let by_parse = uf_flow::parse(sample.source)
+            .expect("a sample is far under every ceiling")
+            .is_ok();
+        let by_validate = uf_flow::validate_source(sample.source)
+            .expect("the parser backend is always available")
+            .is_ok();
+        // The transform reports the first syntax error as an error rather than
+        // carrying diagnostics, so "accepted" is "produced a tree".
+        let by_transform = uf_transform::estree::parse(sample.source).is_ok();
+
+        assert_eq!(
+            by_parse, by_validate,
+            "`{}` parses differently for `uf fmt` and `uf lint`: {}",
+            sample.option, sample.source
+        );
+        assert_eq!(
+            by_parse, by_transform,
+            "`{}` parses differently for `uf fmt` and the transform: {}",
+            sample.option, sample.source
+        );
+    }
+}
+
+/// Every member of `ParseOptions` changes the answer for at least one sample.
+///
+/// The point is coverage of the *struct*, not of the samples: the destructuring
+/// below has no `..`, so a member added to `ParseOptions` upstream stops this
+/// file compiling until someone decides what it means for uf and writes a
+/// sample for it. A member nothing exercises is a member that can be dropped
+/// from one copy of the options without any test noticing, which is exactly
+/// how the three literals stayed equal by coincidence.
+#[test]
+fn every_option_decides_a_sample() {
+    let base = uf_flow::PARSE_OPTIONS;
+    let chosen: Vec<String> = SAMPLES
+        .iter()
+        .map(|sample| fingerprint(&base, sample.source))
+        .collect();
+
+    for option in members() {
+        let flipped = flip(option);
+        let changed: Vec<&str> = SAMPLES
+            .iter()
+            .zip(&chosen)
+            .filter(|(sample, was)| &fingerprint(&flipped, sample.source) != *was)
+            .map(|(sample, _)| sample.option)
+            .collect();
+
+        assert!(
+            !changed.is_empty(),
+            "no sample notices `{option}` changing, so nothing would notice it drifting"
+        );
+        assert!(
+            changed.contains(&option),
+            "`{option}` changes {changed:?} and not its own sample, which is the wrong sample"
+        );
+    }
+}
+
+/// Each member of `ParseOptions`, by name.
+///
+/// Written out rather than derived: there is no reflection here, and a list
+/// that has to be kept in step by hand is only safe because [`flip`] destructures
+/// the struct exhaustively and will not compile if the two disagree in length.
+fn members() -> [&'static str; 13] {
+    [
+        "components",
+        "enums",
+        "pattern_matching",
+        "records",
+        "esproposal_decorators",
+        "types",
+        "ambiguous_types",
+        "enable_types_in_comments",
+        "use_strict",
+        "assert_operator",
+        "module_ref_prefix",
+        "ambient",
+        "allow_return_outside_function",
+    ]
+}
+
+/// uf's options with one member changed away from what uf chose.
+fn flip(option: &str) -> ParseOptions {
+    // No `..`: adding a member upstream breaks this line, which is the point.
+    let ParseOptions {
+        components,
+        enums,
+        pattern_matching,
+        records,
+        esproposal_decorators,
+        types,
+        ambiguous_types,
+        enable_types_in_comments,
+        use_strict,
+        assert_operator,
+        module_ref_prefix,
+        ambient,
+        allow_return_outside_function,
+    } = uf_flow::PARSE_OPTIONS;
+
+    let mut options = ParseOptions {
+        components,
+        enums,
+        pattern_matching,
+        records,
+        esproposal_decorators,
+        types,
+        ambiguous_types,
+        enable_types_in_comments,
+        use_strict,
+        assert_operator,
+        module_ref_prefix,
+        ambient,
+        allow_return_outside_function,
+    };
+
+    match option {
+        "components" => options.components = !options.components,
+        "enums" => options.enums = !options.enums,
+        "pattern_matching" => options.pattern_matching = !options.pattern_matching,
+        "records" => options.records = !options.records,
+        "esproposal_decorators" => options.esproposal_decorators = !options.esproposal_decorators,
+        "types" => options.types = !options.types,
+        "ambiguous_types" => options.ambiguous_types = !options.ambiguous_types,
+        "enable_types_in_comments" => {
+            options.enable_types_in_comments = !options.enable_types_in_comments;
+        }
+        "use_strict" => options.use_strict = !options.use_strict,
+        "assert_operator" => options.assert_operator = !options.assert_operator,
+        // Not a flag: uf leaves it unset, so "changed" is any prefix at all.
+        "module_ref_prefix" => options.module_ref_prefix = Some("m#".into()),
+        "ambient" => options.ambient = !options.ambient,
+        "allow_return_outside_function" => {
+            options.allow_return_outside_function = !options.allow_return_outside_function;
+        }
+        other => panic!("`{other}` is not a member of ParseOptions"),
+    }
+
+    options
+}


### PR DESCRIPTION
Closes #214.

uf handed source to Meta's Flow parser from three places, each with its own `ParseOptions` literal:

* `crates/uf_flow/src/parse.rs` — `uf_flow::parse`, for anything that rewrites a module
* `crates/uf_flow/src/upstream.rs` — `uf_flow::validate_source`, the linter's "does this parse"
* `crates/uf_transform/src/estree.rs` — the transform

Two of them carried a comment saying they mirrored a third. Nothing compared them, and all thirteen members agreed only by coincidence.

Drift there would not have looked like a parser bug. It would have looked like a file that lints clean and will not format, or transforms and will not check — and nothing in either message would say which of the two commands is right. `uf_flow` exists because "a second definition of Flow syntax is a second place for the grammar to drift"; three copies of the options that *select* the grammar is the same mistake one level down.

## What changed

One `uf_flow::PARSE_OPTIONS`. `uf_transform` re-exports it under the name it already published, so nothing downstream moves.

## What keeps it one

`crates/uf_transform/tests/parse_options.rs`, and it is two tests rather than a comparison of constants — a comparison of constants is satisfied by the arrangement this replaces.

**`every_entry_point_parses_the_same_syntax`** runs thirteen sources, one per option, through all three entry points and requires the same answer. Putting the literal back in `estree.rs` with `components: false` fails it by name:

```
assertion `left == right` failed: `components` parses differently for `uf fmt`
and the transform: component Greeting() { return null; }
```

**`every_option_decides_a_sample`** requires each member of `ParseOptions` to change what the parser makes of at least one of those sources. That is what makes the first test complete — an option nothing exercises can be dropped from one copy and no sample notices — and the destructuring it is built on has no `..`, so a member added upstream stops the file compiling until somebody decides what it means for uf.

It compares parsed **trees**, not whether parsing succeeded. With `ambiguous_types` off, `f<T>(x)` is still a program — two comparisons instead of a parameterized call — and `module_ref_prefix` turns a string literal into a module reference without either spelling being an error. A test that asked only "does it parse" would have reported that those two options do nothing, and then let them drift. Both were caught that way while writing it: each failed `no sample notices ... changing` until the fingerprint became the tree.

## Verified

* `cargo test -p uf_flow -p uf_transform` — green, 2 new tests
* `cargo clippy -p uf_flow -p uf_transform --all-targets -- -D warnings` — clean
* `cargo fmt --all -- --check` — clean

Found while investigating #204, whose fix is blocked on the vendored parser; this is one of the two halves that are uf's own. The other is #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791244111&installation_model_id=422833&pr_number=216&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F216&signature=e1a84352df8c5b4faaa5904fb32bfd371f427123b1774534a2b58db12ed2b667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->