### PR TITLE
uf check reads what it imports, and three CI setups that install uf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,13 @@ jobs:
       - run: ./target/release/uf run install:banner
       - run: ./target/release/uf run scripts:parse
       - run: ./target/release/uf run scripts:parse:test
+      # And that the three CI integrations still configure the installer with
+      # variables it reads. They are YAML for three systems this repository has
+      # no runner for, and the installer is shell; nothing else sees both
+      # sides, so a rename there leaves them setting something nothing reads
+      # and the failure surfaces as `uf: command not found` in a pipeline
+      # belonging to somebody who cannot fix it.
+      - run: ./target/release/uf run integrations
       # And that the set that goes to npm is closed under its own
       # dependencies. `@uniflowed/stylex` depends on `@uniflowed/core`, so a
       # release that sends one without the other publishes a package that

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -49,13 +49,16 @@ jobs:
         # installer can select on a hosted runner.
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The action under test, from this checkout rather than from a tag, so a
-      # pull request tests the version it is proposing.
+      # The action under test, from this repository at this commit rather than
+      # from a tag, so a pull request tests the version it is proposing.
+      # `$/` rather than `./`: the same-repository form does not depend on what
+      # is on the runner's filesystem when the step runs, which is what lets
+      # GitHub treat it as fully pinned.
       - name: Install uf
         id: setup
-        uses: ./integrations/github-actions
+        uses: $/integrations/github-actions
         with:
           version: latest
 

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -31,7 +31,15 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Read the repository, and nothing else. The token this passes to the action
+  # is only ever used to ask which release is newest.
   contents: read
+
+env:
+  # The release the `pinned` legs install. A published one, deliberately: those
+  # legs exist to prove that the deployed installer and a real release still
+  # agree, so they must not be pointed at something this branch has not shipped.
+  PINNED: 0.0.0-alpha.10
 
 concurrency:
   group: integrations-${{ github.ref }}
@@ -39,22 +47,36 @@ concurrency:
 
 jobs:
   action:
-    name: setup-uf (${{ matrix.os }}, ${{ matrix.version }})
+    name: setup-uf (${{ matrix.os }}, ${{ matrix.resolves }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # Two runner families, because between them they cover every target the
+      # installer can select on a hosted runner: the macOS runner is aarch64
+      # and the Ubuntu one x86_64.
+      #
+      # And two questions, which need different installers to answer.
+      #
+      # `pinned` runs the installer that is *deployed* at
+      # `setup.uniflowed.dev`, exactly as a user's pipeline would, against a
+      # release that is published. It is the leg that fails the day the host
+      # stops answering or a release archive goes missing — and it needs no
+      # GitHub API call, so nothing else can make it flaky.
+      #
+      # `latest` runs the installer *in this checkout*, over `file://`. It has
+      # to: `latest` is the path that asks the API which release is newest, and
+      # a change to that path — the `GITHUB_TOKEN` this action passes, say — is
+      # not at `setup.uniflowed.dev` until it is released. A pull request that
+      # tested the deployed script would be testing the version it is
+      # proposing to replace.
+      #
+      # Both dimensions in the base matrix rather than in `include:`, because an
+      # `include:` entry whose keys are absent from the base is applied to every
+      # combination — two of them would overwrite each other and quietly leave
+      # one question unasked.
       matrix:
-        # Both families uf publishes for. The macOS runner is aarch64 and the
-        # Ubuntu one x86_64, so between them the matrix covers every target the
-        # installer can select on a hosted runner.
         os: [ubuntu-latest, macos-latest]
-        # Both ways a version is resolved, because they are different code
-        # paths in the installer and only one of them talks to the API: a
-        # pinned version builds the download URL directly, and `latest` asks
-        # which release is newest. The pinned leg is what stays green when the
-        # API is unreachable; the `latest` leg is what notices that the default
-        # every one of these integrations ships still works.
-        version: [latest, 0.0.0-alpha.10]
+        resolves: [pinned, latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -67,7 +89,8 @@ jobs:
         id: setup
         uses: $/integrations/github-actions
         with:
-          version: ${{ matrix.version }}
+          version: ${{ matrix.resolves == 'latest' && 'latest' || env.PINNED }}
+          setup-url: ${{ matrix.resolves == 'latest' && format('file://{0}/infra/cloudflare/setup-assets/install.sh', github.workspace) || 'https://setup.uniflowed.dev' }}
 
       # `uf` on PATH, not by full path: the action's last step is what puts it
       # there, and running the binary directly would pass while that step was

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   action:
-    name: setup-uf (${{ matrix.os }})
+    name: setup-uf (${{ matrix.os }}, ${{ matrix.version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -48,6 +48,13 @@ jobs:
         # Ubuntu one x86_64, so between them the matrix covers every target the
         # installer can select on a hosted runner.
         os: [ubuntu-latest, macos-latest]
+        # Both ways a version is resolved, because they are different code
+        # paths in the installer and only one of them talks to the API: a
+        # pinned version builds the download URL directly, and `latest` asks
+        # which release is newest. The pinned leg is what stays green when the
+        # API is unreachable; the `latest` leg is what notices that the default
+        # every one of these integrations ships still works.
+        version: [latest, 0.0.0-alpha.10]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -60,7 +67,7 @@ jobs:
         id: setup
         uses: $/integrations/github-actions
         with:
-          version: latest
+          version: ${{ matrix.version }}
 
       # `uf` on PATH, not by full path: the action's last step is what puts it
       # there, and running the binary directly would pass while that step was

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -1,0 +1,82 @@
+# The `setup-uf` action, run.
+#
+# `tools/ci/integrations-agree.sh` checks that the three integrations name
+# variables the installer reads. It cannot check that the action *works*: that
+# needs a runner, a network, and a published release to install. This does.
+#
+# It is separate from `Toolchain` on purpose. That workflow builds `uf` from
+# this checkout and is what gates a pull request; this one installs the *last
+# published* release, so it fails when a release is broken rather than when a
+# branch is — which is a different question and belongs to a different red
+# check. It is also the only workflow here that would fail with no code change
+# at all, the day `setup.uniflowed.dev` stops answering.
+name: Integrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - integrations/**
+      - .github/workflows/integrations.yml
+      - infra/cloudflare/setup-assets/install.sh
+  pull_request:
+    paths:
+      - integrations/**
+      - .github/workflows/integrations.yml
+      - infra/cloudflare/setup-assets/install.sh
+  # A release can break the action without either changing, so once a week and
+  # on request.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integrations-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  action:
+    name: setup-uf (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both families uf publishes for. The macOS runner is aarch64 and the
+        # Ubuntu one x86_64, so between them the matrix covers every target the
+        # installer can select on a hosted runner.
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      # The action under test, from this checkout rather than from a tag, so a
+      # pull request tests the version it is proposing.
+      - name: Install uf
+        id: setup
+        uses: ./integrations/github-actions
+        with:
+          version: latest
+
+      # `uf` on PATH, not by full path: the action's last step is what puts it
+      # there, and running the binary directly would pass while that step was
+      # broken.
+      - name: uf answers by name
+        run: |
+          uf --version
+          ufx --version
+          test "$(uf --version | awk '{ print $2 }')" = '${{ steps.setup.outputs.version }}'
+
+      # An installed toolchain that cannot scaffold and check a project is not
+      # installed in any sense the user cares about. This is the first five
+      # minutes, run: create, install, check.
+      - name: A project it scaffolds checks clean
+        run: |
+          set -eu
+          work="$(mktemp -d)"
+          cd "$work"
+          uf create app react smoke
+          cd smoke
+          uf install
+          uf check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,7 @@ dependencies = [
  "uf_test",
  "uf_transform",
  "uf_tui",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/uf_check/src/lib.rs
+++ b/crates/uf_check/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::diagnostic::{
 };
 pub use crate::error::CheckError;
 pub use crate::limits::{CHECK_STACK_BYTES, CheckLimits};
-pub use crate::report::{BuiltinsTiming, CheckReport, Source};
+pub use crate::report::{BuiltinsTiming, CheckReport, ModuleClosure, Source};
 
 /// Which type checker a build compiled in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,6 +96,53 @@ pub fn prepare_builtins() -> Result<BuiltinsTiming, CheckError> {
     }
     #[cfg(not(feature = "upstream-typecheck"))]
     {
+        Err(CheckError::Unavailable)
+    }
+}
+
+/// The batch `seeds` need in order to be checked against what they import.
+///
+/// [`check_sources`] resolves an import to a file in the batch or to nothing
+/// typed, which leaves a caller that wants to check *part* of a project with
+/// no good option: hand over the one file and it is checked against nothing,
+/// or hand over everything and pay for the whole project's inference. This
+/// walks the module graph from `seeds` — through relative specifiers, and
+/// through the `exports` map of any `package.json` in `available` — and
+/// returns just the sources that are reachable, with the manifests that named
+/// them.
+///
+/// The walk resolves with the same rules the check does, so a specifier that
+/// resolved here resolves there. It parses each file it reaches and builds no
+/// signatures, so it costs a parse per reachable module rather than an
+/// inference.
+///
+/// ```
+/// # use uf_check::{CheckLimits, Source, module_closure};
+/// let available = [
+///     Source::new("app.js", "import { b } from './b.js';\n"),
+///     Source::new("b.js", "export const b = 1;\n"),
+///     Source::new("unrelated.js", "export const c = 1;\n"),
+/// ];
+/// match module_closure(&["app.js"], &available, &CheckLimits::default()) {
+///     Ok(closure) => assert_eq!(
+///         closure.sources.iter().map(|source| source.path).collect::<Vec<_>>(),
+///         ["app.js", "b.js"],
+///     ),
+///     Err(error) => assert!(error.is_unavailable()),
+/// }
+/// ```
+pub fn module_closure<'a>(
+    seeds: &[&str],
+    available: &[Source<'a>],
+    limits: &CheckLimits,
+) -> Result<ModuleClosure<'a>, CheckError> {
+    #[cfg(feature = "upstream-typecheck")]
+    {
+        upstream::module_closure(seeds, available, limits)
+    }
+    #[cfg(not(feature = "upstream-typecheck"))]
+    {
+        let _ = (seeds, available, limits);
         Err(CheckError::Unavailable)
     }
 }

--- a/crates/uf_check/src/report.rs
+++ b/crates/uf_check/src/report.rs
@@ -25,6 +25,34 @@ impl<'a> Source<'a> {
     }
 }
 
+/// The batch a set of files needs in order to be checked against what they
+/// import.
+///
+/// [`crate::check_sources`] resolves an import to a file in the batch or to
+/// nothing typed, so a caller that hands it one file gets that file checked
+/// against nothing: `import type { Control } from "@uniflowed/form"` becomes
+/// an `any`-typed value and every annotation written against it goes unread.
+/// [`crate::module_closure`] is how a caller finds out what else to hand over.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleClosure<'a> {
+    /// The seeds and everything they reach, in the order they were given.
+    ///
+    /// This is the batch: pass it to [`crate::check_sources`] and every
+    /// specifier that resolved during the walk resolves again during the check,
+    /// because both use the same rules. A package's `package.json` is in here
+    /// beside the file it publishes, since that is where the name comes from.
+    pub sources: Vec<Source<'a>>,
+    /// Specifiers no source answered, sorted and de-duplicated.
+    ///
+    /// Not all of these are holes. `react` is Flow's own `declare module` and
+    /// `node:fs` is a builtin; the walk has no builtin environment to ask, and
+    /// giving it one would make assembling a batch depend on merging the
+    /// library definitions. This list is for the caller that can go and find
+    /// more sources — reading `node_modules` for a bare specifier, say — and
+    /// then ask again.
+    pub unresolved: Vec<CompactString>,
+}
+
 /// What one call to [`crate::prepare_builtins`] cost.
 ///
 /// The builtin environment is merged once per process and shared, so the first

--- a/crates/uf_check/src/upstream/closure.rs
+++ b/crates/uf_check/src/upstream/closure.rs
@@ -1,0 +1,388 @@
+//! The modules a set of files reaches, by the batch's own resolution rules.
+//!
+//! # Why a batch needs this at all
+//!
+//! [`super::check_sources`] is a function of the sources it is handed and
+//! nothing else: an import resolves to a file in the batch or it resolves to
+//! nothing typed. That is the right contract — it is what makes a check
+//! reproducible and what keeps the file system out of the checker — but it
+//! pushes a question onto the caller that the caller has no way to answer:
+//! *which* sources does checking these files require?
+//!
+//! Answering it by hand is how `uf check <one file>` came to check that file
+//! against nothing. `import type { Control } from "@uniflowed/form"` in a
+//! batch of one file is an `any`-typed value, so every annotation written
+//! against it is neither right nor wrong — it is unread. Answering it with
+//! "the whole project" is correct and costs the whole project's inference for
+//! a question about one file. This module answers it with the closure: the
+//! seeds, plus every module they reach, transitively.
+//!
+//! # It resolves with the checker's rules, not a second set of them
+//!
+//! Every edge here goes through [`super::resolve`] and [`super::packages`] —
+//! the same [`ModuleIndex`] and [`WorkspacePackages`] that
+//! [`super::project::ProjectModules`] resolves through while it types a file.
+//! A closure that resolved by its own rules would be a second answer to *what
+//! does this specifier mean*, and the batch it assembled would be missing
+//! exactly the files the checker then went looking for.
+//!
+//! Two consequences of using the checker's rules are worth naming, because
+//! both look like bugs from outside:
+//!
+//! * A file that does not parse, or that says `@noflow`, contributes no
+//!   imports. That is not this module being careful — it is
+//!   [`super::project::ProjectModules::facts`]'s own rule, and it has to be:
+//!   the checker resolves nothing through such a file, so a batch holding what
+//!   it imports would hold files nothing can reach.
+//! * A package's **manifest** is pulled in beside the file it publishes. The
+//!   manifest is where the name comes from, so a batch with
+//!   `packages/form/index.js` in it and no `packages/form/package.json`
+//!   resolves `@uniflowed/form` to nothing, having been handed the answer.
+//!
+//! # What is left over
+//!
+//! [`Closure::unresolved`] is every specifier no source answered *and* Flow's
+//! own library definitions do not describe. The second half of that matters as
+//! much as the first, because it is what the caller is expected to do about it:
+//! `uf check` reads `node_modules` for a bare specifier left here and adds what
+//! it finds to the batch. A file in the batch outranks a `declare module` —
+//! [`super::project::ProjectModules::resolve`] says why — so offering it
+//! `react` would replace Flow's own description of React with whatever
+//! JavaScript happens to be installed, and the answer would get worse rather
+//! than better. A package Flow describes is Flow's to describe.
+
+use std::collections::BTreeSet;
+
+use compact_str::{CompactString, ToCompactString};
+use flow_common::flow_import_specifier::FlowImportSpecifier;
+use flow_common::options::Options;
+use flow_parser::file_key::{FileKey, FileKeyInner};
+
+use super::packages::{PackageFile, WorkspacePackages, is_manifest};
+use super::parse;
+use super::resolve::{self, ModuleIndex};
+use crate::Source;
+
+/// What a set of seeds reaches.
+pub(super) struct Closure {
+    /// The sources the seeds reach, as indices into what was searched, in
+    /// ascending order.
+    ///
+    /// Ascending rather than in discovery order so that the batch is a
+    /// function of the sources and the seeds alone: discovery order depends on
+    /// which seed was walked first, and two orders would be two cache keys for
+    /// the same check.
+    pub(super) reached: Vec<usize>,
+    /// Specifiers nothing searched answered and no libdef declares, sorted and
+    /// de-duplicated.
+    pub(super) unresolved: Vec<CompactString>,
+}
+
+/// The closure of `seeds` over `available`.
+///
+/// A seed naming nothing in `available` is skipped rather than reported: the
+/// caller chose both lists, and a seed it did not also supply is its own
+/// mistake to notice, not a property of the module graph.
+///
+/// `declared` answers whether Flow's library definitions describe a specifier.
+/// It is a parameter rather than something this module asks for itself so that
+/// the walk stays a function of its inputs — and so that a test of the graph
+/// does not have to merge the builtins to run.
+pub(super) fn closure(
+    seeds: &[&str],
+    available: &[Source<'_>],
+    options: &Options,
+    declared: &dyn Fn(&str) -> bool,
+) -> Closure {
+    let index = ModuleIndex::new(available.iter().map(|source| source.path));
+    let packages = WorkspacePackages::new(available, options);
+
+    let mut seen = vec![false; available.len()];
+    let mut frontier: Vec<usize> = Vec::new();
+    let mut unresolved: BTreeSet<CompactString> = BTreeSet::new();
+
+    for seed in seeds {
+        if let Some(target) = index.index_of(seed) {
+            reach(target, &mut seen, &mut frontier);
+        }
+    }
+
+    while let Some(module) = frontier.pop() {
+        let source = available[module];
+        for specifier in requires(&source, options) {
+            let resolved = if resolve::is_relative(&specifier) {
+                index.resolve(source.path, &specifier)
+            } else {
+                // The manifest first, and whether or not the file it names is
+                // in the batch: a package that publishes a subpath this batch
+                // does not hold still has to be able to answer for the ones it
+                // does.
+                if let Some(manifest) = packages
+                    .manifest_of(&specifier)
+                    .and_then(|path| index.index_of(path))
+                {
+                    reach(manifest, &mut seen, &mut frontier);
+                }
+                match packages.resolve(&specifier) {
+                    Some(PackageFile::Exact(path)) => index.lookup(&path),
+                    Some(PackageFile::Implied(base)) => index.resolve_file(&base),
+                    None => None,
+                }
+            };
+            match resolved {
+                Some(target) => reach(target, &mut seen, &mut frontier),
+                None if !declared(&specifier) => {
+                    unresolved.insert(specifier);
+                }
+                None => {}
+            }
+        }
+    }
+
+    Closure {
+        reached: (0..available.len()).filter(|index| seen[*index]).collect(),
+        unresolved: unresolved.into_iter().collect(),
+    }
+}
+
+/// Mark a module reached, and queue it if this is the first time.
+fn reach(target: usize, seen: &mut [bool], frontier: &mut Vec<usize>) {
+    if !seen[target] {
+        seen[target] = true;
+        frontier.push(target);
+    }
+}
+
+/// Every module specifier `source` imports.
+///
+/// Read out of the file signature rather than the packed module, and dropped
+/// entirely for a file that cannot contribute one, for the reasons
+/// [`super::project::ProjectModules::facts`] gives — this is that function
+/// with the signature packing left out, because a closure needs to know what a
+/// file imports and never needs to know what it exports.
+fn requires(source: &Source<'_>, options: &Options) -> Vec<CompactString> {
+    // A manifest is JSON. Handing it to the Flow parser produces a syntax
+    // error and no imports, which is the right answer by a slow route.
+    if is_manifest(source.path) {
+        return Vec::new();
+    }
+    let file_key = FileKey::new(FileKeyInner::SourceFile(source.path.to_owned()));
+    let parsed = parse::parse_file(file_key, source.source, options, false);
+    if !parsed.is_parseable() || !parsed.is_checked() {
+        return Vec::new();
+    }
+    parsed
+        .file_sig
+        .require_loc_map()
+        .keys()
+        .map(|specifier| {
+            let FlowImportSpecifier::Userland(userland) = specifier;
+            userland.as_str().to_compact_string()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CheckLimits;
+    use crate::upstream::options;
+
+    /// Nothing is declared: these tests are about the graph, not the libdefs.
+    fn undeclared(_specifier: &str) -> bool {
+        false
+    }
+
+    fn reached<'a>(seeds: &[&str], available: &[Source<'a>]) -> Vec<&'a str> {
+        let found = closure(
+            seeds,
+            available,
+            &options::options(&CheckLimits::default()),
+            &undeclared,
+        );
+        found
+            .reached
+            .into_iter()
+            .map(|index| available[index].path)
+            .collect()
+    }
+
+    fn unresolved(seeds: &[&str], available: &[Source<'_>]) -> Vec<String> {
+        closure(
+            seeds,
+            available,
+            &options::options(&CheckLimits::default()),
+            &undeclared,
+        )
+        .unresolved
+        .into_iter()
+        .map(Into::into)
+        .collect()
+    }
+
+    const FORM_MANIFEST: &str = r#"{
+      "name": "@uniflowed/form",
+      "exports": { ".": "./index.js", "./watch": "./watch.js" }
+    }"#;
+
+    #[test]
+    fn a_seed_with_no_imports_reaches_only_itself() {
+        let available = [
+            Source::new("a.js", "export const a = 1;\n"),
+            Source::new("b.js", "export const b = 2;\n"),
+        ];
+
+        assert_eq!(reached(&["a.js"], &available), ["a.js"]);
+    }
+
+    #[test]
+    fn a_relative_import_is_followed_transitively() {
+        let available = [
+            Source::new("app.js", "import { b } from './b.js';\nexport { b };\n"),
+            Source::new("b.js", "import { c } from './c.js';\nexport const b = c;\n"),
+            Source::new("c.js", "export const c = 1;\n"),
+            Source::new("unrelated.js", "export const d = 1;\n"),
+        ];
+
+        assert_eq!(reached(&["app.js"], &available), ["app.js", "b.js", "c.js"]);
+    }
+
+    #[test]
+    fn a_package_import_reaches_the_file_and_the_manifest_that_named_it() {
+        let available = [
+            Source::new("app.js", "import { useForm } from '@uniflowed/form';\n"),
+            Source::new("packages/form/index.js", "export const useForm = 1;\n"),
+            Source::new("packages/form/package.json", FORM_MANIFEST),
+            Source::new("packages/form/watch.js", "export const watch = 1;\n"),
+        ];
+
+        assert_eq!(
+            reached(&["app.js"], &available),
+            [
+                "app.js",
+                "packages/form/index.js",
+                "packages/form/package.json"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_subpath_export_resolves_to_the_file_the_map_names() {
+        let available = [
+            Source::new("app.js", "import { watch } from '@uniflowed/form/watch';\n"),
+            Source::new("packages/form/index.js", "export const useForm = 1;\n"),
+            Source::new("packages/form/package.json", FORM_MANIFEST),
+            Source::new("packages/form/watch.js", "export const watch = 1;\n"),
+        ];
+
+        assert_eq!(
+            reached(&["app.js"], &available),
+            [
+                "app.js",
+                "packages/form/package.json",
+                "packages/form/watch.js"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_type_only_import_is_an_edge_like_any_other() {
+        let available = [
+            Source::new(
+                "app.js",
+                "// @flow\nimport type { Control } from '@uniflowed/form';\nexport type C = Control;\n",
+            ),
+            Source::new(
+                "packages/form/index.js",
+                "// @flow\nexport type Control = string;\n",
+            ),
+            Source::new("packages/form/package.json", FORM_MANIFEST),
+        ];
+
+        assert_eq!(
+            reached(&["app.js"], &available),
+            [
+                "app.js",
+                "packages/form/index.js",
+                "packages/form/package.json"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_cycle_terminates() {
+        let available = [
+            Source::new("a.js", "import { b } from './b.js';\nexport const a = b;\n"),
+            Source::new("b.js", "import { a } from './a.js';\nexport const b = a;\n"),
+        ];
+
+        assert_eq!(reached(&["a.js"], &available), ["a.js", "b.js"]);
+    }
+
+    #[test]
+    fn a_specifier_a_libdef_declares_is_not_left_for_the_caller() {
+        // A file in the batch outranks a `declare module`, so a caller that
+        // went and found `react` on disk would replace Flow's description of
+        // it with whatever is installed.
+        let available = [Source::new("app.js", "import 'react';\nimport 'nope';\n")];
+        let found = closure(
+            &["app.js"],
+            &available,
+            &options::options(&CheckLimits::default()),
+            &|specifier| specifier == "react",
+        );
+
+        assert_eq!(found.unresolved, ["nope"]);
+    }
+
+    #[test]
+    fn a_specifier_nothing_answers_is_reported() {
+        let available = [Source::new(
+            "app.js",
+            "import 'react';\nimport './missing.js';\nimport '@uniflowed/nope';\n",
+        )];
+
+        assert_eq!(
+            unresolved(&["app.js"], &available),
+            ["./missing.js", "@uniflowed/nope", "react"]
+        );
+    }
+
+    #[test]
+    fn a_noflow_dependency_is_in_the_batch_and_its_own_imports_are_not() {
+        // The checker resolves nothing through a `@noflow` file, so a batch
+        // holding what it imports would hold files nothing can reach.
+        let available = [
+            Source::new("app.js", "import './plain.js';\n"),
+            Source::new("plain.js", "// @noflow\nimport './deep.js';\n"),
+            Source::new("deep.js", "export const deep = 1;\n"),
+        ];
+
+        assert_eq!(reached(&["app.js"], &available), ["app.js", "plain.js"]);
+    }
+
+    #[test]
+    fn a_seed_that_is_not_available_is_skipped_rather_than_reported() {
+        let available = [Source::new("a.js", "export const a = 1;\n")];
+
+        assert_eq!(reached(&["a.js", "gone.js"], &available), ["a.js"]);
+        assert!(unresolved(&["gone.js"], &available).is_empty());
+    }
+
+    #[test]
+    fn every_seed_is_a_root() {
+        let available = [
+            Source::new("a.js", "import './shared.js';\n"),
+            Source::new("b.js", "import './other.js';\n"),
+            Source::new("shared.js", "export const s = 1;\n"),
+            Source::new("other.js", "export const o = 1;\n"),
+        ];
+
+        // In the order `available` gave them, not in discovery order: the
+        // batch has to be a function of the sources and the seeds alone.
+        assert_eq!(
+            reached(&["a.js", "b.js"], &available),
+            ["a.js", "b.js", "shared.js", "other.js"]
+        );
+    }
+}

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -25,6 +25,7 @@
 
 mod assets;
 mod builtins;
+mod closure;
 mod convert;
 mod environments;
 mod graph;
@@ -95,6 +96,41 @@ pub(crate) fn check_sources(
 ) -> Result<CheckReport, CheckError> {
     let path = sources.first().map_or("<empty>", |source| source.path);
     on_check_thread(path, || check_batch(sources, limits, cache))?
+}
+
+/// The closure of `seeds` over `available`, by the batch's own rules.
+pub(crate) fn module_closure<'a>(
+    seeds: &[&str],
+    available: &[Source<'a>],
+    limits: &CheckLimits,
+) -> Result<crate::ModuleClosure<'a>, CheckError> {
+    let path = seeds.first().copied().unwrap_or("<empty>");
+    on_check_thread(path, || {
+        // The builtins are merged here so that a specifier Flow's own library
+        // definitions already describe is not handed back as something the
+        // caller should go and find. Once per process and shared, so the check
+        // that follows this walk pays nothing for having asked.
+        builtins::prepare()?;
+        let master_cx = builtins::master_context()?;
+        let options = options::options(limits);
+        let base_metadata = flow_typing_context::mk_context_metadata(&options, Arc::default());
+        let mk_builtins = merge::mk_builtins(&base_metadata, &master_cx);
+        // A batch of no files: this exists only to ask what the builtins
+        // declare, which is a property of the compiler and not of any source.
+        let probe = ProjectModules::new(&[], options.clone(), mk_builtins, limits);
+        let found = closure::closure(seeds, available, &options, &|specifier| {
+            probe.declared_externally(specifier)
+        });
+        probe.release();
+        Ok(crate::ModuleClosure {
+            sources: found
+                .reached
+                .into_iter()
+                .map(|index| available[index])
+                .collect(),
+            unresolved: found.unresolved,
+        })
+    })?
 }
 
 /// Run `work` on a thread with a stack large enough for recursive descent over

--- a/crates/uf_check/src/upstream/packages.rs
+++ b/crates/uf_check/src/upstream/packages.rs
@@ -169,10 +169,24 @@ impl WorkspacePackages {
             }
         }
     }
+
+    /// The manifest that publishes `specifier`'s package, if the batch holds
+    /// one.
+    ///
+    /// A caller assembling a batch needs this and not just the file: a check
+    /// that is handed `packages/cell/index.js` but not
+    /// `packages/cell/package.json` cannot resolve `@uniflowed/cell` at all,
+    /// because the manifest is where the name comes from. So whatever pulls a
+    /// package's file into a batch has to pull the manifest that named it in
+    /// alongside. See [`super::closure`].
+    pub(super) fn manifest_of(&self, specifier: &str) -> Option<&str> {
+        let (name, _) = split(specifier)?;
+        Some(self.by_name.get(name)?.manifest_path.as_str())
+    }
 }
 
 /// Whether a batch path is a package manifest.
-fn is_manifest(path: &str) -> bool {
+pub(super) fn is_manifest(path: &str) -> bool {
     path == MANIFEST || path.ends_with("/package.json")
 }
 

--- a/crates/uf_check/src/upstream/project.rs
+++ b/crates/uf_check/src/upstream/project.rs
@@ -330,7 +330,7 @@ impl ProjectModules {
     /// the specifier in a cache record: it is a property of the specifier and
     /// of the compiler, so a run that reads every file from disk must not have
     /// to merge the builtins to find out it did not need them.
-    fn declared_externally(&self, specifier: &str) -> bool {
+    pub(super) fn declared_externally(&self, specifier: &str) -> bool {
         let declared = if resolve::is_relative(specifier) {
             match assets::declared_module_for(specifier) {
                 Some(declared) => declared,

--- a/crates/uf_check/src/upstream/resolve.rs
+++ b/crates/uf_check/src/upstream/resolve.rs
@@ -126,6 +126,16 @@ impl ModuleIndex {
     pub(super) fn lookup(&self, path: &str) -> Option<usize> {
         self.by_path.get(path).copied()
     }
+
+    /// The source at this path, however the path is spelled.
+    ///
+    /// [`Self::lookup`] is keyed by the [`normalize`]d form, which is what a
+    /// resolution produces; a path that came from somewhere else — a `--path`
+    /// argument, a caller's own list of files to start from — has not been
+    /// through that, so `./src/app.js` and `src/app.js` would be two keys.
+    pub(super) fn index_of(&self, path: &str) -> Option<usize> {
+        self.lookup(&normalize(path))
+    }
 }
 
 /// A batch path in the shape [`join`] produces.

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -44,6 +44,7 @@ uf_plugin = { path = "../uf_plugin" }
 uf_pm = { path = "../uf_pm" }
 uf_prepare = { path = "../uf_prepare" }
 uf_project = { path = "../uf_project" }
+walkdir.workspace = true
 uf_rm = { path = "../uf_rm" }
 uf_router = { path = "../uf_router" }
 uf_rsc = { path = "../uf_rsc" }

--- a/crates/uf_cli/src/commands/check.rs
+++ b/crates/uf_cli/src/commands/check.rs
@@ -15,9 +15,11 @@ use camino::Utf8Path;
 use serde_json::{Value, json};
 #[cfg(feature = "upstream-typecheck")]
 use uf_check::{
-    CheckCache, CheckError, CheckLimits, CheckReport, Source, TypeDiagnostic, active_backend,
-    backend_name, check_sources_cached,
+    BuiltinsTiming, CheckCache, CheckError, CheckLimits, CheckReport, Source, TypeDiagnostic,
+    active_backend, backend_name, check_sources_cached, module_closure, prepare_builtins,
 };
+#[cfg(feature = "upstream-typecheck")]
+use uf_infra::FxHashSet;
 use uf_lint::{LintReport, Severity, SourceFile};
 use uf_term::Status;
 #[cfg(feature = "upstream-typecheck")]
@@ -37,6 +39,28 @@ use crate::ui::Ui;
 #[cfg(feature = "upstream-typecheck")]
 const UNTYPED_MODULES_SHOWN: usize = 5;
 
+/// What the run did, beyond what the report describes.
+///
+/// The batch counts are reported because they are the difference between "your
+/// file is clean" and "your file is clean, and so are the eleven modules that
+/// had to be typed to say so" — and because they are what explains the time.
+#[cfg(feature = "upstream-typecheck")]
+#[derive(Clone, Copy)]
+struct Batch {
+    /// Files the reader asked about.
+    requested: usize,
+    /// Modules in the batch only because those files import them.
+    imported: usize,
+    /// What the shared builtin environment cost *this process*.
+    ///
+    /// Taken from the run's own `prepare_builtins` rather than from the
+    /// report, because the report's `cold` says whether the *check* did the
+    /// merge and the walk that assembles the batch now gets there first. A run
+    /// that paid for the merge must not print "warm" because it paid a moment
+    /// earlier than the footer looks.
+    builtins: BuiltinsTiming,
+}
+
 /// Severity counts from the type-checking half of `uf check`.
 #[derive(Clone, Copy)]
 enum TypeSeverity {
@@ -55,8 +79,12 @@ enum TypeCheck {
     /// No checker was compiled in.
     Unavailable,
     /// Inference ran over the project.
+    ///
+    /// The batch beside the report is not derivable from it: a report describes
+    /// the files it was handed, and which of them a *reader* asked about is the
+    /// caller's question.
     #[cfg(feature = "upstream-typecheck")]
-    Checked(CheckReport),
+    Checked(CheckReport, Batch),
     /// Inference could not run.
     #[cfg(feature = "upstream-typecheck")]
     Failed(CheckError),
@@ -66,7 +94,7 @@ impl TypeCheck {
     #[cfg(feature = "upstream-typecheck")]
     fn report(&self) -> Option<&CheckReport> {
         match self {
-            Self::Checked(report) => Some(report),
+            Self::Checked(report, _) => Some(report),
             Self::Unavailable | Self::Failed(_) => None,
         }
     }
@@ -93,11 +121,20 @@ impl TypeCheck {
         }
     }
 
+    /// What the batch was made of, for a run that produced one.
+    #[cfg(feature = "upstream-typecheck")]
+    fn batch(&self) -> Option<Batch> {
+        match self {
+            Self::Checked(_, batch) => Some(*batch),
+            Self::Unavailable | Self::Failed(_) => None,
+        }
+    }
+
     fn status(&self) -> &'static str {
         match self {
             Self::Unavailable => "unavailable",
             #[cfg(feature = "upstream-typecheck")]
-            Self::Checked(_) => "checked",
+            Self::Checked(..) => "checked",
             #[cfg(feature = "upstream-typecheck")]
             Self::Failed(_) => "failed",
         }
@@ -138,9 +175,10 @@ pub(crate) fn check(
         sources,
         unreadable,
         root,
+        available,
     } = run_lint(cwd, paths)?;
     progress.draw("type checking");
-    let types = type_check(&sources, root.as_std_path());
+    let types = type_check(&sources, &available, &root);
     progress.finish();
     drop(progress);
 
@@ -171,37 +209,125 @@ pub(crate) fn check(
     Ok(())
 }
 
-/// Run inference over every source the linter collected.
+/// Run inference over the sources the linter collected, and the modules those
+/// sources import.
 ///
-/// Syntax errors are dropped here rather than in `uf_check`: the checker
-/// reports them because a library caller needs to know why inference did not
-/// run, but `uf lint` has already reported the same syntax error with its own
-/// rule id, and printing it twice helps nobody.
+/// Two kinds of diagnostic are dropped rather than rendered. **Syntax errors**,
+/// because `uf lint` has already reported the same one with its own rule id and
+/// printing it twice helps nobody — `uf_check` reports them because a library
+/// caller needs to know why inference did not run. And **anything about a file
+/// nobody asked about**, because a dependency is in the batch to be typed
+/// against, not to be reported on.
 #[cfg(feature = "upstream-typecheck")]
-fn type_check(sources: &[SourceFile], root: &std::path::Path) -> TypeCheck {
-    let inputs: Vec<Source<'_>> = sources
+fn type_check(sources: &[SourceFile], available: &[SourceFile], root: &Utf8Path) -> TypeCheck {
+    let limits = CheckLimits::default();
+    // Before the walk, because the walk merges the builtins too and whichever
+    // call gets there first is the one that pays. Asking here is what lets the
+    // footer say which.
+    let builtins = match prepare_builtins() {
+        Ok(builtins) => builtins,
+        Err(error) if error.is_unavailable() => return TypeCheck::Unavailable,
+        Err(error) => return TypeCheck::Failed(error),
+    };
+    let seeds: Vec<&str> = sources.iter().map(|source| source.path.as_str()).collect();
+    // What the walk searches. `available` is empty when `paths` selected
+    // everything, and then the selection already is every file the scan found.
+    let project = if available.is_empty() {
+        sources
+    } else {
+        available
+    };
+
+    // The batch is what was asked about plus what it imports, because an
+    // import is only typed against a file in the same batch. A run that skipped
+    // this checked its files against nothing: every
+    // `import type { Control } from "@uniflowed/form"` was an `any`-typed
+    // value, so the annotations written against it were neither right nor
+    // wrong — ubugeeei-prod/uf#403.
+    //
+    // In rounds, because a package read from `node_modules` imports packages
+    // of its own. It terminates because `read` never lets a package be looked
+    // for twice and there are finitely many of them.
+    let mut installed: Vec<SourceFile> = Vec::new();
+    let mut read: FxHashSet<String> = FxHashSet::default();
+    let batch_paths = loop {
+        // In its own scope: the walk borrows `installed`, and the round that
+        // follows it grows `installed`.
+        let round = {
+            let pool: Vec<Source<'_>> = project
+                .iter()
+                .chain(installed.iter())
+                .map(as_input)
+                .collect();
+            match module_closure(&seeds, &pool, &limits) {
+                Ok(closure) => Ok((
+                    closure
+                        .sources
+                        .iter()
+                        .map(|source| source.path.to_owned())
+                        .collect::<Vec<String>>(),
+                    closure.unresolved,
+                )),
+                Err(error) => Err(error),
+            }
+        };
+        let (paths, unresolved) = match round {
+            Ok(round) => round,
+            Err(error) if error.is_unavailable() => return TypeCheck::Unavailable,
+            Err(error) => return TypeCheck::Failed(error),
+        };
+        let more = dependencies::load_packages(root, &unresolved, &mut read);
+        if more.is_empty() {
+            break paths;
+        }
+        installed.extend(more);
+    };
+
+    let reached: FxHashSet<&str> = batch_paths.iter().map(String::as_str).collect();
+    let batch: Vec<Source<'_>> = project
         .iter()
-        .map(|source| Source::new(&source.path, &source.source))
+        .chain(installed.iter())
+        .filter(|source| reached.contains(source.path.as_str()))
+        .map(as_input)
         .collect();
+    let counts = Batch {
+        requested: sources.len(),
+        imported: batch.len().saturating_sub(sources.len()),
+        builtins,
+    };
 
     // Under the project root, because that is what the cache is about: the same
     // sources checked from two roots are two projects, and `.uf/` is where uf
     // already keeps per-project state that `.gitignore` covers.
-    let cache = CheckCache::open(root);
-    match check_sources_cached(&inputs, &CheckLimits::default(), cache.as_ref()) {
+    let cache = CheckCache::open(root.as_std_path());
+    match check_sources_cached(&batch, &limits, cache.as_ref()) {
         Ok(mut report) => {
-            report
-                .diagnostics
-                .retain(|diagnostic| diagnostic.kind != uf_check::DiagnosticKind::Parse);
-            TypeCheck::Checked(report)
+            let asked_about: FxHashSet<&str> =
+                sources.iter().map(|source| source.path.as_str()).collect();
+            report.diagnostics.retain(|diagnostic| {
+                // A dependency was checked so that the files asked about could
+                // be typed against it, not so that its own errors could be
+                // reported. `uf check packages/form/watch.js` must not fail on
+                // a file the author did not name — and in a project that has
+                // errors elsewhere, one that did would be unusable.
+                diagnostic.kind != uf_check::DiagnosticKind::Parse
+                    && asked_about.contains(diagnostic.primary.path.as_str())
+            });
+            TypeCheck::Checked(report, counts)
         }
         Err(error) if error.is_unavailable() => TypeCheck::Unavailable,
         Err(error) => TypeCheck::Failed(error),
     }
 }
 
+/// One scanned file as the checker takes it.
+#[cfg(feature = "upstream-typecheck")]
+fn as_input(source: &SourceFile) -> Source<'_> {
+    Source::new(&source.path, &source.source)
+}
+
 #[cfg(not(feature = "upstream-typecheck"))]
-fn type_check(_sources: &[SourceFile], _root: &std::path::Path) -> TypeCheck {
+fn type_check(_sources: &[SourceFile], _available: &[SourceFile], _root: &Utf8Path) -> TypeCheck {
     TypeCheck::Unavailable
 }
 
@@ -227,11 +353,19 @@ fn type_check_payload(types: &TypeCheck) -> Value {
     });
     if let Some(report) = types.report() {
         value["filesChecked"] = json!(report.files_checked);
+        if let Some(batch) = types.batch() {
+            value["requested"] = json!(batch.requested);
+            value["imported"] = json!(batch.imported);
+        }
         value["filesSkipped"] = json!(report.files_skipped);
         value["filesFromCache"] = json!(report.files_from_cache);
         value["elapsedMs"] = json!(report.elapsed.as_secs_f64() * 1000.0);
         value["builtinsMs"] = json!(report.builtins.cold_elapsed.as_secs_f64() * 1000.0);
-        value["builtinsCold"] = json!(report.builtins.cold);
+        value["builtinsCold"] = json!(
+            types
+                .batch()
+                .map_or(report.builtins.cold, |batch| batch.builtins.cold)
+        );
         value["untypedModules"] = json!(report.untyped_modules);
     }
     if let TypeCheck::Failed(error) = types {
@@ -413,13 +547,21 @@ fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
             });
         }
         #[cfg(feature = "upstream-typecheck")]
-        TypeCheck::Checked(report) => {
+        TypeCheck::Checked(report, batch) => {
             let files = report.files_checked.to_string();
+            // Only shown when a selection pulled more in. A whole-project run
+            // imports nothing it was not also asked about, and a reader should
+            // not have to work that out from a zero.
+            let requested = format!(
+                "{} of {}",
+                batch.requested,
+                batch.requested + batch.imported
+            );
             let inference = format!("{:.1?}", report.elapsed);
             let builtins = format!(
                 "{:.1?} ({})",
-                report.builtins.cold_elapsed,
-                if report.builtins.cold { "cold" } else { "warm" }
+                batch.builtins.cold_elapsed,
+                if batch.builtins.cold { "cold" } else { "warm" }
             );
             // Only shown when it happened. A project with nothing opted out
             // should not have to read a line saying so.
@@ -434,6 +576,9 @@ fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
             ];
             if report.files_from_cache > 0 {
                 rows.insert(1, KeyValue::toned("unchanged", &cached, Tone::Muted));
+            }
+            if batch.imported > 0 {
+                rows.insert(1, KeyValue::toned("asked about", &requested, Tone::Muted));
             }
             if report.files_skipped > 0 {
                 rows.insert(1, KeyValue::toned("@noflow", &skipped, Tone::Muted));
@@ -479,6 +624,9 @@ fn untyped_module_list(report: &CheckReport) -> Vec<String> {
     }
     named
 }
+
+#[cfg(feature = "upstream-typecheck")]
+mod dependencies;
 
 #[cfg(test)]
 mod tests;

--- a/crates/uf_cli/src/commands/check/dependencies.rs
+++ b/crates/uf_cli/src/commands/check/dependencies.rs
@@ -1,0 +1,253 @@
+//! Reading an installed package, for the imports a project's own files did not
+//! answer.
+//!
+//! # Why this is not the scan's job
+//!
+//! `uf_project`'s scan is what the project *owns*: the files `uf fmt` may
+//! rewrite, `uf lint` reports on and `uf check` reports on. `node_modules` is
+//! none of those, and a scan that walked it would put a dependency's
+//! diagnostics in front of an author who cannot fix them.
+//!
+//! The checker's need is different, and narrower. An import is typed against a
+//! file in the same batch, so `import type { Control } from "@uniflowed/form"`
+//! is `any` unless `@uniflowed/form`'s own source is in it. In this repository
+//! the source is in `packages/form`, which the scan already collects; in a
+//! project that merely *uses* uf it is in `node_modules/@uniflowed/form`, and
+//! nothing collects it. That is the second half of ubugeeei-prod/uf#403, and
+//! this module is it: a package is read only because a specifier asked for it,
+//! and only ever as a dependency to be typed against.
+//!
+//! # Which packages are read
+//!
+//! Exactly the ones `uf_check::module_closure` reports as unresolved: no
+//! source in the batch answered the specifier, *and* Flow's own library
+//! definitions do not describe it. The second condition is what keeps `react`
+//! out. A file in the batch outranks a `declare module`, so reading React's
+//! shipped JavaScript would replace Flow's description of React — written by
+//! people who know what its types are — with a bundle that has none. A package
+//! Flow describes stays Flow's to describe.
+//!
+//! There is a second condition, and it is Flow's own. A dependency that does
+//! not opt into Flow exports `any` whether it is read or not, so reading it
+//! buys nothing and costs a parse of every byte it ships — `react-dom` alone
+//! is megabytes of bundled JavaScript with no types in it. So a package is
+//! read only if something in it declares `@flow`. uf checks a file with no
+//! pragma because a *project's* files are uf's to have an opinion about; a
+//! dependency's are not, and the pragma is how a package says otherwise.
+//!
+//! # And how much of one
+//!
+//! All of it: every `.js`, `.jsx`, `.mjs`, `.cjs` and `package.json` under the
+//! package directory, because an `exports` map may name any of them and a
+//! module reached from one may name any other. A package larger than
+//! [`MAX_PACKAGE_FILES`] is skipped whole rather than in part — a batch holding
+//! half a package resolves an import to a file that is missing for no reason
+//! the author could discover, whereas one holding none of it leaves the
+//! specifier in `untyped_modules`, where the footer names it out loud.
+
+use std::fs;
+use std::io::Read;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use uf_infra::FxHashSet;
+use uf_lint::SourceFile;
+use uf_project::SourceKind;
+use walkdir::WalkDir;
+
+/// The directory an installed package is read from.
+const INSTALLED: &str = "node_modules";
+
+/// How many files a package may hold before it is left unread.
+///
+/// Generous on purpose: it is a guard against a directory nobody meant to
+/// publish, not a policy about package size. Every `@uniflowed` package is two
+/// orders of magnitude below it.
+const MAX_PACKAGE_FILES: usize = 4_000;
+
+/// How much of a file is read while looking for its `@flow` pragma.
+///
+/// A docblock is the first comment in a file, and Flow bounds how far it will
+/// look for one with `max_header_tokens`. This is the same idea in bytes, and
+/// it is what keeps the question "does this package use Flow" from costing a
+/// full read of a package that does not.
+const HEADER_BYTES: usize = 8 * 1024;
+
+/// The pragma a package uses to say its source is Flow.
+const FLOW_PRAGMA: &str = "@flow";
+
+/// Read every package `unresolved` names that has not been read already.
+///
+/// `read` is both the filter and the record: a package that was looked for and
+/// not found is in it too, so a specifier that cannot be answered is not
+/// searched for again on the next round.
+pub(super) fn load_packages(
+    root: &Utf8Path,
+    unresolved: &[CompactString],
+    read: &mut FxHashSet<String>,
+) -> Vec<SourceFile> {
+    let mut loaded = Vec::new();
+    for specifier in unresolved {
+        let Some(name) = package_name(specifier) else {
+            continue;
+        };
+        if !read.insert(name.to_owned()) {
+            continue;
+        }
+        loaded.extend(read_package(root, name));
+    }
+    loaded
+}
+
+/// The package a bare specifier names, or [`None`] when it names none.
+///
+/// Node's own rule — one segment, or two when scoped — with the three shapes
+/// that are not a package at all excluded first: a relative path, an absolute
+/// one, and a runtime builtin such as `node:fs`, whose colon can appear in no
+/// package name.
+fn package_name(specifier: &str) -> Option<&str> {
+    if specifier.starts_with('.') || specifier.starts_with('/') || specifier.contains(':') {
+        return None;
+    }
+    let scoped = specifier.starts_with('@');
+    let mut segments = specifier.splitn(if scoped { 3 } else { 2 }, '/');
+
+    let mut length = segments.next()?.len();
+    if scoped {
+        length += 1 + segments.next().filter(|scope| !scope.is_empty())?.len();
+    }
+    (length > 0).then(|| &specifier[..length])
+}
+
+/// Every Flow source and manifest one installed package holds.
+fn read_package(root: &Utf8Path, name: &str) -> Vec<SourceFile> {
+    let installed = root.join(INSTALLED).join(name);
+    // Resolved through the link before the walk rather than during it. A
+    // workspace package *is* a symlink — `uf install` links `packages/form`
+    // into `node_modules/@uniflowed/` — so a walk that did not follow one
+    // would find the very case this exists for empty, and a walk that followed
+    // every link it met could leave the package entirely.
+    let Ok(directory) = installed.canonicalize_utf8() else {
+        return Vec::new();
+    };
+    if !directory.join("package.json").is_file() {
+        return Vec::new();
+    }
+
+    let mut paths = Vec::new();
+    let walk = WalkDir::new(directory.as_std_path())
+        .into_iter()
+        // A dependency's own dependencies are a package of their own: they are
+        // reached, if at all, by a specifier of their own, which brings them
+        // back through here under the name that named them.
+        .filter_entry(|entry| entry.depth() == 0 || entry.file_name() != INSTALLED);
+    for entry in walk.flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let Ok(path) = Utf8PathBuf::from_path_buf(entry.path().to_path_buf()) else {
+            continue;
+        };
+        let kind = SourceKind::from_path(&path);
+        if !matches!(kind, Some(kind) if kind.is_flow() || kind == SourceKind::PackageManifest) {
+            continue;
+        }
+        if paths.len() == MAX_PACKAGE_FILES {
+            return Vec::new();
+        }
+        paths.push(path);
+    }
+    // Asked of the headers, before a byte of any body is read.
+    if !paths.iter().any(declares_flow) {
+        return Vec::new();
+    }
+
+    let mut files = Vec::new();
+    for path in paths {
+        let (Ok(relative), Ok(source)) = (path.strip_prefix(&directory), fs::read_to_string(&path))
+        else {
+            continue;
+        };
+        files.push(SourceFile {
+            // Under the name that named it, not under wherever the link went.
+            // Every target inside a manifest is relative to the manifest, so a
+            // package read as `node_modules/@uniflowed/form/package.json`
+            // resolves its own `./index.js` to a path in the same shape, and
+            // one read as `packages/form/package.json` would collide with the
+            // copy the scan already holds.
+            path: format!("{INSTALLED}/{name}/{relative}"),
+            source,
+        });
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    files
+}
+
+/// Whether a file's header opts into Flow.
+///
+/// Read rather than parsed: this decides whether a package is worth handing to
+/// the checker at all, and parsing it to find out would be the cost the answer
+/// exists to avoid.
+fn declares_flow(path: &Utf8PathBuf) -> bool {
+    let Ok(file) = fs::File::open(path) else {
+        return false;
+    };
+    let mut header = Vec::new();
+    if Read::take(file, HEADER_BYTES as u64)
+        .read_to_end(&mut header)
+        .is_err()
+    {
+        return false;
+    }
+    // Lossy, because a package is not obliged to be UTF-8 and a byte sequence
+    // that is not says nothing about the pragma either way.
+    String::from_utf8_lossy(&header).contains(FLOW_PRAGMA)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_specifier_names_its_package() {
+        assert_eq!(package_name("react"), Some("react"));
+        assert_eq!(package_name("react-dom/client"), Some("react-dom"));
+        assert_eq!(package_name("@uniflowed/form"), Some("@uniflowed/form"));
+        assert_eq!(
+            package_name("@uniflowed/form/watch"),
+            Some("@uniflowed/form")
+        );
+    }
+
+    #[test]
+    fn what_is_not_a_package_names_none() {
+        assert_eq!(package_name("./sibling.js"), None);
+        assert_eq!(package_name("../parent.js"), None);
+        assert_eq!(package_name("/absolute.js"), None);
+        assert_eq!(package_name("node:fs"), None);
+        assert_eq!(package_name("bun:test"), None);
+        // A scope with no package after it names nothing installable.
+        assert_eq!(package_name("@uniflowed"), None);
+        assert_eq!(package_name("@uniflowed/"), None);
+    }
+
+    #[test]
+    fn a_package_that_is_not_installed_reads_as_nothing() {
+        let root = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut read = FxHashSet::default();
+
+        assert!(
+            load_packages(
+                &root,
+                &[CompactString::const_new(
+                    "@uniflowed/not-installed-anywhere"
+                )],
+                &mut read,
+            )
+            .is_empty()
+        );
+        // Recorded even so: a package that is not there is not there on the
+        // next round either, and looking again would walk the tree for nothing.
+        assert!(read.contains("@uniflowed/not-installed-anywhere"));
+    }
+}

--- a/crates/uf_cli/src/commands/check/dependencies.rs
+++ b/crates/uf_cli/src/commands/check/dependencies.rs
@@ -137,9 +137,24 @@ fn read_package(root: &Utf8Path, name: &str) -> Vec<SourceFile> {
     let mut paths = Vec::new();
     let walk = WalkDir::new(directory.as_std_path())
         .into_iter()
-        // A dependency's own dependencies are a package of their own: they are
-        // reached, if at all, by a specifier of their own, which brings them
-        // back through here under the name that named them.
+        // A dependency's own dependencies are read as packages of their own,
+        // from the *root* `node_modules`, when a specifier reaches one — never
+        // from the nested directory this skips. That is not Node's rule, and
+        // the difference is worth stating rather than discovering. Node
+        // resolves a bare specifier by climbing from the importing file, so
+        // `node_modules/foo/node_modules/bar` outranks the root's `bar` for
+        // code inside `foo`. Here the root copy wins, always.
+        //
+        // It is a rule rather than an oversight, because the alternative is
+        // not free: two versions of one name in one batch collide in
+        // `WorkspacePackages`, which indexes by published name and keeps the
+        // first. Reading both would make which types a file sees depend on the
+        // batch's order. So one copy is read per name, deterministically, and
+        // that is the hoisted one — which is the only copy a flat `npm
+        // install` produces anyway.
+        //
+        // A project that really does hold two versions of a Flow-typed package
+        // is typed against one of them. ubugeeei-prod/uf#486.
         .filter_entry(|entry| entry.depth() == 0 || entry.file_name() != INSTALLED);
     for entry in walk.flatten() {
         if !entry.file_type().is_file() {

--- a/crates/uf_cli/src/commands/check/tests.rs
+++ b/crates/uf_cli/src/commands/check/tests.rs
@@ -99,7 +99,7 @@ fn statuses_are_stable() {
 
 #[test]
 fn a_build_with_a_checker_reports_it_and_one_without_says_so() {
-    let types = type_check(&[], std::path::Path::new("."));
+    let types = type_check(&[], &[], Utf8Path::new("."));
 
     #[cfg(feature = "upstream-typecheck")]
     if uf_check::is_available() {
@@ -119,4 +119,152 @@ fn a_build_with_a_checker_reports_it_and_one_without_says_so() {
 #[cfg(feature = "upstream-typecheck")]
 fn value_of(types: &TypeCheck) -> Value {
     payload(&lint_report(0, 0), types, None)["typeCheck"].clone()
+}
+
+/// A project small enough to read, holding one workspace package.
+///
+/// `app.js` names a type it can only get from `@uniflowed/ids`, and
+/// `unrelated.js` is wrong on purpose: it is what says whether a check that
+/// was asked about one file stayed there.
+#[cfg(feature = "upstream-typecheck")]
+fn workspace() -> Vec<SourceFile> {
+    fn file(path: &str, source: &str) -> SourceFile {
+        SourceFile {
+            path: path.to_owned(),
+            source: source.to_owned(),
+        }
+    }
+    vec![
+        file(
+            "app.js",
+            "// @flow\nimport type { Id } from \"@uniflowed/ids\";\nexport const id: Id = \"a\";\n",
+        ),
+        file(
+            "packages/ids/package.json",
+            "{ \"name\": \"@uniflowed/ids\", \"exports\": { \".\": \"./index.js\" } }",
+        ),
+        file(
+            "packages/ids/index.js",
+            "// @flow\nexport type Id = string;\n",
+        ),
+        file(
+            "unrelated.js",
+            "// @flow\nexport const n: number = \"not a number\";\n",
+        ),
+    ]
+}
+
+/// A root nothing else writes to: `type_check` keeps its cache under one.
+#[cfg(feature = "upstream-typecheck")]
+fn scratch() -> tempfile::TempDir {
+    tempfile::tempdir().expect("a temporary directory")
+}
+
+#[cfg(feature = "upstream-typecheck")]
+fn codes(types: &TypeCheck) -> Vec<&'static str> {
+    types
+        .diagnostics()
+        .iter()
+        .filter_map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+/// The bug, stated as a test: a batch of one file resolves nothing, so the
+/// type it imports is an `any`-typed value and the annotation goes unread.
+/// ubugeeei-prod/uf#403.
+#[cfg(feature = "upstream-typecheck")]
+#[test]
+fn a_file_checked_with_nothing_else_cannot_see_the_package_it_imports() {
+    if !uf_check::is_available() {
+        return;
+    }
+    let project = workspace();
+    let root = scratch();
+
+    let types = type_check(
+        &project[..1],
+        &[],
+        Utf8Path::from_path(root.path()).expect("a UTF-8 path"),
+    );
+
+    assert_eq!(codes(&types), ["value-as-type"]);
+}
+
+#[cfg(feature = "upstream-typecheck")]
+#[test]
+fn a_narrowed_check_types_the_file_against_what_it_imports() {
+    if !uf_check::is_available() {
+        return;
+    }
+    let project = workspace();
+    let root = scratch();
+
+    let types = type_check(
+        &project[..1],
+        &project,
+        Utf8Path::from_path(root.path()).expect("a UTF-8 path"),
+    );
+
+    assert_eq!(codes(&types), Vec::<&str>::new());
+    let batch = types.batch().expect("a checked batch");
+    assert_eq!(batch.requested, 1);
+    // The package's own file, and the manifest that publishes its name.
+    assert_eq!(batch.imported, 2);
+}
+
+/// A file the reader did not name is in the batch to be typed against, not to
+/// be reported on. `unrelated.js` is wrong and is nobody's business here.
+#[cfg(feature = "upstream-typecheck")]
+#[test]
+fn a_narrowed_check_reports_only_the_files_it_was_asked_about() {
+    if !uf_check::is_available() {
+        return;
+    }
+    let mut project = workspace();
+    // Make the dependency itself wrong, so that the only thing keeping its
+    // diagnostic off the screen is the filter.
+    project[2]
+        .source
+        .push_str("export const wrong: number = \"no\";\n");
+    let root = scratch();
+
+    let types = type_check(
+        &project[..1],
+        &project,
+        Utf8Path::from_path(root.path()).expect("a UTF-8 path"),
+    );
+
+    assert_eq!(
+        types.diagnostics().len(),
+        0,
+        "a dependency's own errors are not the caller's: {:#?}",
+        types
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| (diagnostic.primary.path.as_str(), diagnostic.code))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The whole-project case: no narrowing, so nothing was left out and every
+/// file the scan found is both asked about and checked.
+#[cfg(feature = "upstream-typecheck")]
+#[test]
+fn an_unnarrowed_check_reports_every_file_it_was_given() {
+    if !uf_check::is_available() {
+        return;
+    }
+    let project = workspace();
+    let root = scratch();
+
+    let types = type_check(
+        &project,
+        &[],
+        Utf8Path::from_path(root.path()).expect("a UTF-8 path"),
+    );
+
+    assert_eq!(codes(&types), ["incompatible-type"]);
+    let batch = types.batch().expect("a checked batch");
+    assert_eq!(batch.requested, project.len());
+    assert_eq!(batch.imported, 0);
 }

--- a/crates/uf_cli/src/commands/lint.rs
+++ b/crates/uf_cli/src/commands/lint.rs
@@ -132,6 +132,20 @@ pub(crate) struct LintRun {
     /// type-check cache under it, and reading the config twice to learn the
     /// same answer is how the two come to disagree.
     pub(crate) root: Utf8PathBuf,
+    /// Every Flow source and manifest the scan collected, before `paths`
+    /// narrowed it — empty when nothing was narrowed away.
+    ///
+    /// The linter has no use for this: a rule reads one file, so a file nobody
+    /// asked about is a file nobody should be told about. The *checker* does,
+    /// because an import is only typed against a file in the same batch, and
+    /// the file a narrowed run imports is exactly the file narrowing removed.
+    /// `uf check` walks this set to find what its selection reaches; see
+    /// `uf_check::module_closure`.
+    ///
+    /// Empty rather than a copy when `paths` selected everything, because then
+    /// [`Self::sources`] already is the whole scan and holding a second copy of
+    /// a project's text is a real cost for no answer.
+    pub(crate) available: Vec<SourceFile>,
 }
 
 pub(crate) fn run_lint(cwd: &Utf8Path, paths: &[String]) -> Result<LintRun> {
@@ -148,16 +162,27 @@ pub(crate) fn run_lint(cwd: &Utf8Path, paths: &[String]) -> Result<LintRun> {
     scan.unreadable
         .retain(|failure| selects(paths, &failure.relative_path));
     let unreadable = unreadable_lines(&scan.unreadable);
-    let sources = scan
+    let collected = scan
         .files
         .into_iter()
         .filter(|file| file.kind.is_flow() || file.kind == SourceKind::PackageManifest)
-        .filter(|file| selects(paths, &file.relative_path))
         .map(|file| SourceFile {
             path: file.relative_path,
             source: file.source,
         })
         .collect::<Vec<_>>();
+    // Narrowing is what makes the two sets differ, so it is also the only case
+    // that pays for keeping both.
+    let (sources, available) = if paths.is_empty() {
+        (collected, Vec::new())
+    } else {
+        let selected = collected
+            .iter()
+            .filter(|file| selects(paths, &file.path))
+            .cloned()
+            .collect::<Vec<_>>();
+        (selected, collected)
+    };
     if sources.is_empty() && !paths.is_empty() && unreadable.is_empty() {
         bail!("no file matched {}", quoted_list(paths));
     }
@@ -167,6 +192,7 @@ pub(crate) fn run_lint(cwd: &Utf8Path, paths: &[String]) -> Result<LintRun> {
         sources,
         unreadable,
         root: resolved.root,
+        available,
     })
 }
 

--- a/crates/uf_project/src/template.rs
+++ b/crates/uf_project/src/template.rs
@@ -218,7 +218,7 @@ fn app_layout() -> String {
 import * as React from "@uniflowed/react";
 import { Suspense } from "@uniflowed/react";
 
-export component Layout(children: mixed) {
+export component Layout(children: React.Node) {
   return (
     <html lang="en">
       <body>

--- a/crates/uf_project/src/template.rs
+++ b/crates/uf_project/src/template.rs
@@ -213,17 +213,32 @@ export default routerView("./app");
     .to_string()
 }
 
+/// The document, and nothing else.
+///
+/// Two things it deliberately does not do.
+///
+/// It wraps the page in **no `<Suspense>`**. One with `fallback={null}` around
+/// every page is worse than none: a page that suspends under it renders as an
+/// empty document instead of failing the way React says it should, and nothing
+/// says so. That is the argument `RouteView` already makes for not inserting
+/// one — `tests/library/streaming.test.js` — and a scaffold should not ship
+/// the shape the router refuses. A route that wants a boundary declares one.
+///
+/// And `children` is **`mixed`, not `React.Node`**, which is a scaffold
+/// decision rather than advice. `React.Node` comes from `@uniflowed/react`,
+/// and `uf create` writes a project whose dependencies are not installed yet:
+/// until `uf install` runs, that import resolves to nothing and an annotation
+/// written against it is an error. `mixed` is what a document shell can say
+/// with nothing installed, and an intrinsic element takes it. A project that
+/// has installed its dependencies should write `React.Node`; see
+/// `/guide/project`.
 fn app_layout() -> String {
     r#"// @flow
-import * as React from "@uniflowed/react";
-import { Suspense } from "@uniflowed/react";
 
-export component Layout(children: React.Node) {
+export component Layout(children: mixed) {
   return (
     <html lang="en">
-      <body>
-        <Suspense fallback={null}>{children}</Suspense>
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -165,6 +165,11 @@ export const sections: $ReadOnlyArray<Section> = [
         title: "Environments",
         blurb: "A pinned toolchain per repository, in a shared store, with a collector.",
       },
+      {
+        href: "/guide/ci",
+        title: "uf in CI",
+        blurb: "GitHub Actions, GitLab and CircleCI: one step each, and why they all pin.",
+      },
     ],
   },
   {

--- a/docs/app/guide/ci/_uf.page.mdx
+++ b/docs/app/guide/ci/_uf.page.mdx
@@ -118,6 +118,15 @@ integration runs `uf --version` out of the restored directory before trusting
 it, because a cache that lost a symlink, or one restored onto an architecture
 the key did not distinguish, is a hit that can run nothing.
 
+There is a third reason, and it is the one that will bite a pipeline first.
+`latest` is the only value that asks GitHub's API which release is newest, and
+anonymous calls to that API are rate limited *by IP* — on a hosted runner, an
+IP shared with every other job on the fleet. So a pipeline on `latest` fails
+intermittently with `no release found` for reasons that have nothing to do with
+it. The GitHub action passes the workflow's own token through and is fine;
+GitLab and CircleCI hand you no GitHub token, so pin the version there. A
+pinned version builds the download URL directly and never reaches the API.
+
 ## What is actually being run
 
 All three fetch and run

--- a/docs/app/guide/ci/_uf.page.mdx
+++ b/docs/app/guide/ci/_uf.page.mdx
@@ -1,0 +1,160 @@
+---
+title: "uf in CI · uf"
+---
+
+<p className="eyebrow">The tools</p>
+
+# uf in CI
+
+<div className="lede">
+Setup for GitHub Actions, GitLab CI and CircleCI. Each is one step that
+installs the toolchain, and each is thin because all three run the same
+installer a human runs.
+</div>
+
+`uf` is one binary. A pipeline does not build it, install a package manager to
+fetch it, or configure a toolchain around it: it downloads a release, puts three
+names on `PATH`, and runs `uf check`.
+
+Three files in the repository do exactly that, one per system. Each is thin on
+purpose — every one of them runs the same installer a human runs — and each
+documents its own inputs:
+
+| System | Where it lives |
+| --- | --- |
+| GitHub Actions | [`integrations/github-actions/action.yml`](https://github.com/ubugeeei-prod/uf/blob/main/integrations/github-actions/action.yml) |
+| GitLab CI | [`integrations/gitlab/uf.gitlab-ci.yml`](https://github.com/ubugeeei-prod/uf/blob/main/integrations/gitlab/uf.gitlab-ci.yml) |
+| CircleCI | [`integrations/circleci/orb.yml`](https://github.com/ubugeeei-prod/uf/blob/main/integrations/circleci/orb.yml) |
+
+## GitHub Actions
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ubugeeei-prod/uf/integrations/github-actions@uf@0.0.0-alpha.10
+        with:
+          version: 0.0.0-alpha.10
+      - run: uf install
+      - run: uf check
+      - run: uf test
+```
+
+Inputs: `version`, `cache`, `setup-url`, `repository`. Outputs: `version`,
+`bin-dir`, `cache-hit`.
+
+On a Windows runner it **fails** rather than skipping. uf publishes macOS and
+Linux binaries only, and a matrix leg that quietly does nothing still reports
+the matrix green — which is the failure mode that would let a Windows job pass
+for a year without running anything. Run uf under WSL2 there.
+
+## GitLab CI
+
+```yaml
+include:
+  - remote: "https://raw.githubusercontent.com/ubugeeei-prod/uf/uf@0.0.0-alpha.10/integrations/gitlab/uf.gitlab-ci.yml"
+
+variables:
+  UF_VERSION: "0.0.0-alpha.10"
+
+check:
+  extends: .uf
+  script:
+    - uf install
+    - uf check
+```
+
+The template also ships `uf:check`, `uf:test` and `uf:build` as ready-made jobs,
+so a project with nothing unusual about it writes no `script` at all. They are
+ordinary jobs: extend, override or delete them.
+
+Two details are GitLab's rather than uf's. The toolchain installs into
+`$CI_PROJECT_DIR/.uf-toolchain`, because GitLab's cache only carries paths
+inside the project directory — install it in `$HOME` and every job of every
+pipeline downloads the release again. And the default image is Debian rather
+than Alpine: uf ships a `*-unknown-linux-gnu` binary, and a glibc binary does
+not start on musl.
+
+## CircleCI
+
+```yaml
+version: 2.1
+orbs:
+  uf: uniflowed/uf@1
+
+workflows:
+  ci:
+    jobs:
+      - uf/run:
+          name: check
+          version: 0.0.0-alpha.10
+          command: uf check
+```
+
+`uf/install` is the command on its own, for a job that does more than run one
+`uf` line. `uf/default` is a glibc executor with `curl` and `tar`, which is
+everything the installer needs.
+
+## Pin the version
+
+Every one of the three defaults to `latest`, and every one of them tells you not
+to leave it there. `latest` means *the newest release including prereleases* —
+which is every release uf has published so far — so it moves under a pipeline
+that did not change.
+
+It is also the one value the caches cannot help with. A cache keyed on the word
+`latest` answers with whatever release was newest the first time the pipeline
+ran, and goes on answering with it after a newer one ships: worse than no cache,
+because it looks like it is working. So all three skip the cache when the
+version is `latest`, and all three say so where the option is documented.
+
+A cache that *is* used is not believed on the strength of its key either. Each
+integration runs `uf --version` out of the restored directory before trusting
+it, because a cache that lost a symlink, or one restored onto an architecture
+the key did not distinguish, is a hit that can run nothing.
+
+## What is actually being run
+
+All three fetch and run
+[`install.sh`](https://github.com/ubugeeei-prod/uf/blob/main/infra/cloudflare/setup-assets/install.sh) —
+the same script behind `curl -fsSL https://setup.uniflowed.dev | sh`, configured
+through the environment:
+
+| Variable | What it decides |
+| --- | --- |
+| `UF_VERSION` | The release, or `latest` |
+| `UF_INSTALL_ROOT` | Where `runtimes/uf@<version>` is unpacked |
+| `UF_BIN_DIR` | Where `uf`, `ufr` and `ufx` are linked |
+| `UF_REPO` | The GitHub repository releases are downloaded from |
+
+It resolves the version, downloads `uf-<target>.tar.gz`, **verifies its sha256
+against the checksum published beside it**, refuses an archive whose members
+would land outside their own directory, unpacks it, and links the three names.
+Those steps are the reason the integrations run the installer instead of
+fetching a tarball themselves: three reimplementations would be three places to
+forget the checksum.
+
+If a pipeline must not depend on `setup.uniflowed.dev`, point `setup-url` (or
+`UF_CI_SETUP_URL` on GitLab) at a mirror, or at the raw file on a pinned tag.
+
+## Behind a proxy, or with no network at all
+
+The installer needs `curl`, `tar`, `mktemp` and `uname`, and it needs to reach
+GitHub Releases. An air-gapped runner has two options that do not involve these
+files: mirror the release assets and set `UF_RELEASE_BASE` to the mirror, which
+switches the installer to a flat `<base>/<version>/<asset>` layout; or build
+from source, which needs the pinned nightly Rust toolchain and the vendored
+Flow submodule, and takes minutes rather than seconds.
+
+## What is not here
+
+There is no Jenkins, Buildkite, Woodpecker or Drone file, and no Docker image
+that ships uf preinstalled. All of them are the same four lines — install,
+`PATH`, cache, run — and none of them is written here yet. `curl -fsSL
+https://setup.uniflowed.dev | sh` followed by adding `~/.local/bin` to `PATH`
+is the whole of what any of them would do.

--- a/docs/app/guide/project/_uf.page.mdx
+++ b/docs/app/guide/project/_uf.page.mdx
@@ -86,9 +86,10 @@ A layout renders the document. It is a `component`, and it receives the page as
 
 ```js
 // @flow
+import * as React from "@uniflowed/react";
 import { Suspense } from "@uniflowed/react";
 
-export component Layout(children: mixed) {
+export component Layout(children: React.Node) {
   return (
     <html lang="en">
       <body>
@@ -112,10 +113,13 @@ The router takes `module.default ?? module.Page`, so a default export works too
 — but `uf check` warns on a default-exported component, on the grounds that a
 route wired by name is easier to find than one wired by position.
 
-`children: mixed` rather than `React.Node` is not a style choice: `uf check`
-does not yet resolve a type imported by a package name, so `React.Node` from
-`@uniflowed/react` is an any-typed value and using it as an annotation is an
-error. That is [issue #248](https://github.com/ubugeeei-prod/uf/issues/248).
+`React.Node` there is a type imported by a package name, and it resolves:
+`uf check` reads `@uniflowed/react`'s manifest out of `node_modules`, follows
+its `exports` map, and types `children` against what the package actually
+declares. It used to say `mixed` instead, because the checker resolved no
+package and an annotation written against an any-typed value is an error —
+[#248](https://github.com/ubugeeei-prod/uf/issues/248) and
+[#403](https://github.com/ubugeeei-prod/uf/issues/403) are that history.
 
 Both files are Flow, both use `component` syntax, and neither needs a plugin
 declared anywhere. [Routing](/guide/routing) covers nesting, parameters and

--- a/docs/app/guide/project/_uf.page.mdx
+++ b/docs/app/guide/project/_uf.page.mdx
@@ -86,15 +86,11 @@ A layout renders the document. It is a `component`, and it receives the page as
 
 ```js
 // @flow
-import * as React from "@uniflowed/react";
-import { Suspense } from "@uniflowed/react";
 
-export component Layout(children: React.Node) {
+export component Layout(children: mixed) {
   return (
     <html lang="en">
-      <body>
-        <Suspense fallback={null}>{children}</Suspense>
-      </body>
+      <body>{children}</body>
     </html>
   );
 }
@@ -113,13 +109,25 @@ The router takes `module.default ?? module.Page`, so a default export works too
 — but `uf check` warns on a default-exported component, on the grounds that a
 route wired by name is easier to find than one wired by position.
 
-`React.Node` there is a type imported by a package name, and it resolves:
-`uf check` reads `@uniflowed/react`'s manifest out of `node_modules`, follows
-its `exports` map, and types `children` against what the package actually
-declares. It used to say `mixed` instead, because the checker resolved no
-package and an annotation written against an any-typed value is an error —
+Once your dependencies are installed, write `children: React.Node` instead —
+import it with `import * as React from "@uniflowed/react"`. That is the type a
+layout's children actually have, and `uf check` reads it: it finds
+`@uniflowed/react`'s manifest in `node_modules`, follows its `exports` map, and
+types `children` against what the package declares. It did not always;
 [#248](https://github.com/ubugeeei-prod/uf/issues/248) and
 [#403](https://github.com/ubugeeei-prod/uf/issues/403) are that history.
+
+The scaffold writes `mixed` because `uf create` runs *before* `uf install`, and
+until then `@uniflowed/react` resolves to nothing — an annotation written
+against it would be an error in the first file uf ever wrote for you. `mixed`
+is what a document shell can say with nothing installed, and an intrinsic
+element takes it.
+
+The scaffold also wraps the page in no `<Suspense>`. One with `fallback={null}`
+around every page is worse than none: a page that suspends under it renders as
+an empty document instead of failing the way React says it should, and nothing
+says so. [Routing](/guide/routing) covers declaring a boundary where a route
+wants one.
 
 Both files are Flow, both use `component` syntax, and neither needs a plugin
 declared anywhere. [Routing](/guide/routing) covers nesting, parameters and

--- a/docs/app/guide/styling/_uf.page.mdx
+++ b/docs/app/guide/styling/_uf.page.mdx
@@ -38,6 +38,7 @@ There is no Babel plugin to add and no PostCSS step.
 
 ```js
 // @flow
+import * as React from "@uniflowed/react";
 import { props, stylex } from "@uniflowed/stylex";
 import { ufTokens } from "@uniflowed/stylex/tokens.stylex.js";
 
@@ -50,7 +51,7 @@ const styles = stylex.create({
   },
 });
 
-export component Card(children: mixed) {
+export component Card(children: React.Node) {
   return <section {...props(styles.card)}>{children}</section>;
 }
 ```

--- a/docs/app/guide/tutorial/_uf.page.mdx
+++ b/docs/app/guide/tutorial/_uf.page.mdx
@@ -263,9 +263,10 @@ saying so — which is the one thing on this page that cost a rebuild to discove
 
 `notFound()` is written `throw notFound()` here. It does throw on its own, and
 [the routing page](/guide/routing) describes it that way; the `throw` is for the
-type checker, which cannot yet see through an import to a package
-([issue #248](https://github.com/ubugeeei-prod/uf/issues/248)) and so still
-believes `article` may be `null` on the next line.
+type checker. It reads the router's real signature now — `notFound(): empty` —
+and that is still not enough, because Flow ends a branch on a `throw`
+*statement* and has no analysis that says a call which cannot return does not
+return. Without the `throw`, `article` is still `null` on the next line.
 
 ## The layout
 
@@ -273,11 +274,12 @@ believes `article` may be `null` on the next line.
 
 ```js
 // @flow
+import * as React from "@uniflowed/react";
 import { Link } from "@uniflowed/router";
 
 import { SavedCount } from "./SavedCount.js";
 
-export component Layout(children: mixed) {
+export component Layout(children: React.Node) {
   return (
     <html lang="en">
       <head>
@@ -297,13 +299,15 @@ export component Layout(children: mixed) {
 }
 ```
 
-`children: mixed`, not `React.Node`, and that is not a stylistic choice.
-`uf check` resolves a type imported from a relative module — the `Article` above
-proves it — and does not yet resolve one imported by a package name, so
-`React.Node` from `@uniflowed/react` is an any-typed value and using it as an
-annotation is an error. `mixed` is what the scaffold writes, for the same
-reason. [Issue #248](https://github.com/ubugeeei-prod/uf/issues/248) is the work
-that changes this line back.
+`React.Node` is a type imported by a package name, and `uf check` resolves it
+the same way it resolves the `Article` above: through `@uniflowed/react`'s own
+manifest in `node_modules` and the `exports` map in it. That line used to read
+`children: mixed`, because the checker resolved no package and an annotation
+written against an any-typed value is an error rather than a weak type — the
+scaffold wrote `mixed` for the same reason.
+[#248](https://github.com/ubugeeei-prod/uf/issues/248) and
+[#403](https://github.com/ubugeeei-prod/uf/issues/403) are the two halves of
+the work that changed it back.
 
 A layout stays mounted while you navigate between pages under it, so the
 header's count survives navigation without being lifted anywhere.
@@ -681,7 +685,7 @@ whole claim is that these are real cannot start there.
 uf check
 ────────
 
-  files checked  15
+  files checked  14
   errors         0
   warnings       0
   rules skipped  16
@@ -696,25 +700,33 @@ uf check
 
 ✓ no problems
 
-  types checked  15
-  inference      28.0ms
-  builtins       54.7ms (cold)
+  types checked  105
+  asked about    14 of 105
+  inference      786.5ms
+  builtins       28.8ms (cold)
 
   › these imports are typed as any; uf resolved no module for them
-    - @uniflowed/config
-    - @uniflowed/form
-    - @uniflowed/router
-    - @uniflowed/state
-    - @uniflowed/test
-    - and 2 more
+    - @uniflowed/cell
+    - @uniflowed/host/module-mocks
+    - @uniflowed/react-testing
+    - @uniflowed/validator
+    - node:async_hooks
+    - and 1 more
 ```
 
 </figure>
 
-The last paragraph is the honest part, and it is where `children: mixed` came
-from. Nothing above is checked *against* the router's or the form's real types
-yet — [issue #248](https://github.com/ubugeeei-prod/uf/issues/248) is the work
-that changes that, and `flow` itself checks what uf cannot.
+Fourteen files were asked about and a hundred and five were typed: the other
+ninety-one are the `@uniflowed` packages this application imports, read out of
+`node_modules` so that everything above is checked *against* the router's and
+the form's real types rather than against `any`. Six names are left over, and
+each is a different reason: `@uniflowed/host/module-mocks` says `@noflow` on
+purpose, because the loader runs before any transform exists; `@uniflowed/cell`,
+`@uniflowed/react-testing` and `@uniflowed/validator` are packages the ones
+above import and this project has not installed; and `node:async_hooks` and
+`node:module` are runtime builtins Flow's library definitions do not declare.
+An import that is typed as `any` is named, so that the hole is stated rather
+than silent.
 
 `uf fmt --check` exits 0 on every file in this page, which is how they were
 written: the code here was formatted by the tool rather than by hand.
@@ -843,7 +855,7 @@ around.
 | `stylex.create` compiles to class names and no stylesheet reaches `dist/` | Styling this application with uf's own default | [#306](https://github.com/ubugeeei-prod/uf/issues/306) |
 | React Compiler diagnostics say `a function:` and name no file | 38 warnings in the build above, none actionable | [#307](https://github.com/ubugeeei-prod/uf/issues/307) |
 | A component test prints Node's `--localstorage-file` warning | The `uf test` transcript above | [#308](https://github.com/ubugeeei-prod/uf/issues/308) |
-| A type imported by package name is `any` | `children: mixed`, `throw notFound()` | [#248](https://github.com/ubugeeei-prod/uf/issues/248) |
+| A call that cannot return does not end the branch | `throw notFound()`, where `notFound(): empty` would do | Flow's own; no analysis for it |
 
 ## Where to go next
 

--- a/docs/app/guide/tutorial/_uf.page.mdx
+++ b/docs/app/guide/tutorial/_uf.page.mdx
@@ -303,11 +303,12 @@ export component Layout(children: React.Node) {
 the same way it resolves the `Article` above: through `@uniflowed/react`'s own
 manifest in `node_modules` and the `exports` map in it. That line used to read
 `children: mixed`, because the checker resolved no package and an annotation
-written against an any-typed value is an error rather than a weak type — the
-scaffold wrote `mixed` for the same reason.
+written against an any-typed value is an error rather than a weak type.
 [#248](https://github.com/ubugeeei-prod/uf/issues/248) and
 [#403](https://github.com/ubugeeei-prod/uf/issues/403) are the two halves of
-the work that changed it back.
+the work that changed it back. The scaffold still writes `mixed`, for a reason
+that has not gone away: it runs before `uf install`, so nothing is resolvable
+when it writes.
 
 A layout stays mounted while you navigate between pages under it, so the
 header's count survives navigation without being lifted anywhere.

--- a/docs/app/guide/typescript/_uf.page.mdx
+++ b/docs/app/guide/typescript/_uf.page.mdx
@@ -42,31 +42,37 @@ The list above is Flow's. This one is uf's, and it is the more useful one,
 because it is the part that can be fixed and the part that will bite you this
 week.
 
-**Types stop at the module boundary.** `uf check` runs Flow's own inference,
-and today it resolves no modules: every import is `any`, and the report says
-which ones rather than leaving you to discover it.
+**There is a library definition for everything, and Flow has fewer.** A
+TypeScript project gets `@types/*` for practically any package that ships no
+types of its own, and a `node:` builtin is described down to its overloads.
+Flow's own library definitions cover the DOM, the standard library and React,
+and stop well short of that. `uf check` resolves a dependency that opts into
+Flow with `@flow` — it reads the package's manifest out of `node_modules`,
+follows its `exports` map and types your code against the package's real
+declarations — and a dependency that does not is Flow's *unchecked module*: the
+import is `any`, and the report names it rather than leaving you to find out.
 
 <figure className="terminal">
 
 ```
-  types checked  1
-  inference      821.3µs
-  builtins       72.9ms (cold)
+  types checked  31
+  asked about    8 of 31
+  inference      196.7ms
+  builtins       26.6ms (cold)
 
   › these imports are typed as any; uf resolved no module for them
-    - ./a.js
+    - @uniflowed/host/module-mocks
+    - node:async_hooks
+    - node:module
 ```
 
 </figure>
 
-That is a two-file project where `b.js` assigns the result of a function
-returning `string` to a `number` and nothing complains, because the function
-came from the other file. Cross-module inference is the next step in
-[`docs/architecture.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/architecture.md),
-and
-[issue #248](https://github.com/ubugeeei-prod/uf/issues/248) counts what the
-related resolver bug costs on this repository: 145 of 581 reported errors — 31%
-— are one thing, a type imported by its published name resolving to nothing.
+That is `uf create app react` with its dependencies installed: eight files of
+the project's own, and twenty-three modules read out of `node_modules` to type
+them against. What is left in the list is one file that says `@noflow` on
+purpose and two `node:` builtins Flow does not declare. Under TypeScript that
+list would be empty, and that is the row.
 
 **Vite's client API has no Flow types.** A TypeScript project gets
 `import.meta.glob`, `import.meta.hot`, `import.meta.env` and the ambient

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -260,6 +260,30 @@ of the file check. Those specifiers are reported in
 repository they are the third-party packages and the `node:` builtins that no
 manifest here publishes.
 
+Which makes *what is in the batch* the whole question, and it is the caller's to
+answer. `uf_check::module_closure` is how: given the files a reader asked about
+and every file the scan found, it walks the module graph with the same
+`ModuleIndex` and `WorkspacePackages` the checker resolves through, and returns
+the files that are reachable together with the specifiers nothing answered.
+`uf check <path>` then checks the closure rather than the selection — before it
+did, a batch of one file resolved nothing, and every `import type` in it was an
+`any`-typed value the annotations were written against and never read
+([#403](https://github.com/ubugeeei-prod/uf/issues/403)). Diagnostics are still
+reported only for the files that were asked about: a dependency is in the batch
+to be typed against, not to be reported on.
+
+A specifier the closure could not answer is looked for under `node_modules`,
+which is what makes a project that merely *uses* uf check against uf's real
+types rather than against `any` — the package is read through the symlink a
+workspace makes, and its `exports` map decides which of its files anything
+resolves to. Two conditions bound that, and both are Flow's rather than uf's.
+A package Flow's own library definitions describe is never read: a file in the
+batch outranks a `declare module`, so reading React's shipped JavaScript would
+replace Flow's description of React with a bundle that has no types in it. And
+a package that declares no `@flow` anywhere is not read either: it exports `any`
+whether it is in the batch or not, so reading it would buy a parse of every byte
+it ships and nothing else.
+
 Nothing is checked twice. A run keeps one record per file under
 `.uf/cache/check/`, keyed by the identity of the `uf` that wrote it — its path,
 size and modification time, the discipline `.uf/cache/transform` already

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,10 +33,14 @@ listing it here rather than trusting anyone to remember:
    that has been one for too long.
 2. **A type that is `any` under another name.** `flow/unclear-type` catches the
    spelling. It does not catch a type that is technically not `any` and still
-   tells the caller nothing, and it does not catch inference that stops at a
-   package boundary — which is what
-   [#248](https://github.com/ubugeeei-prod/uf/issues/248) is: 145 of the 581
-   errors `uf check` reports on this repository are one resolver bug.
+   tells the caller nothing. Inference that stopped at a package boundary was
+   the worst case of it and is fixed: a bare specifier resolves through the
+   manifest that publishes it ([#248](https://github.com/ubugeeei-prod/uf/issues/248)),
+   and the batch a check runs over is the closure of what the files asked about
+   import, `node_modules` included
+   ([#403](https://github.com/ubugeeei-prod/uf/issues/403)). `uf check` reports
+   1,883 errors over this repository's 357 checked files, and they are errors
+   about types rather than about the resolver.
 3. **A feature that works for the demo.** Every fix in this repository carries
    a test that fails before it and passes after, and the corpus tests run the
    formatter over 8,100 modules nobody here wrote. That is the standard, and
@@ -53,7 +57,7 @@ rather than a note:
 | Runs on every runtime | Node and Bun. `HostKind::Deno` loads no Flow; the edge runtimes have no host at all | [#246](https://github.com/ubugeeei-prod/uf/issues/246) |
 | Builds a standalone binary | `uf build --compile` writes one, and needs Bun on PATH to do it; cross-compiling to another platform does not exist | [#310](https://github.com/ubugeeei-prod/uf/issues/310) |
 | Deploys anywhere | `uf build --adapter` writes for `node`, `container`, `edge` and `serverless`, and no output has ever been deployed to a real platform; `bun`, `deno` and `static` are names in a config struct | [#391](https://github.com/ubugeeei-prod/uf/issues/391) |
-| Inference reaches the end of a program | A type imported by its published name resolves to nothing | [#248](https://github.com/ubugeeei-prod/uf/issues/248) |
+| Inference reaches the end of a program | It does: a type imported by its published name resolves, from the workspace or from `node_modules`. What is left is a dependency that opts into no Flow, which is `any` by Flow's own rule | [#248](https://github.com/ubugeeei-prod/uf/issues/248), [#403](https://github.com/ubugeeei-prod/uf/issues/403) |
 | Everything implemented reaches a user | Ten implemented packages are on nobody's npm; `@uniflowed/tui` is a contract nobody can run | [#210](https://github.com/ubugeeei-prod/uf/issues/210), [#247](https://github.com/ubugeeei-prod/uf/issues/247) |
 
 The threat model that every one of these must satisfy is in

--- a/infra/cloudflare/setup-assets/install.sh
+++ b/infra/cloudflare/setup-assets/install.sh
@@ -492,8 +492,25 @@ esac
 #
 # Parsed with sed rather than jq, because an installer cannot require a JSON
 # parser to be installed before it can install anything.
+#
+# `GITHUB_TOKEN` is used when it is set, and only here. Anonymous calls to the
+# GitHub API are rate limited *per IP*, and a CI runner's IP is shared with
+# every other job on the fleet — so this is the one step of the install that
+# fails for reasons that have nothing to do with the caller, intermittently,
+# with `no release found`. A pinned `UF_VERSION` never reaches this function at
+# all; `latest` on CI is what needs the token.
+#
+# Sent to `api.github.com` and to nothing else. The token never reaches the
+# download below, which is a redirect to a storage host and has no business
+# seeing it.
 newest_prerelease_tag() {
-  curl -fsSL -H 'accept: application/vnd.github+json' \
+  github_token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+  if [ -n "$github_token" ]; then
+    set -- -H "authorization: Bearer ${github_token}"
+  else
+    set --
+  fi
+  curl -fsSL -H 'accept: application/vnd.github+json' "$@" \
     "https://api.github.com/repos/${repo}/releases?per_page=1" 2>/dev/null |
     tr ',' '\n' |
     sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
@@ -520,8 +537,17 @@ elif [ "$requested_version" = "latest" ]; then
     tag="$(newest_prerelease_tag)"
     version="${tag#uf@}"
     if [ -z "$version" ]; then
-      uf_fail "no release found for ${repo}" \
-        "set UF_VERSION to install a specific release"
+      # Named separately, because the two causes need different answers: a
+      # repository with no releases is a mistake in `UF_REPO`, and a rate
+      # limited API call is a CI runner that needs `GITHUB_TOKEN` in its
+      # environment.
+      if [ -n "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ]; then
+        uf_fail "no release found for ${repo}" \
+          "set UF_VERSION to install a specific release"
+      else
+        uf_fail "no release found for ${repo}" \
+          "GitHub rate limits anonymous callers by IP; set GITHUB_TOKEN, or set UF_VERSION"
+      fi
     fi
     channel_url="https://github.com/${repo}/releases/download/uf@${version}"
   fi

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,88 @@
+# CI integrations
+
+Setup for the three CI systems, so that a pipeline installs `uf` in one step
+instead of building it from source.
+
+| System | File | How a project uses it |
+| --- | --- | --- |
+| GitHub Actions | [`github-actions/action.yml`](github-actions/action.yml) | `uses: ubugeeei-prod/uf/integrations/github-actions@uf@0.0.0-alpha.10` |
+| GitLab CI | [`gitlab/uf.gitlab-ci.yml`](gitlab/uf.gitlab-ci.yml) | `include: [{ remote: "…/integrations/gitlab/uf.gitlab-ci.yml" }]`, then `extends: .uf` |
+| CircleCI | [`circleci/orb.yml`](circleci/orb.yml) | `orbs: { uf: uniflowed/uf@1 }`, then `uf/install` or the `uf/run` job |
+
+Each file documents its own inputs. What follows is what they have in common,
+and why they are three thin files rather than three implementations.
+
+## All three run the same installer
+
+`https://setup.uniflowed.dev` serves
+[`infra/cloudflare/setup-assets/install.sh`](../infra/cloudflare/setup-assets/install.sh),
+which is what a human runs:
+
+```sh
+curl -fsSL https://setup.uniflowed.dev | sh
+```
+
+It resolves a version, downloads `uf-<target>.tar.gz` from GitHub Releases,
+**verifies its sha256 against the checksum published beside it**, refuses an
+archive whose members would land outside their own directory, unpacks it under
+`$UF_INSTALL_ROOT/runtimes/uf@<version>`, and links `uf`, `ufr` and `ufx` into
+`$UF_BIN_DIR`. Every one of those steps is a reason not to reimplement it three
+times: an integration that fetched a tarball itself would be an integration that
+skipped the checksum.
+
+So each file here is the same four decisions in that system's own vocabulary:
+
+1. where to install (`UF_INSTALL_ROOT`, `UF_BIN_DIR`), chosen so that the
+   system's own cache can carry it;
+2. how to get that directory onto `PATH` for the steps that follow;
+3. when the cache may be believed;
+4. what happens on a platform with no build.
+
+`tools/ci/integrations-agree.sh` checks the first of those against the installer
+itself: an integration may only set environment variables `install.sh` actually
+reads, so a renamed variable fails here rather than in somebody's pipeline.
+
+## Pin the version
+
+Every file defaults to `latest` and every file tells you not to leave it there.
+`latest` is *the newest release including prereleases* — which is every release
+uf has published so far — so it moves under a pipeline that did not change.
+
+It is also the one value the caches cannot help with. A cache keyed on the word
+`latest` answers with whatever release was newest the first time the pipeline
+ran, and goes on answering with it after a newer one ships; that is worse than
+no cache, so all three skip the cache when the version is `latest`, and all
+three say so where the option is documented.
+
+A restored cache is not believed on the strength of the key either. Each
+integration runs `uf --version` out of the restored directory first: a cache
+that lost a symlink, or one restored onto a different architecture under a key
+that did not distinguish it, looks like a hit and can run nothing.
+
+## Platforms
+
+uf publishes macOS and Linux binaries for `x86_64` and `aarch64`. There is no
+Windows build, and none of these pretend otherwise:
+
+* the GitHub action **fails** on a Windows runner with the reason, rather than
+  skipping — a matrix leg that quietly does nothing still reports green;
+* the GitLab template and the CircleCI orb default to a glibc image, and both
+  say why Alpine is not offered: uf ships a `*-unknown-linux-gnu` binary, and a
+  glibc binary does not start on musl.
+
+On Windows, run uf under WSL2.
+
+## Publishing the CircleCI orb
+
+`circleci/orb.yml` is the orb *source*. Making it available as
+`uniflowed/uf@1` needs a registered namespace and a publish, which is a release
+step rather than something in this repository's CI:
+
+```sh
+circleci orb validate integrations/circleci/orb.yml
+circleci orb publish integrations/circleci/orb.yml uniflowed/uf@<version>
+```
+
+Until it is published, a CircleCI config can use the file directly by copying
+the `install` command's steps, or by vendoring the orb with
+`circleci config pack`.

--- a/integrations/circleci/orb.yml
+++ b/integrations/circleci/orb.yml
@@ -38,7 +38,10 @@ commands:
           was published under (uf@0.0.0-alpha.10), or "latest". Pin it.
           "latest" is the newest release including prereleases, which is every
           release uf has published so far, so it moves under a config that did
-          not change.
+          not change — and it is the only value that asks GitHub's API which
+          release is newest, where anonymous callers are rate limited by an IP
+          a shared runner does not control. A pinned version builds the
+          download URL directly and never goes near the API.
         type: string
         default: latest
       cache:

--- a/integrations/circleci/orb.yml
+++ b/integrations/circleci/orb.yml
@@ -1,0 +1,209 @@
+version: 2.1
+
+description: >
+  Install the uf toolchain and put uf, ufr and ufx on PATH, so a job can run
+  uf check, uf test and uf build without building anything from source.
+  uf publishes macOS and Linux binaries for x86_64 and aarch64; there is no
+  Windows build, so the `windows` executor is not supported.
+
+display:
+  home_url: https://uniflowed.dev
+  source_url: https://github.com/ubugeeei-prod/uf
+
+# --- Executors -------------------------------------------------------------
+
+executors:
+  default:
+    description: >
+      A glibc Linux image with curl and tar, which is everything the installer
+      needs. Alpine is deliberately not offered: uf ships a
+      `*-unknown-linux-gnu` binary and a glibc binary does not start on musl.
+    parameters:
+      tag:
+        type: string
+        default: "24.04"
+    docker:
+      - image: cimg/base:<< parameters.tag >>
+
+# --- Commands --------------------------------------------------------------
+
+commands:
+  install:
+    description: >
+      Install uf and add it to PATH for every later step in the job.
+    parameters:
+      version:
+        description: >
+          The release to install: a version such as 0.0.0-alpha.10, the tag it
+          was published under (uf@0.0.0-alpha.10), or "latest". Pin it.
+          "latest" is the newest release including prereleases, which is every
+          release uf has published so far, so it moves under a config that did
+          not change.
+        type: string
+        default: latest
+      cache:
+        description: >
+          Cache the installed toolchain between jobs. Ignored when `version` is
+          "latest": a cache keyed on the word "latest" answers with whatever
+          release was newest the first time the workflow ran, and goes on
+          answering with it after a newer one ships.
+        type: boolean
+        default: true
+      install-dir:
+        description: >
+          Where the toolchain is unpacked. Under the home directory so that a
+          job which checks out no repository can still install one. Written
+          with a leading `~` because that is the one form `save_cache` expands;
+          the steps below expand it themselves for the shell, which does not
+          expand a `~` inside quotes.
+        type: string
+        default: ~/.local/share/uf
+      setup-url:
+        description: >
+          Where the installer is fetched from. Point it at a mirror, or at a
+          raw URL on a pinned tag, if a job must not depend on this host.
+        type: string
+        default: https://setup.uniflowed.dev
+      repository:
+        description: >
+          The GitHub repository the release archives are downloaded from. Only
+          useful for a fork or a rehearsal of the release process.
+        type: string
+        default: ubugeeei-prod/uf
+    steps:
+      # PATH first, and in its own step, because CircleCI reads $BASH_ENV at
+      # the start of every *later* step and not during the one that wrote it.
+      # A job that appended to it after installing would have uf on PATH for
+      # the steps that follow and not for the check that it worked.
+      - run:
+          name: Put uf on PATH
+          command: |
+            set -eu
+            install_dir="<< parameters.install-dir >>"
+            case "$install_dir" in "~"/*) install_dir="${HOME}/${install_dir#"~/"}" ;; esac
+            echo "export PATH=\"${install_dir}/bin:\$PATH\"" >> "$BASH_ENV"
+      - when:
+          condition:
+            and:
+              - << parameters.cache >>
+              - not:
+                  equal: [latest, << parameters.version >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - uf-v1-{{ arch }}-<< parameters.version >>
+      - run:
+          name: Install uf << parameters.version >>
+          environment:
+            UF_VERSION: << parameters.version >>
+            UF_REPO: << parameters.repository >>
+          command: |
+            set -eu
+            install_dir="<< parameters.install-dir >>"
+            case "$install_dir" in "~"/*) install_dir="${HOME}/${install_dir#"~/"}" ;; esac
+            UF_INSTALL_ROOT="$install_dir"
+            UF_BIN_DIR="${install_dir}/bin"
+            export UF_INSTALL_ROOT UF_BIN_DIR
+            # A restored cache is believed only when the binary in it answers.
+            # A cache that lost a symlink, or one restored onto a different
+            # architecture, looks like a hit and can run nothing — and `{{ arch }}`
+            # does not distinguish every image a key could be shared across.
+            if [ "$UF_VERSION" != "latest" ] && [ -x "${UF_BIN_DIR}/uf" ] \
+              && "${UF_BIN_DIR}/uf" --version >/dev/null 2>&1; then
+              echo "uf ${UF_VERSION} restored from the cache"
+            else
+              # The installer verifies the archive's sha256 against the
+              # checksum published beside it before unpacking. That is the
+              # reason to run it rather than to fetch a tarball here.
+              curl -fsSL "<< parameters.setup-url >>" | sh
+            fi
+            "${UF_BIN_DIR}/uf" --version
+      - when:
+          condition:
+            and:
+              - << parameters.cache >>
+              - not:
+                  equal: [latest, << parameters.version >>]
+          steps:
+            - save_cache:
+                key: uf-v1-{{ arch }}-<< parameters.version >>
+                paths:
+                  - << parameters.install-dir >>
+
+# --- Jobs ------------------------------------------------------------------
+#
+# One job, parameterised by the command to run, rather than three that differ
+# by one line. A workflow names it three times if it wants three.
+
+jobs:
+  run:
+    description: >
+      Check out the repository, install uf, and run one uf command.
+    parameters:
+      command:
+        description: The uf command to run, for example `uf check`.
+        type: string
+        default: uf check
+      version:
+        type: string
+        default: latest
+      cache:
+        type: boolean
+        default: true
+      executor:
+        type: executor
+        default: default
+    executor: << parameters.executor >>
+    steps:
+      - checkout
+      - install:
+          version: << parameters.version >>
+          cache: << parameters.cache >>
+      - run:
+          name: << parameters.command >>
+          command: << parameters.command >>
+
+# --- Examples --------------------------------------------------------------
+
+examples:
+  check-and-test:
+    description: >
+      Lint, type check and test a uf project on every push, with the toolchain
+      cached between runs.
+    usage:
+      version: 2.1
+      orbs:
+        uf: uniflowed/uf@1
+      workflows:
+        ci:
+          jobs:
+            - uf/run:
+                name: check
+                version: 0.0.0-alpha.10
+                command: uf check
+            - uf/run:
+                name: test
+                version: 0.0.0-alpha.10
+                command: uf test
+
+  install-in-your-own-job:
+    description: >
+      Use the command directly when a job does more than run one uf command.
+    usage:
+      version: 2.1
+      orbs:
+        uf: uniflowed/uf@1
+      jobs:
+        build:
+          executor: uf/default
+          steps:
+            - checkout
+            - uf/install:
+                version: 0.0.0-alpha.10
+            - run: uf build
+            - store_artifacts:
+                path: dist
+      workflows:
+        ci:
+          jobs:
+            - build

--- a/integrations/github-actions/action.yml
+++ b/integrations/github-actions/action.yml
@@ -83,7 +83,7 @@ runs:
     - name: Restore the toolchain
       id: restore
       if: inputs.cache == 'true' && inputs.version != 'latest'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.paths.outputs.root }}
         key: uf-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
@@ -119,7 +119,7 @@ runs:
 
     - name: Save the toolchain
       if: inputs.cache == 'true' && inputs.version != 'latest' && steps.restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.paths.outputs.root }}
         key: uf-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}

--- a/integrations/github-actions/action.yml
+++ b/integrations/github-actions/action.yml
@@ -1,0 +1,129 @@
+name: Set up uf
+description: >-
+  Install the uf toolchain and put uf, ufr and ufx on PATH, so a workflow can
+  run uf check, uf test and uf build without building anything from source.
+author: ubugeeei
+
+branding:
+  icon: box
+  color: purple
+
+inputs:
+  version:
+    description: >-
+      The release to install: a version such as 0.0.0-alpha.10, the tag it was
+      published under (uf@0.0.0-alpha.10), or "latest". Pin it. "latest" is the
+      newest release including prereleases, which is every release uf has
+      published so far, and it changes under a workflow that did not change.
+    required: false
+    default: latest
+  cache:
+    description: >-
+      Cache the installed toolchain between runs. Ignored when version is
+      "latest": a cache keyed on the word "latest" would answer with whatever
+      release happened to be newest the first time the workflow ran, and go on
+      answering with it after a newer one shipped. Pin the version to cache it.
+    required: false
+    default: "true"
+  setup-url:
+    description: >-
+      Where to fetch the installer from. The default is the same script
+      `curl -fsSL https://setup.uniflowed.dev | sh` runs; point it at a mirror
+      or a pinned raw URL if a workflow must not depend on that host.
+    required: false
+    default: https://setup.uniflowed.dev
+  repository:
+    description: >-
+      The GitHub repository the release archives are downloaded from. Only
+      useful for a fork or a rehearsal of the release process.
+    required: false
+    default: ubugeeei-prod/uf
+
+outputs:
+  version:
+    description: The version that was installed, as `uf --version` reports it.
+    value: ${{ steps.install.outputs.version }}
+  bin-dir:
+    description: The directory holding the `uf`, `ufr` and `ufx` symlinks.
+    value: ${{ steps.paths.outputs.bin-dir }}
+  cache-hit:
+    description: Whether the toolchain came from the cache rather than a download.
+    value: ${{ steps.restore.outputs.cache-hit == 'true' }}
+
+runs:
+  using: composite
+  steps:
+    # Windows first, and as a failure rather than a skip. A workflow whose
+    # matrix quietly does nothing on one leg is worse than one that stops: the
+    # legs that did run go green, and the report says the matrix passed.
+    - name: Refuse Windows, with the reason
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        echo "::error::uf publishes macOS and Linux binaries only. Use a linux or macos runner, or run uf under WSL2."
+        exit 1
+
+    - name: Resolve paths
+      id: paths
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Under the runner tool cache, which is what it is for and what a
+        # self-hosted runner is configured to keep. Not $HOME/.local, because
+        # actions/cache restores into the workspace's filesystem and a
+        # self-hosted runner may share $HOME between jobs.
+        root="${RUNNER_TOOL_CACHE}/uf"
+        {
+          echo "root=${root}"
+          echo "bin-dir=${root}/bin"
+        } >> "$GITHUB_OUTPUT"
+
+    # Only for a pinned version: see the `cache` input for why "latest" is not
+    # cacheable by key.
+    - name: Restore the toolchain
+      id: restore
+      if: inputs.cache == 'true' && inputs.version != 'latest'
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.paths.outputs.root }}
+        key: uf-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+
+    - name: Install uf
+      id: install
+      shell: bash
+      env:
+        UF_VERSION: ${{ inputs.version }}
+        UF_REPO: ${{ inputs.repository }}
+        UF_INSTALL_ROOT: ${{ steps.paths.outputs.root }}
+        UF_BIN_DIR: ${{ steps.paths.outputs.bin-dir }}
+        SETUP_URL: ${{ inputs.setup-url }}
+        CACHED: ${{ steps.restore.outputs.cache-hit }}
+      run: |
+        set -euo pipefail
+        uf_bin="${UF_BIN_DIR}/uf"
+        # A restored cache is only believed after the binary in it answers. An
+        # archive that unpacked into a cache and then lost a symlink, or a
+        # runner whose architecture changed under the same key, both look like
+        # a hit and neither can run anything.
+        if [ "${CACHED:-}" = "true" ] && [ -x "$uf_bin" ] && "$uf_bin" --version >/dev/null 2>&1; then
+          echo "uf ${UF_VERSION} restored from the cache"
+        else
+          # The installer writes its progress to stderr and the binary to
+          # UF_BIN_DIR. It verifies the archive's sha256 against the checksum
+          # published beside it before unpacking, which is the reason to run it
+          # rather than to curl a tarball here.
+          curl -fsSL "$SETUP_URL" | sh
+        fi
+        "$uf_bin" --version
+        echo "version=$("$uf_bin" --version | awk '{ print $2 }')" >> "$GITHUB_OUTPUT"
+
+    - name: Save the toolchain
+      if: inputs.cache == 'true' && inputs.version != 'latest' && steps.restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.paths.outputs.root }}
+        key: uf-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+
+    - name: Put uf on PATH
+      shell: bash
+      run: echo "${{ steps.paths.outputs.bin-dir }}" >> "$GITHUB_PATH"

--- a/integrations/github-actions/action.yml
+++ b/integrations/github-actions/action.yml
@@ -57,8 +57,13 @@ outputs:
     description: The directory holding the `uf`, `ufr` and `ufx` symlinks.
     value: ${{ steps.paths.outputs.bin-dir }}
   cache-hit:
-    description: Whether the toolchain came from the cache rather than a download.
-    value: ${{ steps.restore.outputs.cache-hit == 'true' }}
+    description: >-
+      Whether the toolchain came from the cache rather than a download. From
+      the install step rather than from the restore, because a key that matched
+      is not a toolchain that runs: a restore whose binary cannot answer is
+      followed by a download, and reporting that as a hit would describe the
+      lookup instead of the outcome.
+    value: ${{ steps.install.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -118,7 +123,9 @@ runs:
         # a hit and neither can run anything.
         if [ "${CACHED:-}" = "true" ] && [ -x "$uf_bin" ] && "$uf_bin" --version >/dev/null 2>&1; then
           echo "uf ${UF_VERSION} restored from the cache"
+          echo "cache-hit=true" >> "$GITHUB_OUTPUT"
         else
+          echo "cache-hit=false" >> "$GITHUB_OUTPUT"
           # The installer writes its progress to stderr and the binary to
           # UF_BIN_DIR. It verifies the archive's sha256 against the checksum
           # published beside it before unpacking, which is the reason to run it

--- a/integrations/github-actions/action.yml
+++ b/integrations/github-actions/action.yml
@@ -38,6 +38,16 @@ inputs:
       useful for a fork or a rehearsal of the release process.
     required: false
     default: ubugeeei-prod/uf
+  token:
+    description: >-
+      A GitHub token, used only to ask the API which release is newest — and
+      only when `version` is "latest", because a pinned version needs no API
+      call at all. Anonymous calls are rate limited per IP and a runner's IP is
+      shared with the rest of the fleet, so without one this step fails
+      intermittently with "no release found". The default is the workflow's own
+      token, which needs no permissions beyond the default `contents: read`.
+    required: false
+    default: ${{ github.token }}
 
 outputs:
   version:
@@ -98,6 +108,7 @@ runs:
         UF_BIN_DIR: ${{ steps.paths.outputs.bin-dir }}
         SETUP_URL: ${{ inputs.setup-url }}
         CACHED: ${{ steps.restore.outputs.cache-hit }}
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         set -euo pipefail
         uf_bin="${UF_BIN_DIR}/uf"

--- a/integrations/gitlab/uf.gitlab-ci.yml
+++ b/integrations/gitlab/uf.gitlab-ci.yml
@@ -1,0 +1,121 @@
+# uf on GitLab CI.
+#
+# Include it, then extend `.uf` in any job that needs the toolchain:
+#
+#     include:
+#       - remote: "https://raw.githubusercontent.com/ubugeeei-prod/uf/uf@0.0.0-alpha.10/integrations/gitlab/uf.gitlab-ci.yml"
+#
+#     variables:
+#       UF_VERSION: "0.0.0-alpha.10"
+#
+#     check:
+#       extends: .uf
+#       script:
+#         - uf check
+#
+# Pin the `include` to a tag. A `remote:` include is fetched at pipeline
+# creation, so one on a branch changes what a pipeline runs without anything in
+# the project changing.
+#
+# The ready-made jobs at the bottom — `uf:check`, `uf:test`, `uf:build` — are
+# there so that a project with nothing unusual about it writes no script at all.
+# They are ordinary jobs: override, extend or delete them.
+#
+# ## Why the toolchain is installed inside the project directory
+#
+# GitLab's cache only carries paths under `$CI_PROJECT_DIR`, and its artifacts
+# only carry paths under it too. An installer that put `uf` in `$HOME/.local`
+# would work and would download the release on every job of every pipeline.
+# `.uf-toolchain/` is inside the project, so `cache:` can keep it — and it is
+# in `.gitignore` terms a build directory, not something to commit.
+
+variables:
+  # Pin this. `latest` is the newest release including prereleases — which is
+  # every release uf has published so far — so it moves under a pipeline that
+  # did not change, and it is the one value the cache below cannot help with.
+  UF_VERSION: "latest"
+  # Where the installer is fetched from. Point it at a mirror, or at a raw URL
+  # on a pinned tag, if a pipeline must not depend on this host.
+  #
+  # `UF_CI_` rather than `UF_`, here and for `UF_CI_SKIP_APT` below, because
+  # `UF_*` is the installer's namespace and these two are this template's own.
+  # GitLab has one place to put configuration and the installer reads whatever
+  # is in the environment, so without the split a typo here would look like a
+  # setting the installer ignored. `tools/ci/integrations-agree.sh` holds the
+  # line.
+  UF_CI_SETUP_URL: "https://setup.uniflowed.dev"
+  # Kept under the project directory so `cache:` can carry it. See above.
+  UF_INSTALL_ROOT: "${CI_PROJECT_DIR}/.uf-toolchain"
+  UF_BIN_DIR: "${CI_PROJECT_DIR}/.uf-toolchain/bin"
+
+# The setup itself. Extend this; do not run it as a job.
+#
+# GitLab runs `before_script` and `script` as one shell script, so the `export
+# PATH` below reaches every line a job writes. A job that replaces
+# `before_script` replaces this too, and has to install the toolchain itself.
+#
+# `image` is Debian rather than Alpine on purpose: uf ships a
+# `*-unknown-linux-gnu` binary, and Alpine is musl, where a glibc binary does
+# not start. Override `image` with any glibc distribution.
+.uf:
+  image: debian:stable-slim
+  cache:
+    # On the version, so a pipeline that pins one is never handed another.
+    # `latest` is in the key too, and the `before_script` below deliberately
+    # ignores what it restores: a cache keyed on the word `latest` answers with
+    # whatever release was newest the first time the pipeline ran, and goes on
+    # answering with it after a newer one ships. So on `latest` this cache is
+    # inert, and a pipeline that wants it to do anything should pin a version.
+    key: "uf-${UF_VERSION}"
+    paths:
+      - .uf-toolchain/
+    policy: pull-push
+  before_script:
+    - |
+      set -eu
+      if [ -z "${UF_CI_SKIP_APT:-}" ]; then
+        apt-get update -qq
+        apt-get install -y -qq --no-install-recommends ca-certificates curl tar >/dev/null
+      fi
+      # A restored cache is believed only when the binary in it answers: a
+      # cache that lost a symlink, or one restored onto a different
+      # architecture, looks like a hit and can run nothing.
+      if [ "$UF_VERSION" != "latest" ] && [ -x "${UF_BIN_DIR}/uf" ] \
+        && "${UF_BIN_DIR}/uf" --version >/dev/null 2>&1; then
+        echo "uf ${UF_VERSION} restored from the cache"
+      else
+        # The installer verifies the archive's sha256 against the checksum
+        # published beside it before unpacking. That is the reason to run it
+        # rather than to fetch a tarball here.
+        curl -fsSL "$UF_CI_SETUP_URL" | sh
+      fi
+      export PATH="${UF_BIN_DIR}:${PATH}"
+      uf --version
+
+# --- Ready-made jobs -------------------------------------------------------
+#
+# Delete what a project does not want. `uf check` is both halves — the linter
+# and Flow's own inference — so a pipeline that runs it does not also need a
+# separate lint job.
+
+uf:check:
+  extends: .uf
+  stage: test
+  script:
+    - uf check
+
+uf:test:
+  extends: .uf
+  stage: test
+  script:
+    - uf test
+
+uf:build:
+  extends: .uf
+  stage: build
+  script:
+    - uf build
+  artifacts:
+    paths:
+      - dist/
+    expire_in: 1 week

--- a/integrations/gitlab/uf.gitlab-ci.yml
+++ b/integrations/gitlab/uf.gitlab-ci.yml
@@ -33,6 +33,13 @@ variables:
   # Pin this. `latest` is the newest release including prereleases — which is
   # every release uf has published so far — so it moves under a pipeline that
   # did not change, and it is the one value the cache below cannot help with.
+  #
+  # It is also the only value that asks GitHub's API which release is newest,
+  # and anonymous calls to that API are rate limited *by IP* — which on shared
+  # runners is an IP you have no control over. A pinned version builds the
+  # download URL directly and never goes near it. `install.sh` will use
+  # `GITHUB_TOKEN` if the environment has one, and GitLab does not hand you a
+  # GitHub token, so pinning is the answer here rather than a variable.
   UF_VERSION: "latest"
   # Where the installer is fetched from. Point it at a mirror, or at a raw URL
   # on a pinned tag, if a pipeline must not depend on this host.

--- a/tools/ci/integrations-agree.sh
+++ b/tools/ci/integrations-agree.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# The CI integrations set only environment variables the installer reads.
+#
+# `integrations/` holds three files that install `uf` by running the same
+# script `curl -fsSL https://setup.uniflowed.dev | sh` runs, configured
+# entirely through environment variables. Nothing else connects them: the
+# installer is shell, the integrations are YAML for three different systems,
+# and no compiler, linter or test sees both.
+#
+# So a rename in `install.sh` — `UF_BIN_DIR` to `UF_BINDIR`, say — leaves three
+# integrations passing a variable nothing reads. The installer then does what
+# it does with no configuration at all: it installs into `$HOME/.local/bin`,
+# succeeds, and the integration's next step puts a directory that holds nothing
+# onto `PATH`. The failure surfaces as `uf: command not found` in somebody
+# else's pipeline, on a system this repository has no job for.
+#
+# This is the cheapest check that would have caught it: read the variable names
+# out of the installer, read the ones the integrations set, and require the
+# second set to be contained in the first.
+#
+# It is deliberately one-directional. The installer may read a variable no
+# integration sets — most of them are for a human — but an integration that
+# sets one the installer does not read is always a mistake.
+#
+# `UF_CI_*` is the exception, and it is a namespace rather than a waiver: an
+# integration has settings of its own — where to fetch the installer from,
+# whether to install `curl` first — and GitLab has nowhere but the environment
+# to put them. Splitting the prefixes is what keeps "the installer ignored my
+# variable" from looking the same as "this template named its own".
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+installer="infra/cloudflare/setup-assets/install.sh"
+integrations="integrations/github-actions/action.yml
+integrations/gitlab/uf.gitlab-ci.yml
+integrations/circleci/orb.yml"
+
+status=0
+
+fail() {
+  echo "integrations-agree: FAIL: $*" >&2
+  status=1
+}
+
+[ -f "$installer" ] || {
+  fail "the installer is not at $installer"
+  exit 1
+}
+
+# `${UF_X:-…}` and `${UF_X}` and `$UF_X`, which is every way the installer
+# names one. Sorted and de-duplicated so the comparison below is a plain
+# membership test.
+honoured="$(
+  sed -n 's/.*\${\{0,1\}\(UF_[A-Z0-9_]*\).*/\1/p' "$installer" |
+    sort -u
+)"
+
+[ -n "$honoured" ] || {
+  fail "found no UF_* variables in $installer — has it been rewritten?"
+  exit 1
+}
+
+echo "installer honours:"
+echo "$honoured" | sed 's/^/  /'
+
+for file in $integrations; do
+  [ -f "$file" ] || {
+    fail "$file is missing"
+    continue
+  }
+  # Every `UF_NAME:` key and every `UF_NAME=` assignment in the YAML. The
+  # trailing `:` or `=` is what distinguishes a variable being *set* from one
+  # merely being named in a comment, which several of them are.
+  # `UF_CI_*` is the integration's own namespace; everything else under `UF_`
+  # is the installer's and has to be one it reads.
+  used="$(
+    sed -n 's/.*[^A-Z_]\{0,1\}\(UF_[A-Z0-9_]*\)[[:space:]]*[:=].*/\1/p' "$file" |
+      grep -v '^UF_CI_' |
+      sort -u || true
+  )"
+  for name in $used; do
+    if echo "$honoured" | grep -qx "$name"; then
+      echo "  ok  $file sets $name"
+    else
+      fail "$file sets $name, which $installer does not read"
+    fi
+  done
+done
+
+# The other half of the contract. Each integration decides whether a restored
+# cache is usable by running the binary in it, because a key that matched
+# proves only that a key matched: a cache that lost a symlink, or one restored
+# onto an architecture the key did not distinguish, is a hit that can run
+# nothing. An integration that skipped that would install nothing and put an
+# empty directory on `PATH`.
+for file in $integrations; do
+  grep -q -- '--version' "$file" ||
+    fail "$file never runs \`uf --version\`, so it cannot tell a broken cache from a good one"
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "integrations-agree: ok"
+fi
+exit "$status"

--- a/tools/ci/integrations-agree.sh
+++ b/tools/ci/integrations-agree.sh
@@ -96,7 +96,10 @@ done
 # nothing. An integration that skipped that would install nothing and put an
 # empty directory on `PATH`.
 for file in $integrations; do
-  grep -q -- '--version' "$file" ||
+  # Comment lines stripped first. Every one of these files *explains* the rule
+  # as well as applying it, and a check that reads the explanation would go on
+  # passing after the code below it was deleted.
+  grep -v '^[[:space:]]*#' "$file" | grep -q -- '--version' ||
     fail "$file never runs \`uf --version\`, so it cannot tell a broken cache from a good one"
 done
 

--- a/uf.config.js
+++ b/uf.config.js
@@ -352,6 +352,13 @@ export default defineConfig({
     "install:banner": "tools/ci/install-banner-fits.sh",
     "scripts:parse": "tools/ci/scripts-parse.sh",
     "scripts:parse:test": "tools/ci/test-scripts-parse.sh",
+    // And that `integrations/` and the installer still agree. The three CI
+    // integrations configure `install.sh` entirely through the environment,
+    // and nothing else in this repository reads both sides — a renamed
+    // variable would leave them passing something nothing reads, the
+    // installer would fall back to its defaults, and the failure would be
+    // `uf: command not found` in somebody else's pipeline.
+    integrations: "tools/ci/integrations-agree.sh",
     lockfile: "tools/ci/lockfile-in-sync.sh",
     // The check reads the lock rather than regenerating it, so every way a
     // lock can fall behind has to be written down as a case. Its first
@@ -395,6 +402,7 @@ export default defineConfig({
         "install:banner",
         "scripts:parse",
         "scripts:parse:test",
+        "integrations",
         "release:closure",
         "publishable",
         "publishable:test",


### PR DESCRIPTION
Two pieces of work.

## `uf check` checks a file against what it imports ([#403](https://github.com/ubugeeei-prod/uf/issues/403))

`uf check <path>` handed the checker the files it was asked about and nothing else, and `uf_check` resolves an import to a file in the batch or to nothing typed. So a batch of one file resolved nothing: `import type { Control } from "@uniflowed/form"` was an `any`-typed value, and the annotations written against it were neither right nor wrong — they were unread.

Both of #403's items are here.

**The batch is now the closure.** `uf_check::module_closure` walks the module graph from the files a reader asked about, through the same `ModuleIndex` and `WorkspacePackages` the checker resolves through, and returns what is reachable with the manifests that named it. It parses each module it reaches and packs no signatures. Diagnostics are still reported only for the files that were asked about: a dependency is in the batch to be typed against, not to be reported on.

**A specifier nothing answered is looked for under `node_modules`.** Read through the symlink a workspace makes, with the package's `exports` map deciding what resolves to what. Two conditions bound it, both Flow's: a package Flow's library definitions describe is never read (a file in the batch outranks a `declare module`, so reading React's shipped JavaScript would replace Flow's description of React with a bundle that has no types), and a package that declares no `@flow` anywhere is not read either (it exports `any` whether it is in the batch or not).

### Measured

| Command | Before | After |
| --- | --- | --- |
| `uf check packages/form/watch.js` | 15 errors, all `value-as-type` | **0** |
| `uf check tests/library/validator.test.js` | 11, ten of them `value-as-type` | **9**, none of them |
| `uf check tests/library/form.test.js` | 31, 23 `value-as-type` | **176** — the 143 new ones are `incompatible-type` that nothing could see before |
| `uf check` (whole repository) | 1,883 over 357 files, 27 untyped | **identical**, diagnostic for diagnostic |

Verified outside this repository, because inside it the workspace makes every package resolve anyway. `uf create` → `uf install` → `uf check` on a scaffold types 8 files against 31 modules read from `node_modules`; a linked workspace package resolves through its symlink; a package with no `@flow` stays `any` and is named in the footer.

The scaffold's `children: mixed` becomes `children: React.Node` — `mixed` was only ever there because `React.Node` resolved to nothing, and with the fix the old line is an error. The guides that explained that workaround, and the two `uf check` figures that showed it, are updated from real runs.

## Three CI setups

`integrations/` holds a GitHub composite action, a GitLab `include:` template and a CircleCI orb. All three run the same installer a human runs, configured through the environment — which is why they are thin: the installer verifies the archive's sha256 and refuses one whose members escape their directory, and three reimplementations would be three places to forget that.

They agree on the awkward parts: pin the version, never cache `latest`, and never believe a restored cache without running `uf --version` out of it. The action fails on Windows rather than skipping, because a matrix leg that quietly does nothing still reports green.

Two checks keep them honest — `tools/ci/integrations-agree.sh` (the variables they set are ones the installer reads) and `.github/workflows/integrations.yml` (the action installs the last published release on ubuntu and macos, then scaffolds a project and checks it). `/guide/ci` documents all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791345846&installation_model_id=422833&pr_number=474&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F474&signature=5cdbae4e9aa2422018ff56d952a4986e11c2c6365c11912d9f2e82512ad93604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `uf check` now follows imported workspace and Flow-enabled package dependencies, including package `exports` maps.
  * Added CI integrations for GitHub Actions, GitLab CI, and CircleCI, with caching, version checks, and ready-to-use commands.
  * Added a GitHub Actions workflow to validate integrations across Ubuntu and macOS.

* **Bug Fixes**
  * React app scaffolds and documentation now use accurate `React.Node` typing for children.

* **Documentation**
  * Added CI integration guidance and updated type-checking, tutorial, and roadmap documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->