### PR TITLE
ci: a package somebody implemented has to be on its way to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,11 @@ jobs:
       # resolves to nothing. No network, so it belongs here rather than in the
       # pre-tag check alone.
       - run: ./target/release/uf run release:closure
+      # And that a package somebody implemented is on its way to npm at all.
+      # Ten were not — about 22,000 lines of Flow that `npm install` answered
+      # `ETARGET` for — because the manifest is a list somebody adds to.
+      - run: ./target/release/uf run publishable
+      - run: ./target/release/uf run publishable:test
       # And that the one command the release bootstrap depends on still runs.
       # It is invoked by hand, once, by one person, so a mistake in it costs a
       # round trip and blocks a release — it has cost three. Stubs, so this

--- a/tools/ci/publishable.sh
+++ b/tools/ci/publishable.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+# Fail when a package with real code behind it is not on its way to npm.
+#
+# `packages/` holds two kinds of directory. Most are declaration modules whose
+# functions call `nativeRuntimeRequired(...)` — a contract with nothing behind
+# it, and publishing one squats a name that cannot run. The rest are libraries
+# somebody wrote, and every one of those has to reach a user somehow, or the
+# work is done and nobody can have it.
+#
+# Ten of them could not. `@uniflowed/state`, `@uniflowed/effect`,
+# `@uniflowed/form`, `@uniflowed/immer` and six more — about 22,000 lines of
+# Flow between them, and `npm install @uniflowed/state` answered `ETARGET`.
+# Nothing said so: `published-packages.txt` is a list somebody adds to, and a
+# list somebody adds to is a list somebody forgets.
+#
+# So the rule is stated from the other side. A package that never calls
+# `nativeRuntimeRequired` is a real implementation, and it must be named in
+# `published-packages.txt` or in `pending-packages.txt` — the second being
+# "implemented, and waiting on the one step a checkout cannot take", which is
+# `npm trust` against a name the registry does not have yet. Being in neither
+# is the case this refuses.
+set -eu
+
+repo_root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+node - <<'EOF'
+const fs = require("node:fs");
+
+const names = (file) =>
+  fs
+    .readFileSync(file, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+
+const published = names("tools/release/published-packages.txt");
+const pending = names("tools/release/pending-packages.txt");
+
+// A *call*, not a mention: `@uniflowed/story`'s header explains that it used
+// to return `nativeRuntimeRequired(…)` and does not any more, and a package
+// that says so in prose is exactly the kind this check must not excuse.
+const CALL = /(?<![A-Za-z0-9_$.])nativeRuntimeRequired\s*\(/;
+
+const modules = function* (directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const path = `${directory}/${entry.name}`;
+    if (entry.isDirectory()) yield* modules(path);
+    else if (entry.name.endsWith(".js")) yield path;
+  }
+};
+
+/** Whether every function this package exports needs a runtime it does not have. */
+const isDeclaration = (name) => {
+  for (const file of modules(`packages/${name}`)) {
+    for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+      const code = line.trimStart();
+      // Comment lines only. A call inside a string would count, and that is the
+      // safe direction: it means "declaration", which needs no publishing —
+      // wrong, and quiet, rather than wrong and blocking a release.
+      if (code.startsWith("//") || code.startsWith("*") || code.startsWith("/*")) continue;
+      if (CALL.test(line)) return true;
+    }
+  }
+  return false;
+};
+
+const directories = fs
+  .readdirSync("packages", { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const problems = [];
+
+for (const name of directories) {
+  if (isDeclaration(name)) continue;
+  if (published.includes(name) || pending.includes(name)) continue;
+  problems.push(
+    `packages/${name} is implemented and is in neither list. Add it to ` +
+      "tools/release/published-packages.txt if `npm trust` has bound it, and to " +
+      "tools/release/pending-packages.txt if it has not.",
+  );
+}
+
+for (const name of pending) {
+  if (published.includes(name)) {
+    problems.push(`${name} is in both lists; it is published, so take it out of the pending one.`);
+  }
+}
+
+for (const [file, list] of [
+  ["published-packages.txt", published],
+  ["pending-packages.txt", pending],
+]) {
+  for (const name of list) {
+    if (!fs.existsSync(`packages/${name}/package.json`)) {
+      problems.push(`${file} names ${name}, and packages/${name} does not exist.`);
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error("the release manifests do not describe packages/.");
+  for (const problem of problems) console.error(`  ${problem}`);
+  process.exit(1);
+}
+
+const implemented = directories.filter((name) => !isDeclaration(name));
+// Counted over the implemented ones rather than over the lists, because
+// `published-packages.txt` also holds packages that are part native —
+// `@uniflowed/core` and `@uniflowed/stylex` both call `nativeRuntimeRequired`
+// for the half of themselves that needs the binary, and belong on npm anyway.
+const shipped = implemented.filter((name) => published.includes(name)).length;
+console.log(
+  `${implemented.length} implemented packages: ${shipped} published, ${pending.length} waiting on npm trust`,
+);
+EOF

--- a/tools/ci/test-publishable.sh
+++ b/tools/ci/test-publishable.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+# `publishable.sh` against a `packages/` it can safely make wrong.
+#
+# The check exists because ten implemented packages — about 22,000 lines of
+# Flow, `@uniflowed/state` and `@uniflowed/effect` among them — were in no
+# release manifest at all, so `npm install @uniflowed/state` answered `ETARGET`
+# and nothing said why. A list somebody adds to is a list somebody forgets, so
+# the rule is stated from the other side and enforced from a scratch tree here.
+#
+# What is worth testing is the discriminator. "Is this a declaration or a
+# library" is the only judgement the check makes, and both ways of getting it
+# wrong are quiet: calling a real package a declaration leaves it unpublished
+# for another release, and calling a declaration real puts a name on npm with
+# nothing behind it.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+script="$repo_root/tools/ci/publishable.sh"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-publishable.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+fail() {
+  echo "test-publishable: FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+# A `packages/` with one of each: a library, a declaration, and a library that
+# is implemented but not yet bound on npm.
+scratch() {
+  root="$work/$1"
+  rm -rf "$root"
+  mkdir -p "$root/tools/ci" "$root/tools/release" \
+    "$root/packages/core" "$root/packages/orm" "$root/packages/state"
+  cp "$script" "$root/tools/ci/publishable.sh"
+  printf '// @flow\nexport const add = (a: number, b: number): number => a + b;\n' \
+    > "$root/packages/core/index.js"
+  printf '// @flow\nimport { nativeRuntimeRequired } from "@uniflowed/core";\nexport const open = (): empty => nativeRuntimeRequired("orm");\n' \
+    > "$root/packages/orm/index.js"
+  printf '// @flow\nexport const atom = <T>(value: T): { value: T } => ({ value });\n' \
+    > "$root/packages/state/index.js"
+  for name in core orm state; do
+    printf '{ "name": "@uniflowed/%s", "version": "0.0.0" }\n' "$name" > "$root/packages/$name/package.json"
+  done
+  printf '# published\ncore\n' > "$root/tools/release/published-packages.txt"
+  printf '# pending\nstate\n' > "$root/tools/release/pending-packages.txt"
+}
+
+run() {
+  set +e
+  out="$("$work/$1/tools/ci/publishable.sh" 2>&1)"
+  status=$?
+  set -e
+}
+
+refuses() {
+  [ "$status" -ne 0 ] || fail "$1 was accepted: $out"
+  case "$out" in
+    *"$2"*) ;;
+    *) fail "$1 is refused without naming \`$2\`: $out" ;;
+  esac
+  pass "$1"
+}
+
+# --- a tree that is described -----------------------------------------------
+scratch clean
+run clean
+[ "$status" -eq 0 ] || fail "a described tree was refused: $out"
+case "$out" in
+  *"2 implemented packages: 1 published, 1 waiting"*) ;;
+  *) fail "the summary does not count what it checked: $out" ;;
+esac
+pass "a library published, a library waiting, and a declaration in neither list"
+
+# --- the case that started this ---------------------------------------------
+scratch forgotten
+printf '# published\ncore\n' > "$work/forgotten/tools/release/pending-packages.txt"
+run forgotten
+refuses "an implemented package in neither list" "packages/state"
+
+# --- a declaration is not required to be anywhere ---------------------------
+# The other direction of the same judgement: `packages/orm` is in no list and
+# must stay that way, because a name with `nativeRuntimeRequired` behind it
+# squats the name and cannot run.
+scratch declaration
+run declaration
+[ "$status" -eq 0 ] || fail "a declaration in no list was refused: $out"
+pass "a declaration is not required to be published"
+
+# --- and prose about it is not a declaration --------------------------------
+# `@uniflowed/story`'s header explains that it used to return
+# `nativeRuntimeRequired(…)` and does not any more. A check that read comments
+# would have excused the largest package in the pending list.
+scratch prose
+printf '// @flow\n//\n// It used to call nativeRuntimeRequired(name) and does not any more.\nexport const play = (): number => 1;\n' \
+  > "$work/prose/packages/state/index.js"
+printf '# pending\n' > "$work/prose/tools/release/pending-packages.txt"
+run prose
+refuses "a package that only mentions the runtime in a comment" "packages/state"
+
+# --- a nested module counts too ---------------------------------------------
+scratch nested
+mkdir -p "$work/nested/packages/orm/internal"
+printf '// @flow\nexport const open = (): empty => nativeRuntimeRequired("orm");\n' \
+  > "$work/nested/packages/orm/internal/driver.js"
+printf '// @flow\nexport { open } from "./internal/driver.js";\n' > "$work/nested/packages/orm/index.js"
+run nested
+[ "$status" -eq 0 ] || fail "a declaration whose call is one directory down was refused: $out"
+pass "a declaration is recognized from any module in it, not only its index"
+
+# --- the lists have to describe the tree ------------------------------------
+scratch both
+printf '# pending\ncore\nstate\n' > "$work/both/tools/release/pending-packages.txt"
+run both
+refuses "a package in both lists" "take it out of the pending one"
+
+scratch ghost
+printf '# published\ncore\nkoru\n' > "$work/ghost/tools/release/published-packages.txt"
+run ghost
+refuses "a published name with no package behind it" "packages/koru does not exist"
+
+scratch ghost-pending
+printf '# pending\nkoru\n' > "$work/ghost-pending/tools/release/pending-packages.txt"
+run ghost-pending
+refuses "a pending name with no package behind it" "packages/koru does not exist"
+
+echo "test-publishable: all checks passed"

--- a/tools/release/pending-packages.txt
+++ b/tools/release/pending-packages.txt
@@ -1,0 +1,37 @@
+# Implemented, and not on npm yet. One per line.
+#
+# A package here has real code behind it and is not in `published-packages.txt`,
+# which is a gap rather than a decision: `@uniflowed/state` is what this project
+# offers instead of Jotai and it resolves to nothing.
+#
+# It is a two-file list rather than one because adding a name to the published
+# list is only half the job, and the other half cannot be done from a checkout.
+# `publish.yml` publishes over OIDC and `npm trust` can only bind a name the
+# registry already has, so a name that has never been published has to be
+# published once, by a person, with an npm session and a 2FA prompt:
+#
+#   npm login
+#   sh tools/release/bootstrap-publish.sh
+#   sh tools/release/trust-npm.sh
+#
+# Until that has happened for a name, putting it in `published-packages.txt`
+# makes the publish job fail *after* the names before it have gone out, which
+# half-sends a release. So it waits here, where `tools/ci/publishable.sh` can
+# see it, rather than being remembered.
+#
+# Move a name to `published-packages.txt` when it is bound. Nothing else needs
+# to change: the closure check reads that file, and this one is only ever a
+# waiting room.
+#
+# See ubugeeei-prod/uf#210.
+
+brand
+cell
+effect
+form
+immer
+mock
+state
+story
+testing
+web

--- a/uf.config.js
+++ b/uf.config.js
@@ -157,6 +157,19 @@ export default defineConfig({
     // The offline half of it: a published package whose dependency is not
     // published resolves to nothing. No network, so `ci` runs it.
     "release:closure": "tools/release/verify-npm.sh --closure-only",
+    // And that a package somebody implemented is on its way to npm at all.
+    // Ten were not, `@uniflowed/state` and `@uniflowed/effect` among them:
+    // about 22,000 lines of Flow that `npm install` answered `ETARGET` for.
+    // A list somebody adds to is a list somebody forgets, so the rule is
+    // stated from the other side — a package that never calls
+    // `nativeRuntimeRequired` has to be named in one of the two manifests.
+    publishable: "tools/ci/publishable.sh",
+    "publishable:test": "tools/ci/test-publishable.sh",
+    // Not in `ci.dependsOn` here, and that is a sequencing detail rather than
+    // an exception: the release branch rewrites that list wholesale to close
+    // an eight-task gap between it and the pipeline, and adding two names to
+    // the old list would conflict with it for nothing. They go in with that
+    // list, which cannot name a task that does not exist yet.
     "install:test": "tools/release/test-install.sh",
     // The bootstrap is run by hand, once, by one person, and every mistake
     // in it costs a round trip and blocks a release. It has cost three, each


### PR DESCRIPTION
Refs #210, which turns out to be four of ten.

`packages/` holds forty-eight directories and `published-packages.txt` names seventeen. Twenty-three of the rest are declaration modules whose functions call `nativeRuntimeRequired`, and publishing one squats a name that cannot run — the list being short is right for those.

**The other ten are libraries somebody wrote:**

```
brand  cell  effect  form  immer  mock  state  story  testing  web
```

About **22,000 lines of Flow** between them. `@uniflowed/state` is what this project offers instead of Jotai, `@uniflowed/effect` instead of Effect, `@uniflowed/form` instead of React Hook Form, `@uniflowed/immer` instead of Immer — and `npm install @uniflowed/state` answers `ETARGET`.

Nothing said so, because the manifest is a list somebody adds to, and a list somebody adds to is a list somebody forgets.

## The rule, stated from the other side

`tools/ci/publishable.sh` refuses a package that never calls `nativeRuntimeRequired` and is named in neither manifest. Being in neither is the case that was silent.

```
$ uf run publishable
25 implemented packages: 15 published, 10 waiting on npm trust
```

(15 rather than 17 because `@uniflowed/core` and `@uniflowed/stylex` are part native — they call `nativeRuntimeRequired` for the half of themselves that needs the binary, and belong on npm anyway. The check is one-directional and does not mind.)

## Why two manifests

Adding a name to the published list is only half the job, and the other half cannot be done from a checkout. `publish.yml` publishes over OIDC; `npm trust` can only bind a name the registry already has; a name that has never been published has to go out once, by hand, with an npm session and a 2FA prompt. A name added before that binding fails the publish job **after** the names before it have gone out, which half-sends a release.

So `tools/release/pending-packages.txt` is where a package waits, visibly, instead of being remembered. Moving a name across is the whole of the change when the binding exists:

```sh
npm login
sh tools/release/bootstrap-publish.sh
sh tools/release/trust-npm.sh
```

The closure holds if all ten move at once — `state` needs `cell`, `story` needs `mock`, and everything else they name is already published.

## The discriminator is the only judgement here

Both ways of getting it wrong are quiet: calling a real package a declaration leaves it unpublished for another release; calling a declaration real puts a name on npm with nothing behind it. So `test-publishable.sh` pins both directions against a scratch tree, and one case is not hypothetical — a package that only **mentions** `nativeRuntimeRequired` in a comment must not be excused, because `@uniflowed/story`'s header explains that it used to return one and does not any more, and it is the largest package in the pending list.

```
  ok  a library published, a library waiting, and a declaration in neither list
  ok  an implemented package in neither list
  ok  a declaration is not required to be published
  ok  a package that only mentions the runtime in a comment
  ok  a declaration is recognized from any module in it, not only its index
  ok  a package in both lists
  ok  a published name with no package behind it
  ok  a pending name with no package behind it
```

## Not in `ci.dependsOn` here

A sequencing detail rather than an exception, and it is written down beside the tasks: #213 rewrites that list wholesale to close an eight-task gap between it and the pipeline, and adding two names to the old list would conflict with it for nothing. They go in with that list, which cannot name a task that does not exist yet.

## Verified

* `uf run publishable`, `uf run publishable:test`, `uf run release:closure` — all pass
* `uf fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791249352&installation_model_id=422833&pr_number=229&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F229&signature=d55d14d4e395a0be79a9cccd3c6657df0b9a6777c544f2ff00182a5ce8be8051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->