### PR TITLE
fix(install): the banner fits the terminal it is printed to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,10 @@ jobs:
       # and the release was reported as failed, over a `verify-npm.sh` that
       # dash would not parse and bash would — and bash is `/bin/sh` on the
       # laptop it was written on. `sh -n` reads and does not run.
+      # And that the installer's banner fits an eighty-column terminal — the
+      # first thing anybody sees from `curl … | sh`, and a line wider than the
+      # window wraps without its indent.
+      - run: ./target/release/uf run install:banner
       - run: ./target/release/uf run scripts:parse
       - run: ./target/release/uf run scripts:parse:test
       # And that the set that goes to npm is closed under its own

--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -426,6 +426,17 @@ uf_logo_blocks() {
   uf_paint '216;75;255'  "   ██████    ██"
 }
 
+# The headline, and the tagline under it rather than beside it.
+#
+# They shared a line until the tagline grew: "Unified Toolchain for Flow ·
+# Build the strongest React development experience with Modern Flow" is 96
+# columns with the indent, against a terminal that is 80 by default. It wrapped
+# mid-sentence onto a second line with no indent, as the first thing anybody
+# sees from `curl … | sh`.
+#
+# Two lines, each measured: 28 columns and at most 72. Nothing here asks the
+# terminal how wide it is — a `tput cols` needs a terminal this may not have,
+# and the installer's whole job is to work before anything is installed.
 uf_brand() {
   printf '\n' >&2
   uf_logo_image || uf_logo_blocks
@@ -433,8 +444,9 @@ uf_brand() {
   if [ -z "$uf_colour" ]; then
     printf '  %s\n\n' "Unified Toolchain for Flow" >&2
   else
-    printf '  \033[1m%s\033[0m \033[2m%s\033[0m\n\n' \
-      "Unified Toolchain for Flow" "· Build the strongest React development experience with Modern Flow" >&2
+    printf '  \033[1m%s\033[0m\n' "Unified Toolchain for Flow" >&2
+    printf '  \033[2m%s\033[0m\n\n' \
+      "Build the strongest React development experience with Modern Flow" >&2
   fi
 }
 

--- a/tools/ci/install-banner-fits.sh
+++ b/tools/ci/install-banner-fits.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# The installer's banner fits in an eighty-column terminal.
+#
+# `curl -fsSL https://setup.uniflowed.dev | sh` prints a mark and two lines of
+# text before it does anything, and those lines are the first uf a person sees.
+# They shared one line until the tagline grew, and
+#
+#   Unified Toolchain for Flow · Build the strongest React development experience with Modern Flow
+#
+# is ninety-six columns with its indent. Eighty is the default width of every
+# terminal emulator worth naming, so it wrapped mid-sentence onto a second line
+# with no indent.
+#
+# The installer cannot ask how wide the terminal is: `tput` needs a terminfo
+# database and a `TERM` that may be `dumb`, `stty` needs a controlling terminal
+# that a piped `sh` does not have, and the whole point of the script is to work
+# before anything is installed. So the width is a property of the text, and
+# this is where that is checked.
+#
+# It runs the real `uf_brand`, extracted from the real installer, rather than
+# measuring string literals a refactor could move: what is being asked is what
+# a person sees, not what the source says.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+installer="$repo_root/infra/cloudflare/setup-assets/install.sh"
+
+LIMIT="${UF_BANNER_COLUMNS:-80}"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-banner.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+# `uf_brand` and nothing else: the file installs things when it is sourced.
+awk '/^uf_brand\(\) \{$/,/^\}$/' "$installer" > "$work/brand.sh"
+if [ ! -s "$work/brand.sh" ]; then
+  echo "install-banner: could not find uf_brand() in $installer" >&2
+  echo "install-banner: if it was renamed, this check has to be told" >&2
+  exit 1
+fi
+
+widest=0
+for colour in "" "1"; do
+  (
+    # The mark is drawn by these two and is a picture, not text.
+    uf_logo_image() { return 0; }
+    uf_logo_blocks() { return 0; }
+    uf_colour="$colour"
+    . "$work/brand.sh"
+    uf_brand
+  ) 2>"$work/out.$colour" >/dev/null
+
+  # Strip the escape sequences: a bold marker is zero columns wide on screen.
+  python3 - "$work/out.$colour" "$LIMIT" <<'PY' || exit 1
+import re, sys
+text = open(sys.argv[1], encoding="utf8").read()
+limit = int(sys.argv[2])
+bad = []
+widest = 0
+for line in text.split("\n"):
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", line)
+    widest = max(widest, len(plain))
+    if len(plain) > limit:
+        bad.append((len(plain), plain))
+print(f"  widest {widest} columns")
+for width, line in bad:
+    print(f"  {width} columns: {line}", file=sys.stderr)
+if bad:
+    print(f"\nThe installer's banner does not fit in {limit} columns.", file=sys.stderr)
+    print("It is the first thing anybody sees from `curl … | sh`, and a line", file=sys.stderr)
+    print("wider than the terminal wraps without its indent.", file=sys.stderr)
+    sys.exit(1)
+PY
+done
+
+echo "install-banner: fits in $LIMIT columns"

--- a/uf.config.js
+++ b/uf.config.js
@@ -266,6 +266,13 @@ export default defineConfig({
     // shell reads as command substitution. It had been correct for weeks —
     // under bash, which is `/bin/sh` on a laptop, where dash is `/bin/sh` on
     // the runner. `sh -n` reads and does not run, so this costs milliseconds.
+    // And that the installer's banner fits an eighty-column terminal. The two
+    // lines `curl … | sh` prints before it does anything are the first uf
+    // anybody sees, and they shared one line until the tagline grew to
+    // ninety-six columns with its indent — wrapping mid-sentence onto a second
+    // line with no indent. The installer cannot ask how wide the terminal is,
+    // so the width is a property of the text and is checked here.
+    "install:banner": "tools/ci/install-banner-fits.sh",
     "scripts:parse": "tools/ci/scripts-parse.sh",
     "scripts:parse:test": "tools/ci/test-scripts-parse.sh",
     lockfile: "tools/ci/lockfile-in-sync.sh",
@@ -308,6 +315,7 @@ export default defineConfig({
         "manifests",
         "lockfile",
         "lockfile:test",
+        "install:banner",
         "scripts:parse",
         "scripts:parse:test",
         "release:closure",


### PR DESCRIPTION
#448 gave the installer the new tagline and left it on the headline's line:

```
  Unified Toolchain for Flow · Build the strongest React development experience with Modern Flow
```

That is **96 columns** with the indent, against a terminal that is 80 by
default. It wrapped mid-sentence onto a second line with no indent — as the
first thing anybody sees from `curl -fsSL https://setup.uniflowed.dev | sh`.

The tagline goes under the headline now: 28 columns and 67. **The wording is
untouched**, and so is the no-colour branch, which prints the headline alone as
it always did.

## Why this is checked rather than remembered

The installer cannot ask how wide the terminal is. `tput` needs a terminfo
database and a `TERM` that may be `dumb`, `stty` needs a controlling terminal a
piped `sh` does not have, and the script's whole job is to work before anything
is installed. So the width is a property of the text, and
`tools/ci/install-banner-fits.sh` is where that property is checked — in
`uf run ci` and in CI's Metadata job.

It runs the **real** `uf_brand`, extracted from the real installer with its two
picture-drawing helpers stubbed, in both the colour and no-colour branches, and
measures what a person sees — escape sequences stripped, because a bold marker
is zero columns wide on screen. What is being asked is what lands on the
terminal, not what the source says, so a refactor that moves the strings does
not move the check.

Against `main`:

```
  96 columns:   Unified Toolchain for Flow · Build the strongest React development experience with Modern Flow

The installer's banner does not fit in 80 columns.
It is the first thing anybody sees from `curl … | sh`, and a line
wider than the terminal wraps without its indent.
```

With this commit:

```
  widest 28 columns
  widest 67 columns
install-banner: fits in 80 columns
```

## Exit codes

`uf run install:banner` 0 · `uf run scripts:parse` 0 (26 scripts) · `uf lint` 0 ·
`uf fmt --check` 0 Flow files of 301 need formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791319455&installation_model_id=422833&pr_number=452&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F452&signature=db69b13080bf8341c8cb3769dea4b19df6551fd1cf0afe1d4fe34a928e928650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->