### PR TITLE
chore(release): the coverage work is in alpha.9 too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ walked down the screen.
 
 ### Added
 
+- **test**: coverage in the author's Flow lines, with thresholds and a reporter CI can read (#456)
 - **assets, web, vite**: Image and Font get the pipeline they were markup for (#454)
 - **tui, term**: a scroll box, a real terminal size, and React Ink measured (#449)
 - **ui**: an overlay that flips and slides, and the three components on it (#421)


### PR DESCRIPTION
#456 merged between the alpha.9 release branch's last catch-up and the release
branch's own merge, so `uf@0.0.0-alpha.9`'s notes name fifteen pull requests and
the tag will contain sixteen.

**The tag is not cut yet**, which is the only reason this is a one-line fix
rather than a release that went out short.

```
in range: 15 | listed: 16 | missing: []
```

## The window this fell through

`tools/ci/changelog-covers-the-release.sh` and `$SP/release-catchup` both ask
"which pull requests in the range does the section not name". Both were run and
both said the section was complete — because #456 did not exist in the range
when they ran. The window is between the last catch-up and the release commit's
own merge, and running the check once more does not close it: something can
always merge after the last time you looked.

This is the third change the changelog has lost to the same shape of race —
`uf@0.0.0-alpha.5` went out with twenty-two commits and twelve in its notes, and
#443 is about a fourth door into the same room. What would actually close it is
making the notes a function of the tag rather than of a branch written before
it: the check that matters is the one between `git tag` and the release job, not
the one before the release pull request merges.

That decision belongs in #443. This commit is the entry.

## Exit codes

`uf run release:changelog` 0 · `uf fmt --check` reports `0 files of 309 need
formatting`; it exits 1 only because this repository names Biome in
`uf.config.js` and Biome is not installed on this machine, which is #446's
deliberate behaviour for a formatter the project asked for by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791324742&installation_model_id=422833&pr_number=459&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F459&signature=7b258b5695e64e02be8587e3c40ff09667782848989b091c9ba1f632515825c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->