### PR TITLE
fix(vite): the compiled config is written where a second command can read it

### DIFF
--- a/packages/host/internal/node-hooks.js
+++ b/packages/host/internal/node-hooks.js
@@ -25,39 +25,12 @@
 // debugging session while `@uniflowed/stylex`'s preset was being written.
 
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { isFlowModule, sharedService, transformFlow, ufBinaryIdentity } from "../transform.js";
-
-/**
- * Write `contents` to `target` so a concurrent reader never sees half of it.
- *
- * `uf test` runs one of these processes per core and they all import the same
- * few modules at once, so two writers and a reader meet on the same cache
- * entry constantly. `writeFileSync` is not atomic — a reader can observe a
- * truncated file and report a module that "does not provide an export" — so
- * the content goes to a private temporary name first and is then renamed,
- * which is atomic within a filesystem.
- *
- * A failure here is not a failure: a read-only checkout still runs, just
- * without the cache.
- */
-function writeAtomically(target, contents) {
-  const temporary = `${target}.${process.pid}.${Math.random().toString(36).slice(2)}`;
-  try {
-    mkdirSync(cacheDirectory, { recursive: true });
-    writeFileSync(temporary, contents);
-    renameSync(temporary, target);
-  } catch {
-    try {
-      unlinkSync(temporary);
-    } catch {
-      // Nothing to clean up.
-    }
-  }
-}
+import { writeAtomically } from "../write-atomically.js";
 
 /**
  * Bumped whenever *this file's* framing of the output changes, to retire old
@@ -166,7 +139,9 @@ async function cachedTransform(source, filename) {
 
   const written = cacheEntryFor(sharedService(root).identity, source, filename);
   if (written) {
-    writeAtomically(written, output);
+    // Tolerant: a cache that cannot be written is a slower run, not a
+    // failed one — a read-only checkout still works.
+    writeAtomically(written, output, { tolerant: true });
   }
   return output;
 }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -11,10 +11,11 @@
     "directory": "packages/host"
   },
   "exports": {
-    "./register": "./register.js",
     "./bun-preload": "./bun-preload.js",
+    "./internal/node-hooks.js": "./internal/node-hooks.js",
+    "./register": "./register.js",
     "./transform": "./transform.js",
-    "./internal/node-hooks.js": "./internal/node-hooks.js"
+    "./write-atomically": "./write-atomically.js"
   },
   "files": [
     "register.js",

--- a/packages/host/write-atomically.js
+++ b/packages/host/write-atomically.js
@@ -1,0 +1,54 @@
+// @noflow
+//
+// Plain JavaScript: this is reached from the loader hooks, which run before
+// any transform, and from the config loader, which runs before them.
+//
+// Writing a file a second process may be reading at the same time.
+//
+// `writeFileSync` truncates and then writes, so a reader can observe the empty
+// file or half of one. When what is being written is a module, the reader does
+// not get an error it can act on — it gets a module with no exports, and says
+// so about the *source*:
+//
+//     uf: uf.config.js must `export default defineConfig({ ... })`
+//
+// which is a sentence about a file that is perfectly correct. That is not
+// hypothetical: two `uf` commands in one project, which is `uf dev` in one
+// terminal and `uf build` in another, produced exactly it. See
+// ubugeeei-prod/uf#240.
+//
+// Writing to a private name and renaming is atomic within a filesystem, so a
+// reader sees the old file or the new one and never a part of either.
+
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Write `contents` to `target` so a concurrent reader never sees half of it.
+ *
+ * The temporary name carries the process id and a random suffix, because two
+ * processes racing to write the *same* target is the case this exists for and
+ * they must not collide on the temporary either.
+ *
+ * @param {string} target absolute path to write
+ * @param {string} contents what to write
+ * @param {{ tolerant?: boolean }} [options] `tolerant` swallows a failure,
+ *   which is what a cache wants — a read-only checkout still runs, just
+ *   without one. A config that cannot be written is a failure the caller has
+ *   to see.
+ */
+export function writeAtomically(target, contents, options = {}) {
+  const temporary = `${target}.${process.pid}.${Math.random().toString(36).slice(2)}`;
+  try {
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(temporary, contents);
+    renameSync(temporary, target);
+  } catch (error) {
+    try {
+      unlinkSync(temporary);
+    } catch {
+      // Nothing to clean up.
+    }
+    if (options.tolerant !== true) throw error;
+  }
+}

--- a/packages/vite/internal/config.js
+++ b/packages/vite/internal/config.js
@@ -17,11 +17,12 @@
 // data and cannot use the functions.
 
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { transformFlow } from "@uniflowed/host/transform";
+import { writeAtomically } from "@uniflowed/host/write-atomically";
 
 /** The one config file name uf reads. */
 export const CONFIG_FILES = ["uf.config.js"];
@@ -94,8 +95,13 @@ async function compileConfig(source, file, root) {
 
   const out = await transformFlow(source, file, { root, sourceMap: false });
   const code = rewriteRelativeImports(out?.code ?? source, path.dirname(file));
-  mkdirSync(directory, { recursive: true });
-  writeFileSync(target, `// Compiled from ${file}. Do not edit; edit the source.\n${code}`);
+  // Atomically, because two `uf` commands in one project write this same path
+  // at the same time — the hash is of the source, so they agree on the name —
+  // and `writeFileSync` truncates before it writes. A reader that caught it
+  // mid-write imported a module with no exports and reported it as
+  // `uf.config.js must export default defineConfig({ ... })`, which is a
+  // sentence about a file that is perfectly correct. See ubugeeei-prod/uf#240.
+  writeAtomically(target, `// Compiled from ${file}. Do not edit; edit the source.\n${code}`);
   return target;
 }
 

--- a/tests/library/write-atomically.test.js
+++ b/tests/library/write-atomically.test.js
@@ -1,0 +1,140 @@
+// @flow
+//
+// Writing a file a second process may be reading at the same time.
+//
+// A person runs `uf dev` in one terminal and `uf build` in another, and
+// nothing tells them not to. Both compile `uf.config.js` to
+// `.uf/config/uf.config.<hash of the source>.mjs` — the same path, because
+// they agree on the hash — and then import it.
+//
+// `writeFileSync` truncates before it writes, so the second process could
+// import that file while the first was inside that call. What it got was not
+// an error it could act on. It was a module with no exports, reported as
+//
+//     uf: uf.config.js must `export default defineConfig({ ... })`
+//
+// a sentence about a file that is perfectly correct. It took down
+// `build_renders_the_docs_site_through_vite` on two unrelated pull requests
+// before anybody read it as a race. See ubugeeei-prod/uf#240.
+//
+// `packages/host/internal/node-hooks.js` had learned this already — its cache
+// writes went through a `writeAtomically` whose comment names this exact
+// symptom — and the config loader had not. It is one helper now, and this is
+// its test.
+//
+// The test races real processes, because the race is between processes: within
+// one, the writes are ordered by the event loop and nothing overlaps.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "@uniflowed/test";
+
+/** This checkout, found by the file under test rather than by counting `..`. */
+const repository: string = (() => {
+  const wanted = path.join("packages", "host", "write-atomically.js");
+  let directory = process.env.UF_PROJECT_ROOT ?? process.cwd();
+  for (let up = 0; up < 8; up += 1) {
+    if (fs.existsSync(path.join(directory, wanted))) return directory;
+    directory = path.dirname(directory);
+  }
+  throw new Error(`could not find ${wanted} above ${process.cwd()}`);
+})();
+
+/** Big enough that a write takes more than one syscall to land. */
+const SIZE = 512 * 1024;
+
+/** How many times each writer rewrites the file. */
+const ROUNDS = 40;
+
+/**
+ * A writer process: `ROUNDS` rewrites of `target`, each a different byte.
+ *
+ * Each round's content is one repeated character, so a reader can tell a whole
+ * file from two halves of different ones without knowing which round it caught
+ * — the check is "every byte is the same and there are enough of them", which
+ * a truncated or half-overwritten file fails.
+ */
+const writer = (target: string): string => `
+import { writeAtomically } from ${JSON.stringify(path.join(repository, "packages/host/write-atomically.js"))};
+const alphabet = "abcdefghijklmnopqrstuvwxyz";
+for (let round = 0; round < ${ROUNDS}; round += 1) {
+  writeAtomically(${JSON.stringify(target)}, alphabet[round % alphabet.length].repeat(${SIZE}));
+}
+`;
+
+/**
+ * A reader process: read `target` until the writers stop, and report anything
+ * that was not a whole file.
+ *
+ * A missing file is not a fault — the first write has not landed yet. A file
+ * of the wrong length, or one holding two different characters, is: that is
+ * half of one round beside half of another, which is what an importer sees as
+ * a module with no exports.
+ */
+const reader = (target: string): string => `
+const deadline = Date.now() + 15_000;
+let seen = 0;
+while (Date.now() < deadline) {
+  let text;
+  try {
+    text = require("node:fs").readFileSync(${JSON.stringify(target)}, "utf8");
+  } catch {
+    continue;
+  }
+  seen += 1;
+  if (text.length !== ${SIZE} || text !== text[0].repeat(text.length)) {
+    process.stdout.write("torn:" + text.length);
+    process.exit(0);
+  }
+  if (seen > 400) break;
+}
+process.stdout.write("whole:" + seen);
+`;
+
+/** Run a script and resolve with what it said. */
+const run = (script: string): Promise<{ out: string, err: string }> =>
+  new Promise((resolve) => {
+    const child = spawn(process.execPath, [script], { encoding: "utf8" });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (chunk) => {
+      out += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      err += String(chunk);
+    });
+    child.on("close", () => resolve({ out, err }));
+  });
+
+describe("writing a file somebody else is reading", () => {
+  it("is never observed half written", async () => {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "uf-atomic-")));
+    try {
+      const target = path.join(root, "module.mjs");
+      const writerScript = path.join(root, "writer.mjs");
+      const readerScript = path.join(root, "reader.cjs");
+      fs.writeFileSync(writerScript, writer(target));
+      fs.writeFileSync(readerScript, reader(target));
+
+      // Started together and left to overlap — two writers rather than one,
+      // because the target is a path two commands agree on, so they race each
+      // other as well as the reader.
+      const [first, second, read] = await Promise.all([
+        run(writerScript),
+        run(writerScript),
+        run(readerScript),
+      ]);
+
+      expect(first.err).toBe("");
+      expect(second.err).toBe("");
+      expect(read.err).toBe("");
+      expect(read.out.startsWith("whole:")).toBe(true);
+      // And it did read something: a reader that found nothing proves nothing.
+      expect(Number(read.out.slice("whole:".length))).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #240. **This is what has been failing the merge queue.**

`build_renders_the_docs_site_through_vite` failed in CI on two unrelated pull requests — one that adds an ignored test to `uf_check`, one that changes a CLI argument — in the same way, on a config that is perfectly correct:

```
✗ uf: uf.config.js must `export default defineConfig({ ... })`
```

## The race

The two tests in that file run in parallel against `docs/`, so two `uf` commands were in one project. That is not a test artefact: it is `uf dev` in one terminal and `uf build` in another, and nothing tells anybody not to.

Both compile `uf.config.js` to `.uf/config/uf.config.<hash of the source>.mjs` — the same path, because they agree on the hash — and then import it. `writeFileSync` truncates before it writes, so the second could import the file while the first was inside that call. What came back was not an error it could act on: a module with no exports, reported against the source.

## The fix, and where it already existed

`packages/host/internal/node-hooks.js` had learned this already. Its cache writes went through a `writeAtomically` whose comment names this exact symptom — *"a reader can observe a truncated file and report a module that 'does not provide an export'"* — and the config loader, one package over, did not.

So it is one helper now, `@uniflowed/host/write-atomically`, used by both. The cache keeps its tolerance of a failed write, because a cache that cannot be written is a slower run rather than a failed one; the config does not, because a config that cannot be written is a failure the caller has to see.

## Test

`tests/library/write-atomically.test.js` races two writers and a reader as **real processes** — within one process the writes are ordered by the event loop and nothing overlaps. Each round writes half a megabyte of one repeated character, so the reader can tell a whole file from two halves of different ones without knowing which round it caught.

Writing straight to the target instead fails it three times out of three:

```
✗ 0 passed, 1 failed in 1.23s
✗ 0 passed, 1 failed in 1.17s
✗ 0 passed, 1 failed in 1.29s
```

and the fix passes in 1.2 s, so it is cheap enough to keep.

End to end: two concurrent `uf build` runs against `docs/` no longer produce the config error (`grep -c` of it in both outputs is 0).

## Found, not fixed

Those two concurrent builds still collide, on `.uf/build/server`: Vite empties that directory and two of them race `rmSync` into `ENOTEMPTY`. A second hazard in the same family, not what CI hit — there only one of the two commands was a build — and recorded on #240 rather than fixed here.

## Verified

* `uf test#library` — `✓ 1114 passed, 0 failed, 1 skipped`
* `uf fmt --check` — clean
* JavaScript only; no Rust touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791256899&installation_model_id=422833&pr_number=241&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F241&signature=ed88bb2ece70cfbb0eb3067c47253ecc0fb7a9807acd0f1ddd5622fa3271b804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->