### PR TITLE
fix(release): the release verification parses under the shell that runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,13 @@ jobs:
       # It reads the two files rather than asking npm to regenerate one, so
       # nothing but these cases says it works.
       - run: ./target/release/uf run lockfile:test
+      # And that every shell script in the repository parses under the shell
+      # this runner uses. `uf@0.0.0-alpha.8` published all seventeen packages
+      # and the release was reported as failed, over a `verify-npm.sh` that
+      # dash would not parse and bash would — and bash is `/bin/sh` on the
+      # laptop it was written on. `sh -n` reads and does not run.
+      - run: ./target/release/uf run scripts:parse
+      - run: ./target/release/uf run scripts:parse:test
       # And that the set that goes to npm is closed under its own
       # dependencies. `@uniflowed/stylex` depends on `@uniflowed/core`, so a
       # release that sends one without the other publishes a package that

--- a/tools/ci/scripts-parse.sh
+++ b/tools/ci/scripts-parse.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Every shell script in this repository parses under a POSIX shell.
+#
+# `uf@0.0.0-alpha.8` published all seventeen packages and the release was
+# reported as failed, because `tools/release/verify-npm.sh` would not parse:
+#
+#     tools/release/verify-npm.sh: 1: Syntax error: end of file unexpected
+#
+# The script had been correct for weeks under the shell it was written with.
+# These scripts say `#!/usr/bin/env sh` or `#!/bin/sh`, and what that means
+# depends on the machine: `/bin/sh` is bash on macOS, where every contributor
+# writes them, and dash on Ubuntu, where CI runs them. Bash accepts things dash
+# refuses, so a script can be committed, reviewed and merged, and first fail in
+# the one job nobody wants to be the first to run it.
+#
+# In that case the difference was a here-document opened with an unquoted
+# delimiter, whose body used backticks as punctuation. To a shell a backtick in
+# an unquoted here-document is command substitution, and the body contained
+# `@uniflowed/<name>` — a redirection with nothing after the `>`. Bash deferred
+# the complaint; dash refused the file. Printing that message would also have
+# *run* `npm trust` and `tools/release/bootstrap-publish.sh`, which is the
+# reason this check is worth having beyond the parse itself.
+#
+# `sh -n` reads a script and does not run it, so this costs a few milliseconds
+# per file and can gate every pull request. It answers only "does it parse" —
+# `shellcheck` is the tool for the rest, and this is deliberately not that:
+# a parse failure is not a style opinion, and it should never need a waiver.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+# The shell CI actually uses. `dash` where it exists, so a contributor on macOS
+# gets the answer the Ubuntu runner will give rather than the one bash gives.
+shell=sh
+if command -v dash >/dev/null 2>&1; then
+  shell=dash
+fi
+echo "scripts-parse: checking with $shell"
+
+# Tracked files only: a scratch directory or a dependency's script is not this
+# repository's to answer for. `upstream/flow` is a submodule and is Meta's.
+scripts="$(git ls-files '*.sh' | grep -v '^upstream/')"
+
+failed=""
+count=0
+for script in $scripts; do
+  count=$((count + 1))
+  if ! output="$("$shell" -n "$script" 2>&1)"; then
+    printf '  broken     %s\n' "$script"
+    printf '             %s\n' "$output"
+    failed="$failed $script"
+  fi
+done
+
+if [ -n "$failed" ]; then
+  printf '\nThese do not parse under %s:%s\n' "$shell" "$failed" >&2
+  printf '\nThey may still run under bash. `/bin/sh` is bash on macOS and dash on the\n' >&2
+  printf 'CI runner, so a script that only bash accepts fails where it is least\n' >&2
+  printf 'convenient. Run `%s -n <script>` to see it locally.\n' "$shell" >&2
+  exit 1
+fi
+
+printf '  %s scripts parse\n' "$count"

--- a/tools/ci/test-scripts-parse.sh
+++ b/tools/ci/test-scripts-parse.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# `scripts-parse.sh` against a repository it can safely make wrong.
+#
+# The check is one line of real work, so what is worth testing is that it
+# *notices*. A guard that reports success over an empty list is the failure it
+# was written to prevent, wearing a green tick — and the bug it exists for,
+# `uf@0.0.0-alpha.8`'s `verify-npm.sh`, was a script that had passed every
+# review and every local run.
+#
+# So: the exact shape that broke, planted in a scratch repository, and a check
+# that the guard fails on it and passes without it.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+script="$repo_root/tools/ci/scripts-parse.sh"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-scripts-parse.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+fail() {
+  echo "test-scripts-parse: FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+# A repository with the check in it and one script beside it. `git ls-files` is
+# what the check reads, so this has to be a real repository with real commits.
+scratch() {
+  root="$work/$1"
+  rm -rf "$root"
+  mkdir -p "$root/tools/ci"
+  cp "$script" "$root/tools/ci/scripts-parse.sh"
+  printf '#!/bin/sh\necho fine\n' > "$root/tools/ci/subject.sh"
+  ( cd "$root" \
+    && git init -q . \
+    && git add -A \
+    && git -c user.email=t@e -c user.name=t commit -qm one ) >/dev/null 2>&1
+  echo "$root"
+}
+
+# 1. A repository whose scripts all parse.
+root="$(scratch clean)"
+( cd "$root" && sh tools/ci/scripts-parse.sh >/dev/null 2>&1 ) \
+  || fail "rejected a repository in which every script parses"
+pass "passes when every script parses"
+
+# 2. The shape that broke the alpha.8 release: an unquoted here-document whose
+#    body has a backtick around something containing `>`.
+root="$(scratch broken)"
+cat > "$root/tools/ci/subject.sh" <<'SUBJECT'
+#!/bin/sh
+cat >&2 <<MESSAGE
+look for `npm notice @uniflowed/<name>`
+MESSAGE
+SUBJECT
+if ( cd "$root" && sh tools/ci/scripts-parse.sh >/dev/null 2>&1 ); then
+  fail "accepted an unquoted here-document with a backtick redirection in it"
+fi
+pass "rejects the here-document that broke uf@0.0.0-alpha.8"
+
+# 3. And it is the *parse* it objects to, not the file's name or its presence:
+#    quoting the delimiter is the fix, and the same file then passes.
+cat > "$root/tools/ci/subject.sh" <<'SUBJECT'
+#!/bin/sh
+cat >&2 <<'MESSAGE'
+look for `npm notice @uniflowed/<name>`
+MESSAGE
+SUBJECT
+( cd "$root" && sh tools/ci/scripts-parse.sh >/dev/null 2>&1 ) \
+  || fail "still rejected the file after the delimiter was quoted"
+pass "accepts the same body once the delimiter is quoted"
+
+# 4. An untracked script is not this repository's to answer for, and a check
+#    that read the working tree instead of the index would fail on one.
+printf '#!/bin/sh\nif [ ; then\n' > "$root/tools/ci/untracked.sh"
+( cd "$root" && sh tools/ci/scripts-parse.sh >/dev/null 2>&1 ) \
+  || fail "read an untracked file that git does not track"
+pass "ignores an untracked script"
+
+echo "test-scripts-parse: ok"

--- a/tools/release/verify-npm.sh
+++ b/tools/release/verify-npm.sh
@@ -60,12 +60,10 @@ for name in $packages; do
 done
 
 if [ -n "$missing_closure" ]; then
-  cat >&2 <<MESSAGE
-
-Not closed:$missing_closure
-
-A package whose dependency is not published resolves to nothing. Either add
-the dependency to $list — and bind it with
+  printf '\nNot closed:%s\n' "$missing_closure" >&2
+  printf '\nA package whose dependency is not published resolves to nothing. Either add\n' >&2
+  printf 'the dependency to %s — and bind it with\n' "$list" >&2
+  cat >&2 <<'MESSAGE'
 tools/release/trust-npm.sh — or take the dependent out.
 MESSAGE
   exit 1
@@ -162,12 +160,22 @@ for name in $absent; do
 done
 
 if [ -n "$absent" ]; then
-  cat >&2 <<MESSAGE
-
-Not on the registry at $version:$absent
-
-The tag says this version was released. npm does not have it after retrying for
-$WAIT_SECONDS seconds, so nobody can install it.
+  printf '\nNot on the registry at %s:%s\n' "$version" "$absent" >&2
+  printf '\nThe tag says this version was released. npm does not have it after retrying for\n' >&2
+  printf '%s seconds, so nobody can install it.\n' "$WAIT_SECONDS" >&2
+  # Quoted delimiter, and it has to stay quoted: the body below is full of
+  # backticks, and in an unquoted here-document a backtick is command
+  # substitution, not punctuation. This message used to be written with an
+  # unquoted `<<MESSAGE`, and `sh` — dash on Ubuntu, where this runs — refused
+  # to parse the whole script over it, because `@uniflowed/<name>` inside a
+  # backtick is a redirection with nothing after the `>`:
+  #
+  #     tools/release/verify-npm.sh: 1: Syntax error: end of file unexpected
+  #
+  # Every package of `uf@0.0.0-alpha.8` was on npm and this job reported the
+  # release as failed. Had it parsed, printing the message would have *run*
+  # `npm trust` and `tools/release/bootstrap-publish.sh`.
+  cat >&2 <<'MESSAGE'
 
 Two things this can be, and they are told apart by the publish job above:
 
@@ -175,7 +183,7 @@ Two things this can be, and they are told apart by the publish job above:
     in that job. If it is absent, the name is not bound by `npm trust` and
     `tools/release/bootstrap-publish.sh` has not been run for it. See #210.
   * npm accepted it and the registry had not caught up. The notice is there,
-    and `npm view @uniflowed/<name>@$version` answers now. Re-run this job.
+    and `npm view @uniflowed/<name>@<version>` answers now. Re-run this job.
 
 Either way npm is additive, so the names that did go out stay.
 MESSAGE

--- a/uf.config.js
+++ b/uf.config.js
@@ -247,6 +247,15 @@ export default defineConfig({
     // package was added and the lock was not regenerated, each reporting a
     // package none of those jobs is about. This says it once, where the
     // manifests are the subject.
+    // And that every shell script in the repository parses under the shell CI
+    // uses. `uf@0.0.0-alpha.8` published all seventeen packages and the release
+    // was reported as failed, because `verify-npm.sh` would not parse: an
+    // unquoted here-document whose body used backticks as punctuation, which a
+    // shell reads as command substitution. It had been correct for weeks —
+    // under bash, which is `/bin/sh` on a laptop, where dash is `/bin/sh` on
+    // the runner. `sh -n` reads and does not run, so this costs milliseconds.
+    "scripts:parse": "tools/ci/scripts-parse.sh",
+    "scripts:parse:test": "tools/ci/test-scripts-parse.sh",
     lockfile: "tools/ci/lockfile-in-sync.sh",
     // The check reads the lock rather than regenerating it, so every way a
     // lock can fall behind has to be written down as a case. Its first
@@ -287,6 +296,8 @@ export default defineConfig({
         "manifests",
         "lockfile",
         "lockfile:test",
+        "scripts:parse",
+        "scripts:parse:test",
         "release:closure",
         "publishable",
         "publishable:test",


### PR DESCRIPTION
`uf@0.0.0-alpha.8` published all seventeen packages, and the release was
reported as failed:

```
  on npm      @uniflowed/config@0.0.0-alpha.8
  …seventeen of these…
tools/release/verify-npm.sh: 1: Syntax error: end of file unexpected
##[error]Process completed with exit code 2
```

Nothing was wrong with the release. `verify-npm.sh` would not parse.

## Why bash accepted it and the runner did not

Its failure message is a here-document opened with an unquoted delimiter, and
its body writes shell names in backticks as punctuation:

```sh
cat >&2 <<MESSAGE
  * npm never accepted the name — look for `npm notice 📦  @uniflowed/<name>`
    in that job. If it is absent, the name is not bound by `npm trust` and
    `tools/release/bootstrap-publish.sh` has not been run for it. See #210.
MESSAGE
```

To a shell, a backtick in an **unquoted** here-document is command
substitution — the body is code. And inside one of those, `@uniflowed/<name>`
is a redirection with nothing after the `>`, so the parser reaches the closing
backtick still waiting for a filename. dash refuses the whole file and reports
line 1; bash defers the complaint.

`/bin/sh` is bash on the macOS laptop these scripts are written on, and dash on
the Ubuntu runner. So it was correct locally for weeks and failed in the one job
nobody wants to be the first to run it.

Had it parsed, printing that message would have **run** `npm trust` and
`tools/release/bootstrap-publish.sh`.

Both here-documents are quoted now, with the two values each needs printed
before them.

## The class, not the instance

`tools/ci/scripts-parse.sh` runs `sh -n` — dash where it exists, so a
contributor on macOS gets the answer the runner will give — over every tracked
`*.sh`. It reads and does not run, so it costs milliseconds and can gate every
pull request. It is in `uf run ci` and in CI's Metadata job.

Against `main`'s tree:

```
scripts-parse: checking with dash
  broken     tools/release/verify-npm.sh
             tools/release/verify-npm.sh: 1: Syntax error: end of file unexpected

These do not parse under dash: tools/release/verify-npm.sh

They may still run under bash. `/bin/sh` is bash on macOS and dash on the
CI runner, so a script that only bash accepts fails where it is least
convenient. Run `dash -n <script>` to see it locally.
```

With this branch: `24 scripts parse`.

It answers only "does it parse". `shellcheck` is the tool for the rest, and this
is deliberately not that: a parse failure is not a style opinion and should
never need a waiver.

## What holds the guard

`test-scripts-parse.sh`, from a scratch repository — because a guard that
reports success over an empty list is the failure it was written to prevent,
wearing a green tick:

```
  ok  passes when every script parses
  ok  rejects the here-document that broke uf@0.0.0-alpha.8
  ok  accepts the same body once the delimiter is quoted
  ok  ignores an untracked script
```

The second and third are the same file twice, differing only in whether the
delimiter is quoted, so the test pins the actual rule rather than the filename.
The fourth exists because a check that read the working tree instead of the
index would fail on anybody's scratch script.

## Exit codes

`uf run scripts:parse` 0 · `uf run scripts:parse:test` 0 ·
`uf run release:closure` 0 · `uf test#library` 0 (1635 passed, 1 skipped) ·
`uf lint` 0 · `uf fmt --check` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791306500&installation_model_id=422833&pr_number=444&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F444&signature=e07c986012a84302bd66e9e17d36c468f95549c4740cd930688b14a9a79b0542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->