### PR TITLE
docs(site): the heading says what uf is for

### DIFF
--- a/docs/app/_uf.page.js
+++ b/docs/app/_uf.page.js
@@ -2,10 +2,15 @@
 //
 // The home page.
 //
-// It leads with the thing itself — one command, and what that command really
-// prints — because the argument for uf is not a feature list, it is that the
-// list collapses into one binary. Every claim below links to the page that
-// backs it, and the ones uf loses are on that list too.
+// The heading says what uf is for: writing React, in Flow, better than the
+// assembled toolchains do. That is the promise, and everything under it is
+// the evidence — one command, and what that command really prints. The
+// heading used to be "One binary between your code and the web", which
+// described uf's shape rather than what it gets you, and left a reader who
+// had never heard of uf to work out what the binary was for.
+//
+// Every claim below links to the page that backs it, and the ones uf loses
+// are on that list too.
 
 import * as React from "@uniflowed/react";
 import { Link } from "@uniflowed/router";
@@ -45,9 +50,9 @@ export default component Home() {
         <div className="hero-copy">
           <Eyebrow>Unified toolchain for Flow</Eyebrow>
           <h1>
-            One binary between
+            React at its best,
             <br />
-            your code and the web.
+            typed by Flow.
           </h1>
           <Lede>
             uf runs, builds, tests, formats and lints Flow and React from a single command. No Babel


### PR DESCRIPTION
The home page led with

> **One binary between**
> **your code and the web.**

which describes uf's shape rather than what it gets you. A reader who has never
heard of uf has to work out what the binary is *for*, and "between your code and
the web" is where every front-end tool claims to sit.

Now:

> **React at its best,**
> **typed by Flow.**

That is the promise the rest of the page is evidence for, and it names both
halves a reader needs in order to place uf at all: React, and Flow.

It can afford to be a claim rather than a description because the two lines
around it already carry the mechanism — the eyebrow above says "Unified
toolchain for Flow", and the lede below says "uf runs, builds, tests, formats
and lints Flow and React from a single command."

Nothing else changes. The metadata description — the line search results and
link previews show — already said what the binary does in plain words:

> One binary that runs, builds, tests, formats and lints Flow and React. No
> Babel, no plugin list, no second config file.

## Exit codes

`tools/docs/build.sh` 0 · `uf lint` 0 · `uf fmt --check` 0.

Rendered, from `docs/dist/docs/index.html`:

```
React at its best, typed by Flow.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791299151&installation_model_id=422833&pr_number=413&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F413&signature=a45faa7a0426057fa1627449cb60ba6da363287991b69faa32a55399efd90ebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->