### PR TITLE
fix(lint): a rule about what code does does not read strings

### DIFF
--- a/crates/uf_lint/src/runner/flow_module.rs
+++ b/crates/uf_lint/src/runner/flow_module.rs
@@ -28,6 +28,12 @@ pub(crate) fn run_flow_mixed_import_and_require(
     for (position, line) in scan.lines.iter().enumerate() {
         let code = line.code();
         for at in find_words(code, "require") {
+            // `node -e "… require('node:fs') …"` is a shell command this module
+            // hands to a task runner, not a module system it mixes in. That is
+            // `uf.config.js` in this repository, twice on one line.
+            if line.in_string(at) {
+                continue;
+            }
             if prev_non_space(code, at).is_some_and(|(_, byte)| byte == b'.') {
                 continue;
             }
@@ -98,6 +104,9 @@ pub(crate) fn run_flow_export_renamed_default(
         let code = line.code();
         for at in find_all(code, "as default")
             .filter(|&at| starts_word(code, at) && ends_word(code, at + "as default".len()))
+            // Prose about the rule is not the rule being broken: a message
+            // saying `export it as default` renames nothing.
+            .filter(|&at| !line.in_string(at))
         {
             push_in_code(
                 diagnostics,

--- a/crates/uf_lint/src/runner/security.rs
+++ b/crates/uf_lint/src/runner/security.rs
@@ -4,7 +4,7 @@
 
 use uf_config::UniflowedConfig;
 
-use crate::scan::{FileScan, find_words, identifier_len, next_non_space, previous_word};
+use crate::scan::{FileScan, Line, find_words, identifier_len, next_non_space, previous_word};
 use crate::{Diagnostic, push_in_code, severity};
 
 /// The sanitizing package whose helpers may feed `dangerouslySetInnerHTML`.
@@ -32,16 +32,16 @@ pub(crate) fn run_security_no_dangerously_set_inner_html(
     for (position, line) in scan.lines.iter().enumerate() {
         let code = line.code();
         for at in find_words(code, "dangerouslySetInnerHTML") {
+            // Naming the sink is not reaching for it. The rule's own message
+            // names it, and so does every page that documents it.
+            if line.in_string(at) {
+                continue;
+            }
             // The `__html` value may wrap onto the next line, so both are checked.
-            let next = scan
-                .lines
-                .get(position + 1)
-                .map(|line| line.code())
-                .unwrap_or("");
-            if sanitizers
-                .iter()
-                .any(|&name| is_called_in(code, name) || is_called_in(next, name))
-            {
+            let next = scan.lines.get(position + 1);
+            if sanitizers.iter().any(|&name| {
+                is_called_in(line, name) || next.is_some_and(|next| is_called_in(next, name))
+            }) {
                 continue;
             }
             push_in_code(
@@ -86,10 +86,18 @@ fn markdown_sanitizers<'a>(scan: &FileScan<'a>) -> Vec<&'a str> {
     names
 }
 
-/// Whether `name` is used as a call or a namespace member in `code`.
-fn is_called_in(code: &str, name: &str) -> bool {
+/// Whether `name` is used as a call or a namespace member on `line`.
+///
+/// Inside a string it is a mention, not a call, and this answer suppresses a
+/// finding rather than raising one — so reading a sanitizer's name out of a
+/// message would hide a real sink, which is the expensive direction to be
+/// wrong in.
+fn is_called_in(line: &Line<'_>, name: &str) -> bool {
+    let code = line.code();
     find_words(code, name).any(|at| {
-        next_non_space(code, at + name.len()).is_some_and(|(_, byte)| byte == b'(' || byte == b'.')
+        !line.in_string(at)
+            && next_non_space(code, at + name.len())
+                .is_some_and(|(_, byte)| byte == b'(' || byte == b'.')
     })
 }
 
@@ -112,6 +120,9 @@ pub(crate) fn run_security_no_eval(
         let code = line.code();
 
         for at in find_words(code, "eval") {
+            if line.in_string(at) {
+                continue;
+            }
             if !next_non_space(code, at + "eval".len()).is_some_and(|(_, byte)| byte == b'(') {
                 continue;
             }
@@ -127,6 +138,9 @@ pub(crate) fn run_security_no_eval(
         }
 
         for at in find_words(code, "Function") {
+            if line.in_string(at) {
+                continue;
+            }
             if !next_non_space(code, at + "Function".len()).is_some_and(|(_, byte)| byte == b'(') {
                 continue;
             }
@@ -146,6 +160,9 @@ pub(crate) fn run_security_no_eval(
 
         for timer in TIMER_FUNCTIONS {
             for at in find_words(code, timer) {
+                if line.in_string(at) {
+                    continue;
+                }
                 let Some((paren_at, b'(')) = next_non_space(code, at + timer.len()) else {
                     continue;
                 };

--- a/crates/uf_lint/src/tests/flow_module.rs
+++ b/crates/uf_lint/src/tests/flow_module.rs
@@ -25,6 +25,29 @@ fn mixed_import_and_require_accepts_a_pure_esm_module() {
 }
 
 #[test]
+fn mixed_import_and_require_ignores_a_require_inside_a_string() {
+    // `uf.config.js` in this repository: a `node -e "…"` task whose command
+    // happens to contain `require(...)`. Twice on one line, and neither of
+    // them a module system this file mixes in.
+    let diagnostics = lint_js(
+        "flow/mixed-import-and-require",
+        "// @flow\nimport { defineConfig } from '@uniflowed/config';\nexport default defineConfig({ tasks: { m: \"node -e \\\"require('node:fs')\\\"\" } });\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+}
+
+#[test]
+fn export_renamed_default_ignores_the_phrase_inside_a_string() {
+    let diagnostics = lint_js(
+        "flow/export-renamed-default",
+        "// @flow\nexport const advice = 'do not export it as default';\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+}
+
+#[test]
 fn non_const_var_export_rejects_mutable_exports() {
     let diagnostics = lint_js(
         "flow/non-const-var-export",

--- a/crates/uf_lint/src/tests/security.rs
+++ b/crates/uf_lint/src/tests/security.rs
@@ -36,6 +36,33 @@ fn dangerously_set_inner_html_allows_the_value_on_the_next_line() {
 }
 
 #[test]
+fn naming_the_sink_in_a_string_is_not_reaching_for_it() {
+    // Every page that documents the rule, and the rule's own message, contain
+    // the word.
+    let diagnostics = lint_js(
+        "security/no-dangerously-set-inner-html",
+        "// @flow\nexport const advice = 'never use dangerouslySetInnerHTML on untrusted input';\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+}
+
+#[test]
+fn a_sanitizer_named_in_a_string_does_not_excuse_a_sink() {
+    // The dangerous direction: this answer *suppresses* a finding, so reading
+    // a helper's name out of a message would hide a real sink.
+    // The mention has to be on the line the sink is on, or on the one after
+    // it, because those are the two lines the suppression reads.
+    let diagnostics = lint_js(
+        "security/no-dangerously-set-inner-html",
+        "// @flow\nimport { renderMarkdown } from '@uniflowed/markdown';\ncomponent Body(html: string) {\n  return <div dangerouslySetInnerHTML={{ __html: html }} title='call renderMarkdown(md) first' />;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    assert_eq!(diagnostics[0].line, 4);
+}
+
+#[test]
 fn a_markdown_import_does_not_whitelist_an_unrelated_value() {
     let diagnostics = lint_js(
         "security/no-dangerously-set-inner-html",
@@ -57,6 +84,18 @@ fn eval_and_friends_are_rejected() {
     assert_eq!((diagnostics[1].line, diagnostics[1].column), (3, 11));
     assert_eq!(diagnostics[2].line, 4);
     assert_eq!(diagnostics[3].line, 5);
+}
+
+#[test]
+fn the_eval_family_named_inside_strings_is_accepted() {
+    // A message about the rule, a task that shells out, documentation prose:
+    // all three contain the words and none of them executes anything.
+    let diagnostics = lint_js(
+        "security/no-eval",
+        "// @flow\nconst why = 'eval(x) executes arbitrary code';\nconst also = 'new Function(body) compiles it';\nconst timer = `setTimeout(\"tick()\", 10) is the string form`;\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:#?}");
 }
 
 #[test]

--- a/uf.config.js
+++ b/uf.config.js
@@ -91,11 +91,20 @@ export default defineConfig({
     // check in the pipeline.
     //
     // Not in `ci` yet, and the reason is written down rather than left to be
-    // rediscovered: it reports 315 errors today. The largest groups are
-    // `flow/unclear-type` (125), `flow/react-intrinsic-overlap` (89) and
-    // `react/hooks-rules` (86), and each needs looking at on its own terms —
-    // some are real findings in uf's packages, and some are rules that are
-    // wrong the way `flow/ambiguous-object-type` was wrong.
+    // rediscovered: it reports 153 errors and 11 warnings over 280 files.
+    // `flow/unclear-type` is 139 of them — 81 in `tests/library`, 58 in
+    // shipped packages, which are not the same question — and
+    // `react/no-render-side-effects` is 8, all of them `packages/test`'s fake
+    // timers, where a `useX` name that is not a hook is read as one. The rest
+    // are one small fix each. ubugeeei-prod/uf#225 counts them and says what
+    // each group needs.
+    //
+    // The numbers were wrong here for a while, which is its own lesson: this
+    // said 315 errors and named `flow/react-intrinsic-overlap` (89) and
+    // `react/hooks-rules` (86) as the largest groups, and both of those report
+    // nothing at all today — the first is one of sixteen rules that need type
+    // inference uf does not implement yet, so it is skipped rather than
+    // passing.
     "check:lib": {
       command: "./target/release/uf lint",
       dependsOn: ["build"],


### PR DESCRIPTION
Refs #225.

`Line::code` keeps string literals on purpose — `uniflowed/no-npm-script-invocation` exists to look inside them — so a rule about what the code *does* has to ask `line.in_string(at)` before it fires. **Seven scans did not**, across two runners, and the first fires on this repository:

```
uf.config.js:175  this module already uses `import`; do not mix in `require`
uf.config.js:175  this module already uses `import`; do not mix in `require`
```

Twice on one line, both inside `"node -e \"… require('node:fs') …\""` — a shell command the config hands to a task runner, not a module system this file mixes in.

The other six are the same mistake waiting for a file to write it. `eval`, `new Function` and the string form of `setTimeout` are named in every message and every page explaining why not to use them; `dangerouslySetInnerHTML` is named by its own rule's message; `as default` appears in the sentence telling you not to.

## One of them is the dangerous direction

The sanitizer check in `security/no-dangerously-set-inner-html` **suppresses** a finding, so reading a helper's name out of a string hides a real sink rather than inventing a false one:

```js
<div dangerouslySetInnerHTML={{ __html: html }} title='call renderMarkdown(md) first' />
```

was silently accepted. `is_called_in` takes the `Line` now instead of the text, which is what lets it ask.

## Every guard is load-bearing

Removing any one of the seven fails its own test and no other. Removing all seven and running the suite names them one at a time. The suppression test had to be rewritten to earn that: the first draft put the mention two lines above the sink, where the check never looks, so the mutation passed — the test now puts it on the same line.

## The comment in `uf.config.js`

Brought up to date in the same commit, because it was three numbers and two rules out of date. It said `check:lib` reports 315 errors and named `flow/react-intrinsic-overlap` (89) and `react/hooks-rules` (86) as the largest groups; both report nothing today, the first because it is one of sixteen rules needing type inference uf does not implement yet — so it is *skipped*, not passing. #225 counts what is actually there and says what each group needs.

## Verified

* `cargo test -p uf_lint` — 203 tests, green (7 new)
* `cargo clippy -p uf_lint --all-targets -- -D warnings` — clean
* `cargo fmt --all -- --check` — clean
* `uf lint` on this repository: **155 errors → 153**, warnings unchanged at 11
* `uf fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791248615&installation_model_id=422833&pr_number=227&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F227&signature=b9e10f7cb72dd6b9b71b63115ec73d82eed7aece7663d60299ab2eb7bfb030a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->