### PR TITLE
chore(release): uf@0.0.0-alpha.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## uf@0.0.0-alpha.11
+
+_2026-09-07_
+
+`uf check` reads what a file imports. It used to check the files it was handed
+and nothing else, so `uf check <path>` resolved nothing:
+`import type { Control } from "@uniflowed/form"` was an `any`-typed value and
+every annotation written against it went unread — fifteen `value-as-type`
+errors on `packages/form/watch.js` about types that were correct. The batch is
+now the closure of what the requested files import, assembled with the
+checker's own resolution rules, and a specifier the project cannot answer is
+looked for under `node_modules`. So a project that merely *uses* uf is checked
+against uf's real types: a scaffold types its eight files against thirty-one
+modules read from the install, where before it typed them against `any`. Two
+conditions bound what is read, and both are Flow's — a package Flow's own
+library definitions describe is left to them, and a package that declares no
+`@flow` exports `any` whether it is read or not. Diagnostics are still reported
+only for the files that were asked about.
+
+And uf installs itself in CI in one step. `integrations/` holds a GitHub
+composite action, a GitLab `include:` template and a CircleCI orb, all three
+running the same installer a human runs — which is why they are thin, and why
+none of them skips the checksum. They agree on the awkward parts: pin the
+version, never cache `latest`, and never believe a restored cache without
+running the binary in it.
+
+### Added
+
+- **build, router**: a sitemap and a robots.txt, and three manifests out of dist/ (#471)
+
+### Other
+
+- uf check reads what it imports, and three CI setups that install uf (#474)
+
 ## uf@0.0.0-alpha.10
 
 _2026-09-07_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,7 +3385,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_assets"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "base64",
  "brotli",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "base64",
  "brotli",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "serde",
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "serde",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "criterion",
  "phf",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "compact_str",
  "serde",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "serde",
  "smallvec",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3765,14 +3765,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "camino",
  "compact_str",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.10"
+version = "0.0.0-alpha.11"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.10",
-    "@uniflowed/config": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10",
-    "@uniflowed/router": "0.0.0-alpha.10",
-    "@uniflowed/vite": "0.0.0-alpha.10",
-    "@uniflowed/web": "0.0.0-alpha.10",
+    "@uniflowed/brand": "0.0.0-alpha.11",
+    "@uniflowed/config": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11",
+    "@uniflowed/router": "0.0.0-alpha.11",
+    "@uniflowed/vite": "0.0.0-alpha.11",
+    "@uniflowed/web": "0.0.0-alpha.11",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.10",
-        "@uniflowed/config": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10",
-        "@uniflowed/router": "0.0.0-alpha.10",
-        "@uniflowed/vite": "0.0.0-alpha.10",
-        "@uniflowed/web": "0.0.0-alpha.10",
+        "@uniflowed/brand": "0.0.0-alpha.11",
+        "@uniflowed/config": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11",
+        "@uniflowed/router": "0.0.0-alpha.11",
+        "@uniflowed/vite": "0.0.0-alpha.11",
+        "@uniflowed/web": "0.0.0-alpha.11",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -4377,61 +4377,61 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.10",
-        "@uniflowed/test": "0.0.0-alpha.10"
+        "@uniflowed/config": "0.0.0-alpha.11",
+        "@uniflowed/test": "0.0.0-alpha.11"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.10",
-        "@uniflowed/validator": "0.0.0-alpha.10"
+        "@uniflowed/react": "0.0.0-alpha.11",
+        "@uniflowed/validator": "0.0.0-alpha.11"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4439,10 +4439,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.10"
+        "@uniflowed/fetch": "0.0.0-alpha.11"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4450,18 +4450,18 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/react": "0.0.0-alpha.11"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4469,115 +4469,115 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.10",
-        "@uniflowed/core": "0.0.0-alpha.10",
-        "@uniflowed/fetch": "0.0.0-alpha.10"
+        "@uniflowed/cell": "0.0.0-alpha.11",
+        "@uniflowed/core": "0.0.0-alpha.11",
+        "@uniflowed/fetch": "0.0.0-alpha.11"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.10",
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/config": "0.0.0-alpha.11",
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/hooks": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4585,7 +4585,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4593,28 +4593,28 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10",
+        "@uniflowed/core": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4624,7 +4624,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4633,19 +4633,19 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.10",
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/config": "0.0.0-alpha.11",
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/server": "0.0.0-alpha.10"
+        "@uniflowed/server": "0.0.0-alpha.11"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4654,43 +4654,43 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/cell": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10",
-        "@uniflowed/react-testing": "0.0.0-alpha.10",
-        "@uniflowed/test": "0.0.0-alpha.10"
+        "@uniflowed/mock": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11",
+        "@uniflowed/react-testing": "0.0.0-alpha.11",
+        "@uniflowed/test": "0.0.0-alpha.11"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4698,53 +4698,53 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.10"
+        "@uniflowed/host": "0.0.0-alpha.11"
       }
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.10",
-        "@uniflowed/test": "0.0.0-alpha.10"
+        "@uniflowed/react-testing": "0.0.0-alpha.11",
+        "@uniflowed/test": "0.0.0-alpha.11"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.10",
+        "@uniflowed/react": "0.0.0-alpha.11",
         "react-reconciler": "^0.33.0"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.10",
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/hooks": "0.0.0-alpha.11",
+        "@uniflowed/react": "0.0.0-alpha.11"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4752,18 +4752,18 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.10",
-        "@uniflowed/server": "0.0.0-alpha.10",
+        "@uniflowed/host": "0.0.0-alpha.11",
+        "@uniflowed/server": "0.0.0-alpha.11",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4778,19 +4778,19 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.10",
-        "@uniflowed/core": "0.0.0-alpha.10"
+        "@uniflowed/browser": "0.0.0-alpha.11",
+        "@uniflowed/core": "0.0.0-alpha.11"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.10",
+      "version": "0.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.10"
+        "@uniflowed/react": "0.0.0-alpha.11"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow implementation for @uniflowed/cell, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.10",
-    "@uniflowed/test": "0.0.0-alpha.10"
+    "@uniflowed/config": "0.0.0-alpha.11",
+    "@uniflowed/test": "0.0.0-alpha.11"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -25,8 +25,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.10",
-    "@uniflowed/validator": "0.0.0-alpha.10"
+    "@uniflowed/react": "0.0.0-alpha.11",
+    "@uniflowed/validator": "0.0.0-alpha.11"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.10"
+    "@uniflowed/fetch": "0.0.0-alpha.11"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/react": "0.0.0-alpha.11"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10",
-    "@uniflowed/cell": "0.0.0-alpha.10",
-    "@uniflowed/fetch": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11",
+    "@uniflowed/cell": "0.0.0-alpha.11",
+    "@uniflowed/fetch": "0.0.0-alpha.11"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.10",
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/config": "0.0.0-alpha.11",
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/hooks": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10",
+    "@uniflowed/core": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.10",
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/config": "0.0.0-alpha.11",
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -31,6 +31,6 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/server": "0.0.0-alpha.10"
+    "@uniflowed/server": "0.0.0-alpha.11"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/cell": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,10 +22,10 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10",
-    "@uniflowed/react-testing": "0.0.0-alpha.10",
-    "@uniflowed/test": "0.0.0-alpha.10"
+    "@uniflowed/mock": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11",
+    "@uniflowed/react-testing": "0.0.0-alpha.11",
+    "@uniflowed/test": "0.0.0-alpha.11"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.10"
+    "@uniflowed/host": "0.0.0-alpha.11"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.10",
-    "@uniflowed/test": "0.0.0-alpha.10"
+    "@uniflowed/react-testing": "0.0.0-alpha.11",
+    "@uniflowed/test": "0.0.0-alpha.11"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "A React renderer whose host is a terminal, following OpenTUI, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.10",
+    "@uniflowed/react": "0.0.0-alpha.11",
     "react-reconciler": "^0.33.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -48,8 +48,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.10",
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/hooks": "0.0.0-alpha.11",
+    "@uniflowed/react": "0.0.0-alpha.11"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -25,8 +25,8 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.10",
-    "@uniflowed/server": "0.0.0-alpha.10",
+    "@uniflowed/host": "0.0.0-alpha.11",
+    "@uniflowed/server": "0.0.0-alpha.11",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.10",
-    "@uniflowed/core": "0.0.0-alpha.10"
+    "@uniflowed/browser": "0.0.0-alpha.11",
+    "@uniflowed/core": "0.0.0-alpha.11"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.10",
+  "version": "0.0.0-alpha.11",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,6 +22,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.10"
+    "@uniflowed/react": "0.0.0-alpha.11"
   }
 }


### PR DESCRIPTION
Version bump and changelog for `uf@0.0.0-alpha.11`. Nothing else: every change in it is already on `main`.

## What is in it

**`uf check` reads what a file imports** ([#474](https://github.com/ubugeeei-prod/uf/pull/474), closing [#403](https://github.com/ubugeeei-prod/uf/issues/403)). The batch is the closure of what the requested files reach, assembled with the checker's own resolution rules, and a specifier the project cannot answer is looked for under `node_modules`. `uf check packages/form/watch.js` went from fifteen `value-as-type` errors about correct types to zero; a scaffold with its dependencies installed types its eight files against thirty-one modules read from `node_modules`, where before every one of them was `any`.

**uf installs itself in CI in one step** ([#474](https://github.com/ubugeeei-prod/uf/pull/474)). `integrations/` holds a GitHub composite action, a GitLab `include:` template and a CircleCI orb.

**A sitemap, a robots.txt and three manifests out of `dist/`** ([#471](https://github.com/ubugeeei-prod/uf/pull/471)).

## After the merge

`git tag uf@0.0.0-alpha.11 && git push origin uf@0.0.0-alpha.11`, which builds the four targets and publishes to npm on the trusted trigger. `tools/release/promote-latest.sh` is still a person's step — moving `latest` is an authenticated `PUT` that asks a 2FA account for a one-time password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791350230&installation_model_id=422833&pr_number=487&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F487&signature=1bb8c5624e281a9e4e8922be84f8b4ad5309026311dd8fba060257f4118e8fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `uf check` now handles transitive imports and dependency resolution.
  - Added CI installation integrations for GitHub, GitLab, and CircleCI.
  - Added build and router sitemap and robots manifests.

- **Release**
  - Published version `0.0.0-alpha.11`, with updated package metadata across the product suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->