### PR TITLE
docs: sharpen uf React hero copy

### DIFF
--- a/docs/app/_uf.layout.js
+++ b/docs/app/_uf.layout.js
@@ -26,7 +26,7 @@ const VERSION = "0.0.0-alpha";
 export const metadata: {| readonly title: string, readonly description: string |} = {
   title: "uf — Unified Toolchain for Flow",
   description:
-    "One binary that runs, builds, tests, formats and lints Flow and React. No Babel, no plugin list, no second config file.",
+    "The best React experience for Flow: run, build, test, format and lint from one command, without Babel or plugin assembly.",
 };
 
 /**

--- a/docs/app/_uf.page.js
+++ b/docs/app/_uf.page.js
@@ -2,12 +2,10 @@
 //
 // The home page.
 //
-// The heading says what uf is for: writing React, in Flow, better than the
-// assembled toolchains do. That is the promise, and everything under it is
-// the evidence — one command, and what that command really prints. The
-// heading used to be "One binary between your code and the web", which
-// described uf's shape rather than what it gets you, and left a reader who
-// had never heard of uf to work out what the binary was for.
+// The heading says what uf is for: the best React experience for Flow, with
+// the assembled toolchain collapsed into one command. That is the promise,
+// and everything under it is the evidence — one command, and what that
+// command really prints.
 //
 // Every claim below links to the page that backs it, and the ones uf loses
 // are on that list too.
@@ -50,7 +48,7 @@ export default component Home() {
         <div className="hero-copy">
           <Eyebrow>Unified toolchain for Flow</Eyebrow>
           <h1>
-            React at its best,
+            The best React experience,
             <br />
             typed by Flow.
           </h1>


### PR DESCRIPTION
## Summary
- revise the uf home hero around a clearer Flow-powered React experience claim
- align the default metadata description with that positioning
- remove the old binary-first framing from the home-page source comment

## Verification
- git diff --check
- rg -n "codex" docs/app/_uf.page.js docs/app/_uf.layout.js

## Notes
- The docs build is covered by the GitHub Actions docs jobs for this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791303467&installation_model_id=422833&pr_number=440&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F440&signature=3392d28e094b8d0de52f4d6c546b1b74a77225134f4b0b989fec4cf9a7b03553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->