### PR TITLE
chore(release): uf@0.0.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## uf@0.0.0-alpha.6
+
+_2026-09-06_
+
+### Added
+
+- **dev**: `uf dev --port` binds that port or says why it cannot (#239)
+
+### Fixed
+
+- **release**: the npm check waits for the registry to catch up (#243)
+
+### Documentation
+
+- uf@0.0.0-alpha.5 contains twenty-one pull requests, not twelve (#244)
+
+### Internal
+
+- **check**: keep the reproduction for a match over a generic in the repository (#226)
+
 ## uf@0.0.0-alpha.5
 
 _2026-09-06_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,7 +3292,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "brotli",
  "camino",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "serde",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "serde",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "criterion",
  "phf",
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "compact_str",
  "serde",
@@ -3573,7 +3573,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "serde",
  "smallvec",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3644,14 +3644,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.5",
-    "@uniflowed/config": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5",
-    "@uniflowed/router": "0.0.0-alpha.5",
-    "@uniflowed/vite": "0.0.0-alpha.5",
-    "@uniflowed/web": "0.0.0-alpha.5",
+    "@uniflowed/brand": "0.0.0-alpha.6",
+    "@uniflowed/config": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6",
+    "@uniflowed/router": "0.0.0-alpha.6",
+    "@uniflowed/vite": "0.0.0-alpha.6",
+    "@uniflowed/web": "0.0.0-alpha.6",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.5",
-        "@uniflowed/config": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5",
-        "@uniflowed/router": "0.0.0-alpha.5",
-        "@uniflowed/vite": "0.0.0-alpha.5",
-        "@uniflowed/web": "0.0.0-alpha.5",
+        "@uniflowed/brand": "0.0.0-alpha.6",
+        "@uniflowed/config": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6",
+        "@uniflowed/router": "0.0.0-alpha.6",
+        "@uniflowed/vite": "0.0.0-alpha.6",
+        "@uniflowed/web": "0.0.0-alpha.6",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -4362,61 +4362,61 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.5",
-        "@uniflowed/test": "0.0.0-alpha.5"
+        "@uniflowed/config": "0.0.0-alpha.6",
+        "@uniflowed/test": "0.0.0-alpha.6"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.5",
-        "@uniflowed/validator": "0.0.0-alpha.5"
+        "@uniflowed/react": "0.0.0-alpha.6",
+        "@uniflowed/validator": "0.0.0-alpha.6"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4424,10 +4424,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.5"
+        "@uniflowed/fetch": "0.0.0-alpha.6"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4435,18 +4435,18 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/react": "0.0.0-alpha.6"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4454,115 +4454,115 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.5",
-        "@uniflowed/core": "0.0.0-alpha.5",
-        "@uniflowed/fetch": "0.0.0-alpha.5"
+        "@uniflowed/cell": "0.0.0-alpha.6",
+        "@uniflowed/core": "0.0.0-alpha.6",
+        "@uniflowed/fetch": "0.0.0-alpha.6"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.5",
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/config": "0.0.0-alpha.6",
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/hooks": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4570,7 +4570,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4578,28 +4578,28 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5",
+        "@uniflowed/core": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4609,7 +4609,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4618,19 +4618,19 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.5",
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/config": "0.0.0-alpha.6",
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/server": "0.0.0-alpha.5"
+        "@uniflowed/server": "0.0.0-alpha.6"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4639,43 +4639,43 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/cell": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5",
-        "@uniflowed/react-testing": "0.0.0-alpha.5",
-        "@uniflowed/test": "0.0.0-alpha.5"
+        "@uniflowed/mock": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6",
+        "@uniflowed/react-testing": "0.0.0-alpha.6",
+        "@uniflowed/test": "0.0.0-alpha.6"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4683,53 +4683,53 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.5"
+        "@uniflowed/host": "0.0.0-alpha.6"
       }
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.5",
-        "@uniflowed/test": "0.0.0-alpha.5"
+        "@uniflowed/react-testing": "0.0.0-alpha.6",
+        "@uniflowed/test": "0.0.0-alpha.6"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/core": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.5",
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/hooks": "0.0.0-alpha.6",
+        "@uniflowed/react": "0.0.0-alpha.6"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4737,17 +4737,17 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.5",
+        "@uniflowed/host": "0.0.0-alpha.6",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4762,19 +4762,19 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.5",
-        "@uniflowed/core": "0.0.0-alpha.5"
+        "@uniflowed/browser": "0.0.0-alpha.6",
+        "@uniflowed/core": "0.0.0-alpha.6"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.5",
+      "version": "0.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.5"
+        "@uniflowed/react": "0.0.0-alpha.6"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow implementation for @uniflowed/cell, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.5",
-    "@uniflowed/test": "0.0.0-alpha.5"
+    "@uniflowed/config": "0.0.0-alpha.6",
+    "@uniflowed/test": "0.0.0-alpha.6"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -25,8 +25,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.5",
-    "@uniflowed/validator": "0.0.0-alpha.5"
+    "@uniflowed/react": "0.0.0-alpha.6",
+    "@uniflowed/validator": "0.0.0-alpha.6"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.5"
+    "@uniflowed/fetch": "0.0.0-alpha.6"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/react": "0.0.0-alpha.6"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5",
-    "@uniflowed/cell": "0.0.0-alpha.5",
-    "@uniflowed/fetch": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6",
+    "@uniflowed/cell": "0.0.0-alpha.6",
+    "@uniflowed/fetch": "0.0.0-alpha.6"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.5",
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/config": "0.0.0-alpha.6",
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/hooks": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5",
+    "@uniflowed/core": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.5",
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/config": "0.0.0-alpha.6",
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -29,6 +29,6 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/server": "0.0.0-alpha.5"
+    "@uniflowed/server": "0.0.0-alpha.6"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/cell": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,10 +22,10 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5",
-    "@uniflowed/react-testing": "0.0.0-alpha.5",
-    "@uniflowed/test": "0.0.0-alpha.5"
+    "@uniflowed/mock": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6",
+    "@uniflowed/react-testing": "0.0.0-alpha.6",
+    "@uniflowed/test": "0.0.0-alpha.6"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.5"
+    "@uniflowed/host": "0.0.0-alpha.6"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.5",
-    "@uniflowed/test": "0.0.0-alpha.5"
+    "@uniflowed/react-testing": "0.0.0-alpha.6",
+    "@uniflowed/test": "0.0.0-alpha.6"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/tui, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/core": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -25,8 +25,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.5",
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/hooks": "0.0.0-alpha.6",
+    "@uniflowed/react": "0.0.0-alpha.6"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.5",
+    "@uniflowed/host": "0.0.0-alpha.6",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.5",
-    "@uniflowed/core": "0.0.0-alpha.5"
+    "@uniflowed/browser": "0.0.0-alpha.6",
+    "@uniflowed/core": "0.0.0-alpha.6"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.5",
+  "version": "0.0.0-alpha.6",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,6 +22,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.5"
+    "@uniflowed/react": "0.0.0-alpha.6"
   }
 }


### PR DESCRIPTION
One version across the workspace, the changelog for it, and the tag that publishes it.

`tools/release/bump-version.sh` sets the Cargo workspace version, every `packages/*/package.json` and its pinned `@uniflowed/*` dependencies, the docs manifest, and both lockfiles — `release.yml` refuses to build a tag whose version disagrees with the workspace.

## uf@0.0.0-alpha.6

_2026-09-06_

### Added

- **dev**: `uf dev --port` binds that port or says why it cannot (#239)

### Fixed

- **release**: the npm check waits for the registry to catch up (#243)

### Documentation

- uf@0.0.0-alpha.5 contains twenty-one pull requests, not twelve (#244)

### Internal

- **check**: keep the reproduction for a match over a generic in the repository (#226)

The tag goes on `main` after this merges. `uf@0.0.0-alpha.3` was cut on a branch that was then squash-merged, which left it unreachable from `main`: `git describe` walked past it, and this version's changelog first came out with fifty-four entries, most of them already released. The generator now takes the most recently created tag rather than the nearest reachable one, and tagging `main` is what keeps that honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791267472&installation_model_id=422833&pr_number=288&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F288&signature=2526ba7400c004f05272f0a7a4cfec7d3a191ce517937f5c3afed990a5ab4c48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->