### PR TITLE
docs: the four pages a stranger reads before they try uf

### DIFF
--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -70,6 +70,11 @@ export const sections: $ReadOnlyArray<Section> = [
         title: "Your first project",
         blurb: "From an empty directory to a built site.",
       },
+      {
+        href: "/guide/migrate",
+        title: "Migrating to uf",
+        blurb: "From CRA, Vite or Next.js: what survives, what is lost, what it costs.",
+      },
     ],
   },
   {

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -51,6 +51,11 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb: "The refusals, and the gaps — the second list with issue numbers.",
       },
       {
+        href: "/guide/compare",
+        title: "uf compared",
+        blurb: "Against Next.js, Vite, Bun and CRA, including the rows uf loses.",
+      },
+      {
         href: "/guide/vite-plus",
         title: "uf and Vite+",
         blurb: "Where uf sits next to the toolchain it will be compared to.",

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -36,6 +36,11 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb: "What Flow says about React that nothing else can, and what it costs.",
       },
       {
+        href: "/guide/typescript",
+        title: "Flow and TypeScript",
+        blurb: "The rows TypeScript wins, the four Flow wins, and why uf is possible.",
+      },
+      {
         href: "/guide/architecture",
         title: "Architecture",
         blurb: "What went wrong with create-react-app, and the lines uf will not cross.",

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -46,6 +46,11 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb: "What went wrong with create-react-app, and the lines uf will not cross.",
       },
       {
+        href: "/guide/scope",
+        title: "What uf does not do",
+        blurb: "The refusals, and the gaps — the second list with issue numbers.",
+      },
+      {
         href: "/guide/vite-plus",
         title: "uf and Vite+",
         blurb: "Where uf sits next to the toolchain it will be compared to.",

--- a/docs/app/guide/compare/_uf.page.mdx
+++ b/docs/app/guide/compare/_uf.page.mdx
@@ -1,0 +1,180 @@
+---
+title: "uf compared · uf"
+---
+
+<p className="eyebrow">Getting started</p>
+
+# uf compared
+
+<div className="lede">
+Against the four things people actually arrive from. The rows uf loses are in
+the same tables as the rows it wins, because a comparison that only lists
+strengths tells you nothing you could not have guessed from the home page.
+</div>
+
+## The one-screen version
+
+| | `create-react-app` | Vite + React | Next.js | Bun | uf |
+| --- | --- | --- | --- | --- | --- |
+| Status | [deprecated by React](https://react.dev/blog/2025/02/14/sunsetting-create-react-app) (Feb 2025) | maintained | maintained | maintained | `0.0.0-alpha`, not on npm |
+| Language | TypeScript or JS | TypeScript or JS | TypeScript or JS | TypeScript or JS | **Flow** |
+| `component` / `hook` / `renders` / `match` | Babel preset | Babel preset | Babel preset | no | **native** |
+| Dev server and build | webpack | Vite | Turbopack (or webpack) | `bun build` | **Vite 8** |
+| Test runner | Jest | you add one | you add one | `bun test` | `uf test` |
+| Formatter | you add one | you add one | you add one | none | in the binary |
+| Linter | ESLint, wired in | you add one | ESLint, wired in | none | in the binary |
+| Type checker | `tsc` | `tsc` | `tsc` | `tsc` | `uf check` (Flow) |
+| Production server | — | — | `next start` | `Bun.serve`, you write it | **none yet** |
+| Config files | none, then all of them after `eject` | one per tool | one per tool | one per tool | **`uf.config.js`, and only it** |
+
+Two rows in that table decide most of the question. If you write TypeScript,
+the syntax row is worth nothing to you and every other row is a downgrade. If
+you need the production-server row, uf cannot serve you at all yet.
+
+## Read the losses first
+
+| What uf loses | To | By how much |
+| --- | --- | --- |
+| Test throughput | `bun test` | 0.20 s against **0.06 s** on 50 files, 1,000 tests, 2,000 assertions ([Testing](/guide/testing)) |
+| A deployable application | Next.js | `uf build` prerenders and stops; SSR, route handlers and every adapter exist only under `uf dev` ([#250](https://github.com/ubugeeei-prod/uf/issues/250)) |
+| Server Components | Next.js | the analysis is complete and nothing reads it — every page module ships to the browser ([#252](https://github.com/ubugeeei-prod/uf/issues/252)) |
+| The typed ecosystem | everything | a package with no Flow libdef is `any` ([Flow and TypeScript](/guide/typescript)) |
+| Being installable | everything | `@uniflowed/*` is not on npm ([#210](https://github.com/ubugeeei-prod/uf/issues/210)) |
+| Runtime coverage | Bun, Next.js | Node.js and Bun load Flow; Deno is a name in an enum and edge runtimes have no host ([#246](https://github.com/ubugeeei-prod/uf/issues/246)) |
+| Being three years old | all four | pre-release, no stability guarantee, interfaces move without warning |
+
+[What uf does not do](/guide/scope) is the complete version of that list,
+sorted into refusals and gaps.
+
+## Against `create-react-app`
+
+CRA is the honest ancestor: an all-in-one tool that hid a build behind one
+dependency. React
+[deprecated it in February 2025](https://react.dev/blog/2025/02/14/sunsetting-create-react-app)
+and recommends a framework or a build tool instead.
+
+**What uf takes from it:** the shape. One command, no configuration to copy,
+a project that runs before you have made a single decision.
+
+**What uf takes from its failure:** everything in
+[`docs/red-lines.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/red-lines.md).
+CRA's three failures were an `eject` cliff with a one-way door, a single
+package serialising every upgrade in the ecosystem, and solving the build and
+stopping. uf answers the first with a continuum and no `eject`, the second by
+owning orchestration rather than implementation, and the third by being a
+framework as well — which is the one of the three uf has not finished.
+
+**What CRA still has that uf does not:** a decade of tutorials that assume it,
+and the fact that it runs on stable, published, installable software.
+
+## Against Vite + React
+
+This is the closest comparison and the least adversarial one, because **uf's
+dev server and build are Vite** — `packages/vite/package.json` depends on
+`vite: "^8.2.2"` and uf drives it over a JSON protocol. Bundling performance is
+not a row: it is the same bundler.
+
+**What uf adds.** Flow's React syntax with no Babel anywhere in the pipeline;
+one config file instead of a `vite.config.ts` plus a test config plus a
+formatter config plus a linter config; and a test runner, formatter, linter and
+type checker that read the same syntax tree the build does.
+
+**What plain Vite keeps that uf gives up.**
+
+- **TypeScript**, and with it every typed package on npm.
+- **`vite preview`.** uf has no equivalent; the driver implements one and
+  nothing reaches it ([#255](https://github.com/ubugeeei-prod/uf/issues/255)).
+- **`vite/client`'s types.** `import.meta.glob`, `import.meta.hot` and asset
+  imports are type errors or `any` under `uf check`
+  ([#264](https://github.com/ubugeeei-prod/uf/issues/264)).
+- **`.env` files**, which uf turns off in the Vite config it generates
+  ([#259](https://github.com/ubugeeei-prod/uf/issues/259)) — reachable again
+  with `vite: { envFile: true }`.
+- **Any Vite version you like.** uf pins the line it tests against.
+
+What does *not* change is the escape hatch: the `vite` key in `uf.config.js` is
+merged over what uf generates, and `plugins` is a list of ordinary Vite plugins.
+
+## Against Next.js
+
+The largest gap, and the one worth being blunt about.
+
+`next build` produces a running application: `next start` serves it,
+[`output: 'standalone'`](https://nextjs.org/docs/app/api-reference/config/next-config-js/output)
+writes a self-contained `server.js`, and `output: 'export'` is the *opt-in* for
+the fully static case. In uf, the static case is the only case.
+
+| Capability | Next.js | uf today |
+| --- | --- | --- |
+| File-system routing, nested layouts | yes | yes ([Routing](/guide/routing)) |
+| Data loading before render | yes | `loader` exports |
+| Route handlers | yes | written, dispatched **only under `uf dev`** ([#250](https://github.com/ubugeeei-prod/uf/issues/250)) |
+| Server Components, server actions | yes | analysed, never executed ([#252](https://github.com/ubugeeei-prod/uf/issues/252)) |
+| Streaming, Suspense boundaries | yes | `renderToString`, so no ([#254](https://github.com/ubugeeei-prod/uf/issues/254)) |
+| ISR, caching, revalidation | yes | four booleans in a manifest ([#277](https://github.com/ubugeeei-prod/uf/issues/277)) |
+| Middleware | yes | reserved, discovered, never called ([#260](https://github.com/ubugeeei-prod/uf/issues/260)) |
+| Image optimisation | yes | markup only: no resizing, no formats, no `srcset` ([#273](https://github.com/ubugeeei-prod/uf/issues/273)) |
+| Error boundaries | yes | none ([#257](https://github.com/ubugeeei-prod/uf/issues/257)) |
+| Deployment adapters | many | none |
+
+**What uf has that Next.js does not.** Flow's React syntax, checked by Flow's
+own inference. A formatter and a linter and a test runner in the same binary,
+reading the same tree — Next.js is a framework and expects you to bring those.
+And a framework that does not own a server, which is a feature exactly when you
+did not want one.
+
+**If you are building an application that renders per request, use Next.js.**
+uf will tell you this again on [What uf does not do](/guide/scope) rather than
+letting you find it out at deploy time.
+
+## Against Bun
+
+Bun and uf overlap less than the feature lists suggest: Bun is a runtime that
+brings a package manager, a bundler and a test runner; uf is a toolchain that
+runs *on* a runtime — Bun included.
+
+**Where Bun wins, measured.** `bun test` runs the same suite in 0.06 s against
+`uf test`'s 0.20 s warm and 0.30 s cold, on 50 files, 1,000 tests and 2,000
+assertions, best of five on an 8-core M-series Mac. That is about three times
+faster, and the reason is structural: Bun runs everything in one process with
+the runner written into the engine, while uf spawns a worker per core, gives
+each worker one file at a time, and pays the start-up. `bun test` also ships
+snapshots, coverage and a
+[JUnit reporter](https://bun.com/docs/cli/test); `uf test` has none of those
+([#280](https://github.com/ubugeeei-prod/uf/issues/280)).
+
+**Where uf wins the same comparison.** `uf test` is about nine times faster
+than `vitest run` on that suite (1.96 s), it runs on Node.js as well as Bun,
+and it runs Flow — `bun test` has no `component` or `hook` syntax at all.
+
+**Package management.** `uf install` does not implement one: it detects the
+project's package manager and runs it, refusing a manifest that declares npm
+scripts. `uf_pm`'s operation table names ten commands and the CLI ships one —
+no `uf add`, no `uf remove`, no frozen install for CI
+([#287](https://github.com/ubugeeei-prod/uf/issues/287)). Bun's installer is a
+finished product; uf's is a policy in front of yours.
+
+## And Vite+
+
+Vite+ is the toolchain uf will be compared to most often, and it has its own
+page: [uf and Vite+](/guide/vite-plus). The short version is that they answer
+different questions — Vite+ unifies the TypeScript toolchain, uf makes Flow's
+React syntax usable — and Vite+ has a company and a support contract, which uf
+does not.
+
+## So which one
+
+- **Writing TypeScript, shipping to production this quarter:** Next.js if you
+  need a server, Vite if you do not. uf is not competing for this.
+- **Writing TypeScript, unhappy about the number of config files:** Vite+.
+- **Writing Flow, or wanting to:** uf, and there is currently nothing else —
+  which is the whole reason it exists.
+- **Building a static site, curious, willing to be early:** uf builds this one.
+  `uf build` prerenders every page of this documentation, and the output is
+  what you are reading.
+
+## Where to go next
+
+[Migrating to uf](/guide/migrate) is the honest cost of moving from any of the
+above. [Flow and TypeScript](/guide/typescript) is the language decision, which
+is the one that actually matters.

--- a/docs/app/guide/migrate/_uf.page.mdx
+++ b/docs/app/guide/migrate/_uf.page.mdx
@@ -1,0 +1,209 @@
+---
+title: "Migrating to uf · uf"
+---
+
+<p className="eyebrow">Getting started</p>
+
+# Migrating to uf
+
+<div className="lede">
+From `create-react-app`, from Vite + React, or from Next.js: what survives, what
+you rewrite, what you lose, and roughly what it costs. There is no `uf migrate`
+command and there is not going to be a false number here either — nobody has
+moved a large application to uf yet, because the packages are not on npm
+([#210](https://github.com/ubugeeei-prod/uf/issues/210)).
+</div>
+
+## Three questions that mean "not yet"
+
+Answer these before you read the rest. Each one is a wall, not a speed bump.
+
+**Does your application render per request in production?** `uf build`
+prerenders every static route and stops. There is no `uf start`, no
+`uf preview`, and the server bundle is written outside `dist/` — so SSR, route
+handlers and every deployment adapter work under `uf dev` and disappear at build
+time ([#250](https://github.com/ubugeeei-prod/uf/issues/250)). If your answer is
+yes, stop here and read [uf compared](/guide/compare) instead.
+
+**Do you have TypeScript you cannot convert?** uf transforms `.js`, `.jsx`,
+`.mjs` and `.cjs` in your project and nothing else. A `.ts` file is handed to
+Biome for formatting and is invisible to everything else uf does. Migration
+means converting the whole application, not adding uf beside `tsc`.
+
+**Do you depend on typed packages?** Every dependency without a Flow
+[libdef](https://flow.org/en/docs/libdefs/) is `any`. Count them now: that
+number, not the file count, is what decides whether this is worth doing.
+[Flow and TypeScript](/guide/typescript) is the long version.
+
+## What every migration has in common
+
+### Files you delete
+
+| You have | uf replaces it with |
+| --- | --- |
+| `babel.config.js`, `@babel/preset-flow`, the syntax plugins | nothing — Flow reaches JavaScript inside the binary |
+| `tsconfig.json` | nothing — the type system is Flow |
+| `.prettierrc` | `fmt` in `uf.config.js` |
+| `.eslintrc` | `lint` in `uf.config.js`, alongside Flow's own lints |
+| `jest.config.js`, `vitest.config.ts` | `test` in `uf.config.js` |
+| `vite.config.ts` | `uf.config.js`, with a `vite` key for everything uf has no opinion about |
+| `scripts` in `package.json` | `tasks` in `uf.config.js` — `uf install` **refuses** a manifest that declares scripts |
+| `index.html` | the root layout: a `component` that renders `<html>` |
+
+`uf create app react my-app` in a scratch directory is the fastest way to see
+the shape you are aiming at — nine files, and
+[Your first project](/guide/project) walks through them.
+
+### What stays exactly as it is
+
+- **`public/`.** Served from the root, copied into the build untouched.
+- **CSS.** Plain imports, `.module.css`, and the preprocessors Vite supports.
+- **Vite plugins.** `plugins` in `uf.config.js` is a list of ordinary Vite
+  plugins, appended to uf's own.
+- **React itself.** React 19, the same hooks, the same rendering model. uf
+  compiles `component` and `hook` declarations to plain functions and hands
+  them to the official React Compiler.
+
+### Converting the types
+
+Rename `.ts` and `.tsx` to `.js`, put `// @flow` on the first line, then work
+through the constructs. Most of them are a one-line change:
+
+| TypeScript | Flow |
+| --- | --- |
+| `interface Props { … }` | a `type` alias — and Flow's object types are exact by default |
+| `function C({a, b}: Props)` | `component C(a: A, b: B)` — the parameter list is the props |
+| `React.FC<Props>` | `component` |
+| a custom hook | `hook useThing(…)` — the rules of hooks become type errors |
+| `unknown` | `mixed` |
+| `readonly x: T` | `+x: T` (Flow also accepts `readonly`) |
+| `x as T` | `(x: T)`, or a documented `$FlowFixMe` |
+| a `.d.ts` you wrote | a libdef, or Flow types in the source |
+| `switch` with a `default: never` | [`match`](https://flow.org/en/docs/match/), which is exhaustive by construction |
+
+Two things that will surprise you. **`uf check` resolves no modules yet**: every
+import is `any` and the report names them, so a converted file can look clean
+and still be wrong across a boundary
+([#248](https://github.com/ubugeeei-prod/uf/issues/248)). And **top-level
+`await` does not parse**, so a module using it cannot be checked, formatted,
+transformed or built ([#204](https://github.com/ubugeeei-prod/uf/issues/204)).
+
+## From `create-react-app`
+
+The best-supported path, because CRA applications are usually a client-rendered
+bundle and that is what uf builds.
+
+1. `uf create app react ../my-app-uf`, then copy `src/` into it.
+2. Delete `react-scripts`. Its `scripts` block goes with it — `uf install`
+   refuses a manifest that declares one.
+3. Move the contents of `public/index.html` into `app/_uf.layout.js`. The
+   `<div id="root">` goes away: uf renders the whole document.
+4. Turn each screen into a route directory under `app/`. uf's file-system
+   router is the routing uf builds against; `app.router.enabled: false` makes
+   the project a library rather than an application, so it is not a way to keep
+   React Router.
+5. Convert the types, if the project had any.
+6. `uf fmt`, then `uf lint`, then `uf check`, then `uf test`.
+
+**What you lose.** Jest — `uf test` has the API but no snapshots, no coverage
+and no module mocking ([#280](https://github.com/ubugeeei-prod/uf/issues/280),
+[#283](https://github.com/ubugeeei-prod/uf/issues/283)), so a suite that leans
+on any of the three does not come across. `REACT_APP_*` environment variables
+do not arrive either, because uf turns Vite's `.env` loading off
+([#259](https://github.com/ubugeeei-prod/uf/issues/259)); `vite: { envFile: true }`
+turns it back on and the prefix becomes `VITE_`.
+
+**Cost.** The route and entry work is a day's shape regardless of size; the
+long pole is the test suite, in proportion to how much of it uses snapshots.
+
+## From Vite + React
+
+The mechanics are smaller — you are already on the same bundler — and the
+language change is the whole job.
+
+1. `vite.config.ts` becomes `uf.config.js`. Options uf owns (`dev.port`,
+   `build.outDir`) have names; everything else goes under the `vite` key
+   unchanged, including `resolve.alias` and `server.warmup`.
+2. `index.html` becomes `app/_uf.layout.js`. Vite runs in `appType: "custom"`
+   under uf: there is no HTML entry to fall back to, and the document comes from
+   the layout.
+3. Your entry module becomes `app.js` plus a page under `app/`.
+4. Convert the types.
+5. Replace Vitest with `uf test` — the `describe`/`it`/`expect` surface is the
+   same, and `expect` has 25 matchers, `.not`, `.resolves`, `.rejects` and
+   `fn()`.
+
+**What you lose.**
+
+- **`vite preview`.** uf has no equivalent
+  ([#255](https://github.com/ubugeeei-prod/uf/issues/255)).
+- **`vite/client`'s types.** `import.meta.glob`, `import.meta.hot` and asset
+  imports are type errors or `any` under `uf check` — five errors in a five-line
+  file ([#264](https://github.com/ubugeeei-prod/uf/issues/264)). The code still
+  runs; the checker cannot see it.
+- **Choosing your Vite version.** uf depends on `vite: "^8.2.2"`.
+
+**Cost.** A day for the configuration and the entry, then the type conversion,
+which is the part that scales with the codebase.
+
+## From Next.js
+
+Read [What uf does not do](/guide/scope) first, then this.
+
+**A Next.js application that needs a server cannot move to uf today.** Server
+Components are analysed and never executed, so every page module ships to the
+browser ([#252](https://github.com/ubugeeei-prod/uf/issues/252)); server actions
+have a registry and no dispatcher; nothing streams
+([#254](https://github.com/ubugeeei-prod/uf/issues/254)); there is no
+revalidation ([#277](https://github.com/ubugeeei-prod/uf/issues/277)); and
+`middleware.ts` has an exact counterpart in uf that is discovered, reported by
+`uf inspect --json`, and never called
+([#260](https://github.com/ubugeeei-prod/uf/issues/260)).
+
+What can move is an application you could already build with
+`output: 'export'` — static pages, client-side data fetching, no per-request
+rendering.
+
+The conventions line up more closely than the capabilities do:
+
+| Next.js | uf |
+| --- | --- |
+| `app/page.tsx` | `app/_uf.page.js` |
+| `app/layout.tsx` | `app/_uf.layout.js` |
+| `app/[slug]/page.tsx` | `app/[slug]/_uf.page.js` |
+| `app/[...rest]/` | `app/[...rest]/` |
+| `app/(group)/` | `app/(group)/` |
+| `app/api/x/route.ts` | `app/api/x/_uf.route.js` — `Request` in, `Response` out, **`uf dev` only** |
+| `not-found.tsx` | `_uf.not-found.js`, read at the router root only ([#263](https://github.com/ubugeeei-prod/uf/issues/263)) |
+| `middleware.ts` | `_uf.middleware.js`, never called |
+| `generateStaticParams` | `generateStaticParams` |
+| `export const metadata` | `metadata` on a page or layout, merged along the path with the page last |
+| `next/link` | `Link` from `@uniflowed/router`, prefetching on intent |
+| `next/image` | `Image` from `@uniflowed/web` — layout-stable markup, no pipeline ([#273](https://github.com/ubugeeei-prod/uf/issues/273)) |
+| `loading.tsx`, `error.tsx` | neither exists yet ([#257](https://github.com/ubugeeei-prod/uf/issues/257)) |
+
+**Cost.** For a statically exportable site, the same as the Vite path plus the
+route renaming. For anything else, it is not a cost — it is a blocker, and the
+issues above are where to watch for it to lift.
+
+## Estimating your own migration
+
+There is no measured migration to quote, so here is the arithmetic instead. The
+job is three numbers you can count today:
+
+1. **Modules to convert.** Mechanical, and mostly the table above.
+2. **Dependencies with no Flow libdef.** Each one is `any` at the boundary, and
+   this is the number that decides whether the type system pays you back.
+3. **Tests using snapshots, coverage or module mocks.** These have no
+   destination yet.
+
+And one number you can produce: convert a single leaf directory, run
+`uf check`, and read the count. That is the real conversion rate for your
+codebase, and it beats any figure this page could assert.
+
+## Where to go next
+
+[Your first project](/guide/project) is the shape you are converting into.
+[What uf does not do](/guide/scope) is the list of walls, kept current with
+issue numbers. If the answer turns out to be "not yet", that is a supported
+answer — it is why the list exists.

--- a/docs/app/guide/scope/_uf.page.mdx
+++ b/docs/app/guide/scope/_uf.page.mdx
@@ -1,0 +1,161 @@
+---
+title: "What uf does not do · uf"
+---
+
+<p className="eyebrow">Getting started</p>
+
+# What uf does not do
+
+<div className="lede">
+A boundary you discover on a Thursday afternoon is a limitation. The same
+boundary, read before you start, is a promise about what the tool will never do
+to you. This page is both lists: what uf refuses to do on purpose, and what it
+does not do yet — the second list with issue numbers, because a gap without one
+is a wish.
+</div>
+
+## The refusals
+
+### It will never grow an `eject`
+
+There is no `uf eject`, and there will not be a `uf config --write` or a
+"print the effective Vite config so you can copy it" flag either, because that
+becomes one in practice. `create-react-app` put a cliff between *zero config*
+and *fully customisable*, with a one-way door at the bottom of it; uf replaces
+the door with a continuum:
+
+```
+convention  →  configuration  →  provider replacement  →  raw provider API
+```
+
+Each step is smaller than the one before, and none of them locks. A project
+that needs one Vite plugin adds one Vite plugin, and does not inherit a build
+system. The reasoning, and the audit of where uf does not yet live up to it, is
+[Architecture](/guide/architecture).
+
+### It does not own the bundler, and will not fork it
+
+The dev server and the production build are Vite — `packages/vite/package.json`
+depends on `vite: "^8.2.2"`, and uf drives it over a JSON protocol. If uf needs
+behaviour Vite does not have, the answer is a plugin or an upstream change,
+never a fork. That is the first red line and it is first for a reason: a
+vendored, patched Vite would be uf's forever.
+
+The consequence you can use: **anything Vite can do, a uf project can do,
+without waiting for a uf release.** The `vite` key in `uf.config.js` is merged
+over what uf generates and uf does not read it.
+
+### It does not type-check your code
+
+Flow does. `uf check` runs Flow's own inference and reports what Flow says.
+uf reimplementing type inference would produce a second opinion about your
+program, which is the exact failure this toolchain exists to remove.
+
+### It does not invent a name for something Flow already names
+
+A file says it is plain JavaScript with `@noflow`. uf will not add a
+`check.exclude` list, because that would be a second answer to a question that
+already has one, in a place a reader is not looking.
+
+### It will not run npm lifecycle scripts
+
+`uf install` refuses a manifest that declares `scripts` before it fetches
+anything:
+
+<figure className="terminal">
+
+```
+error: package manifest /…/my-site/package.json declares scripts;
+       use uf tasks in uf.config.js
+```
+
+</figure>
+
+Install-time scripts are a remote-code-execution path on a machine that just
+cloned a repository, and the threat model is written down in
+[`docs/security.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/security.md).
+Project automation lives in `uf.config.js` tasks instead, which is also why a
+generated project has no npm scripts.
+
+### It will not bind a routable address quietly
+
+`uf dev --host` refuses to start while `dev.allowedHosts` is empty, before any
+process is spawned. A dev server on `0.0.0.0` with no allow-list is a file
+server for your source tree, and uf never writes `*` on your behalf.
+
+### It will not format what it cannot reproduce
+
+`uf fmt` formats the GraphQL inside a tagged template, and **leaves a template
+alone, byte for byte, when it cannot match Prettier exactly** — a `#` comment
+in the document, a string holding a control character, more than 128 levels of
+nesting. Of the 1,138 `graphql` templates in Relay's test suite it reproduces
+Prettier on 1,092 and declines 46, every one of them for a comment. Approximately
+right is not a thing a formatter may be; [Formatting and
+linting](/guide/format) has the rest.
+
+### It is not framework-agnostic, and does not want to be
+
+uf is Flow and React. A project's `.js`, `.jsx`, `.mjs` and `.cjs` files are
+uf's to transform; a third-party dependency under `node_modules` is not, except
+`@uniflowed/*`, which ship Flow source. A TypeScript file in your application is
+not a Flow module — the formatter will hand it to Biome, and nothing else in uf
+will read it.
+
+### It will not share a process between two test files
+
+`uf test` gives each worker one file at a time. Two files sharing a process
+share globals, and a suite that passes alone and fails beside another is the
+worst failure a runner can produce. It costs real time: uf spawns a worker per
+core and each one loads the test API before it can do anything, which is where
+the gap to `bun test` comes from. It is not a trade uf intends to make back by
+removing the isolation. [Testing](/guide/testing) has the measurements.
+
+### It will not answer "who did that?" with silence
+
+`uf inspect --json` prints the resolved configuration and the route table.
+`uf explain <command>` names the provider for every stage of `dev`, `build`,
+`test`, `fmt`, `lint` and `check` — which binary runs it and what it does. A
+stage that cannot be explained is a stage that should not exist.
+
+## What it does not do yet
+
+Everything above is a decision. Everything below is unfinished, and each row
+links to the issue that tracks it. If you need one of these, uf is not ready
+for you — that is a better thing to learn here than three days in.
+
+| What is missing | Where it actually stands | Issue |
+| --- | --- | --- |
+| **A production server.** `uf build` prerenders and stops: no `uf start`, no `uf preview`, and the server bundle is written to `.uf/build/server/` rather than `dist/`. SSR, route handlers and every deploy adapter exist only under `uf dev` | The driver already implements a `preview()` that nothing reaches | [#250](https://github.com/ubugeeei-prod/uf/issues/250), [#255](https://github.com/ubugeeei-prod/uf/issues/255) |
+| **React Server Components.** `"use client"` and `"use server"` are scanned, graphed and manifested; nothing downstream reads the result | Every page module ships to the browser, and no server action is callable | [#252](https://github.com/ubugeeei-prod/uf/issues/252), [#281](https://github.com/ubugeeei-prod/uf/issues/281) |
+| **Streaming and loading boundaries.** The renderer is `renderToString` | Synchronous SSR; no Suspense boundary streams | [#254](https://github.com/ubugeeei-prod/uf/issues/254) |
+| **An error boundary.** A component that throws takes the response with it; there is no `_uf.error.js` | — | [#257](https://github.com/ubugeeei-prod/uf/issues/257) |
+| **Middleware.** `_uf.middleware.js` is a reserved name, discovered by the router, reported by `uf inspect --json` — and never called | Every part except the call | [#260](https://github.com/ubugeeei-prod/uf/issues/260) |
+| **`.env` files.** `env.files` and `env.active` have no reader, `uf env use` writes a file nothing reads, and the Vite driver sets `envFile: false` | A project can turn Vite's own loader back on with `vite: { envFile: true }` | [#259](https://github.com/ubugeeei-prod/uf/issues/259) |
+| **Caching and revalidation.** `rendering.cache` is four booleans copied into a manifest | There is no cache | [#277](https://github.com/ubugeeei-prod/uf/issues/277) |
+| **Deno, and every edge runtime.** Node.js and Bun load Flow; `HostKind::Deno` loads none, and Cloudflare Workers, Vercel Edge and Deno Deploy have no host at all | One and a half of the three named hosts | [#246](https://github.com/ubugeeei-prod/uf/issues/246) |
+| **Task caching.** `uf run` is `sh -c`, one task at a time: no input hashing, no parallel dependencies, no workspace filter | The roadmap's "cached, dependency-aware task execution" is not what happens today | [#272](https://github.com/ubugeeei-prod/uf/issues/272) |
+| **Test coverage, and a reporter CI can read.** No coverage, no snapshots, no module mocking — seven of the mocking bindings raise `UnsupportedError` | `uf test --json` exists; nothing emits LCOV or JUnit | [#280](https://github.com/ubugeeei-prod/uf/issues/280), [#283](https://github.com/ubugeeei-prod/uf/issues/283) |
+| **`uf lint --fix`.** The fix catalogue exists and only an editor can reach it | `uf prepare` can tell you a file is misformatted and cannot format it | [#290](https://github.com/ubugeeei-prod/uf/issues/290) |
+| **An image and font pipeline.** `Image` and `Font` are the markup and none of the pipeline: no resizing, no formats, no `srcset` | They prevent layout shift and double downloads, which is what they claim | [#273](https://github.com/ubugeeei-prod/uf/issues/273) |
+| **Packages on npm.** Nothing under `@uniflowed/*` is published | They resolve through this repository's workspace, which is how this site imports them | [#210](https://github.com/ubugeeei-prod/uf/issues/210) |
+
+The uncomfortable summary: **uf builds a static site today.** Everything that
+needs a server at run time works while `uf dev` is running and disappears at
+`uf build`.
+
+## How to tell a refusal from a gap
+
+A refusal has a reason, written down in
+[`docs/red-lines.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/red-lines.md),
+and no issue will ever close it. A gap has an issue number and an owner.
+
+If you hit a boundary that has neither — no reason on this page and no issue to
+link — that is a defect in this page, and worth
+[reporting](https://github.com/ubugeeei-prod/uf/issues) as one.
+
+## Where to go next
+
+[uf compared](/guide/compare) puts the two lists above beside Next.js, Vite,
+Bun and `create-react-app`. [Migrating to uf](/guide/migrate) is what moving
+actually involves. [Architecture](/guide/architecture) is the audit uf keeps
+against its own rules.

--- a/docs/app/guide/typescript/_uf.page.mdx
+++ b/docs/app/guide/typescript/_uf.page.mdx
@@ -1,0 +1,208 @@
+---
+title: "Flow and TypeScript · uf"
+---
+
+<p className="eyebrow">Getting started</p>
+
+# Flow and TypeScript
+
+<div className="lede">
+You already write TypeScript. Everyone arriving here does, and pretending the
+comparison is close would be the fastest way to lose your attention. TypeScript
+wins most of the rows. Flow wins four that only exist because it is the type
+system React itself is written in — and one fact about Flow's implementation is
+the reason a toolchain like uf can be built at all.
+</div>
+
+## The rows TypeScript wins
+
+**The ecosystem.** A package on npm ships `.d.ts`. Flow reads
+[library definitions](https://flow.org/en/docs/libdefs/), and a package that has
+none is `any` until somebody writes one. `flow-typed` covers a fraction of what
+DefinitelyTyped covers. If your application stands on twenty typed
+dependencies, this is the bill, and it does not get smaller by choosing uf.
+
+**Editors.** uf ships `uf lsp`, and every editor integration under
+[`editors/`](https://github.com/ubugeeei-prod/uf/tree/main/editors) is a client
+of it. What it advertises in `initialize` is the whole of what it can do:
+diagnostics, `textDocument/formatting`, `textDocument/codeAction`
+(`quickfix` and `source.fixAll.uf`) and `textDocument/hover`. There is no
+rename, no go-to-definition, no find-references, no auto-import.
+`tests/library/lsp.test.js` drives the real binary and asserts both the
+capabilities the READMEs claim and the absence of the ones they disclaim.
+
+**People.** More engineers have written TypeScript, more answers exist, and the
+odds that your next contributor has seen `renders` before are low.
+
+uf does not argue with any of that.
+
+## The rows uf loses, which is a different list
+
+The list above is Flow's. This one is uf's, and it is the more useful one,
+because it is the part that can be fixed and the part that will bite you this
+week.
+
+**Types stop at the module boundary.** `uf check` runs Flow's own inference,
+and today it resolves no modules: every import is `any`, and the report says
+which ones rather than leaving you to discover it.
+
+<figure className="terminal">
+
+```
+  types checked  1
+  inference      821.3µs
+  builtins       72.9ms (cold)
+
+  › these imports are typed as any; uf resolved no module for them
+    - ./a.js
+```
+
+</figure>
+
+That is a two-file project where `b.js` assigns the result of a function
+returning `string` to a `number` and nothing complains, because the function
+came from the other file. Cross-module inference is the next step in
+[`docs/architecture.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/architecture.md),
+and
+[issue #248](https://github.com/ubugeeei-prod/uf/issues/248) counts what the
+related resolver bug costs on this repository: 145 of 581 reported errors — 31%
+— are one thing, a type imported by its published name resolving to nothing.
+
+**Vite's client API has no Flow types.** A TypeScript project gets
+`import.meta.glob`, `import.meta.hot`, `import.meta.env` and the ambient
+declarations for `*.svg`, `?raw` and `?url` from `vite/client`. There is no Flow
+equivalent, from Vite or from uf, so a five-line file using them reports five
+type errors — [issue #264](https://github.com/ubugeeei-prod/uf/issues/264) has
+the file and the output.
+
+**Top-level `await` does not parse.** ES2022, accepted by Flow, refused by uf's
+parse options — so a module using it cannot be checked, formatted, transformed,
+tested or built.
+[Issue #204](https://github.com/ubugeeei-prod/uf/issues/204).
+
+None of those three is an argument about Flow. They are uf's, they have issue
+numbers, and [what uf does not do](/guide/scope) keeps the rest of the list.
+
+## What Flow says that TypeScript has no spelling for
+
+### Props are the parameter list
+
+```js
+component Avatar(src: string, size: number = 32, alt?: string) {
+  return <img src={src} width={size} height={size} alt={alt ?? ""} />;
+}
+```
+
+The TypeScript that does the same job is three declarations of one thing:
+
+```ts
+type AvatarProps = { src: string; size?: number; alt?: string };
+
+function Avatar({ src, size = 32, alt }: AvatarProps) {
+  return <img src={src} width={size} height={size} alt={alt ?? ""} />;
+}
+```
+
+An interface, a destructuring pattern and a defaults list: three places that
+describe one prop and can drift apart. The default is the clearest case —
+`size?: number` says a caller may omit it, and says nothing about the 32 they
+get when they do. Flow's
+[component syntax](https://flow.org/en/docs/react/component-syntax/) has one
+place to write a prop, so there is nothing to keep in step.
+
+It also means the React Compiler is *told* this is a component instead of
+inferring it from a capital letter — see [Flow, the modern
+parts](/guide/flow) for what uf hands it.
+
+### The rules of hooks are a type error
+
+```js
+hook useNow(interval: number): Date { … }
+```
+
+Flow refuses to let that be called from anything but a component or another
+hook. TypeScript's answer to the same problem is `eslint-plugin-react-hooks`: a
+lint rule, in a second tool, with a second configuration, enforcing something
+the type checker has no opinion about.
+[Flow's hook syntax](https://flow.org/en/docs/react/hook-syntax/) makes it the
+same checker that checks everything else.
+
+### A component can constrain its children
+
+```js
+component Tab(label: string) renders React.Node { … }
+component Tabs(children: renders* Tab) { … }
+```
+
+`renders Tab` says the component's output eventually renders a `Tab`; `renders?`
+allows nothing instead, and `renders*` allows any number.
+TypeScript's nearest expression is
+`children: ReactElement<ComponentProps<typeof Tab>>`, which checks the *props*
+of the element — so a different component that happens to take a `label: string`
+satisfies it, and a wrapper around `Tab` does not. Flow checks the render chain,
+which is the thing a design system actually means.
+[Render types](https://flow.org/en/docs/react/render-types/).
+
+### Exhaustiveness that is a language feature
+
+```js
+enum Status { Idle, Loading, Failed }
+
+const label = match (status) {
+  Status.Idle => "Ready",
+  Status.Loading => "Working…",
+  Status.Failed => "Failed",
+};
+```
+
+[`match`](https://flow.org/en/docs/match/) reports `match-not-exhaustive` when a
+case is missing and flags patterns that can never run, and
+[Flow enums](https://flow.org/en/docs/enums/) are real runtime values with
+`cast`, `isValid`, `members` and `getName` — a union of string literals is none
+of those, and TypeScript's `enum` is a different construct with its own
+history. uf lowers both where it parses them, with no import added to your
+module; [Flow, the modern parts](/guide/flow) has the output.
+
+## Why uf could be built at all
+
+This is the part written nowhere else, and it is the actual reason this project
+exists rather than a wish for better React types.
+
+**Flow's parser and type checker have an official Rust port**, and uf links it.
+`upstream/flow` is a git submodule pinned to a commit;
+`upstream/flow/rust_port/crates/flow_parser` is the parser Flow itself runs, and
+`uf_check` embeds the typing crates beside it. There is no second backend and no
+feature flag selecting one, because a build of uf that spoke a different dialect
+would make `uf lint` and `uf check` disagree with the grammar this site
+documents.
+
+So the dev server, the production build, the test runner, the formatter and the
+linter read one syntax tree produced by Meta's own code. That is not an
+integration uf is proud of having assembled — it is the reason there is nothing
+to assemble.
+
+**What it costs, in the same paragraph.** 23 crates in the port declare
+`#![feature(box_patterns)]`, and that feature was removed from the compiler
+around the 2026-09-01 nightly, so `rust-toolchain.toml` pins the whole workspace
+to `nightly-2026-08-01`. **No stable Rust toolchain can build uf.** The
+`Upstream Flow` CI job builds the parser on the floating channel as an early
+warning, so the pin moves deliberately rather than being discovered when it
+breaks. Every number and every embedding hazard is in
+[`docs/architecture.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/architecture.md).
+
+## How to decide
+
+**Stay on TypeScript** if your application leans on many typed dependencies, if
+your team is hiring, or if anything on the list of rows uf loses is load-bearing
+for you this quarter. That is most people, and it is a reasonable answer.
+
+**Try uf** if you are writing React rather than JavaScript-with-React — if the
+things you want the type system to catch are a missing prop, a hook called from
+the wrong place, a child component that does not belong, and a `match` you
+forgot to extend — and if you can work in pre-release software where the
+packages are not on npm yet
+([issue #210](https://github.com/ubugeeei-prod/uf/issues/210)).
+
+The syntax argument in full is [Why Flow](/guide/why). The boundaries are
+[What uf does not do](/guide/scope). If you want the head-to-head against the
+tool you are actually using today, that is [uf compared](/guide/compare).


### PR DESCRIPTION
Four pages for the reader who has never heard of uf, in the order they ask
their questions.

| Route | What it does |
|---|---|
| `/guide/typescript` | Flow or TypeScript. The rows TypeScript wins first, then the rows uf loses — module-boundary `any`, no Flow types for `vite/client`, top-level `await` — then the thing written nowhere on this site: Flow's parser and checker have an official Rust port, uf links it through `upstream/flow`, and the cost is that 23 of those crates need `box_patterns`, so no stable Rust toolchain builds uf. |
| `/guide/scope` | What uf does not do. The refusals with their reasons — no `eject`, no Vite fork, no npm lifecycle scripts, no `--host` without an allow-list — then a gap table where every row carries an issue number. It ends on the sentence the site never quite says: today, uf builds a static site. |
| `/guide/compare` | uf compared to CRA, Vite, Next.js and Bun, with the losses table above the comparisons rather than below them. Next.js gets its own capability table; uf loses eight of its ten rows. |
| `/guide/migrate` | What moving from each of those actually costs, as three questions that mean "not yet", then the conversion tables, then a path per tool. |

All four are in `docs/app/_design/nav.js`, in reading order inside "Getting
started".

## Why these four

The site assumed its reader. It explained `uf.config.js` before it explained
why a person would want a checker in their bundler, and it never once said
what uf is worse at than the tool the reader already has. A page that only
lists wins is read as marketing and closed, so each of these four leads with
what it costs.

## Verified

`tools/docs/build.sh` exits 0 and a link check across all 22 built pages finds
0 broken internal links. Every external URL was fetched. `uf fmt --check`
passes. Claims were checked against the binary rather than the docs: `uf check`
really does type every cross-module import as `any` (the page pastes the real
output), `uf install` really does refuse a manifest with `scripts`, `uf create
app react` really does write nine files.

## Found while writing, filed as #309

Seven things the existing docs say that the binary does not do — starting with
`uf create app my-site`, printed on the home page, which exits 2 because the
first positional is the template. Not fixed here: this branch adds pages, and
mixing corrections into it would hide them.

Two pages could not be written at all, and #309 says so: deployment, because
there is no `uf preview` and no adapter to point at, and styling, because
`guide/styling` says CSS-in-JS is not planned while the roadmap makes StyleX
the default engine. Picking a side there is not a documentation change.

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791269421&installation_model_id=422833&pr_number=311&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F311&signature=cf4e6de2c6a835674c7f85e50be9103c9da635c2ade639be99d36e4d07ffd84b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->