### PR TITLE
feat(flow): say what is wrong with top-level await, and point at it

### DIFF
--- a/crates/uf_flow/src/explain.rs
+++ b/crates/uf_flow/src/explain.rs
@@ -1,0 +1,206 @@
+//! Parser errors uf can say more about than the parser did.
+//!
+//! The Flow parser reports the token it did not expect. That is the right
+//! answer for a typo and the wrong one for a construct it does not implement:
+//! the reader is shown a token that is fine, in a line that is fine, with no
+//! hint that the limit is the parser's rather than the file's.
+//!
+//! There is one of those today, [`TOP_LEVEL_AWAIT`], and the shape of this
+//! module is set by it: recognise a *specific* failure from the source around
+//! it, and leave every other error exactly as the parser phrased it. A layer
+//! that rewrote messages in general would be a second, worse parser.
+
+use flow_parser::loc::{Loc, Position};
+
+use crate::scan::tokenize;
+
+/// What uf says when a module uses `await` outside an `async` function.
+///
+/// Node has run top-level `await` in a module since ES2022, and the parser uf
+/// vendors — Meta's own, the one Flow ships — does not accept it: `ParseOptions`
+/// has no member for it and `ParserEnvFlags::allow_await` is turned on only by
+/// entering an `async` function. So a module Node runs cannot be checked,
+/// formatted, transformed or tested here, and what the reader was told was
+/// `Unexpected identifier, expected the token ';'`, with the caret on the
+/// operand — a token that is not the problem, in a line that is not the
+/// problem. See ubugeeei-prod/uf#204 for what the fix upstream would be.
+const TOP_LEVEL_AWAIT: &str = "`await` outside an `async` function is not supported: Node runs it at the top level of a \
+     module, and the Flow parser uf vendors does not parse it";
+
+/// A parser error, as uf reports it: the parser's message and position unless
+/// uf recognises the failure and can say something truer.
+///
+/// The message is compared rather than the error's variant because
+/// `ParseError` is the port's type and matching on it here would be a
+/// dependency on which of its variants happens to be produced for a token the
+/// parser reached in a state it did not expect — which is a detail of the
+/// parser's recovery, not of the language.
+#[must_use]
+pub fn explained(source: &str, loc: &Loc, message: String) -> (String, Position) {
+    if let Some(position) = top_level_await(source, loc, &message) {
+        return (TOP_LEVEL_AWAIT.to_owned(), position);
+    }
+    (message, loc.start)
+}
+
+/// Where the `await` is, when this error is the parser refusing one.
+///
+/// The test is that the token *before* the one the parser tripped on is the
+/// identifier `await`, and that is exact rather than a guess: `allow_await` is
+/// off only outside an `async` function, and inside one `await` is an operator
+/// and reaches no error at all. So an `await` immediately before an unexpected
+/// token is this and nothing else.
+///
+/// It is deliberately not "the source contains `await`". A module with an
+/// `await` on line 3 and a missing brace on line 90 must still be told about
+/// the brace.
+fn top_level_await(source: &str, loc: &Loc, message: &str) -> Option<Position> {
+    // The parser recovers, so it produces this message for every token that
+    // cannot start a statement — a gate rather than a decision, and cheap
+    // enough to run before tokenizing.
+    if !message.starts_with("Unexpected ") {
+        return None;
+    }
+
+    let offset = byte_offset(source, loc.start)?;
+    let tokens = tokenize(source);
+    // "The token before" is a step in the token list, not a distance in bytes:
+    // the scanner leaves out whitespace and comments, so `await /* soon */ x`
+    // still has `await` immediately before `x`.
+    let index = tokens.iter().position(|token| token.start >= offset)?;
+    let previous = tokens.get(index.checked_sub(1)?)?;
+    if !previous.is_ident(source, "await") {
+        return None;
+    }
+
+    Some(position_of(source, previous.start))
+}
+
+/// The byte offset of a parser position, or `None` when the source has no such
+/// place.
+///
+/// The port counts lines from one and columns in *bytes* from zero — "the
+/// column offset are measured by bytes", `flow_parser::loc`. Not code points,
+/// and not the UTF-16 code units the transform converts to for source maps, so
+/// the conversion is arithmetic on lines and nothing else. It is here rather
+/// than at the call sites so there is one place to be wrong.
+fn byte_offset(source: &str, position: Position) -> Option<usize> {
+    let line = usize::try_from(position.line).ok()?.checked_sub(1)?;
+    let column = usize::try_from(position.column).ok()?;
+
+    let mut start = 0;
+    for _ in 0..line {
+        start += source[start..].find('\n')? + 1;
+    }
+    let offset = start.checked_add(column)?;
+    let end = source[start..]
+        .find('\n')
+        .map_or(source.len(), |newline| start + newline);
+
+    // A column past the end of its line, or inside a character, is not a place
+    // in this source: the caller reports what the parser said instead of
+    // inventing a position from a number it could not use.
+    (offset <= end && source.is_char_boundary(offset)).then_some(offset)
+}
+
+/// The parser position of a byte offset: the inverse of [`byte_offset`].
+fn position_of(source: &str, offset: usize) -> Position {
+    let before = &source[..offset];
+    let line = before.matches('\n').count() + 1;
+    let column = before
+        .rfind('\n')
+        .map_or(offset, |newline| offset - newline - 1);
+
+    Position {
+        line: i32::try_from(line).unwrap_or(i32::MAX),
+        column: i32::try_from(column).unwrap_or(i32::MAX),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The diagnostic uf reports for `source`, as (message, line, column).
+    fn report(source: &str) -> (String, i32, i32) {
+        let outcome = crate::validate_source(source).expect("the parser is always available");
+        let first = outcome
+            .diagnostics
+            .first()
+            .expect("the source is meant to be refused")
+            .clone();
+        (
+            first.message,
+            first.line.unwrap_or(0) as i32,
+            first.column.unwrap_or(0) as i32,
+        )
+    }
+
+    #[test]
+    fn says_what_is_wrong_with_top_level_await() {
+        let (message, line, column) = report("// @flow\nconst value = await load();\n");
+        assert_eq!(message, TOP_LEVEL_AWAIT);
+        assert_eq!((line, column), (2, 14), "the caret belongs on `await`");
+    }
+
+    #[test]
+    fn says_it_for_an_await_that_is_a_statement_of_its_own() {
+        let (message, ..) = report("// @flow\nawait ready();\n");
+        assert_eq!(message, TOP_LEVEL_AWAIT);
+    }
+
+    #[test]
+    fn an_await_before_a_line_break_is_not_an_error_to_explain() {
+        // Not an oversight, and worth knowing: outside an `async` function
+        // `await` is an ordinary identifier, so a line break after it ends the
+        // statement and the operand becomes a statement of its own. The module
+        // parses, means something else entirely, and there is no error here for
+        // this module to improve on.
+        let outcome = crate::validate_source("// @flow\nconst value = await\n  load();\n")
+            .expect("the parser is always available");
+        assert!(outcome.is_ok(), "{:?}", outcome.diagnostics);
+    }
+
+    #[test]
+    fn says_it_through_a_comment_between_the_two() {
+        let (message, ..) = report("// @flow\nconst value = await /* soon */ load();\n");
+        assert_eq!(message, TOP_LEVEL_AWAIT);
+    }
+
+    #[test]
+    fn leaves_an_await_inside_an_async_function_alone() {
+        let outcome = crate::validate_source("// @flow\nasync function f() { await load(); }\n")
+            .expect("the parser is always available");
+        assert!(outcome.is_ok(), "{:?}", outcome.diagnostics);
+    }
+
+    #[test]
+    fn leaves_an_unrelated_error_in_a_module_that_also_awaits() {
+        // The whole risk of this module: a file with an `await` in it must
+        // still be told about the error it actually has.
+        let (message, line, _) =
+            report("// @flow\nasync function f() { await load(); }\nconst a = ;\n");
+        assert_ne!(message, TOP_LEVEL_AWAIT);
+        assert_eq!(line, 3);
+    }
+
+    #[test]
+    fn leaves_an_identifier_named_await_alone() {
+        // `await` is a plain identifier outside an async function, so this
+        // parses; nothing to explain, and nothing to get wrong.
+        let outcome = crate::validate_source("// @flow\nconst await = 1;\nconst b = await;\n")
+            .expect("the parser is always available");
+        assert!(outcome.is_ok(), "{:?}", outcome.diagnostics);
+    }
+
+    #[test]
+    fn counts_columns_in_bytes_the_way_the_parser_does() {
+        // Four bytes for the wave, one column each, because that is what the
+        // port means by a column. Getting this wrong puts the caret inside a
+        // character on any line that has one.
+        let (message, line, column) =
+            report("// @flow\nconst s = \"🌊\"; const v = await load();\n");
+        assert_eq!(message, TOP_LEVEL_AWAIT);
+        assert_eq!((line, column), (2, 28));
+    }
+}

--- a/crates/uf_flow/src/lib.rs
+++ b/crates/uf_flow/src/lib.rs
@@ -7,14 +7,18 @@
 //! grammar uf documents, which is what happened while a QuickJS-hosted build of
 //! Flow's JavaScript parser stood in for it on stable toolchains.
 //!
-//! Two things sit beside that boundary, and both are here rather than in the
-//! crates that use them because this is the crate that owns Flow syntax:
+//! Three things sit beside that boundary, and all of them are here rather than
+//! in the crates that use them because this is the crate that owns Flow syntax:
 //!
 //! * [`scan`] is the byte-level token scanner — one scanner for uf source, used
 //!   by the eraser below and by anything else that rewrites a module;
 //! * [`strip`] erases Flow types, which is what turns a `// @flow` module into
-//!   the JavaScript a browser runs.
+//!   the JavaScript a browser runs;
+//! * [`explain`] is what uf says about the one failure the parser describes
+//!   badly, because it is describing a construct it does not implement rather
+//!   than a mistake.
 
+pub mod explain;
 pub mod parse;
 pub mod scan;
 pub mod strip;
@@ -28,6 +32,24 @@ pub use parse::{
     parse,
 };
 pub use strip::{MAX_STRIP_BYTES, StripError, Stripped, strip_types};
+
+/// One parser error, as uf reports it.
+///
+/// The one place a `(Loc, ParseError)` becomes a diagnostic, because it is also
+/// the place [`explain`] gets its chance: an error uf can describe better than
+/// the parser did must be described better by every command, and three
+/// conversions would have been three chances to forget one.
+fn diagnostic_from_error(
+    source: &str,
+    (loc, error): &(flow_parser::loc::Loc, flow_parser::parse_error::ParseError),
+) -> ParseDiagnostic {
+    let (message, position) = explain::explained(source, loc, error.to_string());
+    ParseDiagnostic {
+        message,
+        line: u32::try_from(position.line).ok(),
+        column: u32::try_from(position.column).ok(),
+    }
+}
 
 /// A single syntax diagnostic reported by the active Flow parser.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/uf_flow/src/parse.rs
+++ b/crates/uf_flow/src/parse.rs
@@ -21,7 +21,6 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use flow_parser::ParseOptions;
-use flow_parser::parse_error::ParseError;
 use thiserror::Error;
 
 pub use flow_parser::ast;
@@ -261,16 +260,11 @@ pub fn parse(source: &str) -> Result<Parsed, ParseFailure> {
 
     Ok(Parsed {
         program,
-        diagnostics: errors.iter().map(diagnostic_from_error).collect(),
+        diagnostics: errors
+            .iter()
+            .map(|error| crate::diagnostic_from_error(source, error))
+            .collect(),
     })
-}
-
-fn diagnostic_from_error((loc, error): &(Loc, ParseError)) -> ParseDiagnostic {
-    ParseDiagnostic {
-        message: error.to_string(),
-        line: u32::try_from(loc.start.line).ok(),
-        column: u32::try_from(loc.start.column).ok(),
-    }
 }
 
 /// What the depth scanner is inside: JavaScript, with the number of `{`

--- a/crates/uf_flow/src/upstream.rs
+++ b/crates/uf_flow/src/upstream.rs
@@ -8,21 +8,16 @@ use flow_parser::loc::Loc;
 use flow_parser::parse_error::ParseError;
 
 use crate::parse::PARSE_OPTIONS;
-use crate::{FlowError, ParseDiagnostic, ParseOutcome};
+use crate::{FlowError, ParseOutcome};
 
 pub(crate) fn validate_source(source: &str) -> Result<ParseOutcome, FlowError> {
     let (_program, errors): (_, Vec<(Loc, ParseError)>) =
         flow_parser::parse_program_without_file(false, None, Some(PARSE_OPTIONS), Ok(source));
 
     Ok(ParseOutcome {
-        diagnostics: errors.iter().map(diagnostic_from_error).collect(),
+        diagnostics: errors
+            .iter()
+            .map(|error| crate::diagnostic_from_error(source, error))
+            .collect(),
     })
-}
-
-fn diagnostic_from_error((loc, error): &(Loc, ParseError)) -> ParseDiagnostic {
-    ParseDiagnostic {
-        message: error.to_string(),
-        line: u32::try_from(loc.start.line).ok(),
-        column: u32::try_from(loc.start.column).ok(),
-    }
 }

--- a/crates/uf_transform/src/estree.rs
+++ b/crates/uf_transform/src/estree.rs
@@ -60,11 +60,16 @@ pub fn parse(source: &str) -> Result<Value, TransformError> {
         flow_parser::parse_program_without_file(false, None, Some(PARSE_OPTIONS), Ok(source));
 
     if let Some((loc, error)) = errors.first() {
+        // Through `uf_flow` so a module that fails to transform is refused in
+        // the same words `uf check` and `uf lint` refuse it. A construct the
+        // parser does not implement described three ways is three bugs to
+        // report.
+        let (message, start) = uf_flow::explain::explained(source, loc, error.to_string());
         let position = offsets
-            .convert_flow_position_to_js_position(loc.start)
-            .unwrap_or(loc.start);
+            .convert_flow_position_to_js_position(start)
+            .unwrap_or(start);
         return Err(TransformError::Syntax {
-            message: error.to_string(),
+            message,
             line: u32::try_from(position.line).unwrap_or(u32::MAX),
             column: u32::try_from(position.column).unwrap_or(u32::MAX),
         });
@@ -89,6 +94,18 @@ mod tests {
         assert_eq!(body[0]["type"], "ComponentDeclaration");
         assert_eq!(body[0]["params"][0]["type"], "ComponentParameter");
         assert_eq!(program["comments"][0]["type"], "Line");
+    }
+
+    #[test]
+    fn refuses_top_level_await_in_the_same_words_as_the_linter() {
+        // The same module, the same sentence, whichever command reached it.
+        let source = "// @flow\nconst value = await load();\n";
+        let TransformError::Syntax { message, line, .. } = parse(source).unwrap_err() else {
+            panic!("expected a syntax error");
+        };
+        let expected = uf_flow::validate_source(source).unwrap().diagnostics[0].clone();
+        assert_eq!(message, expected.message);
+        assert_eq!(line, expected.line.unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Closes #215.

A module that uses `await` at the top level cannot be checked, formatted, transformed or tested here. That is #204, and it is blocked on the vendored parser: `ParseOptions` has no member for it and `allow_await` is turned on only by entering an `async` function. What was never blocked is what uf *says* about it.

**Before**

```
  error[flow/syntax]: Unexpected identifier, expected the token `;`
   --> a.js:2:29
    │
  2 │ const value: number = await Promise.resolve(1);
    │                             ^^^^^^^
```

The reader is shown `Promise` — a token that is fine, in a line Node runs — and told nothing about what uf will not accept or what to do instead. The transform said the same thing at run time, with no source line beside it.

**After**

```
  error[flow/syntax]: `await` outside an `async` function is not supported:
  Node runs it at the top level of a module, and the Flow parser uf vendors
  does not parse it
   --> a.js:2:23
    │
  2 │ const value: number = await Promise.resolve(1);
    │                       ^^^^^
```

Same sentence from `uf check`, `uf lint`, `uf fmt` and the transform, because the three places that turned a `(Loc, ParseError)` into a diagnostic are now one place in `uf_flow` — which is also where the explanation gets its chance. A construct the parser does not implement, described three ways, is three bugs to report.

## How narrow the recognition is

`crates/uf_flow/src/explain.rs` recognises this one failure and leaves every other error exactly as the parser phrased it. The test is that the token **before** the one the parser tripped on is the identifier `await`, which is exact rather than a heuristic: `allow_await` is off only outside an `async` function, and inside one `await` is an operator that reaches no error at all. So it is never "the source contains an `await`" — a module with an `await` on line 3 and a missing brace on line 90 is still told about the brace, and a test says so.

## Two things the tests found

* **The port measures columns in bytes**, not code points — `flow_parser::loc`: "the column offset are measured by bytes". A code-point column puts the caret inside a character on any line holding one, so there is a test with an astral character in it.
* **`const value = await` + newline + operand is not an error at all.** Outside an `async` function `await` is an ordinary identifier, so the line break ends the statement and the operand becomes a statement of its own: the module parses, and means something else entirely. Nothing to explain, and the test that says so is what stops someone widening the recognition until it fires there.

## Verified

* `cargo test --workspace` — green apart from `uf_cli --test vite`'s `dev_serves_the_docs_site_through_vite`, which fails on this machine before and after: `TcpListener::bind` is `PermissionDenied` in the local sandbox. Confirmed by stashing the change and re-running.
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo fmt --all -- --check` — clean
* `uf fmt --check` on this repository — clean
* Both outputs above are from the built binary against a scratch project.

Follows #216, which made the parse options one copy; this makes the diagnostic one copy for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791245827&installation_model_id=422833&pr_number=222&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F222&signature=dc0abdf71c65da726bc2c176968a0179b980930358ac0b9582d32959a3a21f7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->