### PR TITLE
fix(test): the stub formatter is run once before it is relied on

### DIFF
--- a/crates/uf_fmt/src/non_flow/tests.rs
+++ b/crates/uf_fmt/src/non_flow/tests.rs
@@ -395,4 +395,35 @@ fn stub_formatter(root: &Utf8Path) {
         .permissions();
     permissions.set_mode(0o755);
     std::fs::set_permissions(&stub, permissions).expect("the stub is executable");
+
+    // And then run it, until the kernel agrees that it can be run.
+    //
+    // `execve` answers `ETXTBSY` while *any* process holds the file open for
+    // writing, and the descriptor that matters is not this thread's — that one
+    // is closed by `fs::write` before it returns. `cargo test` runs these tests
+    // across several threads in one binary, so between this thread's `open` and
+    // its `close`, another thread can `fork` to spawn something of its own. The
+    // child inherits every descriptor and holds them until its own `exec`, and
+    // a stub executed inside that window is refused:
+    //
+    //     Err(Failed { formatter: "biome", detail: "Text file busy (os error 26)" })
+    //
+    // Rust opens files `O_CLOEXEC`, which closes the descriptor at the child's
+    // `exec` — but `fork` to `exec` is the window. See ubugeeei-prod/uf#467.
+    //
+    // The retry belongs here rather than around an assertion: a test that
+    // retries its subject cannot tell "the machine was busy" from "the
+    // formatter is broken", and that distinction is what these tests are for.
+    // By the time this returns, the file has been executed once, so no
+    // descriptor is open on it and every later spawn in the test is safe.
+    for attempt in 0..50 {
+        match std::process::Command::new(&stub).arg("--version").output() {
+            Ok(_) => return,
+            Err(error) if error.raw_os_error() == Some(26) => {
+                std::thread::sleep(std::time::Duration::from_millis(10 * (attempt + 1)));
+            }
+            Err(error) => panic!("the stub could not be run: {error}"),
+        }
+    }
+    panic!("the stub was still `Text file busy` after fifty attempts");
 }


### PR DESCRIPTION
`a_write_run_reports_the_files_the_formatter_changed` failed on #466's CI:

```
---- non_flow::tests::a_write_run_reports_the_files_the_formatter_changed stdout ----
assertion `left == right` failed: a file the formatter left alone must not be reported as rewritten
  left: Err(Failed { formatter: "biome", detail: "Text file busy (os error 26)" })
 right: Ok(Formatted { rewritten: ["messy.json"] })
```

`main` is green at the moment and the test is on `main`, so this reddens
unrelated pull requests at random — the class of failure that teaches a team to
ignore a red check, and the third one this week after #445 and
`standalone.test.js`'s socket case.

## It is not about this test's own file handle

`stub_formatter` writes the script with `std::fs::write`, which closes its
descriptor before returning, and then `chmod`s it. That is correct, and it is
not enough.

`ETXTBSY` is what `execve` answers while **any** process holds the file open for
writing. `cargo test` runs these tests across several threads in one binary, so
between this thread's `open` and its `close` inside `fs::write`, another thread
can `fork` to spawn something of its own. The child inherits every descriptor,
including this one, and holds it until its own `exec`. A stub executed inside
that window is refused.

Rust opens files `O_CLOEXEC`, which closes the descriptor at the child's `exec`
— but `fork` to `exec` is exactly the window. It is the same race cargo itself
hit and works around.

## The fix, and where it is not

`stub_formatter` runs the stub itself before returning, retrying on that one
errno with a bounded backoff. By the time it returns the file has been executed
once, so no descriptor is open on it and every later spawn in that test is safe.

**The retry is in the helper and not around an assertion, deliberately.** A test
that retries its subject cannot tell "the machine was busy" from "the formatter
is broken", and that distinction is the whole reason these tests exist. Any
error that is not `ETXTBSY` still panics immediately, naming it.

## Evidence

Thirty consecutive runs of `cargo test -p uf_fmt --lib` on a machine with four
other agents compiling: **0 failures**. `cargo clippy -p uf_fmt --all-targets --
-D warnings` 0, `cargo fmt --check` 0.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791332085&installation_model_id=422833&pr_number=468&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F468&signature=d17525ef0d3c6b0d3097dfa3e7426f3e5cc95d3ac0d7ceebc5dee0e04747422e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->