### PR TITLE
docs: uf@0.0.0-alpha.5 contains twenty-one pull requests, not twelve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,11 @@ jobs:
       # the second run — resuming a release, or writing the changelog in the
       # wrong order — so the release that went right does not catch them.
       - run: ./target/release/uf run release:bump:test
+      # And that a released version's changelog says what the release contains.
+      # alpha.5 went out with twenty-two commits in it and twelve in its notes:
+      # the section is written before the branch stops waiting for CI.
+      - run: ./target/release/uf run release:changelog
+      - run: ./target/release/uf run release:changelog:test
 
   upstream-integrations:
     name: Upstream Integrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ _2026-09-06_
 - **story**: the story runner, and four wrong answers the tests found (#211)
 - **prepare**: the command does the five things it lists
 - **flow**: say what is wrong with top-level await, and point at it (#222)
+- **fmt**: the GraphQL inside a tagged template is formatted and re-indented —
+  1,402 of Relay's 1,463 templates byte-identical to Prettier, and the 61 that
+  are not are declined rather than approximated (#238)
 
 ### Fixed
 
@@ -17,9 +20,21 @@ _2026-09-06_
   `@uniflowed/ui`'s 73 type errors, one per element it renders (#220)
 - **test**: a line a finished test's callback printed is still that test's (#221)
 - **test**: an event that outlives its file is not the next file's (#228)
+- **host**: the transform cache key says which `uf` compiled the entry, so a
+  rebuilt compiler stops serving what the previous one produced (#219)
+- **vite**: the compiled config is written where a second command can read it,
+  so `uf dev` and `uf build` in one project stop corrupting each other (#241)
 - **flow**: a parse tree is freed where there is room, not where it is held (#230)
-- **router**: `_uf.not-found` is a reserved name, and the linter says so (#224)
+- **lint**: the ceilings that protect `uf fmt` protect `uf lint` too — a
+  generated file no longer aborts the process (#232)
 - **lint**: a rule about what code does no longer reads strings (#227)
+- **lint**: `fetch/no-global-override` is about the assignment, not the name (#236)
+- **react**: a `useX` name is a hook only where the module says React (#237)
+- **router**: `_uf.not-found` is a reserved name, and the linter says so (#224)
+- **fmt**: the container that breaks a JSX arrow body is the one above the
+  call (#233)
+- **types**: a shipped package says what it knows — 45 of the 58 `any`s in
+  published packages are real types now, and `uf check` gained none (#242)
 
 ### Internal
 
@@ -27,9 +42,10 @@ _2026-09-06_
 - a package somebody implemented has to be on its way to npm (#229)
 - check that `package-lock.json` still describes the manifests, and the two
   mistakes the version bump made on its second run
-- say which Prettier `uf fmt` is compatible with (#223)
 - match the changelog heading literally, and run in `uf run ci` what the
   pipeline runs — the two had drifted eight tasks apart
+- the dev-server test says what the server did, and tries again (#235)
+- say which Prettier `uf fmt` is compatible with (#223)
 
 ## uf@0.0.0-alpha.4
 

--- a/tools/ci/changelog-covers-the-release.sh
+++ b/tools/ci/changelog-covers-the-release.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Fail when a released version's changelog section leaves a pull request out.
+#
+# The section is written by `uf release <bump>` from the commits that exist
+# when it runs, and then the release branch sits in the queue while more land.
+# `uf@0.0.0-alpha.5` went out with twenty-two commits in it and twelve in its
+# changelog: the ten that merged while the release was waiting for CI are in
+# the tarball, on npm, and in nobody's notes.
+#
+# So the section is compared against the range its own tag names. Every pull
+# request merged between the previous tag and this one has to be mentioned
+# somewhere in the section — by number, anywhere, because how it is grouped and
+# worded is a judgement and *whether it is there* is not.
+#
+# The release's own commit is not required to name itself.
+set -eu
+
+repo_root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+node - <<'EOF'
+const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+
+// Where this check begins, and it only ever moves forward.
+//
+// `uf@0.0.0-alpha.3` and earlier were written before this existed, and
+// bringing them up to it is archaeology rather than a guarantee — alpha.3's
+// section names 40 of the 130 pull requests in its range, and its tag is not
+// even on `main`, which is the defect `tools/release/tag-release` now prevents.
+// Nothing is gained by rewriting them and something is lost by pretending they
+// were checked.
+const FROM = "0.0.0-alpha.4";
+
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" }).trim();
+const tags = new Set(git("tag", "--list", "uf@*").split("\n").filter(Boolean));
+
+const changelog = fs.readFileSync("CHANGELOG.md", "utf8");
+const headings = [...changelog.matchAll(/^## uf@(\S+)$/gm)].map((match) => ({
+  version: match[1],
+  at: match.index,
+}));
+
+const problems = [];
+
+for (const [index, heading] of headings.entries()) {
+  const tag = `uf@${heading.version}`;
+  // An unreleased section is the one being written; there is nothing to
+  // compare it against yet.
+  if (!tags.has(tag)) continue;
+  if (heading.version < FROM) continue;
+
+  const previous = headings[index + 1];
+  if (previous == null || !tags.has(`uf@${previous.version}`)) {
+    problems.push(`${tag} has no previous tag in the changelog to measure from`);
+    continue;
+  }
+
+  const end = index + 1 < headings.length ? headings[index + 1].at : changelog.length;
+  const section = changelog.slice(heading.at, end);
+  const named = new Set([...section.matchAll(/#(\d+)/g)].map((match) => match[1]));
+
+  const merged = git("log", "--format=%s", `uf@${previous.version}..${tag}`)
+    .split("\n")
+    .map((subject) => ({ subject, pull: /\(#(\d+)\)$/.exec(subject)?.[1] }))
+    .filter(({ pull }) => pull != null)
+    // The release commit is the section itself; it does not cite itself.
+    .filter(({ subject }) => !subject.startsWith("chore(release):"));
+
+  const missing = merged.filter(({ pull }) => !named.has(pull));
+  for (const { subject } of missing) {
+    problems.push(`${tag} does not mention: ${subject}`);
+  }
+}
+
+if (problems.length > 0) {
+  console.error("a released changelog section leaves out what the release contains.");
+  for (const problem of problems) console.error(`  ${problem}`);
+  console.error("");
+  console.error("Add them to the section. `git log <previous tag>..<tag>` is the list.");
+  process.exit(1);
+}
+
+const checked = headings.filter((h) => tags.has(`uf@${h.version}`) && h.version >= FROM);
+console.log(
+  `every pull request in ${checked.length} released version(s) is named in the changelog`,
+);
+EOF

--- a/tools/ci/test-changelog-covers.sh
+++ b/tools/ci/test-changelog-covers.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# `changelog-covers-the-release.sh` against a repository whose history it can
+# be told to have.
+#
+# The check reads `git log` between two tags, so testing it needs a repository
+# with tags — a scratch one, built here, rather than assertions about this
+# project's own history, which would change every release.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+script="$repo_root/tools/ci/changelog-covers-the-release.sh"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-changelog.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+fail() {
+  echo "test-changelog-covers: FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+# A repository with two releases in it: one before the version this check
+# begins at, and one after.
+scratch() {
+  root="$work/$1"
+  rm -rf "$root"
+  mkdir -p "$root/tools/ci"
+  cp "$script" "$root/tools/ci/changelog-covers-the-release.sh"
+
+  git -C "$root" init --quiet
+  git -C "$root" config user.email uf@example.com
+  git -C "$root" config user.name uf
+  commit() {
+    printf '%s\n' "$2" > "$root/file.txt"
+    git -C "$root" add file.txt
+    git -C "$root" -c commit.gpgsign=false commit --quiet -m "$1"
+  }
+  commit "feat: the first thing (#1)" one
+  git -C "$root" tag "uf@0.0.0-alpha.3"
+  commit "feat: the second thing (#2)" two
+  git -C "$root" tag "uf@0.0.0-alpha.4"
+  commit "fix: the third thing (#3)" three
+  commit "fix: the fourth thing (#4)" four
+  commit "chore(release): uf@0.0.0-alpha.5 (#5)" release
+  git -C "$root" tag "uf@0.0.0-alpha.5"
+}
+
+run() {
+  set +e
+  out="$(cd "$work/$1" && ./tools/ci/changelog-covers-the-release.sh 2>&1)"
+  status=$?
+  set -e
+}
+
+changelog() {
+  printf '%s' "$2" > "$work/$1/CHANGELOG.md"
+}
+
+complete='# Changelog
+
+## uf@0.0.0-alpha.5
+
+- the third thing (#3)
+- the fourth thing (#4)
+
+## uf@0.0.0-alpha.4
+
+- the second thing (#2)
+
+## uf@0.0.0-alpha.3
+
+- the first thing (#1)
+'
+
+# --- a section that names everything in its range ----------------------------
+scratch complete
+changelog complete "$complete"
+run complete
+[ "$status" -eq 0 ] || fail "a complete section was refused: $out"
+case "$out" in
+  *"2 released version(s)"*) ;;
+  *) fail "the pass does not say how many releases it checked: $out" ;;
+esac
+pass "a section that names every pull request in its range passes"
+
+# --- the case that started this ---------------------------------------------
+# `uf@0.0.0-alpha.5` went out with twenty-two commits and twelve in its
+# changelog: the ones that merged while the release waited for CI.
+scratch missing
+changelog missing "$(printf '%s' "$complete" | grep -v 'the fourth thing')"
+run missing
+[ "$status" -ne 0 ] || fail "a section missing a merged pull request was accepted: $out"
+case "$out" in
+  *"the fourth thing (#4)"*) ;;
+  *) fail "the refusal does not name what is missing: $out" ;;
+esac
+pass "a pull request that merged while the release waited is missed"
+
+# --- the release does not have to cite itself --------------------------------
+scratch itself
+changelog itself "$complete"
+run itself
+[ "$status" -eq 0 ] || fail "the release commit was required to name itself: $out"
+case "$out" in
+  *"#5"*) fail "the release commit was reported: $out" ;;
+  *) ;;
+esac
+pass "the release's own commit is not something the section has to mention"
+
+# --- and the boundary holds --------------------------------------------------
+# `uf@0.0.0-alpha.3` is below where this check begins, so its section may say
+# anything. Older releases were written before the check existed.
+scratch boundary
+changelog boundary "$(printf '%s' "$complete" | grep -v 'the first thing')"
+run boundary
+[ "$status" -eq 0 ] || fail "a version below the starting point was checked: $out"
+pass "a release from before this check began is not checked"
+
+echo "test-changelog-covers: all checks passed"

--- a/uf.config.js
+++ b/uf.config.js
@@ -188,6 +188,12 @@ export default defineConfig({
     // changelog written after the version moved, and a resumed release that
     // was told its Cargo.toml has no version.
     "release:bump:test": "tools/release/test-bump-version.sh",
+    // And that a released version's changelog says what the release contains.
+    // `uf@0.0.0-alpha.5` went out with twenty-two commits in it and twelve in
+    // its notes: the section is written before the branch stops waiting for
+    // CI, and what merges meanwhile is in the tarball and in nobody's notes.
+    "release:changelog": "tools/ci/changelog-covers-the-release.sh",
+    "release:changelog:test": "tools/ci/test-changelog-covers.sh",
     // `npm trust` binds a name the registry already has and cannot create
     // one, so a name that has never been published is published once by a
     // person and is the workflow's from then on.
@@ -247,6 +253,8 @@ export default defineConfig({
         "publishable:test",
         "release:trust:test",
         "release:bump:test",
+        "release:changelog",
+        "release:changelog:test",
         // Not `install:test`. It packages a release before installing it, and
         // packaging needs `wild-linker`, which CI installs in that job and a
         // laptop has no reason to have. A `uf run ci` that fails on a fresh


### PR DESCRIPTION
`uf@0.0.0-alpha.5` went out with twenty-two commits in it and **twelve** in its notes.

Nothing was wrong with any of them. The section is written by `uf release <bump>` from the commits that exist when it runs, and the release branch then sat in the queue for hours while ten more merged. They are in the tarball, on npm, and were in nobody's notes — the GraphQL formatter (#238) and forty per cent of the `any` in the shipped packages (#242) among them.

## The section

All twenty-one now, checked against `git log uf@0.0.0-alpha.4..uf@0.0.0-alpha.5`.

## The check

`tools/ci/changelog-covers-the-release.sh` compares a released version against the range its own tag names: every pull request merged between the previous tag and this one has to be mentioned somewhere in the section, **by number, anywhere**. How it is grouped and worded is a judgement; whether it is there is not. The release's own commit is not asked to cite itself.

Dropping one entry:

```
a released changelog section leaves out what the release contains.
  uf@0.0.0-alpha.5 does not mention: fix(fmt): the container that breaks a JSX
  arrow body is the one above the call (#233)

Add them to the section. `git log <previous tag>..<tag>` is the list.
```

## Where it begins, and why that is written down

`0.0.0-alpha.4`. `uf@0.0.0-alpha.3` names 40 of the 130 pull requests in its range and its tag is **not on `main` at all** — the defect `tools/release/tag-release` now prevents — so rewriting it would be archaeology rather than a guarantee. The boundary only moves forward, and the reason is in the source rather than in a commit message nobody will find.

## Test

`test-changelog-covers.sh` builds a scratch repository with two releases in it rather than asserting anything about this project's own history, which changes every release. Four cases: a complete section, a pull request that merged while the release waited, the release commit not having to cite itself, and the boundary holding.

## Verified

* `uf run release:changelog`, `uf run release:changelog:test` — pass, and both are in `ci.dependsOn` and the `Metadata` job
* `uf fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791262546&installation_model_id=422833&pr_number=244&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F244&signature=b8b462823b2e3d0af7f96542c94345dc734448d941e9289a7eb7d622741bef1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->