### PR TITLE
fix(test): the packaging check reads code, not the prose beside it

### DIFF
--- a/tests/library/published-packages.test.js
+++ b/tests/library/published-packages.test.js
@@ -73,19 +73,84 @@ const exportTargets = (node: mixed, into: Array<string>): Array<string> => {
 };
 
 /**
+ * `source` with its comments replaced by spaces, and everything else — the
+ * string, template and regular-expression literals included — left where it
+ * was.
+ *
+ * Scanning raw source for import specifiers reads the ones inside comments
+ * too, and a package whose comment shows `await import("./client.js")` as an
+ * example was reported as publishing a file it does not have. Deleting the
+ * comments first is the whole fix, and doing it correctly means knowing when a
+ * `/` opens one: inside a string it does not, and after a value a `/` is
+ * division rather than the start of a regular expression whose body could
+ * contain `//`.
+ *
+ * Comments become spaces rather than nothing so that every offset, and so
+ * every line, is the one the file has.
+ */
+const withoutComments = (source: string): string => {
+  const out = source.split("");
+  const blank = (from: number, to: number) => {
+    for (let at = from; at < to; at += 1) if (out[at] !== "\n") out[at] = " ";
+  };
+  // The last thing that could end a value. A `/` after one is division; a `/`
+  // anywhere else opens a regular expression.
+  let afterValue = false;
+  let at = 0;
+  while (at < source.length) {
+    const char = source[at];
+    if (char === "/" && source[at + 1] === "/") {
+      let end = source.indexOf("\n", at);
+      if (end === -1) end = source.length;
+      blank(at, end);
+      at = end;
+    } else if (char === "/" && source[at + 1] === "*") {
+      const end = source.indexOf("*/", at + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      blank(at, stop);
+      at = stop;
+    } else if (char === '"' || char === "'" || char === "`") {
+      at += 1;
+      while (at < source.length && source[at] !== char) {
+        at += source[at] === "\\" ? 2 : 1;
+      }
+      at += 1;
+      afterValue = true;
+    } else if (char === "/" && !afterValue) {
+      at += 1;
+      let inClass = false;
+      while (at < source.length && (inClass || source[at] !== "/")) {
+        if (source[at] === "\\") at += 1;
+        else if (source[at] === "[") inClass = true;
+        else if (source[at] === "]") inClass = false;
+        at += 1;
+      }
+      at += 1;
+      afterValue = true;
+    } else {
+      if (!/\s/.test(char)) afterValue = /[\w$)\].]/.test(char);
+      at += 1;
+    }
+  }
+  return out.join("");
+};
+
+/**
  * The relative specifiers `source` imports.
  *
- * A regular expression, not a parser, because the packages are ordinary ESM
- * and the question is only which relative paths appear in an import position.
- * `the scan finds the imports it is looking for` below holds it to that: a
- * pattern that quietly stopped matching would make every assertion here pass
- * over nothing, which is the one way this test could rot without failing.
+ * A regular expression over the comment-free source, not a parser, because
+ * the packages are ordinary ESM and the question is only which relative paths
+ * appear in an import position. `the scan reads code and not prose` below
+ * holds it to that: a pattern that quietly stopped matching would make every
+ * assertion here pass over nothing, which is the one way this test could rot
+ * without failing.
  */
 const relativeImports = (source: string): Array<string> => {
   const pattern = /(?:\bfrom|\bimport|\brequire)\s*\(?\s*["'](\.[^"']*)["']/g;
+  const code = withoutComments(source);
   const found = [];
   let match;
-  while ((match = pattern.exec(source)) !== null) found.push(match[1]);
+  while ((match = pattern.exec(code)) !== null) found.push(match[1]);
   return found;
 };
 
@@ -114,6 +179,36 @@ describe("what the published packages pack", () => {
     expect(
       relativeImports(`import x from "./a.js";\nconst y = await import('../b/c.js');`),
     ).toEqual(["./a.js", "../b/c.js"]);
+  });
+
+  it("the scan reads code and not prose", () => {
+    // The other half of the same guard, and the one that was missing: a
+    // package documenting `import("./client.js")` in a comment was reported
+    // as publishing a file it does not have.
+    expect(relativeImports(`// see await import("./doc.js")\nimport a from "./real.js";`)).toEqual([
+      "./real.js",
+    ]);
+    expect(
+      relativeImports(`/* import x from "./block.js"; */\nimport a from "./real.js";`),
+    ).toEqual(["./real.js"]);
+
+    // And the two places a `/` is not the start of a comment. Blanking either
+    // would eat the import that follows it.
+    expect(relativeImports(`const u = "https://x//y";\nimport a from "./real.js";`)).toEqual([
+      "./real.js",
+    ]);
+    expect(relativeImports(`const r = /a\\/\\/b/;\nimport a from "./real.js";`)).toEqual([
+      "./real.js",
+    ]);
+    expect(relativeImports('const t = `//${x}`;\nimport a from "./real.js";')).toEqual([
+      "./real.js",
+    ]);
+
+    // Division, so the `/` is not a regular expression that would swallow the
+    // rest of the line.
+    expect(relativeImports(`const n = a / b / c;\nimport a from "./real.js";`)).toEqual([
+      "./real.js",
+    ]);
   });
 
   // One `npm pack` per package, read by both assertions. The packages are


### PR DESCRIPTION
#410 added a test that every published package ships the files its own modules
import. It scanned the raw source, so it read the specifiers inside comments
too. A package whose comment shows an example import —

```js
//   * so `await import("./client.js")` — after the mock — is how a test reaches
```

— was reported as publishing a file it does not have:

```
✗ what the published packages pack > every package publishes every file its published files import
    expected ["@uniflowed/test: internal/modules.js imports ./client.js"] to equal []
```

Found by the branch for #283, on a comment that is entirely correct. Left alone
it would reject any package that documents an import, which is most of them
eventually.

## The fix, and the part of it that is not obvious

The comments are removed before the scan. Doing that correctly means knowing
when a `/` opens one:

- inside a string, a template or a regular expression, `/` opens nothing;
- after a value, `/` is division — not the start of a regular expression whose
  body could contain `//`.

Blanking either of those would swallow the rest of the line, and the import on
the line after it with no failure to show for it. Comments become spaces rather
than nothing, so every offset — and so every line — is still the one the file
has.

## What holds it

`the scan reads code and not prose` covers all six cases, each beside a real
import that has to survive the pass:

| in the source | what the scan must return |
|---|---|
| `// see await import("./doc.js")` | only `./real.js` |
| `/* import x from "./block.js"; */` | only `./real.js` |
| `const u = "https://x//y";` | only `./real.js` |
| ``const r = /a\/\/b/;`` | only `./real.js` |
| ``const t = `//${x}`;`` | only `./real.js` |
| `const n = a / b / c;` | only `./real.js` |

The existing guard is unchanged: the scanner still has to find the import #409
was about in the real `internal/node-hooks.js`, so one that stopped matching
cannot pass by matching nothing.

## Exit codes

`uf test#library` 0 (1590 passed, 1 skipped) · `uf lint` 0 · `uf fmt --check` 0.

And against the tree that found it — the #283 branch, unmodified except for this
file — `4 passed, 0 failed`, where it had reported the false positive above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791299692&installation_model_id=422833&pr_number=414&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F414&signature=61dcdad0226c186b3498f1c591aed58cfb38d7bbef163b279c15cd2e2196f3d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->