### PR TITLE
docs: sharpen Modern Flow React tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # uf
 
-**The best React experience, typed by Flow.**
+**Build the strongest React development experience with Modern Flow.**
 
 [Documentation](https://docs.uniflowed.dev) ·
 [Install](https://docs.uniflowed.dev/guide/install) ·

--- a/brand/index.js
+++ b/brand/index.js
@@ -15,7 +15,7 @@ export const ufBrand = {
   name: "uf",
   fullName: "uniflowed",
   headline: "Unified Toolchain for Flow",
-  tagline: "All-in-one toolchain for Flow and React.",
+  tagline: "Build the strongest React development experience with Modern Flow.",
 };
 
 export const ufBrandAssets = {

--- a/brand/tokens.json
+++ b/brand/tokens.json
@@ -2,7 +2,7 @@
   "name": "uf",
   "fullName": "uniflowed",
   "headline": "Unified Toolchain for Flow",
-  "tagline": "All-in-one toolchain for Flow and React.",
+  "tagline": "Build the strongest React development experience with Modern Flow.",
   "assets": {
     "sourceMark": "brand/uf.png",
     "primaryLogo": "brand/uniflowed-logo.png",

--- a/crates/uf_cli/src/brand.rs
+++ b/crates/uf_cli/src/brand.rs
@@ -6,7 +6,8 @@ use uf_term::{
 };
 
 pub(crate) const HEADLINE: &str = "Unified Toolchain for Flow";
-pub(crate) const TAGLINE: &str = "All-in-one toolchain for Flow and React.";
+pub(crate) const TAGLINE: &str =
+    "Build the strongest React development experience with Modern Flow.";
 pub(crate) const DOCS_URL: &str = "https://docs.uniflowed.dev";
 pub(crate) const CURL_INSTALL: &str = "curl -fsSL https://setup.uniflowed.dev | sh";
 pub(crate) const NIX_RUN: &str = "nix run github:ubugeeei-prod/uf#uf -- --version";

--- a/docs/app/_uf.page.js
+++ b/docs/app/_uf.page.js
@@ -2,10 +2,9 @@
 //
 // The home page.
 //
-// The heading says what uf is for: the best React experience for Flow, with
-// the assembled toolchain collapsed into one command. That is the promise,
-// and everything under it is the evidence — one command, and what that
-// command really prints.
+// The heading says what uf is for: the strongest React development experience
+// with Modern Flow. Everything under it is evidence: one command, and what
+// that command really prints.
 //
 // Every claim below links to the page that backs it, and the ones uf loses
 // are on that list too.
@@ -48,13 +47,14 @@ export default component Home() {
         <div className="hero-copy">
           <Eyebrow>Unified toolchain for Flow</Eyebrow>
           <h1>
-            The best React experience,
+            Build the strongest React
             <br />
-            typed by Flow.
+            experience with Modern Flow.
           </h1>
           <Lede>
-            uf runs, builds, tests, formats and lints Flow and React from a single command. No Babel
-            in the pipeline, no plugin list to assemble, and one config file for all of it.
+            uf gives Flow-first React apps one native command for dev, builds, tests, formatting and
+            linting. The official Flow parser, React Compiler and oxc stay in the same toolchain,
+            with one config file for the whole path.
           </Lede>
         </div>
 

--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -434,7 +434,7 @@ uf_brand() {
     printf '  %s\n\n' "Unified Toolchain for Flow" >&2
   else
     printf '  \033[1m%s\033[0m \033[2m%s\033[0m\n\n' \
-      "Unified Toolchain for Flow" "· one binary for Flow and React" >&2
+      "Unified Toolchain for Flow" "· Build the strongest React development experience with Modern Flow" >&2
   fi
 }
 

--- a/packages/brand/index.js
+++ b/packages/brand/index.js
@@ -17,7 +17,7 @@ export const ufBrand = {
   name: "uf",
   fullName: "uniflowed",
   headline: "Unified Toolchain for Flow",
-  tagline: "All-in-one toolchain for Flow and React.",
+  tagline: "Build the strongest React development experience with Modern Flow.",
 };
 
 export const ufBrandAssets = {


### PR DESCRIPTION
## Summary
- replace the home-page hero copy with the Modern Flow React promise
- align brand tokens, package brand metadata, CLI brand text, and installer banner
- keep the unified toolchain headline as the product category while making the catch clearer

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- stale copy search: no matches for `One binary between`, `one binary for Flow and React`, `All-in-one toolchain for Flow and React`, or `The best React experience, typed by Flow`

## Local note
- `cargo test -p uf_cli --test output renders_the_brand` was blocked because this fresh worktree has no hydrated `upstream/flow/rust_port/crates/flow_aloc` checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791315205&installation_model_id=422833&pr_number=448&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F448&signature=86e9f5340866325fcda7c6091ebd81b8e0555f528f213baad4ac5d999a1e55e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->