### PR TITLE
fix(router): `_uf.not-found` is a reserved name, and the linter says so

### DIFF
--- a/crates/uf_lint/src/runner/router.rs
+++ b/crates/uf_lint/src/runner/router.rs
@@ -31,6 +31,25 @@ pub(crate) fn run_router_reserved_files(
         severity,
         1,
         1,
-        "reserved file names are _uf.<layout|page|middleware|route|story>[.<native|ios|android|web|test>].js",
+        grammar(),
     );
+}
+
+/// The grammar, spelled from the enums that define it.
+///
+/// It used to be a string literal here, and it was wrong: it listed five roles
+/// while `_uf.not-found` was a sixth the build router had reserved all along,
+/// so a file the framework resolves was reported as a name it would not
+/// recognize — and the message told the reader to rename it. A message that
+/// lists what is allowed has to be generated from what is allowed.
+fn grammar() -> String {
+    let roles = uf_router::ReservedRole::all()
+        .map(uf_router::ReservedRole::as_str)
+        .join("|");
+    let variants = uf_router::ReservedVariant::all()
+        .iter()
+        .filter_map(|variant| variant.as_str())
+        .collect::<Vec<_>>()
+        .join("|");
+    format!("reserved file names are _uf.<{roles}>[.<{variants}>].js")
 }

--- a/crates/uf_router/src/reserved.rs
+++ b/crates/uf_router/src/reserved.rs
@@ -11,11 +11,20 @@
 //! read it from here rather than each spelling out the same `matches!`.
 //!
 //! Not every role is the router's. `route` answers a request and `story` names
-//! a rendered state of a component; neither is resolved by
-//! [`ReservedRole::all`], which is the roles a route is built from. They are
-//! here because the *grammar* is the toolchain's rather than the router's: a
-//! second spelling for the same idea is how the scaffold, the router and the
-//! linter drifted apart the first time.
+//! a rendered state of a component; neither is one of
+//! [`ReservedRole::route_parts`], which is the roles a rendered route is built
+//! from. They are here because the *grammar* is the toolchain's rather than the
+//! router's: a second spelling for the same idea is how the scaffold, the
+//! router and the linter drifted apart the first time.
+//!
+//! It drifted again anyway, in the direction this module could not see.
+//! `packages/vite/internal/routes.js` is the router the build actually runs,
+//! it keeps its own `RESERVED` table, and its comment says the two "cannot be
+//! allowed to disagree" — while `_uf.not-found` was in that table and not in
+//! this enum, so `uf lint` rejected the file name uf's own documentation site
+//! uses for its 404 page. `every_name_the_build_router_reserves_is_a_role`
+//! reads that table now, which is the part that was missing: a rule that both
+//! files must agree, enforced by neither, is a comment.
 
 use std::str::FromStr;
 
@@ -28,6 +37,12 @@ pub enum ReservedRole {
     Page,
     /// Runs before a route resolves.
     Middleware,
+    /// Renders a path no route matched.
+    ///
+    /// A page in every way that matters — it is wrapped in the layouts above
+    /// it and rendered like one — except that no path leads to it, which is
+    /// why it is not one of [`route_parts`](ReservedRole::route_parts).
+    NotFound,
     /// Answers a request instead of rendering a page.
     Route,
     /// Names a rendered state of a component, for `@uniflowed/story`.
@@ -42,14 +57,38 @@ impl ReservedRole {
             Self::Layout => "layout",
             Self::Page => "page",
             Self::Middleware => "middleware",
+            Self::NotFound => "not-found",
             Self::Route => "route",
             Self::Story => "story",
         }
     }
 
     /// Every role, in declaration order.
+    ///
+    /// Named to mean the same thing [`ReservedVariant::all`] does, which it did
+    /// not: this returned three of the five roles, because it was written when
+    /// "every role" and "every role a route is built from" were the same set.
+    /// Two `all` in one module meaning two different things is the drift this
+    /// module exists to prevent, one level up.
     #[must_use]
-    pub const fn all() -> [Self; 3] {
+    pub const fn all() -> [Self; 6] {
+        [
+            Self::Layout,
+            Self::Page,
+            Self::Middleware,
+            Self::NotFound,
+            Self::Route,
+            Self::Story,
+        ]
+    }
+
+    /// The roles a rendered route is built from.
+    ///
+    /// A `route` answers a request rather than rendering, a `story` names a
+    /// state of a component, and a `not-found` is reached by no path — so none
+    /// of the three composes a route, though all three are reserved names.
+    #[must_use]
+    pub const fn route_parts() -> [Self; 3] {
         [Self::Layout, Self::Page, Self::Middleware]
     }
 }
@@ -62,6 +101,7 @@ impl FromStr for ReservedRole {
             "layout" => Ok(Self::Layout),
             "page" => Ok(Self::Page),
             "middleware" => Ok(Self::Middleware),
+            "not-found" => Ok(Self::NotFound),
             "route" => Ok(Self::Route),
             "story" => Ok(Self::Story),
             _ => Err(()),
@@ -243,8 +283,25 @@ mod tests {
             ReservedVariant::Native
         );
         assert!(
-            !ReservedRole::all().contains(&ReservedRole::Story),
+            !ReservedRole::route_parts().contains(&ReservedRole::Story),
             "a story is not something a route is built from"
+        );
+    }
+
+    #[test]
+    fn a_not_found_file_is_reserved_without_a_route_leading_to_it() {
+        // The file uf's own documentation site uses for its 404 page.
+        // `packages/vite/internal/routes.js` has reserved this name since the
+        // router was written; this enum did not, so `uf lint` told the site to
+        // rename a file the router resolves. See `tests/reserved_names.rs`.
+        assert_eq!(recognized("_uf.not-found.js").role, ReservedRole::NotFound);
+        assert_eq!(
+            recognized("_uf.not-found.web.js").variant,
+            ReservedVariant::Web
+        );
+        assert!(
+            !ReservedRole::route_parts().contains(&ReservedRole::NotFound),
+            "no path leads to a not-found page, so no route is built from one"
         );
     }
 

--- a/crates/uf_router/tests/reserved_names.rs
+++ b/crates/uf_router/tests/reserved_names.rs
@@ -1,0 +1,105 @@
+//! The reserved-name grammar, against the router that actually runs.
+//!
+//! `crates/uf_router/src/reserved.rs` calls itself the single source of truth
+//! for `_uf.<role>[.<variant>]`, and `packages/vite/internal/routes.js` is the
+//! file-system router the build runs, with a `RESERVED` table of its own and a
+//! comment saying the two "cannot be allowed to disagree". Nothing compared
+//! them, and they disagreed: `_uf.not-found` was in the JavaScript table and
+//! not in the Rust enum, so `uf lint`'s `router/reserved-files` reported the
+//! file name uf's own documentation site uses for its 404 page as one the
+//! router would not recognize — and told the reader to rename it.
+//!
+//! A rule that two files must agree, enforced by neither, is a comment. This
+//! is the enforcement.
+//!
+//! It is one direction plus a named exception rather than an equality, because
+//! the two sets are not meant to be equal: the grammar is the toolchain's and
+//! the table is the router's, so a role no router resolves belongs in the first
+//! and not the second. `story` is that role today, and naming it here is what
+//! makes adding a second one a decision somebody has to write down.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use uf_router::ReservedRole;
+
+/// Roles that are reserved names without being anything the router resolves.
+///
+/// `story` names a rendered state of a component and is found by `uf story`,
+/// which walks the project itself. Adding to this list means saying that a
+/// reserved name is deliberately invisible to the build router; that is a real
+/// decision and the point of writing it here is that it cannot be made by
+/// forgetting.
+const NOT_THE_ROUTERS: &[ReservedRole] = &[ReservedRole::Story];
+
+/// The `_uf.*` names `packages/vite/internal/routes.js` reserves.
+///
+/// Read out of the source rather than duplicated, because a copy here would be
+/// a fourth spelling of the grammar and this file exists to stop the third.
+/// The table is a frozen object literal of `key: "_uf.name"` pairs, so the
+/// names are every `"_uf.…"` string inside it — no JavaScript parser needed,
+/// and a table that stops having that shape fails loudly below rather than
+/// quietly matching nothing.
+fn build_router_names() -> BTreeSet<String> {
+    let source = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/vite/internal/routes.js"),
+    )
+    .expect("the build router is in this repository");
+
+    let table = source
+        .split_once("export const RESERVED = Object.freeze({")
+        .expect("`RESERVED` is a frozen object literal; if it is not, this test is out of date")
+        .1
+        .split_once("});")
+        .expect("the literal is closed")
+        .0;
+
+    let names: BTreeSet<String> = table
+        .split('"')
+        .filter(|value| value.starts_with("_uf."))
+        .map(|value| value["_uf.".len()..].to_owned())
+        .collect();
+
+    assert!(
+        names.len() > 1,
+        "read {} name(s) out of the build router's table, which is not a table:\n{table}",
+        names.len()
+    );
+    names
+}
+
+#[test]
+fn every_name_the_build_router_reserves_is_a_role() {
+    let roles: BTreeSet<&str> = ReservedRole::all().map(ReservedRole::as_str).into();
+
+    for name in build_router_names() {
+        assert!(
+            roles.contains(name.as_str()),
+            "`packages/vite/internal/routes.js` reserves `_uf.{name}` and `ReservedRole` has no \
+             such role, so `uf lint` rejects a file the router resolves"
+        );
+    }
+}
+
+#[test]
+fn every_role_the_router_resolves_is_in_the_build_router() {
+    let names = build_router_names();
+
+    for role in ReservedRole::all() {
+        if NOT_THE_ROUTERS.contains(&role) {
+            assert!(
+                !names.contains(role.as_str()),
+                "`{}` is listed as not the router's and the build router reserves it; one of the \
+                 two is wrong",
+                role.as_str()
+            );
+            continue;
+        }
+        assert!(
+            names.contains(role.as_str()),
+            "`ReservedRole::{role:?}` is a reserved name the build router does not scan for, so \
+             `uf lint` accepts a file name nothing resolves. Add it to `RESERVED` in \
+             `packages/vite/internal/routes.js`, or to `NOT_THE_ROUTERS` here with a reason"
+        );
+    }
+}


### PR DESCRIPTION
`crates/uf_router/src/reserved.rs` calls itself the single source of truth for the `_uf.<role>[.<variant>]` grammar. `packages/vite/internal/routes.js` is the router the build actually runs, keeps a `RESERVED` table of its own, and says in its header that the two "cannot be allowed to disagree".

Nothing compared them, and they disagreed.

`_uf.not-found` has been in the JavaScript table since the router was written — the build resolves it, wraps it in the layouts above it, and emits `404.html` from it — and was not in the Rust enum. So `router/reserved-files` reported `docs/app/_uf.not-found.js`, the 404 page of uf's own documentation site, as a name the router would not recognize, and the message told the reader to rename a file that works.

## What changed

`ReservedRole::NotFound`, and three things around it.

**The linter's message is generated.** It was a string literal listing five roles — a third spelling of the grammar, wrong in the same way and for the same reason. A message that says what is allowed has to be built from what is allowed.

**`ReservedRole::all` now means what `ReservedVariant::all` means.** It returned three of the five roles, because it was written when "every role" and "every role a route is built from" were the same set. The narrow one is `route_parts` now. Two `all` in one module meaning two different things is this module's own subject, one level up.

**`crates/uf_router/tests/reserved_names.rs` reads the JavaScript table** — out of the source, because a copy would be a fourth spelling of the grammar and this test exists to stop the third.

It is one direction plus a named exception rather than an equality, because the two sets are not meant to be equal: the grammar is the toolchain's and the table is the router's, so a role no router resolves belongs in the first and not the second. `story` is that role today, and it sits in a `NOT_THE_ROUTERS` list whose comment says what adding to it means — so a second one is a decision somebody writes down rather than something that happens by forgetting.

Dropping `NotFound` again fails both tests by name:

```
`packages/vite/internal/routes.js` reserves `_uf.not-found` and `ReservedRole`
has no such role, so `uf lint` rejects a file the router resolves
```

## Verified

* `cargo test -p uf_router` — 22 unit + 2 integration, green
* `cargo test --workspace` — green apart from `uf_cli --test vite`'s `dev_serves_the_docs_site_through_vite`, which fails on this machine before and after (`TcpListener::bind` → `PermissionDenied` in the local sandbox) and passes in CI
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo fmt --all -- --check` — clean
* `uf lint` on this repository: `router/reserved-files` findings 1 → 0
* `uf test#library` — `✓ 1098 passed`, `uf fmt --check` — clean

One of the findings standing between `uf lint` and CI; the rest are being triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791247205&installation_model_id=422833&pr_number=224&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F224&signature=98f878494f719db09a0ad1351a784e3caa71f6ff6a66c7e62ed55d1f2bc90c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->