### PR TITLE
docs(fmt): say which Prettier uf is compatible with

### DIFF
--- a/docs/app/guide/format/_uf.page.mdx
+++ b/docs/app/guide/format/_uf.page.mdx
@@ -29,6 +29,15 @@ width is 100 rather than Prettier's 80; `fmt.lineWidth` changes it.
 That claim is checked rather than asserted: every fixture in `uf_fmt`'s suite
 is compared byte for byte against Prettier's own output for the same input.
 
+One difference, and it is a feature uf does not have rather than a rule it gets
+wrong. Prettier formats the code *inside* a tagged template when it recognises
+the tag — `graphql`, `css`, `html`, `sql`, `markdown` — and re-indents it to
+the code around it. uf leaves every template's contents exactly as written. So
+uf matches `prettier --embedded-language-formatting=off`, which is not
+Prettier's default, and a `graphql` template that stops moving when the code
+around it moves is this and not a bug. The one that matters for a Flow React
+toolchain is `graphql`; see [ubugeeei-prod/uf#177](https://github.com/ubugeeei-prod/uf/issues/177).
+
 Files uf has no opinion about are handed to Biome, which is also Rust and also
 fast, so a repository with a `README.md` and a `package.json` in it does not
 need a second formatter installed.


### PR DESCRIPTION
Refs #177 — the first half of it, which is a paragraph.

The formatter guide says the output follows Prettier's conventions, and that the claim is checked byte for byte against Prettier's own output for the same input. Both are true, and between them they leave out the one thing a reader finds by being surprised: Prettier formats the code **inside** a tagged template it recognises — `graphql`, `css`, `html`, `sql`, `markdown` — and re-indents it to the code around it. uf leaves every template exactly as written.

So uf matches `prettier --embedded-language-formatting=off`, which is not Prettier's default. A `graphql` template that stops moving when the code around it moves is that, and not a bug.

It is six of the twenty-three genuine layout divergences in the 500-module corpus sweep, all of them Relay tests:

```diff
-      fragment useFragmentNodeTestNestedUserFragment on User {
-        username
-      }
+        fragment useFragmentNodeTestNestedUserFragment on User {
+          username
+        }
```

`docs/architecture.md` has said this since the sweep. The page a user reads before running `uf fmt` did not. It says it now in the same words and with the same issue reference, so the two cannot drift into disagreeing.

The other half of #177 — actually formatting embedded GraphQL, which is the one embedded language that matters for a toolchain shipping `@uniflowed/graphql` and `@uniflowed/relay` — is its own piece of work and is not this.

## Verified

* `uf run docs:build` — `✓ build succeeded in 6.18s`
* `uf fmt --check` — `✓ every file is already formatted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791246321&installation_model_id=422833&pr_number=223&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F223&signature=ea853201495a7e3154e1b3a86c13a322f136978a89b564b330de7645c3a4f41b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->