### PR TITLE
fix(test): an event that outlives its file is not the next file's

### DIFF
--- a/crates/uf_cli/tests/testing.rs
+++ b/crates/uf_cli/tests/testing.rs
@@ -8,10 +8,20 @@
 //!
 //! They skip — loudly — where Node or the installed workspace is missing, so a
 //! checkout that never ran `npm ci` still passes `cargo test`.
+//!
+//! One test drives [`uf_test::Worker`] rather than the `uf` binary, because
+//! what it asserts is a promise the worker protocol makes and the protocol is
+//! only observable on the wire — see
+//! `a_worker_that_answers_for_a_finished_file_does_not_disturb_the_running_one`.
+//! It still needs a real host, which is why it lives here and not in `uf_test`.
 
 mod support;
 
 use std::path::Path;
+use std::time::Duration;
+
+use camino::Utf8PathBuf;
+use uf_test::{FileStatus, HostCommand, HostKind, TestStatus, Worker};
 
 use support::{Project, assert_plain, host_ready, uf};
 
@@ -352,6 +362,275 @@ it("still runs after it", () => {
             .unwrap()
             .contains("timed out"),
         "{failing}"
+    );
+}
+
+/// Two files on one worker, the second releasing a callback the first left
+/// behind.
+///
+/// The issue writes the reproduction as `setTimeout(…, 50)` and lets the next
+/// file happen to be running fifty milliseconds later. That reproduces the bug
+/// and makes a poor test: what has to be shown is that the line arrived *after*
+/// its file had been reported, and a sleep shows that only while the machine is
+/// idle. So the second file hands the first one a switch, through a module
+/// neither of them is: both import `switch.js` without the cache-busting query
+/// the worker puts on a test file, so both get the one instance the worker's
+/// registry holds. The callback is still detached — scheduled by a case that
+/// returned long before it fires — but it cannot run until the second file has
+/// started, and the second file cannot finish until it has.
+///
+/// The first file is deliberately the longer of the two, because the schedule
+/// is longest-expected-first and a cold file's expectation is its size: this is
+/// what puts it ahead of the second rather than the tie-break on path.
+const STRAGGLER: [(&str, &str); 3] = [
+    (
+        "src/switch.js",
+        r#"// @flow
+let release: () => void = () => {};
+export const begun: Promise<void> = new Promise((resolve) => {
+  release = resolve;
+});
+export function begin(): void {
+  release();
+}
+
+let settle: () => void = () => {};
+export const printed: Promise<void> = new Promise((resolve) => {
+  settle = resolve;
+});
+export function donePrinting(): void {
+  settle();
+}
+"#,
+    ),
+    (
+        "src/a-leaves-a-callback.test.js",
+        r#"// @flow
+// This file is padded to be the longer of the two, so that the schedule —
+// longest expected first, and a cold file is expected to cost what its size
+// suggests — runs it before the file that releases its callback. Without that
+// the order would rest on the tie-break, which is alphabetical and would
+// happen to agree; resting on a coincidence is not the same as being ordered.
+import { expect, it } from "@uniflowed/test";
+import { begun, donePrinting } from "./switch.js";
+
+it("schedules something it does not wait for", () => {
+  begun.then(() => {
+    setTimeout(() => {
+      console.log("from the previous file");
+      donePrinting();
+    }, 0);
+  });
+  expect(true).toBe(true);
+});
+"#,
+    ),
+    (
+        "src/b-runs-after-it.test.js",
+        r#"// @flow
+import { expect, it } from "@uniflowed/test";
+import { begin, printed } from "./switch.js";
+
+it("is running when it fires", async () => {
+  begin();
+  await printed;
+  expect(true).toBe(true);
+});
+"#,
+    ),
+];
+
+/// One file's report out of the `--json` document.
+fn file_report<'a>(document: &'a serde_json::Value, file: &str) -> &'a serde_json::Value {
+    document["fileReports"]
+        .as_array()
+        .expect("the document lists its files")
+        .iter()
+        .find(|report| report["file"] == file)
+        .unwrap_or_else(|| panic!("{file} is missing from {document}"))
+}
+
+#[test]
+fn a_line_printed_after_its_file_finished_is_not_reported_under_the_next_one() {
+    if !host_ready() {
+        return;
+    }
+    let project = Project::new(&STRAGGLER);
+
+    // One worker, so the second file is served by the process the first one
+    // left its callback running in. That is the only condition the bug needs.
+    let document = json(project.path(), &["-j", "1"]);
+
+    assert_eq!(document["passed"], 2, "{document}");
+    assert_eq!(document["failed"], 0, "{document}");
+    assert_eq!(document["files"], 2, "src/switch.js declares no tests");
+
+    let printed_under_a_case_of_the_second = document["tests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|test| test["file"] == "src/b-runs-after-it.test.js")
+        .any(|test| {
+            serde_json::to_string(&test["output"])
+                .unwrap()
+                .contains("from the previous file")
+        });
+    assert!(
+        !printed_under_a_case_of_the_second,
+        "a line the previous file printed was reported under a case of this one: {document}"
+    );
+
+    // The runner's own notes and what the file printed are both `output`, so
+    // they are told apart the way a reader tells them apart: by the prefix.
+    let second = file_report(&document, "src/b-runs-after-it.test.js");
+    let chunks = second["output"]
+        .as_array()
+        .expect("a file report lists its output");
+    let (notes, printed): (Vec<_>, Vec<_>) = chunks.iter().partition(|chunk| {
+        chunk["text"]
+            .as_str()
+            .is_some_and(|text| text.starts_with("[uf] "))
+    });
+    assert!(
+        !printed
+            .iter()
+            .any(|chunk| chunk["text"] == "from the previous file\n"),
+        "a line the previous file printed became this file's own: {document}"
+    );
+
+    // Dropped, but not silently: the note names the file the line came from,
+    // which is where a reader chasing the message has to look. It cannot be
+    // put in that file's report — that report was streamed to the terminal
+    // when the file finished, before this line existed.
+    let [note] = notes.as_slice() else {
+        panic!("the drop is noted exactly once: {document}");
+    };
+    let text = note["text"].as_str().unwrap();
+    assert!(text.contains("src/a-leaves-a-callback.test.js"), "{text}");
+    assert!(text.contains("from the previous file"), "{text}");
+    assert_eq!(note["stream"], "stderr", "{text}");
+
+    // And the file it came from does not gain it either. Saying so here is the
+    // point: the line is genuinely lost from the report, and the note is what
+    // is offered in its place.
+    let first = file_report(&document, "src/a-leaves-a-callback.test.js");
+    assert!(
+        !serde_json::to_string(first)
+            .unwrap()
+            .contains("from the previous file"),
+        "{first}"
+    );
+}
+
+/// A worker that answers from a script instead of running anything.
+///
+/// The three kinds of late event are not equally easy to provoke from a test
+/// file. A stray `console.log` is; a case that reports after its file has ended
+/// is not, and an abandoned promise ends the worker as it goes, so watching for
+/// the report it produced is watching for a write that races a `process.exit`.
+/// None of that is what is being tested. What is being tested is what `uf` does
+/// with each kind, so each kind is a line in a script here — which is also the
+/// only way to write "and the second file was reported correctly *anyway*" as
+/// an assertion rather than a hope.
+///
+/// It speaks the same protocol as `packages/test/worker.js` and nothing else:
+/// a request per line in, one event per line out, each event stamped with the
+/// generation it belongs to.
+const CANNED_WORKER: &str = r#"import { createInterface } from "node:readline";
+
+const write = (event) => process.stdout.write(`${JSON.stringify(event)}\n`);
+let served = 0;
+
+createInterface({ input: process.stdin }).on("line", (line) => {
+  if (line.trim() === "") {
+    return;
+  }
+  const now = JSON.parse(line).generation;
+  served += 1;
+  if (served === 1) {
+    write({ event: "test", name: "the first file's case", status: "passed", generation: now });
+    write({ event: "file", status: "completed", generation: now });
+    return;
+  }
+  // Everything the first file had left running, arriving in the middle of the
+  // second: a line it printed, a case that only now reported, and a promise it
+  // abandoned, which is a *file* result and would otherwise end this file.
+  const before = now - 1;
+  write({
+    event: "output",
+    stream: "stdout",
+    test: "the first file's case",
+    text: "from the previous file\n",
+    generation: before,
+  });
+  write({
+    event: "test",
+    name: "the first file's case",
+    status: "failed",
+    message: "resolved after its file had gone",
+    generation: before,
+  });
+  write({
+    event: "file",
+    status: "run-failed",
+    message: "unhandled rejection: left behind",
+    generation: before,
+  });
+  write({ event: "output", stream: "stdout", test: "the second file's case", text: "mine\n", generation: now });
+  write({ event: "test", name: "the second file's case", status: "passed", generation: now });
+  write({ event: "file", status: "completed", generation: now });
+});
+
+process.stdin.on("close", () => process.exit(0));
+"#;
+
+#[test]
+fn a_worker_that_answers_for_a_finished_file_does_not_disturb_the_running_one() {
+    if !host_ready() {
+        return;
+    }
+    let project = Project::new(&[("canned-worker.js", CANNED_WORKER)]);
+    let root = Utf8PathBuf::from_path_buf(project.path().to_path_buf()).unwrap();
+    let command = HostCommand::new(
+        HostKind::Node,
+        Utf8PathBuf::from("node"),
+        root.join("canned-worker.js"),
+        root,
+    );
+    let mut worker = Worker::spawn(&command).expect("node starts");
+
+    let budget = Duration::from_secs(5);
+    let first = worker.run_file("/first.test.js", "first.test.js", None, budget, budget);
+    let second = worker.run_file("/second.test.js", "second.test.js", None, budget, budget);
+    worker.kill();
+
+    assert_eq!(first.status, FileStatus::Completed);
+    assert_eq!(first.records.len(), 1, "{first:?}");
+
+    // The `file` event from the first file did not end the second, which is the
+    // damage worth measuring: accepting it would have cut the report here and
+    // stamped this file `run-failed` with a message from code it does not
+    // contain, and the case below would never have been reported at all.
+    assert_eq!(second.status, FileStatus::Completed, "{second:?}");
+    let [record] = second.records.as_slice() else {
+        panic!("only this file's own case is a record of it: {second:?}");
+    };
+    assert_eq!(record.name, "the second file's case");
+    assert_eq!(record.status, TestStatus::Passed);
+    assert_eq!(record.output[0].text, "mine\n");
+
+    // One note for the three dropped events, quoting the first of them, and
+    // naming the file they came from rather than the number.
+    let [note] = second.output.as_slice() else {
+        panic!("the drops are one note, before nothing else: {second:?}");
+    };
+    assert!(
+        note.text.contains("3 events arrived from `first.test.js`"),
+        "{note:?}"
+    );
+    assert!(
+        note.text.contains("output \"from the previous file\""),
+        "{note:?}"
     );
 }
 

--- a/crates/uf_test/src/host.rs
+++ b/crates/uf_test/src/host.rs
@@ -8,7 +8,7 @@
 //! the host's Flow loader so the module is transformed by the same
 //! `uf transform` a build uses.
 //!
-//! Three properties the design is built around:
+//! Four properties the design is built around:
 //!
 //! * **One file at a time per worker.** Two files sharing a process share
 //!   globals and module state, and a suite that passes alone but fails beside
@@ -22,7 +22,15 @@
 //! * **A dead worker is a reported file, not a lost run.** Whatever happens to
 //!   one process — a crash, a `process.exit`, a stream that stops — the file
 //!   is named with what went wrong and the run continues on a fresh worker.
+//! * **Every event says which file it belongs to.** "One file at a time" bounds
+//!   what the worker *starts*, not what a finished file left running: a
+//!   `setTimeout` nobody waited for still fires, and its events land in the
+//!   middle of the next file's. Each request carries a generation number, every
+//!   event is stamped with the generation it was written under, and an event
+//!   stamped with a request this worker has already finished is dropped with a
+//!   note instead of being handed to the file running now.
 
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
@@ -169,6 +177,21 @@ struct Request<'a> {
     filter: Option<&'a str>,
     /// Per-case budget in milliseconds.
     timeout_ms: u64,
+    /// Which request this is, counting from one within this worker.
+    ///
+    /// The worker stamps it on every event it writes while serving this
+    /// request — including from a callback the file left behind, which is the
+    /// whole point — and [`Worker::run_file`] refuses an event stamped with any
+    /// other. It is the same number the worker already used to bust its import
+    /// cache; making it part of the protocol is what lets the two sides agree
+    /// on which file an event came from.
+    ///
+    /// Assigned here rather than counted in the worker because the side that
+    /// has to check a number should be the side that chose it. The worker
+    /// counts the requests it serves too, so the two agree by construction, and
+    /// its count is only ever used as a fallback for a host too old to send
+    /// this field.
+    generation: u64,
 }
 
 /// One line the worker wrote.
@@ -182,6 +205,37 @@ enum Event {
     /// Something printed. A test's `console.log` arrives here rather than as a
     /// raw line, which is what stops it from being read as a malformed event.
     Output(OutputEvent),
+}
+
+impl Event {
+    /// Which request the worker was serving when it wrote this.
+    const fn generation(&self) -> u64 {
+        match self {
+            Self::Test(event) => event.generation,
+            Self::File(event) => event.generation,
+            Self::Output(event) => event.generation,
+        }
+    }
+
+    /// How a note names this event, when it arrived too late to be reported.
+    ///
+    /// Everything quoted here was chosen by the worker, so everything quoted
+    /// here goes through [`excerpt`]: a note about untrusted output must not
+    /// itself be a way to write a screen's worth of it.
+    fn describe(&self) -> String {
+        match self {
+            Self::Test(event) => format!("the case \"{}\"", excerpt(&event.name)),
+            Self::File(event) => match &event.message {
+                Some(message) => format!(
+                    "the file result \"{}\": {}",
+                    excerpt(&event.status),
+                    excerpt(message)
+                ),
+                None => format!("the file result \"{}\"", excerpt(&event.status)),
+            },
+            Self::Output(event) => format!("output \"{}\"", excerpt(&event.text)),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -207,6 +261,9 @@ struct TestEvent {
     received: Option<String>,
     #[serde(default)]
     site: Option<Site>,
+    /// The request this was written under. See [`Request::generation`].
+    #[serde(default)]
+    generation: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -223,6 +280,9 @@ struct FileEvent {
     message: Option<String>,
     #[serde(default)]
     stack: Option<String>,
+    /// The request this was written under. See [`Request::generation`].
+    #[serde(default)]
+    generation: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -237,6 +297,152 @@ struct OutputEvent {
     test: Option<String>,
     #[serde(default)]
     text: String,
+    /// The request this was written under. See [`Request::generation`].
+    #[serde(default)]
+    generation: u64,
+}
+
+/// Whether `stamp` names a request other than the one being served.
+///
+/// Zero is not a request. It is what an event carries when nothing said which
+/// one it belonged to: a worker older than this field, or a host whose
+/// asynchronous storage did not reach the callback that wrote it — Deno 1.31
+/// does not carry a store through `setTimeout`, and Bun does not carry one into
+/// its unhandled-rejection hook. An unstamped event is taken as the file being
+/// served, which is exactly what every event was taken as before generations
+/// existed.
+///
+/// Treating a missing stamp as stale was the first answer and it was wrong
+/// twice over. A `file` event is how a file *ends*, so dropping an unstamped
+/// one leaves the host waiting for a reply that has already been given, until a
+/// deadline sixty times the per-case budget; and an event that names no request
+/// is not evidence that it came from another one, so refusing it would trade a
+/// wrong attribution for a hang.
+const fn is_stale(stamp: u64, serving: u64) -> bool {
+    stamp != 0 && stamp != serving
+}
+
+/// Most finished requests one file's notes will name.
+///
+/// Everything read from a worker is untrusted, and a generation is a number the
+/// worker chose. Without a cap, a stream of events each claiming a different
+/// one would grow the ledger without limit from inside a test. Eight covers the
+/// shape this exists for — a file or two whose timers outlived them — and the
+/// rest are counted rather than named.
+const MAX_STALE_REQUESTS_NAMED: usize = 8;
+
+/// Longest excerpt a note quotes from an event it dropped.
+const MAX_STALE_EXCERPT_CHARS: usize = 80;
+
+/// A short, single-line rendering of text the worker chose.
+///
+/// Only the first line, because a note is one line and the interesting part of
+/// a `console.log` is its beginning. Control characters are left as they are:
+/// the renderer escapes them on the way to a terminal, and doing it twice would
+/// show a reader `\\n` where the test wrote a newline.
+fn excerpt(text: &str) -> String {
+    let line = text.lines().next().unwrap_or("").trim();
+    let mut kept: String = line.chars().take(MAX_STALE_EXCERPT_CHARS).collect();
+    if kept.chars().count() < line.chars().count() {
+        kept.push('…');
+    }
+    kept
+}
+
+/// What one finished request sent after it finished.
+#[derive(Debug)]
+struct StaleTally {
+    /// How many of its events were dropped.
+    count: usize,
+    /// [`Event::describe`] of the first, which is the one worth quoting: it is
+    /// the earliest thing the file did after it was supposed to be over.
+    first: String,
+}
+
+/// Events the worker wrote for a request that had already finished.
+///
+/// They are dropped — see [`Worker::run_file`] for why each kind cannot go
+/// anywhere else — and this ledger is what stops the dropping from being
+/// silent. It is a tally rather than a note per event because one abandoned
+/// `setInterval` produces thousands, and a file whose report is mostly an
+/// apology about another file is not a report.
+#[derive(Debug, Default)]
+struct StaleEvents {
+    /// Tallies by the generation that sent them, in order.
+    named: BTreeMap<u64, StaleTally>,
+    /// Events from requests beyond [`MAX_STALE_REQUESTS_NAMED`].
+    beyond: usize,
+}
+
+impl StaleEvents {
+    /// Record one dropped event.
+    fn record(&mut self, generation: u64, description: String) {
+        if let Some(tally) = self.named.get_mut(&generation) {
+            tally.count += 1;
+        } else if self.named.len() < MAX_STALE_REQUESTS_NAMED {
+            self.named.insert(
+                generation,
+                StaleTally {
+                    count: 1,
+                    first: description,
+                },
+            );
+        } else {
+            self.beyond += 1;
+        }
+    }
+
+    /// The notes to put in the report, given the files this worker has served.
+    ///
+    /// Deliberately outside [`MAX_OUTPUT_BYTES_PER_FILE`]: a budget on what a
+    /// test may print must not be able to silence the explanation of why
+    /// something is missing from the report. What it costs is bounded by
+    /// [`MAX_STALE_REQUESTS_NAMED`] notes of [`MAX_STALE_EXCERPT_CHARS`] each.
+    fn notes(&self, served: &[String]) -> Vec<OutputChunk> {
+        let mut notes = Vec::new();
+        for (generation, tally) in &self.named {
+            // A generation the worker invented names no file, and a generation
+            // is one-based, so both ends of the lookup can fail.
+            let origin = generation
+                .checked_sub(1)
+                .and_then(|at| usize::try_from(at).ok())
+                .and_then(|at| served.get(at))
+                .map_or_else(
+                    || format!("a request this worker never served ({generation})"),
+                    |file| format!("`{file}`"),
+                );
+            // "That run of it" rather than "that file": a retry re-runs the
+            // same path, so the file a straggler came from can be the file
+            // being reported, one attempt earlier.
+            let text = if tally.count == 1 {
+                format!(
+                    "[uf] one event arrived from {origin} after that run of it had finished, and \
+                     was dropped rather than reported here: {}\n",
+                    tally.first
+                )
+            } else {
+                format!(
+                    "[uf] {} events arrived from {origin} after that run of it had finished, and \
+                     were dropped rather than reported here; the first was {}\n",
+                    tally.count, tally.first
+                )
+            };
+            notes.push(OutputChunk {
+                stream: OutputStream::Stderr,
+                text,
+            });
+        }
+        if self.beyond > 0 {
+            notes.push(OutputChunk {
+                stream: OutputStream::Stderr,
+                text: format!(
+                    "[uf] and {} more from further runs this worker had already finished\n",
+                    self.beyond
+                ),
+            });
+        }
+        notes
+    }
 }
 
 /// What one file produced.
@@ -324,6 +530,23 @@ impl PendingOutput {
     }
 }
 
+/// One file's output: the notes about what was refused, then what it printed.
+///
+/// The notes come first, out of the order things happened in, because the
+/// terminal draws only the first twenty lines of this section (`uf_cli`'s
+/// `OUTPUT_LINES_SHOWN`) and a note saying why something is missing from the
+/// report must not be what a chatty file pushes out of view. `--json` carries
+/// both either way.
+fn file_output(
+    pending: &mut PendingOutput,
+    stale: &StaleEvents,
+    served: &[String],
+) -> Vec<OutputChunk> {
+    let mut output = stale.notes(served);
+    output.append(&mut pending.drain());
+    output
+}
+
 /// A worker process, and the thread reading its output.
 ///
 /// The reader is a thread because a blocking read cannot be given a deadline;
@@ -334,6 +557,13 @@ pub struct Worker {
     stdin: ChildStdin,
     events: Receiver<String>,
     reader: Option<JoinHandle<()>>,
+    /// Every file this worker has been asked to run, in the order it was asked.
+    ///
+    /// The index is the request's generation minus one, which is how a note
+    /// about an event that arrived too late can name the file it came from
+    /// rather than only the number. One short path per file the worker ran,
+    /// against a source text per file the run already holds.
+    served: Vec<String>,
 }
 
 /// Why a worker could not be started.
@@ -412,6 +642,7 @@ impl Worker {
             stdin,
             events,
             reader: Some(reader),
+            served: Vec::new(),
         })
     }
 
@@ -420,6 +651,37 @@ impl Worker {
     /// `deadline` bounds the whole file. Passing it kills the worker, which is
     /// why the caller must replace it afterwards — [`FileOutcome`] carrying a
     /// [`FileStatus::TimedOut`] means this worker is gone.
+    ///
+    /// # Events from a file that has already finished
+    ///
+    /// A worker's events are one stream, and a file's code can outlive the
+    /// file: a `setTimeout` nobody awaited fires while the *next* file is
+    /// running, and everything it does arrives here. Each event carries the
+    /// generation of the request it was written under, and one from any other
+    /// request is dropped and tallied in [`StaleEvents`] rather than reported.
+    ///
+    /// All three kinds are dropped, and the reason is the same for all three
+    /// even though the damage is not. The file an event belongs to has already
+    /// been returned from this method and handed to the observer — the report
+    /// is streamed, a file is drawn as it finishes — so "attribute it to the
+    /// file it came from" is not on the table by the time the event is read.
+    /// That leaves reporting it under the wrong file, or not at all:
+    ///
+    /// * A `test` event would add a case to a file that does not declare it,
+    ///   counted in that file's totals and stamped with that file's path by
+    ///   [`record_of`], turning one file red for something another file did.
+    /// * An `output` event would be filed under whichever case of *this* file
+    ///   shares the name it carries, and the same case name in two files is
+    ///   ordinary — `describe("adds")` is not a unique identifier. Failing to
+    ///   match is no better: the chunk becomes this file's own printing.
+    /// * A `file` event is the worst of the three, because it is how a file
+    ///   *ends*: accepting one would cut this file's report short and stamp it
+    ///   with another file's status. The worker's unhandled-rejection handler
+    ///   is exactly this shape — it writes a `file` event and exits — so a
+    ///   promise the previous file abandoned used to fail the next one with a
+    ///   message from code it does not contain. Dropped, this file keeps
+    ///   running; if the worker then exits under it, it is reported as a worker
+    ///   that died, which is what happened.
     pub fn run_file(
         &mut self,
         file: &str,
@@ -428,10 +690,16 @@ impl Worker {
         case_timeout: Duration,
         deadline: Duration,
     ) -> FileOutcome {
+        // Pushed before the request is sent, so the generation is the file's
+        // place in this worker's history whether or not the send succeeds. A
+        // send that fails ends the worker anyway.
+        self.served.push(relative.to_string());
+        let generation = u64::try_from(self.served.len()).unwrap_or(u64::MAX);
         let request = Request {
             file,
             filter,
             timeout_ms: case_timeout.as_millis().min(u128::from(u64::MAX)) as u64,
+            generation,
         };
         let mut line = match serde_json::to_string(&request) {
             Ok(line) => line,
@@ -454,6 +722,7 @@ impl Worker {
         // file that hung after printing is the case where the printing is most
         // of the evidence there is.
         let mut pending = PendingOutput::default();
+        let mut stale = StaleEvents::default();
         loop {
             let remaining = deadline.checked_sub(started.elapsed());
             let Some(remaining) = remaining else {
@@ -463,11 +732,14 @@ impl Worker {
                         budget_micros: u64::try_from(deadline.as_micros()).unwrap_or(u64::MAX),
                     },
                     records,
-                    output: pending.drain(),
+                    output: file_output(&mut pending, &stale, &self.served),
                 };
             };
             match self.events.recv_timeout(remaining) {
                 Ok(line) => match serde_json::from_str::<Event>(&line) {
+                    Ok(event) if is_stale(event.generation(), generation) => {
+                        stale.record(event.generation(), event.describe());
+                    }
                     Ok(Event::Test(event)) => {
                         let mut record = record_of(relative, event);
                         record.output = pending.take(&record.name);
@@ -478,7 +750,7 @@ impl Worker {
                         return FileOutcome {
                             status: file_status(event),
                             records,
-                            output: pending.drain(),
+                            output: file_output(&mut pending, &stale, &self.served),
                         };
                     }
                     Err(error) => {
@@ -488,7 +760,7 @@ impl Worker {
                                 message: format!("unreadable worker output: {error}: {line}"),
                             },
                             records,
-                            output: pending.drain(),
+                            output: file_output(&mut pending, &stale, &self.served),
                         };
                     }
                 },
@@ -499,7 +771,7 @@ impl Worker {
                             budget_micros: u64::try_from(deadline.as_micros()).unwrap_or(u64::MAX),
                         },
                         records,
-                        output: pending.drain(),
+                        output: file_output(&mut pending, &stale, &self.served),
                     };
                 }
                 // The reader ended, which means the process did: it exited or
@@ -512,7 +784,7 @@ impl Worker {
                     return FileOutcome {
                         status: FileStatus::HostFailed { message: how },
                         records,
-                        output: pending.drain(),
+                        output: file_output(&mut pending, &stale, &self.served),
                     };
                 }
             }
@@ -679,6 +951,7 @@ mod tests {
                     line: 4,
                     column: 12,
                 }),
+                generation: 1,
             },
         );
 
@@ -796,6 +1069,7 @@ mod tests {
                 stream: String::from("stdout"),
                 test: None,
                 text: "x".repeat(4096),
+                generation: 1,
             });
         }
 
@@ -810,6 +1084,7 @@ mod tests {
             stream: String::from("stdout"),
             test: None,
             text: "x".repeat(MAX_OUTPUT_BYTES_PER_FILE - 1),
+            generation: 1,
         });
         // Two bytes of one character, with one byte of room: neither byte is
         // kept, because half of a character is not a character.
@@ -817,6 +1092,7 @@ mod tests {
             stream: String::from("stdout"),
             test: None,
             text: String::from("é"),
+            generation: 1,
         });
 
         let chunks = pending.drain();
@@ -835,16 +1111,167 @@ mod tests {
             stream: String::from("stdout"),
             test: None,
             text: "x".repeat(MAX_OUTPUT_BYTES_PER_FILE - 1),
+            generation: 1,
         });
         for _ in 0..10_000 {
             pending.push(OutputEvent {
                 stream: String::from("stdout"),
                 test: None,
                 text: String::from("é"),
+                generation: 1,
             });
         }
 
         assert_eq!(pending.drain().len(), 1);
+    }
+
+    #[test]
+    fn every_kind_of_event_says_which_request_it_came_from() {
+        // The stamp is what makes the stream self-describing, so all three
+        // kinds have to carry it — not only `output`, which is the kind the
+        // issue was reported against.
+        for line in [
+            r#"{"event":"test","name":"a > b","status":"passed","generation":4}"#,
+            r#"{"event":"file","status":"completed","generation":4}"#,
+            r#"{"event":"output","stream":"stdout","text":"hi\n","generation":4}"#,
+        ] {
+            let event = serde_json::from_str::<Event>(line).expect("an event must parse");
+            assert_eq!(event.generation(), 4, "in {line}");
+        }
+    }
+
+    #[test]
+    fn an_event_from_a_request_that_has_finished_is_stale() {
+        assert!(is_stale(1, 2), "the file before this one");
+        assert!(!is_stale(2, 2), "the file being served");
+        // A worker cannot be ahead of the host, so this is a worker saying
+        // something impossible; it is still not this file's, which is the only
+        // question being asked.
+        assert!(is_stale(9, 2), "a request that has not been sent");
+    }
+
+    #[test]
+    fn an_event_that_names_no_request_is_the_file_being_served() {
+        // Not stale, deliberately. `0` is what an unstamped event carries — a
+        // worker older than the field, or a host whose storage did not reach
+        // the callback — and dropping a `file` event on that basis would leave
+        // the run waiting for an answer it had already been given.
+        assert!(!is_stale(0, 1));
+        assert!(!is_stale(0, 7));
+    }
+
+    #[test]
+    fn a_dropped_event_is_counted_and_named_after_the_file_it_came_from() {
+        let served = vec![String::from("src/a.test.js"), String::from("src/b.test.js")];
+        let mut stale = StaleEvents::default();
+        for text in ["from the previous file\n", "and again\n"] {
+            let line = output_line(Some("a > b"), text.trim_end());
+            let event = serde_json::from_str::<Event>(&line).expect("an event must parse");
+            stale.record(1, event.describe());
+        }
+
+        let notes = stale.notes(&served);
+        assert_eq!(notes.len(), 1, "one note per originating request");
+        assert_eq!(notes[0].stream, OutputStream::Stderr);
+        let text = &notes[0].text;
+        assert!(
+            text.starts_with("[uf] 2 events arrived from `src/a.test.js`"),
+            "{text}"
+        );
+        // The first is quoted, because it is the earliest thing the file did
+        // after it was supposed to be over; the second is only counted.
+        assert!(text.contains("from the previous file"), "{text}");
+        assert!(!text.contains("and again"), "{text}");
+        assert!(text.ends_with('\n'), "a note is one line: {text}");
+    }
+
+    #[test]
+    fn a_note_names_the_kind_of_event_it_dropped() {
+        let served = vec![String::from("src/a.test.js")];
+        for (line, expected) in [
+            (
+                r#"{"event":"test","name":"a > b","status":"failed","generation":1}"#,
+                "the case \"a > b\"",
+            ),
+            (
+                r#"{"event":"file","status":"run-failed","message":"unhandled rejection: boom","generation":1}"#,
+                "the file result \"run-failed\": unhandled rejection: boom",
+            ),
+        ] {
+            let event = serde_json::from_str::<Event>(line).expect("an event must parse");
+            let mut stale = StaleEvents::default();
+            stale.record(1, event.describe());
+            let notes = stale.notes(&served);
+            assert!(notes[0].text.contains(expected), "{}", notes[0].text);
+        }
+    }
+
+    #[test]
+    fn a_note_quotes_a_bounded_amount_of_what_a_test_wrote() {
+        // The note is the runner's own line about untrusted text, so the
+        // untrusted text must not be able to become the line. Both bounds are
+        // exercised: one long write, and one that spans many lines.
+        let long = "x".repeat(4096);
+        assert_eq!(excerpt(&long).chars().count(), MAX_STALE_EXCERPT_CHARS + 1);
+        assert!(excerpt(&long).ends_with('…'));
+        assert_eq!(excerpt("first\nsecond\nthird\n"), "first");
+        assert_eq!(excerpt(""), "");
+    }
+
+    #[test]
+    fn the_number_of_requests_a_note_names_is_bounded() {
+        // A generation is a number the worker chose, so a test that writes one
+        // event per invented generation would otherwise grow this ledger for
+        // as long as the file it is running beside lasts.
+        let mut stale = StaleEvents::default();
+        for generation in 100..10_000u64 {
+            stale.record(generation, String::from("output \"x\""));
+        }
+
+        let notes = stale.notes(&[]);
+        assert_eq!(notes.len(), MAX_STALE_REQUESTS_NAMED + 1, "and one summary");
+        // A generation this worker never served names no file, and says so
+        // rather than pointing at whichever file happens to be at that index.
+        assert!(
+            notes[0]
+                .text
+                .contains("a request this worker never served (100)"),
+            "{}",
+            notes[0].text
+        );
+        assert!(
+            notes[MAX_STALE_REQUESTS_NAMED]
+                .text
+                .contains("and 9892 more from further runs"),
+            "{}",
+            notes[MAX_STALE_REQUESTS_NAMED].text
+        );
+    }
+
+    #[test]
+    fn the_notes_come_before_what_the_file_printed() {
+        // The terminal draws only the first lines of the output section, so a
+        // note explaining what is missing from the report has to be above the
+        // printing rather than after it.
+        let mut pending = PendingOutput::default();
+        let Ok(Event::Output(event)) = serde_json::from_str::<Event>(&output_line(None, "hello"))
+        else {
+            panic!("an output line must parse as an output event");
+        };
+        pending.push(event);
+        let mut stale = StaleEvents::default();
+        stale.record(1, String::from("output \"gone\""));
+
+        let output = file_output(&mut pending, &stale, &[String::from("src/a.test.js")]);
+        assert_eq!(output.len(), 2);
+        assert!(output[0].text.starts_with("[uf] "), "{}", output[0].text);
+        assert_eq!(output[1].text, "hello\n");
+    }
+
+    #[test]
+    fn a_file_that_dropped_nothing_says_nothing() {
+        let mut pending = PendingOutput::default();
+        assert!(file_output(&mut pending, &StaleEvents::default(), &[]).is_empty());
     }
 
     #[test]
@@ -868,6 +1295,7 @@ mod tests {
                     expected: None,
                     received: None,
                     site: None,
+                    generation: 1,
                 },
             );
             assert_eq!(record.status, TestStatus::Skipped { reason: expected });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -429,13 +429,17 @@ from durations `.uf/test-timings.json` recorded, and fans them across worker
 processes on the project's Capability JS Host. Each worker takes one file at a
 time — two files sharing a process share globals, and a suite that passes alone
 but fails beside another is the worst failure a runner can produce — imports it
-through the host's Flow loader, and streams one JSON line per case back.
+through the host's Flow loader, and streams one JSON line per case back. Each
+request is numbered and each line says which request it came from, because "one
+file at a time" bounds what a worker *starts* and not what a finished file left
+running.
 
 | Concern | Decision |
 | --- | --- |
 | A test that never settles | Raced against a per-case budget in the worker, *and* a wall-clock deadline in Rust that kills the process, because a wedged event loop would never run its own timer |
 | A module that throws while importing | A file result, not a test result: there were no tests to fail, and "0 tests" for a module that could not load would be a lie |
 | A worker that dies | The file is named with what went wrong and the run continues on a fresh worker |
+| An event from a file that has already finished | Dropped, with a note naming the file it came from. The worker stamps every event with the generation of the request whose asynchronous context produced it, so a `setTimeout` a file left behind is not read as the next file's — and the file it does belong to has already been reported, because the report is streamed |
 | A retry | Re-runs the *file* with a filter naming one case, so the retry sees the module state a first run would |
 | `.only` | Decided per file after the module body has run, because a file's `.only` can appear after the tests it excludes |
 | A failing assertion's position | The matcher's own message, and the line from the stack — which points at the Flow source because the transform emits a source map and the worker runs with it enabled |

--- a/packages/test/worker.js
+++ b/packages/test/worker.js
@@ -7,24 +7,48 @@
 // Flow loader, so the module is transformed by the same `uf transform` the
 // build uses), runs what it registered, and writes one event per line back.
 //
-//   → {"file": "src/math.test.js", "filter": "adds", "timeoutMs": 5000}
-//   ← {"event": "test", "name": "math > adds", "status": "passed", …}
-//   ← {"event": "output", "stream": "stdout", "test": "math > adds", "text": "hi\n"}
-//   ← {"event": "file", "status": "completed", "durationMicros": 1234}
+//   → {"file": "src/math.test.js", "filter": "adds", "timeoutMs": 5000, "generation": 7}
+//   ← {"event": "test", "name": "math > adds", "status": "passed", "generation": 7, …}
+//   ← {"event": "output", "stream": "stdout", "test": "math > adds", "text": "hi\n", "generation": 7}
+//   ← {"event": "file", "status": "completed", "durationMicros": 1234, "generation": 7}
 //
-// Three decisions worth stating. Results are streamed as they happen rather
+// Four decisions worth stating. Results are streamed as they happen rather
 // than batched at the end, so `uf test` can draw progress and `--bail` can stop
 // a long run early. A file that throws while being *imported* is a file result,
 // not a test result: there were no tests to fail, and saying "0 tests" for a
-// module that could not load would be a lie. And the protocol does not share
-// its stream with the tests: a test's own printing becomes an `output` event
+// module that could not load would be a lie. The protocol does not share its
+// stream with the tests: a test's own printing becomes an `output` event
 // (`internal/output.js`), so a `console.log` cannot land in the middle of a
-// line `uf` is parsing.
+// line `uf` is parsing. And every event says which request it belongs to —
+// see "Which file an event belongs to" below.
 //
 // This module runs on import by design — it is a process entry point, the way
 // `@uniflowed/vite`'s loaders are.
+//
+// # Which file an event belongs to
+//
+// One worker's events are one stream, and a file's code outlives the file: a
+// `setTimeout` nobody awaited fires while the *next* file is running, and what
+// it prints used to be reported under a test in a different file. The same held
+// for anything else the abandoned work reached — including the unhandled
+// rejection handler at the bottom of this module, which ends a file.
+//
+// So an event says which request it came from rather than leaving `uf` to
+// assume it came from the one in progress. `uf` numbers the requests it sends;
+// this module runs each file inside an `AsyncLocalStorage` holding that number,
+// and stamps every event with what the storage says *at the moment of writing*.
+// Work a file leaves behind inherits its store however late it runs, so a
+// straggler carries the generation of the file that scheduled it, and `uf`
+// drops it instead of handing it to whatever is running now. See
+// ubugeeei-prod/uf#203 and `crates/uf_test/src/host.rs`.
+//
+// A module-level "the file we are serving now" variable was the obvious answer
+// and it is exactly the bug: at the moment the straggler writes, the file being
+// served *is* the next one. The number has to come from where the work was
+// started, which is what asynchronous storage is.
 
 import * as output from "./internal/output.js";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { writeChangedSnapshots } from "./internal/snapshot.js";
 import { createInterface } from "node:readline";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -37,7 +61,29 @@ type Request = {|
   readonly file: string,
   readonly filter?: string | null,
   readonly timeoutMs?: number,
+  /**
+   * Which request this is, counting from one within this worker.
+   *
+   * Optional only for a `uf` older than the field; `serve` falls back to its
+   * own count of the requests it has served, which is the same number.
+   */
+  readonly generation?: number,
 |};
+
+/**
+ * The request whose work the code running right now descends from.
+ *
+ * Read by `write`, so a callback a finished file left behind stamps its events
+ * with that file's number rather than with the number of the file the worker
+ * has moved on to.
+ *
+ * `node:async_hooks` is not guarded for: Node, Deno and Bun all provide it
+ * under the `node:` specifier, and a host with no `node:` builtins could not
+ * link this module at all — `node:readline` and `node:url` are imported above.
+ * A host whose storage does not reach a particular callback is a different
+ * matter and is handled by the fallback in `write`.
+ */
+const serving: AsyncLocalStorage<number> = new AsyncLocalStorage();
 
 /**
  * The protocol's own stdout, and the capture that gave it up.
@@ -60,16 +106,35 @@ const emit: (chunk: string) => void = output.install((chunk) => {
   });
 });
 
+/**
+ * Write one event, stamped with the request it belongs to.
+ *
+ * Stamped here rather than at each of the five places that build an event, so
+ * there is no way to write one without a generation — the module-level
+ * unhandled rejection handler included, which is the one that most needed it.
+ *
+ * `0` is what an event carries when the storage has nothing to say: a write
+ * from outside any request (a malformed request line, which `uf` answers to
+ * immediately), or a host that does not carry a store into the callback that
+ * wrote it — Deno 1.31 does not carry one through `setTimeout`, and Bun does
+ * not carry one into `unhandledRejection`. `uf` reads `0` as "the file being
+ * served", which is what every event meant before this field existed: of the
+ * two ways to be less than exact, saying nothing about a straggler is the
+ * behaviour that was already there, and refusing an unstamped `file` event
+ * would hang a file that had in fact answered.
+ */
 function write(event: { readonly [string]: mixed }): void {
-  emit(`${JSON.stringify(event)}\n`);
+  emit(`${JSON.stringify({ ...event, generation: serving.getStore() ?? 0 })}\n`);
 }
 
 /**
  * Import and run one file.
  *
- * The module is imported with a cache-busting query so a watch-mode rerun in
- * the same worker sees the edited file rather than the one the module registry
- * already holds.
+ * `generation` is the request's number, and it does two jobs with one value:
+ * it busts the module cache so a watch-mode rerun in the same worker sees the
+ * edited file rather than the one the registry already holds, and — through
+ * the `serving` store this runs inside — it is what every event written from
+ * this file, or from anything this file leaves behind, is stamped with.
  */
 async function runFile(request: Request, generation: number): Promise<void> {
   const started = performance.now();
@@ -133,10 +198,15 @@ async function runFile(request: Request, generation: number): Promise<void> {
  * a time, because two files sharing a process would share globals and module
  * state, and a test suite that passes alone but fails beside another is the
  * worst failure a runner can produce.
+ *
+ * "In order" bounds what the worker *starts*, not what a file leaves running,
+ * which is why each file runs inside `serving`. The store is entered here and
+ * not in `runFile` so that the whole of a file's work, its module import
+ * included, is inside it.
  */
 function serve(): void {
   let queue: Promise<void> = Promise.resolve();
-  let generation = 0;
+  let served = 0;
 
   createInterface({ input: process.stdin }).on("line", (line) => {
     if (line.trim() === "") {
@@ -146,6 +216,9 @@ function serve(): void {
     try {
       request = JSON.parse(line);
     } catch (error) {
+      // Outside any `serving.run`, so this is stamped `0` — which is right:
+      // there is no request to attribute it to, and `uf` is waiting for an
+      // answer to the line it just wrote.
       write({
         event: "file",
         status: "run-failed",
@@ -153,9 +226,14 @@ function serve(): void {
       });
       return;
     }
-    generation += 1;
-    const at = generation;
-    queue = queue.then(() => runFile(request, at));
+    served += 1;
+    // `uf` chooses the number, because `uf` is the side that checks it. This
+    // count of served requests is the same sequence and stands in for a `uf`
+    // too old to send one — without something monotonic here the import below
+    // would be cache-busted with `undefined` and a watch-mode rerun would see
+    // the module it already had.
+    const at = request.generation ?? served;
+    queue = queue.then(() => serving.run(at, () => runFile(request, at)));
   });
 
   process.stdin.on("close", () => {
@@ -165,6 +243,13 @@ function serve(): void {
 
 // Unhandled rejections would otherwise take the worker down mid-file with no
 // explanation; reporting one as a file failure keeps the run honest.
+//
+// The file it fails is whichever one the rejected promise was created in, not
+// whichever one is running when Node gets round to reporting it: `write` reads
+// the store, and on Node the store follows the promise. That matters because
+// this is a `file` event and a `file` event *ends* a file — a promise the
+// previous file abandoned used to end the next one, with a message from code
+// that file does not contain.
 process.on("unhandledRejection", (reason: mixed) => {
   const error = reason instanceof Error ? reason : new Error(String(reason));
   write({

--- a/tests/library/event-generation.test.js
+++ b/tests/library/event-generation.test.js
@@ -1,0 +1,290 @@
+// @flow
+//
+// Which *file* an event belongs to.
+//
+// A worker runs whole files one after another and its events are one stream.
+// "One file at a time" bounds what the worker starts, not what a finished file
+// left running: a `setTimeout` nobody awaited fires while the next file is
+// running, and everything it does — printing, and in the case of an abandoned
+// promise, ending a file — arrived with nothing on it to say where it came
+// from. `uf` read it as the running file's. That is ubugeeei-prod/uf#203.
+//
+// The fix is a number: `uf` numbers the requests it sends, the worker runs each
+// file inside an `AsyncLocalStorage` holding that number, and every event
+// carries the number the storage held *at the moment it was written*. Work a
+// file leaves behind inherits its file's store however late it runs, so a
+// straggler carries the generation of the file that scheduled it and `uf` can
+// tell it apart from the file it interrupted (`crates/uf_test/src/host.rs`).
+//
+// The stamp is a property of the wire, and only of the wire: by the time a case
+// could look at one, that case is the thing being described. So this drives a
+// real worker exactly the way `host.rs` drives one — a request per line on its
+// stdin, one JSON event per line back — the way `lsp.test.js` talks to a real
+// `uf lsp` over its real wire, and reads the events it wrote.
+//
+// The reproductions are written to a temporary directory rather than kept
+// beside this file, because a file in this workspace that registers cases *is*
+// a test of this repository: `uf test` discovers by reading a file, not by
+// naming it, so a fixture here would be collected and run by the very suite
+// that is supposed to be running it. Nothing outside the project has a
+// `node_modules` to resolve `@uniflowed/test` from, so a fixture reaches the
+// package by path.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "@uniflowed/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repository = path.resolve(here, "..", "..");
+
+/**
+ * The switch that makes the race deterministic.
+ *
+ * The issue writes the reproduction as `setTimeout(…, 50)` in one file and
+ * lets the next file happen to be running fifty milliseconds later, which does
+ * reproduce the bug and makes a poor test: what has to be shown is not only
+ * that the line carries the first file's number but that it *arrived after that
+ * file had ended*, and a sleep proves that only while the machine is idle.
+ *
+ * So the second file hands the first one a switch. The callback is still a
+ * detached one — registered in the first file, run from a timer, printing long
+ * after the case that wrote it returned — but it cannot now run until the
+ * second file has started, and the second file cannot finish until it has run.
+ *
+ * Both files import this module *without* the cache-busting query the worker
+ * puts on a test file, so both get the one instance the worker's registry
+ * already holds. That sharing is the whole mechanism.
+ */
+const SWITCH = `
+let release;
+export const begun = new Promise((resolve) => {
+  release = resolve;
+});
+export function begin() {
+  release();
+}
+
+let settle;
+export const printed = new Promise((resolve) => {
+  settle = resolve;
+});
+export function donePrinting() {
+  settle();
+}
+`;
+
+/** The file that leaves a callback behind, and ends long before it fires. */
+const FIRST = `
+import { begun, donePrinting } from "./switch.js";
+
+describe("the first file", () => {
+  it("schedules something it does not wait for", () => {
+    console.log("from the first file, while it was still running");
+    begun.then(() => {
+      setTimeout(() => {
+        console.log("from the previous file");
+        donePrinting();
+      }, 0);
+    });
+  });
+});
+`;
+
+/** The file that is running when the callback finally fires. */
+const SECOND = `
+import { begin, printed } from "./switch.js";
+
+describe("the second file", () => {
+  it("is running when the previous file's callback fires", async () => {
+    begin();
+    await printed;
+  });
+});
+`;
+
+/** One request, in the shape `host.rs` writes it. */
+type Request = {|
+  readonly file: string,
+  readonly timeoutMs: number,
+  readonly generation?: number,
+|};
+
+/** One line the worker wrote back, in the shape `host.rs` reads. */
+type Event = {
+  event: string,
+  generation?: number,
+  stream?: string,
+  test?: string | null,
+  text?: string,
+  name?: string,
+  status?: string,
+};
+
+/**
+ * How this host starts a worker, mirroring `HostCommand::with_flow_loader`.
+ *
+ * The worker imports Flow — `@uniflowed/test` is Flow source — so it needs the
+ * host's loader, and each host registers one its own way. Deno has none in
+ * `@uniflowed/host` yet, so it cannot run this at all; a named failure is
+ * better than a skip that reads like a pass.
+ */
+function loaderArguments(): Array<string> {
+  const host = path.basename(process.execPath);
+  if (host.startsWith("node")) {
+    const register = path.join(repository, "packages", "host", "register.js");
+    return ["--enable-source-maps", "--import", pathToFileURL(register).href];
+  }
+  if (host.startsWith("bun")) {
+    return ["--preload", path.join(repository, "packages", "host", "bun-preload.js")];
+  }
+  throw new Error(`no Flow loader for ${host}: this test drives the worker uf would have started`);
+}
+
+/**
+ * Run `requests` in one worker, in order, and collect every event it wrote.
+ *
+ * One worker for all of them, because a worker serving a second file after a
+ * first is the entire subject: two workers would have nothing to confuse. The
+ * requests are written together and the worker queues them, which is what
+ * `host.rs` does one at a time — either way the second file is imported only
+ * after the first has reported.
+ *
+ * The environment is inherited because that is where `UF_PROJECT_ROOT` and
+ * `UF_BINARY` are: `uf test` sets both when it starts this suite, so the nested
+ * worker transforms through the same binary and shares its transform cache
+ * instead of building a second one. The worker exits when its stdin closes,
+ * which is what ends the run — the same handshake `host.rs` uses.
+ */
+function runInWorker(requests: Array<Request>): Promise<Array<Event>> {
+  return new Promise((resolve, reject) => {
+    const worker = path.join(repository, "packages", "test", "worker.js");
+    const child = spawn(process.execPath, [...loaderArguments(), worker], {
+      // Its stderr is the host's own noise and is not part of the report;
+      // inherited so a person debugging this sees it, as `host.rs` does.
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    let written = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      written += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", () => {
+      try {
+        resolve(
+          written
+            .split("\n")
+            .filter((line) => line !== "")
+            .map((line) => JSON.parse(line)),
+        );
+      } catch (error) {
+        reject(new Error(`the worker wrote something that is not an event: ${String(error)}`));
+      }
+    });
+    child.stdin.end(requests.map((request) => `${JSON.stringify(request)}\n`).join(""));
+  });
+}
+
+/**
+ * The run as one readable list: which request each event says it came from,
+ * and what it was.
+ *
+ * Kept as strings because the order is half of what is being asserted — a
+ * straggler that arrived *before* its file's `file` event would prove nothing —
+ * and a failing `toEqual` over strings shows exactly which line moved.
+ */
+function transcript(events: Array<Event>): Array<string> {
+  return events.map((event) => {
+    const from = `[${String(event.generation)}]`;
+    if (event.event === "output") {
+      return `${from} output: ${String(event.text).trimEnd()}`;
+    }
+    if (event.event === "test") {
+      return `${from} test ${String(event.name)} ${String(event.status)}`;
+    }
+    return `${from} file ${String(event.status)}`;
+  });
+}
+
+let directory = "";
+
+/**
+ * Write the two files and the switch they share into `directory`.
+ *
+ * `switch.js` is not a test file and is never handed to the worker as a
+ * request; it is reached only through the two that are.
+ */
+function fixtures(): Array<string> {
+  const entry = pathToFileURL(path.join(repository, "packages", "test", "index.js")).href;
+  fs.writeFileSync(path.join(directory, "switch.js"), SWITCH);
+  const written = [];
+  for (const [name, source] of [
+    ["first.js", FIRST],
+    ["second.js", SECOND],
+  ]) {
+    const file = path.join(directory, name);
+    fs.writeFileSync(file, `import { describe, it } from "${entry}";\n${source}`);
+    written.push(file);
+  }
+  return written;
+}
+
+let events: Array<Event> = [];
+let unnumbered: Array<Event> = [];
+
+beforeAll(async () => {
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), "uf-event-generation-"));
+  const [first, second] = fixtures();
+  events = await runInWorker([
+    { file: first, timeoutMs: 5000, generation: 1 },
+    { file: second, timeoutMs: 5000, generation: 2 },
+  ]);
+  // The same first file again, from a `uf` that does not know about the field.
+  unnumbered = await runInWorker([{ file: first, timeoutMs: 5000 }]);
+});
+
+afterAll(() => {
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe("an event written after its file has finished", () => {
+  it("says it came from that file, not from the one that is running", () => {
+    // The fourth line is the whole issue. It sits *after* the first file's
+    // `file` event, so it was written when that file was over and the second
+    // one had started, and it still says `1`. Before the fix there was no
+    // number on it at all, and `uf` had nothing to read but "whatever is
+    // running now" — which is the second file.
+    expect(transcript(events)).toEqual([
+      "[1] output: from the first file, while it was still running",
+      "[1] test the first file > schedules something it does not wait for passed",
+      "[1] file completed",
+      "[1] output: from the previous file",
+      "[2] test the second file > is running when the previous file's callback fires passed",
+      "[2] file completed",
+    ]);
+  });
+
+  it("does not stop the file it arrived in from being reported as its own", () => {
+    // The other half: numbering the straggler must not cost the file that was
+    // interrupted anything. Every event of the second file still says `2`.
+    const second = events.filter((event) => event.event !== "output" && event.generation === 2);
+    expect(second.map((event) => String(event.status))).toEqual(["passed", "completed"]);
+  });
+});
+
+describe("a request that carries no generation", () => {
+  it("is still numbered, so the worker's import cache is still busted", () => {
+    // The fallback for a `uf` older than the field, and it is not decoration:
+    // the number is what the worker appends to the import specifier, so
+    // without something monotonic here a watch-mode rerun in the same worker
+    // would ask for `?uf-run=undefined` twice and be handed the module it
+    // already had. The worker's own count of served requests is that number.
+    expect(unnumbered.length).toBeGreaterThan(0);
+    for (const event of unnumbered) {
+      expect(event.generation).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
Closes #203.

Nothing in the worker protocol said which file an event belonged to. A worker serves whole files one after another and its events are one stream; "one file at a time" bounds what the worker *starts*, not what a finished file left running. A `setTimeout` nobody awaited fires while the next file is being served, and everything it reaches — `console.log`, and the module-scope `unhandledRejection` handler in `packages/test/worker.js`, which writes a `file` event — arrived on that stream with nothing on it, so `host.rs` read it as the running file's.

## The fix

`uf` numbers each request (`Request::generation`, chosen host-side because the host is the side that checks it; it is the same number the worker already used to bust its import cache). The worker runs each file inside an `AsyncLocalStorage` and stamps every event in `write()` with what the store says **at the moment of writing**, so work a file leaves behind inherits its file's number however late it runs.

A module-level "file being served now" is the obvious answer and is exactly the bug: when the straggler writes, the file being served *is* the next one.

## What each kind does with a stale generation, and why

**All three are dropped, with a note**, and for one reason rather than three: by the time `uf` reads a late event, the file it belongs to has already been returned from `run_file` and handed to the observer, because the report is streamed and a file is drawn as it finishes. Attributing it to the file it came from is not on the table. What is left is the wrong file or no file, and only the damage differs:

* `test` — would count a case in a file that does not declare it, stamped with that file's path by `record_of`: one file turned red for another file's work.
* `output` — would be filed under whichever case of the *current* file shares the name it carries, and the same case name in two files is ordinary (`describe("adds")` is not an identifier). Failing to match is no better: it becomes this file's own printing.
* `file` — worst, because it is how a file *ends*: it cut the running file's report short and stamped it with another file's status. This is the `unhandledRejection` path.

Each is tallied in `StaleEvents` (capped at 8 named generations, 80-char excerpts — the generation is a number the *worker* chose, so it is untrusted), and the file's report carries one note per originating request, naming the file and quoting the first event, placed **ahead** of what the file printed so the terminal's 20-line cap on that section cannot hide it.

**An unstamped event (generation 0) is still read as the running file's.** Treating a missing stamp as stale was tried first and is wrong twice: a dropped `file` event leaves the run waiting for a reply it has already had, until a deadline 60× the case budget; and an event that names no request is not evidence it came from another one. Generation 0 happens for a worker older than the field, and on hosts whose storage does not reach the callback — measured here: **Deno 1.31 does not carry a store through `setTimeout`, Bun 1.1.27 does not carry one into `unhandledRejection`**, Node 25.8.1 carries it through both.

## Three regression tests, all deterministic

The issue's `setTimeout(…, 50)` reproduces the bug and makes a poor test: what must be shown is that the event arrived *after* its file was reported, and a sleep shows that only on an idle machine. In every test the second file hands the first one a switch through a shared module, so the callback cannot fire before the second file has started and the second file cannot finish until it has.

**`tests/library/event-generation.test.js`** drives a real worker over its real wire, two requests to one worker, the way `lsp.test.js` drives `uf lsp`.

```
before:  ✗ 0 passed, 3 failed
         expected ["[undefined] output: from the first file, while it was still running",
                   "[undefined] file completed",
                   "[undefined] output: from the previous file", …]
             to equal ["[1] …", "[1] file completed", "[1] output: from the previous file",
                       "[2] test the second file > … passed", "[2] file completed"]
after:   ✓ 3 passed, 0 failed
```

**`a_worker_that_answers_for_a_finished_file_does_not_disturb_the_running_one`** drives `uf_test::Worker` against a scripted worker, so all three late-event kinds are lines in a script rather than a race — a case reporting after its file is hard to provoke, and an abandoned promise takes the worker down as it goes. One line of "before" shows all four symptoms at once:

```
FileOutcome { status: HostFailed { message: "unhandled rejection: left behind" },
  records: [TestRecord { file: "second.test.js", name: "the first file's case",
    status: Failed { … "resolved after its file had gone" … },
    output: [OutputChunk { text: "from the previous file\n" }] }],
  output: [] }
```

The previous file's rejection ended this file, its case became this file's record, its output came with it, and this file's own case never reported.

**`a_line_printed_after_its_file_finished_is_not_reported_under_the_next_one`** — the whole stack, `uf test --json -j 1` over two real files. Before, the line is in the next file's case; after, that case's output is empty and the file report carries the note.

Plus nine unit tests in `host.rs` for `is_stale`, `Event::generation`/`describe`, the ledger's caps and note wording, and note-before-printing ordering.

## Interaction with #221

**No conflict, textual or semantic**, and this was run rather than assumed: `git merge --no-ff cc/test-output-owner` applies cleanly and the merged tree is green — 1103 library tests, 29 `uf_cli --test testing`, 196 `uf_test` unit tests.

The file sets are disjoint by design: #221 owns `packages/test/internal/output.js` and `run.js`; this confines the JavaScript side to `worker.js`, which #221 never touches. Two `AsyncLocalStorage` instances at two levels — theirs for the case, this one for the file — and this one is read in `worker.js`'s `write()`, which runs synchronously inside the straggler's own context, so it needs nothing from theirs.

One thing to flag: #221's commit says "sending it to the file it belongs to still needs the generation number in the protocol". That turns out **not** to be achievable — that file's `FileReport` has already gone to the observer, and holding files back would break streamed progress and `--bail` for an event that may never arrive — so this takes the issue's other option, drop-with-a-note. After both land, a straggler carries file 1's generation *and* file 1's case name; the host drops on the generation before it ever consults the name.

## Verified

* `cargo test --workspace --no-fail-fast` — green except `uf_cli --test vite`'s `dev_serves_the_docs_site_through_vite` (the known sandbox `TcpListener::bind` → `PermissionDenied`; passes in CI)
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo fmt --all -- --check` — clean
* `uf test#library` — `1101 passed, 0 failed, 1 skipped`; `uf fmt --check` clean
* `uf run docs:build` — succeeded (a row added to the testing table in `docs/architecture.md`)

## Found, not fixed

`TestRunner::retry_failures` keeps only `retried.records` and discards the re-run's file-level output, so a note produced during a retried attempt is lost. Pre-existing — a retry's file-level output has never been reported — and called out in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791248675&installation_model_id=422833&pr_number=228&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F228&signature=5a7059708985ea8e309f320e9fa69bed6af2200267afdd7af3fed9fd5929c35e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->