### PR TITLE
docs: what uf is for, and the four places it is not that yet

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,9 @@ on every runtime and deploys anywhere, including as a single executable file.
 
 ### The three ways this fails
 
-Stated as failures because each is easier to notice than its opposite, and
-each already has a check behind it:
+Stated as failures because each is easier to notice than its opposite. Two of
+the three have a check behind them; the third says so, which is the point of
+listing it here rather than trusting anyone to remember:
 
 1. **A declared API that throws.** `packages/*` holds both real libraries and
    declaration modules whose functions call `nativeRuntimeRequired`, and a
@@ -52,7 +53,7 @@ rather than a note:
 | Runs on every runtime | Node and Bun. `HostKind::Deno` loads no Flow; the edge runtimes have no host at all | [#246](https://github.com/ubugeeei-prod/uf/issues/246) |
 | Builds a standalone binary | `uf build` emits bundles; there is no `--compile` | [#245](https://github.com/ubugeeei-prod/uf/issues/245) |
 | Inference reaches the end of a program | A type imported by its published name resolves to nothing | [#248](https://github.com/ubugeeei-prod/uf/issues/248) |
-| Everything shipped is real | Ten implemented packages are not on npm; `@uniflowed/tui` is a contract with nothing behind it | [#210](https://github.com/ubugeeei-prod/uf/issues/210), [#247](https://github.com/ubugeeei-prod/uf/issues/247) |
+| Everything implemented reaches a user | Ten implemented packages are on nobody's npm; `@uniflowed/tui` is a contract nobody can run | [#210](https://github.com/ubugeeei-prod/uf/issues/210), [#247](https://github.com/ubugeeei-prod/uf/issues/247) |
 
 The threat model that every one of these must satisfy is in
 [docs/security.md](security.md): each row names a published CVE in an

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,11 @@
 
 ## North Star
 
+**uf alone is enough to build a React application — any React application —
+and everything it provides is production-ready.** Comprehensive, fast, and
+typed strongly enough that inference reaches the end of a real program. It runs
+on every runtime and deploys anywhere, including as a single executable file.
+
 - Beat Vite+ on Flow React DX, framework completeness, build latency, and dev
   server feedback loops.
 - Use Vite Task for cached, dependency-aware task execution while beating Vitest
@@ -9,6 +14,45 @@
   performance, and integrated toolchain coverage.
 - Keep Vite itself as the internal bundler, dev server, and plugin system, but
   make `uf.config.js` the only user-authored config entry.
+- Reach the feature surface of the tools a user would otherwise reach for —
+  Next.js for the framework, Bun and Vite for the toolchain, shadcn/ui for the
+  components, Effect, Jotai and React Hook Form for the libraries. Where uf
+  deliberately differs, the reason is written down; where it simply does not
+  have something, that is a gap and it has an issue.
+
+### The three ways this fails
+
+Stated as failures because each is easier to notice than its opposite, and
+each already has a check behind it:
+
+1. **A declared API that throws.** `packages/*` holds both real libraries and
+   declaration modules whose functions call `nativeRuntimeRequired`, and a
+   declaration is not a feature. `tools/ci/publishable.sh` refuses a real
+   implementation that is on its way nowhere; nothing yet refuses a declaration
+   that has been one for too long.
+2. **A type that is `any` under another name.** `flow/unclear-type` catches the
+   spelling. It does not catch a type that is technically not `any` and still
+   tells the caller nothing, and it does not catch inference that stops at a
+   package boundary — which is what
+   [#248](https://github.com/ubugeeei-prod/uf/issues/248) is: 145 of the 581
+   errors `uf check` reports on this repository are one resolver bug.
+3. **A feature that works for the demo.** Every fix in this repository carries
+   a test that fails before it and passes after, and the corpus tests run the
+   formatter over 8,100 modules nobody here wrote. That is the standard, and
+   it is the reason a benchmark claim in these documents is expected to have a
+   number beside it.
+
+### Where it is not true yet
+
+Honesty about this is the point of writing it down, and each line is an issue
+rather than a note:
+
+| Claim | Today | |
+| --- | --- | --- |
+| Runs on every runtime | Node and Bun. `HostKind::Deno` loads no Flow; the edge runtimes have no host at all | [#246](https://github.com/ubugeeei-prod/uf/issues/246) |
+| Builds a standalone binary | `uf build` emits bundles; there is no `--compile` | [#245](https://github.com/ubugeeei-prod/uf/issues/245) |
+| Inference reaches the end of a program | A type imported by its published name resolves to nothing | [#248](https://github.com/ubugeeei-prod/uf/issues/248) |
+| Everything shipped is real | Ten implemented packages are not on npm; `@uniflowed/tui` is a contract with nothing behind it | [#210](https://github.com/ubugeeei-prod/uf/issues/210), [#247](https://github.com/ubugeeei-prod/uf/issues/247) |
 
 The threat model that every one of these must satisfy is in
 [docs/security.md](security.md): each row names a published CVE in an


### PR DESCRIPTION
The North Star said what uf should *beat*. It did not say what uf is *for*, and the owner's answer is a stronger claim than any of the comparisons:

> **uf alone is enough to build a React application — any React application — and everything it provides is production-ready.** Comprehensive, fast, and typed strongly enough that inference reaches the end of a real program. It runs on every runtime and deploys anywhere, including as a single executable file.

Written into `docs/roadmap.md` rather than into a document of its own, because a second place to say what the project is for is a second place for it to drift.

## Three ways it fails

Stated as failures because each is easier to notice than its opposite, and each already has a check behind it — or an issue saying it has none:

1. **A declared API that throws.** `tools/ci/publishable.sh` refuses a real implementation on its way nowhere; nothing yet refuses a declaration that has been one for too long.
2. **A type that is `any` under another name.** `flow/unclear-type` catches the spelling, not inference that stops at a package boundary.
3. **A feature that works for the demo.** Every fix here carries a test that fails before and passes after, and the corpus runs the formatter over 8,100 modules nobody here wrote.

## Four places the claim is not true today

| Claim | Today | |
| --- | --- | --- |
| Runs on every runtime | Node and Bun. `HostKind::Deno` loads no Flow; the edge runtimes have no host at all | #246 |
| Builds a standalone binary | `uf build` emits bundles; there is no `--compile` | #245 |
| Inference reaches the end of a program | A type imported by its published name resolves to nothing — 145 of 581 errors | #248 |
| Everything shipped is real | Ten implemented packages are not on npm; `@uniflowed/tui` is a contract with nothing behind it | #210, #247 |

A goal without an honest account of the distance to it is a slogan. The table is the part that makes this worth committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791266965&installation_model_id=422833&pr_number=251&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F251&signature=8c24e25b7f43b1bf805f95102c11af0d07938f31772d74e0c37de7d3949d6195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the product roadmap with production-readiness criteria.
  - Added explicit failure criteria and a table outlining current gaps in runtime support, standalone binaries, type inference, and package completeness.
  - Linked each documented gap to a corresponding issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->