### PR TITLE
fix(test): a line a finished test's callback printed is still that test's

### DIFF
--- a/packages/test/internal/output.js
+++ b/packages/test/internal/output.js
@@ -21,25 +21,58 @@
 // # Why this is its own module
 //
 // Two callers need it and neither owns it: `worker.js` installs the capture at
-// start-up, and `run.js` says which case is running so a chunk can be named.
-// "Who printed this" is also state with a lifetime of its own — set around a
-// case's body and hooks, cleared between them — exactly like the snapshot key
-// in `snapshot.js`, and for the same reason it lives beside the thing it
-// describes rather than inside either caller.
+// start-up, and `run.js` runs each case inside the ownership kept here, so a
+// chunk can be named. "Who printed this" is also state with a lifetime of its
+// own — one case's hooks and body — exactly like the snapshot key in
+// `snapshot.js`, and for the same reason it lives beside the thing it describes
+// rather than inside either caller.
 //
 // # What "the test that printed it" means
 //
-// The name a chunk carries is the case the *worker* is running when the chunk
-// arrives, which is not the same as the case whose code produced it. A
-// `setTimeout` a test leaves behind prints while the next case is running and
-// is filed under that one; a chunk from no case at all is filed under the
-// file.
+// The case whose *asynchronous context* the write happened in, which is the
+// case whose code produced it.
 //
-// Getting this exactly right needs the printing to be tied to the asynchronous
-// context the case ran in — `AsyncLocalStorage` and everything under it — and
-// that is a bigger change than this module, because it has to reach the
-// scheduler that runs the cases. It is written down here rather than left to
-// be discovered from a confusing report. See ubugeeei-prod/uf#207.
+// The obvious answer was a module-level variable the runner set before a case
+// and cleared after it, and it was wrong in one shape that matters: the name a
+// chunk carried was whatever the worker happened to be running when the chunk
+// arrived. A `setTimeout` a test left behind fires while the *next* case is
+// running, so the line it printed was reported under that next case — a test
+// accused of printing something it never printed, which is worse than not
+// naming it at all, because a reader chasing the message finds it under code
+// that does not contain it. See ubugeeei-prod/uf#207.
+//
+// So the owner is an `AsyncLocalStorage`, and what `run.js` calls is
+// `runInTest` rather than an `enterTest` / `exitTest` pair: the store is only
+// carried by work started *inside* the case, so the case's setup, body and
+// teardown have to run within it. Everything they schedule inherits it,
+// whenever it eventually runs.
+//
+// # When there is no owner
+//
+// `getStore()` answers nothing outside a case, and a chunk with no owner is
+// filed under the file — which is right for an import, a `beforeAll`, or a
+// straggler from a case that is long gone.
+//
+// It is also the answer on a host whose storage does not reach the callback.
+// Deno 1.31 has `AsyncLocalStorage` and propagates it across `await`, but not
+// through `setTimeout`, so a detached callback there is filed under the file
+// rather than under the case that scheduled it. That degradation is the point:
+// of the two ways to be less than exact, naming the file says less, and naming
+// the next case says something false.
+//
+// `node:async_hooks` itself is not guarded for, because a guard could not run.
+// Node, Deno and Bun all provide it under the `node:` specifier, and a host
+// that had no `node:` builtins could not start this worker at all — `node:util`
+// is imported below, `node:readline` and `node:url` by `worker.js`. A `typeof`
+// check around the constructor would only ever execute on a host where this
+// module had already linked.
+//
+// The one thing this does not answer is a straggler that outlives its *file*:
+// the worker runs the next file in the same process, and a chunk still carrying
+// a name from the file before is a name the next file's report has no test for.
+// The host files it under the file it arrived in, which is honest but not
+// exact, and closing it properly needs the file's generation in the protocol.
+// That is ubugeeei-prod/uf#203, and it is not this module's to fix.
 
 // # Bounds
 //
@@ -49,6 +82,7 @@
 // nothing after it is kept. The budget starts over for each file, so a chatty
 // file does not silence the next one in the same worker.
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { format, inspect } from "node:util";
 
 import { userFrames } from "./frames.js";
@@ -95,9 +129,16 @@ const DECODER = new TextDecoder();
 /** What a stream's `write` calls when it has taken the chunk. */
 type WriteCallback = () => mixed;
 
+/**
+ * The case a write belongs to, kept in the asynchronous context it ran in.
+ *
+ * Full names rather than a record, because that is the whole of what a chunk
+ * needs to say and the protocol carries it as a string either way.
+ */
+const owner: AsyncLocalStorage<string> = new AsyncLocalStorage();
+
 let sink: OutputSink | null = null;
 let raw: ((chunk: string) => void) | null = null;
-let current: string | null = null;
 let captured = 0;
 let stopped = false;
 
@@ -159,7 +200,7 @@ function capture(stream: OutputStream, text: string): void {
     stopped = true;
   }
   captured += kept.length;
-  to({ stream, test: current, text: kept });
+  to({ stream, test: owner.getStore() ?? null, text: kept });
 }
 
 /** A stand-in for `process.stdout.write` / `process.stderr.write`. */
@@ -236,25 +277,33 @@ export function install(to: OutputSink): (chunk: string) => void {
 }
 
 /**
- * Say which case is running, so what it prints can be named.
+ * Run `body` as `name`, so what it prints — and what it leaves behind to print
+ * later — is filed under that case.
  *
- * The runner calls this around a case's body and hooks and clears it between
- * them: output written while the module is being imported, from a `beforeAll`,
- * or after the last case finished belongs to the file, not to whichever case
- * happened to run last.
+ * The runner wraps one case's `beforeEach`, body and `afterEach` in a single
+ * call, because those are the one case's work. Whatever `body` returns is
+ * returned unchanged, so an `await` on this is an `await` on the case.
+ *
+ * Nothing here needs an "and now nothing is running" counterpart. Output from
+ * an import, a `beforeAll` or a case that has already been reported was never
+ * inside this call, so it has no owner and is the file's — which is the
+ * property the previous module-level variable had to be reset to keep, and
+ * kept only for as long as nothing straggled.
  */
-export function enterTest(name: string): void {
-  current = name;
+export function runInTest<T>(name: string, body: () => T): T {
+  return owner.run(name, body);
 }
 
-/** Say that no case is running. */
-export function exitTest(): void {
-  current = null;
-}
-
-/** Start one file's output budget over, with no case running. */
+/**
+ * Start one file's output budget over.
+ *
+ * Only the budget: there is no current case to clear, because a case's
+ * ownership lives in the callbacks it started rather than in this module. A
+ * straggler from the file before still carries the name it was written under,
+ * which the host cannot match to a test of the new file and files under that
+ * file instead. See ubugeeei-prod/uf#203.
+ */
 export function startFile(): void {
   captured = 0;
   stopped = false;
-  current = null;
 }

--- a/packages/test/internal/run.js
+++ b/packages/test/internal/run.js
@@ -193,34 +193,40 @@ async function runCase(
 
   const timeoutMs = test.timeoutMs ?? options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   let outcome: Outcome = { status: "passed" };
-  // From here to the end of teardown is exactly the window in which this
-  // case's own code runs, so it is exactly the window whose printing is this
-  // case's. The cases above never reach it: nothing runs for a `todo`, a
-  // `skip` or a filtered-out case, so nothing of theirs can print.
-  output.enterTest(name);
-  try {
-    for (const hook of context.beforeEach) {
-      await withTimeout(hook, timeoutMs);
-    }
-    await withTimeout(test.body, timeoutMs);
-  } catch (thrown) {
-    outcome = failure(thrown);
-  }
-  // Teardown runs whatever happened above, and only reports its own failure
-  // when the body had not already failed.
-  for (const hook of context.afterEach) {
+  // Setup, body and teardown run *inside* the case's output context, and that
+  // nesting is the whole of the fix for #207. What names a printed line is no
+  // longer where the runner had got to when the line arrived — which named the
+  // next case for anything a `setTimeout` left behind — but which case's work
+  // the write descends from. A callback scheduled here keeps this name however
+  // late it fires.
+  //
+  // The cases above never reach this: nothing runs for a `todo`, a `skip` or a
+  // filtered-out case, so nothing of theirs can print.
+  await output.runInTest(name, async () => {
     try {
-      await withTimeout(hook, timeoutMs);
+      for (const hook of context.beforeEach) {
+        await withTimeout(hook, timeoutMs);
+      }
+      await withTimeout(test.body, timeoutMs);
     } catch (thrown) {
-      if (outcome.status === "passed") {
-        outcome = failure(thrown);
+      outcome = failure(thrown);
+    }
+    // Teardown runs whatever happened above, and only reports its own failure
+    // when the body had not already failed.
+    for (const hook of context.afterEach) {
+      try {
+        await withTimeout(hook, timeoutMs);
+      } catch (thrown) {
+        if (outcome.status === "passed") {
+          outcome = failure(thrown);
+        }
       }
     }
-  }
-  // No test is running once this one is reported, so a snapshot taken outside
-  // one fails with something better than a key belonging to whichever test
-  // happened to run last, and a line printed outside one is the file's.
-  output.exitTest();
+  });
+  // The `await` above resumes outside the context it entered, so this line and
+  // everything after it belong to no case again — a line printed between cases
+  // is the file's, and a snapshot taken outside one fails with something better
+  // than a key belonging to whichever test happened to run last.
   snapshot.exitTest();
   report(outcome);
   return outcome.status !== "failed";

--- a/tests/library/output-owner.test.js
+++ b/tests/library/output-owner.test.js
@@ -1,0 +1,218 @@
+// @flow
+//
+// Which case a printed line is filed under.
+//
+// `uf test` reports what a test printed under the test that printed it, and
+// the hard half of that promise is a callback a test leaves behind. One
+// scheduled by a case fires after that case has been reported, while the next
+// one is running, and the runner used to name the case it had got to rather
+// than the case the callback came from. The line was then reported under a
+// test whose source does not contain it, which is the one wrong answer a
+// reader cannot recover from — worse than not naming it at all. That is
+// ubugeeei-prod/uf#207; ownership now lives in the asynchronous context the
+// case ran in (`packages/test/internal/output.js`).
+//
+// Attribution is not observable from inside a test. The name a chunk carries
+// belongs to the protocol between the worker and `uf`, and by the time a case
+// could look at it, that case is the thing being named. So this drives a real
+// worker exactly the way `crates/uf_test/src/host.rs` drives one — a request
+// per line on its stdin, one JSON event per line back — and reads the `output`
+// events for the `test` field they carry. `lsp.test.js` talks to `uf lsp` over
+// its real wire for the same reason: a promise made on a wire has to be
+// checked on that wire.
+//
+// The reproduction is written to a temporary directory rather than kept beside
+// this file, because a file in this workspace that registers cases *is* a test
+// of this repository. `uf test` discovers by reading a file, not by naming it,
+// so a fixture here would be collected and run by the very suite that is
+// supposed to be running it. Nothing outside the project has a `node_modules`
+// to resolve `@uniflowed/test` from, so the fixture reaches the package by
+// path — the same modules the worker loads, so the two halves share one
+// registry rather than each collecting into its own.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "@uniflowed/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repository = path.resolve(here, "..", "..");
+
+/**
+ * The reproduction from the issue, made deterministic.
+ *
+ * The issue writes it as a `setTimeout(…, 30)` in one case and an
+ * `await sleep(60)` in the next, and that does reproduce the bug. It makes a
+ * poor test, though: what this file has to show is not only that the line is
+ * named correctly but that it *arrived after its own case had been reported*,
+ * and with two sleeps racing each other that proof holds only as long as the
+ * machine is not busy. So the second case hands the first one a switch. The
+ * callback is still a detached one — registered inside the first case, run
+ * from a timer, printing long after the case that wrote it returned — but it
+ * cannot now run before the next case has started.
+ */
+const REPRODUCTION = `
+// Printed while the module is being imported. No case is running, and no case
+// should be blamed for it.
+console.log("while the file was still loading");
+
+let begin;
+const started = new Promise((resolve) => {
+  begin = resolve;
+});
+let printed;
+
+describe("late output", () => {
+  it("prints, and leaves a callback behind", () => {
+    console.log("from the test itself");
+    // Registered here, so this case's context is what it carries; run from a
+    // timer the next case releases, so it prints when this case is over.
+    printed = started.then(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            console.log("from the test before");
+            resolve();
+          }, 0);
+        }),
+    );
+  });
+
+  it("is the case that happens to be running when it fires", async () => {
+    begin();
+    await printed;
+  });
+});
+`;
+
+/** One line the worker wrote back, in the shape `host.rs` reads. */
+type Event = {
+  event: string,
+  stream?: string,
+  test?: string | null,
+  text?: string,
+  name?: string,
+  status?: string,
+};
+
+/**
+ * How this host starts a worker, mirroring `HostCommand::with_flow_loader`.
+ *
+ * The worker imports Flow — `@uniflowed/test` is Flow source — so it needs the
+ * host's loader, and each host registers one its own way. Deno has none in
+ * `@uniflowed/host` yet, so it cannot run this at all; a named failure is
+ * better than a skip that reads like a pass.
+ */
+function loaderArguments(): Array<string> {
+  const host = path.basename(process.execPath);
+  if (host.startsWith("node")) {
+    const register = path.join(repository, "packages", "host", "register.js");
+    return ["--enable-source-maps", "--import", pathToFileURL(register).href];
+  }
+  if (host.startsWith("bun")) {
+    return ["--preload", path.join(repository, "packages", "host", "bun-preload.js")];
+  }
+  throw new Error(`no Flow loader for ${host}: this test drives the worker uf would have started`);
+}
+
+/**
+ * Run `file` in a worker of its own and collect every event it wrote.
+ *
+ * The environment is inherited because that is where `UF_PROJECT_ROOT` and
+ * `UF_BINARY` are: `uf test` sets both when it starts this suite, so the
+ * nested worker transforms through the same binary and shares its transform
+ * cache instead of building a second one. The worker exits when its stdin
+ * closes, which is what ends the run — the same handshake `host.rs` uses.
+ */
+function runInWorker(file: string): Promise<Array<Event>> {
+  return new Promise((resolve, reject) => {
+    const worker = path.join(repository, "packages", "test", "worker.js");
+    const child = spawn(process.execPath, [...loaderArguments(), worker], {
+      // Its stderr is the host's own noise and is not part of the report;
+      // inherited so a person debugging this sees it, as `host.rs` does.
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    let written = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      written += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", () => {
+      try {
+        resolve(
+          written
+            .split("\n")
+            .filter((line) => line !== "")
+            .map((line) => JSON.parse(line)),
+        );
+      } catch (error) {
+        reject(new Error(`the worker wrote something that is not an event: ${String(error)}`));
+      }
+    });
+    child.stdin.end(`${JSON.stringify({ file, timeoutMs: 5000 })}\n`);
+  });
+}
+
+/**
+ * The run as one readable list: who each line was filed under, in order,
+ * with the case reports left in between.
+ *
+ * Kept as strings rather than objects because the order is half of what is
+ * being asserted, and a failing `toEqual` over strings shows which line moved.
+ */
+function transcript(events: Array<Event>): Array<string> {
+  return events.map((event) => {
+    if (event.event === "output") {
+      return `${event.test ?? "<the file>"}: ${String(event.text).trimEnd()}`;
+    }
+    if (event.event === "test") {
+      return `${String(event.name)} ${String(event.status)}`;
+    }
+    return `file ${String(event.status)}`;
+  });
+}
+
+let events: Array<Event> = [];
+let directory = "";
+
+beforeAll(async () => {
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), "uf-output-owner-"));
+  const fixture = path.join(directory, "late-output.js");
+  const entry = pathToFileURL(path.join(repository, "packages", "test", "index.js")).href;
+  fs.writeFileSync(fixture, `import { describe, it } from "${entry}";\n${REPRODUCTION}`);
+  events = await runInWorker(fixture);
+});
+
+afterAll(() => {
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe("output from a callback a finished test left behind", () => {
+  it("is filed under the case that scheduled it, not the case that was running", () => {
+    // The fourth line is the whole issue. It sits *after* the first case's
+    // report, so it arrived when that case was over and the next one was
+    // running, and it is still that case's line. Before the fix it read
+    // `late output > is the case that happens to be running when it fires`.
+    expect(transcript(events)).toEqual([
+      "<the file>: while the file was still loading",
+      "late output > prints, and leaves a callback behind: from the test itself",
+      "late output > prints, and leaves a callback behind passed",
+      "late output > prints, and leaves a callback behind: from the test before",
+      "late output > is the case that happens to be running when it fires passed",
+      "file completed",
+    ]);
+  });
+
+  it("leaves a line that belongs to no case under the file", () => {
+    // The other half of the contract, and the one the fallback rests on: a
+    // chunk with no owner names no test. A host whose storage does not reach a
+    // detached callback lands here rather than on the wrong case, which is why
+    // "no owner" has to keep meaning the file.
+    const loading = events.filter((event) => event.text === "while the file was still loading\n");
+    expect(loading).toHaveLength(1);
+    expect(loading[0].test).toBe(null);
+  });
+});


### PR DESCRIPTION
Closes #207.

`packages/test/internal/output.js` kept "who is printing" in a module-level variable that `run.js` set before a case and cleared after it. That makes the name on a chunk a fact about **when the write arrived**, not about **whose code produced it**. The two agree only for output written synchronously inside a case:

```js
it("leaves something behind", () => {
  setTimeout(() => console.log("from the test before"), 30);
});

it("is blamed for it", async () => {
  await new Promise((resolve) => setTimeout(resolve, 60));
});
```

The timer fires after the first case has been reported, while the second is running, so the variable already held the second name. The line was then a report of something a test never printed — strictly worse than not attributing it at all, because a reader chasing the message lands on code that cannot have written it.

## The fix

`output.js` holds an `AsyncLocalStorage<string>` and exports `runInTest(name, body)` in place of the `enterTest`/`exitTest` pair; `capture()` reads the store. `run.js` wraps a case's `beforeEach`, body and `afterEach` in one `runInTest`, which is why this could not be a change inside the capture module: only the scheduler can put all three inside one context. The `await` resumes outside the store, so a line printed between cases is still the file's, and `startFile()` keeps only the byte budget — there is no current case left to clear.

At the protocol level, on the issue's exact snippet:

```
before: {"event":"output",...,"test":"printing from a test > is blamed for it","text":"from the test before\n"}
after:  {"event":"output",...,"test":"printing from a test > leaves something behind","text":"from the test before\n"}
```

## Regression test

`tests/library/output-owner.test.js`. Attribution is not observable from inside a test — the name lives on the worker↔`uf` protocol, and by the time a case could look at it, that case is the thing being named — so the test drives a real worker the way `crates/uf_test/src/host.rs` does, with a fixture in a temp directory. Precedent: `tests/library/lsp.test.js` drives the real `uf lsp` over its real wire.

The reproduction uses a detached callback the *next* case releases rather than the issue's two racing sleeps, so "the line arrived after its own case was reported" is deterministic rather than a function of machine load. A second case pins the other half of the contract: a chunk with no owner is filed under the file.

Before (fix stashed, test kept):

```
✗ is filed under the case that scheduled it, not the case that was running
    expected  [..., "late output > prints, and leaves a callback behind: from the test before", ...]
    received  [..., "late output > is the case that happens to be running when it fires: from the test before", ...]
```

After: `✓ 2 passed, 0 failed`.

## AsyncLocalStorage on the three hosts

Checked on this machine rather than assumed: node 25.8.1, bun 1.1.27 and deno 1.31.3 all have it under `node:async_hooks`, and the full worker was run end-to-end under bun, which attributes correctly.

One real finding: **Deno 1.31.3 propagates the store across `await` but not through `setTimeout`**, so `getStore()` is `undefined` in a timer callback there. That is the honest fallback, and it is structural rather than conditional — no store ⇒ `test: null` ⇒ filed under the file, never under the wrong case. In-test printing still attributes correctly. No `typeof AsyncLocalStorage === "function"` guard, and the header says why: the import is static, so a host lacking the module fails to link `output.js`, and a guard could only run where the module had already linked.

## Interaction with #203

Measured, not assumed. A straggler that outlives its *file*:

* before, the chunk carried a real test of the **next** file, so the host matched it and blamed that innocent test;
* after, it carries its own file's test, which the next file's report has no entry for, so it is filed under the next **file**.

The cross-file case degrades from "wrong test" to "right-ish file" — the same honest degradation. It makes #203 easier rather than harder: the true owner's name now survives in the chunk, and a file generation would nest around the per-case context instead of racing a module variable the next file overwrites. Written down on `startFile`, pointing at #203.

## Verified

* `./target/release/uf test#library` — `✓ 1100 passed, 0 failed, 1 skipped`, run four times
* `./target/release/uf fmt --check` — clean
* JavaScript only; no Rust touched

## Found, not fixed

* `uf check` goes 661 → 665, all four instances of libdef gaps this repository already carries in the same shapes (`AsyncLocalStorage` as a type is `value-as-type` exactly as in `packages/server/internal/context.js`; `import.meta.url` typed `void` as in `tests/library/story.test.js`). Fixing them means fixing the vendored Node libdefs.
* Snapshot ownership still uses the module-variable pattern (`snapshot.enterTest`/`exitTest`). The same bug in principle and far less reachable — `toMatchSnapshot()` is called synchronously from a case body in every real usage — so it is left alone rather than widened without a test to justify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791244282&installation_model_id=422833&pr_number=221&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F221&signature=96d91985b0603cc74c83a7ae5042cf0134bf5a681afc23e7bc39a91187d41cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->