### PR TITLE
fix(release): a release that went out is not a release that failed

### DIFF
--- a/tools/release/verify-npm.sh
+++ b/tools/release/verify-npm.sh
@@ -100,7 +100,16 @@ echo "verify-npm: checking @uniflowed/* at $version on the registry"
 # as the kernel lets it, so a message promising "a minute of asking" would be a
 # claim nothing enforced — and seventeen names times six rounds is a lot of
 # chances to be stalled.
-WAIT_SECONDS=60
+#
+# Three minutes, not one. `uf@0.0.0-alpha.7` published all seventeen names and
+# this job failed anyway: sixteen were on the registry within three seconds and
+# `@uniflowed/host` was not there at 55 seconds, when the backoff ran out of
+# deadline. It was there a few minutes later, unchanged and correct. A release
+# that went out and is reported as broken costs more than a release that never
+# went out being reported slowly — and the case this budget was tightened for,
+# a publish that produced nothing, is still bounded, because every name is
+# asked in the same rounds rather than one after another.
+WAIT_SECONDS=180
 REQUEST_SECONDS=10
 deadline=$(( $(date +%s) + WAIT_SECONDS ))
 
@@ -158,8 +167,17 @@ if [ -n "$absent" ]; then
 Not on the registry at $version:$absent
 
 The tag says this version was released. npm does not have it after retrying for
-$WAIT_SECONDS seconds, so nobody can install it. Re-run the publish job once
-the names are bound; npm is additive, so the ones that did go out stay.
+$WAIT_SECONDS seconds, so nobody can install it.
+
+Two things this can be, and they are told apart by the publish job above:
+
+  * npm never accepted the name — look for `npm notice 📦  @uniflowed/<name>`
+    in that job. If it is absent, the name is not bound by `npm trust` and
+    `tools/release/bootstrap-publish.sh` has not been run for it. See #210.
+  * npm accepted it and the registry had not caught up. The notice is there,
+    and `npm view @uniflowed/<name>@$version` answers now. Re-run this job.
+
+Either way npm is additive, so the names that did go out stay.
 MESSAGE
   exit 1
 fi


### PR DESCRIPTION
`uf@0.0.0-alpha.7` published all seventeen names and the Publish job failed
anyway:

```
  on npm      @uniflowed/vite@0.0.0-alpha.7
  waiting     24s for host
  MISSING     @uniflowed/host@0.0.0-alpha.7

Not on the registry at 0.0.0-alpha.7: host
```

Sixteen were on the registry within three seconds. `@uniflowed/host` was not
there at 55 seconds, when the shared backoff ran out of its 60-second deadline
— and it was there a few minutes later, unchanged and correct. The publish
job's own log has `npm notice 📦  @uniflowed/host@0.0.0-alpha.7` in it. Nothing
was wrong except the waiting.

This is the check from #243, doing its job in the wrong direction: it exists
because `uf@0.0.0-alpha.2` had a tag, a GitHub release and nothing on npm, and
nobody noticed. A check that cries wolf on a good release teaches people to
ignore it, which costs exactly what #243 was buying.

## Three minutes, not one

A release that went out and is reported as broken costs more than a release
that never went out being reported slowly. The case the budget was tightened
for is still bounded, because every name is asked in the same rounds rather
than one after another.

Measured, not estimated:

| | before | after |
|---|---|---|
| `verify-npm.sh 0.0.0-alpha.7` (all seventeen published) | failed at 60s | **13s**, no waiting at all |
| `verify-npm.sh 0.0.0-alpha.999` (never published) | 60s | 182s, all seventeen named |

## And the message tells the two apart

They need different answers, and the publish job's log says which it is:

```
  * npm never accepted the name — look for `npm notice 📦  @uniflowed/<name>`
    in that job. If it is absent, the name is not bound by `npm trust` and
    `tools/release/bootstrap-publish.sh` has not been run for it. See #210.
  * npm accepted it and the registry had not caught up. The notice is there,
    and `npm view @uniflowed/<name>@$version` answers now. Re-run this job.
```

`uf@0.0.0-alpha.7` itself is fine: all seventeen packages are installable at
that version right now, and `@uniflowed/core`'s `alpha` dist-tag points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791287096&installation_model_id=422833&pr_number=395&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F395&signature=78b8acc04ba5d825ed4200d46c896b2bec26ddc4c7d57833de53a4f5d131b08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->