### PR TITLE
feat(pm): uf ls, uf audit, uf search and uf uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ reference, with every flag and exit code.
 | `uf check` | Flow's own inference. uf has no second opinion about your types |
 | `uf install` | The project's package manager, with lifecycle scripts refused |
 | `uf add`, `uf remove`, `uf update`, `uf why` | The same manager, one dependency at a time, rewriting the lockfile and the store |
+| `uf ls`, `uf audit`, `uf search` | The same manager, reading — and, where it has no such command, saying so rather than reaching for another one |
 | `uf run`, `ufx` | A task from `uf.config.js`; a package's binary |
 | `uf info`, `uf inspect`, `uf explain` | What uf found, what your config resolved to, and which provider does each stage of a command |
 | `uf prepare` | The code generation and checks a commit should not go without; `--fix` makes the checks write |

--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -387,6 +387,11 @@ pub(crate) enum Commands {
     /// Takes them out of every dependency field that lists them, out of the
     /// lockfile, and out of `node_modules`. A name the manifest never listed is
     /// not an error: the project ends up the way it was asked to be either way.
+    ///
+    /// `uninstall` is the same command. npm and pnpm both accept that spelling,
+    /// and a reader who types it should not meet clap's "unrecognized
+    /// subcommand" over a word two of the five managers call it by.
+    #[command(alias = "uninstall")]
     Remove {
         /// The packages, by name.
         #[arg(value_name = "NAME", required = true)]
@@ -505,6 +510,43 @@ pub(crate) enum Commands {
     Use {
         /// The toolchain to activate.
         runtime: String,
+    },
+    /// List the installed dependency tree, through the project's own package
+    /// manager.
+    Ls {
+        /// Package names, which narrow the tree to what depends on them.
+        ///
+        /// Names only. A manager's own flags are the manager's own surface and
+        /// are reached with `uf exec` — uf cannot know which of them only read,
+        /// and `pnpm audit --fix` rewrites a lockfile. Refusing a flag also
+        /// keeps `uf ls --oops` at exit 2, uf failing to parse its own
+        /// argument, rather than exit 1 from a manager uf handed a word to.
+        #[arg(value_name = "NAME", trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+    /// Audit the installed tree for known vulnerabilities.
+    ///
+    /// Every manager uf supports has one, and each spells its severity
+    /// threshold and its fix differently, so the flags are its own.
+    Audit {
+        /// Package names, where the manager narrows an audit to them.
+        ///
+        /// Names only, for the reason `uf ls` gives: every manager spells its
+        /// severity threshold and its `--fix` differently, and one of those
+        /// rewrites a lockfile.
+        #[arg(value_name = "NAME", trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+    /// Search the registry.
+    ///
+    /// npm and pnpm can. Yarn and bun cannot, and uf says so rather than
+    /// running a manager the project did not choose — a tool that quietly
+    /// reaches for a different one is how a lockfile comes to be written by
+    /// something nobody selected.
+    Search {
+        /// What to search for.
+        #[arg(value_name = "TERM", required = true, trailing_var_arg = true)]
+        terms: Vec<String>,
     },
     /// Explain why a package is in the dependency tree.
     ///

--- a/crates/uf_cli/src/commands/completion.rs
+++ b/crates/uf_cli/src/commands/completion.rs
@@ -33,6 +33,7 @@ use crate::ui::Ui;
 /// against clap's own in `tests`, so it cannot drift.
 const COMMANDS: &[&str] = &[
     "add",
+    "audit",
     "build",
     "check",
     "create",
@@ -47,13 +48,16 @@ const COMMANDS: &[&str] = &[
     "install",
     "i",
     "lint",
+    "ls",
     "lsp",
     "prepare",
     "preview",
     "publish",
     "release",
     "remove",
+    "uninstall",
     "run",
+    "search",
     "start",
     "test",
     "update",
@@ -83,8 +87,23 @@ const CREATE_KINDS: &[&str] = &["app", "lib"];
 /// people reach for are here; the four package-manager ones are here because
 /// naming the manager that will run is the whole reason to ask.
 const EXPLAINABLE: &[&str] = &[
-    "dev", "build", "preview", "start", "doc", "test", "fmt", "lint", "check", "add", "remove",
-    "update", "why",
+    "dev",
+    "build",
+    "preview",
+    "start",
+    "doc",
+    "test",
+    "fmt",
+    "lint",
+    "check",
+    "add",
+    "remove",
+    "update",
+    "why",
+    "ls",
+    "audit",
+    "search",
+    "uninstall",
 ];
 
 /// Print the completion script for `shell`.

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -66,7 +66,7 @@ pub(crate) fn explain(cwd: &Utf8Path, ui: &mut Ui, command: &str, as_json: bool)
             },
             "writes the specifiers into dependencies, the lockfile and node_modules",
         ),
-        "remove" => dependency_stages(
+        "remove" | "uninstall" => dependency_stages(
             &resolved,
             Operation::Remove,
             "takes the names out of every dependency field, the lockfile and node_modules",
@@ -77,6 +77,23 @@ pub(crate) fn explain(cwd: &Utf8Path, ui: &mut Ui, command: &str, as_json: bool)
             "moves the lockfile to the newest versions the manifest ranges already allow",
         ),
         "why" => why_stages(&resolved),
+        "ls" => query_stages(
+            &resolved,
+            Operation::List,
+            "the manager reads its own lockfile and prints the tree it installed",
+        ),
+        "audit" => query_stages(
+            &resolved,
+            Operation::Audit,
+            "the manager sends the tree to its registry's advisory endpoint and reports what \
+             came back",
+        ),
+        "search" => query_stages(
+            &resolved,
+            Operation::Search,
+            "the manager queries its own registry — which is the reason uf does not substitute \
+             another manager's search for one that has none",
+        ),
         "upgrade" => upgrade_stages(&resolved),
         "use" | "env" => runtime_stages(&resolved),
         "prepare" => prepare_stages(&resolved),
@@ -248,11 +265,10 @@ fn exec_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
         },
         Stage {
             name: "everything else",
-            provider: command_for(
+            provider: provider_for(
                 fetchable(detect_package_manager(&resolved.root).package_manager),
                 Operation::DlxExec,
-            )
-            .to_string(),
+            ),
             detail: format!(
                 "a package that is not installed: refused unless --yes, because fetching a name {} does not pin runs code the project never asked for",
                 resolved.config.pm.lockfile
@@ -318,7 +334,7 @@ fn dependency_stages(
         },
         Stage {
             name: "resolution and install",
-            provider: command_for(manager, operation).to_string(),
+            provider: provider_for(manager, operation),
             detail: what.to_string(),
         },
         Stage {
@@ -332,12 +348,38 @@ fn dependency_stages(
     ]
 }
 
+/// The command a manager runs for an operation, or the fact that it has none.
+///
+/// `uf explain` answers "which provider does each part", and for a manager
+/// without the command the honest answer is that nothing does — not the
+/// command some other manager would have run.
+fn provider_for(manager: uf_pm::PackageManager, operation: Operation<'_>) -> String {
+    command_for(manager, operation).map_or_else(
+        || format!("none — {manager} has no `{}`", operation.name()),
+        |invocation| invocation.to_string(),
+    )
+}
+
+/// `uf ls`, `uf audit` and `uf search`: one stage, because they write nothing.
+///
+/// The same shape as [`why_stages`]. Separate because the answer for a manager
+/// that has no such command is the interesting one, and [`provider_for`] is
+/// where it is said.
+fn query_stages(resolved: &ResolvedConfig, operation: Operation<'_>, what: &str) -> Vec<Stage> {
+    let manager = installable(&detect_package_manager(&resolved.root)).0;
+    vec![Stage {
+        name: "the answer",
+        provider: provider_for(manager, operation),
+        detail: what.to_owned(),
+    }]
+}
+
 /// `uf why`, which changes nothing and therefore has one stage.
 fn why_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
     let manager = installable(&detect_package_manager(&resolved.root)).0;
     vec![Stage {
         name: "the answer",
-        provider: command_for(manager, Operation::Why).to_string(),
+        provider: provider_for(manager, Operation::Why),
         detail: format!(
             "the manager reads its own lockfile and prints the chain; uf writes nothing, not even {}",
             resolved.config.pm.lockfile

--- a/crates/uf_cli/src/commands/pm.rs
+++ b/crates/uf_cli/src/commands/pm.rs
@@ -4,7 +4,7 @@
 mod deps;
 mod install;
 
-pub(crate) use deps::{add, remove, update, why};
+pub(crate) use deps::{add, query, remove, update, why};
 pub(crate) use install::install;
 
 use std::fs;

--- a/crates/uf_cli/src/commands/pm/deps.rs
+++ b/crates/uf_cli/src/commands/pm/deps.rs
@@ -109,6 +109,59 @@ pub(crate) fn update(cwd: &Utf8Path, ui: &mut Ui, packages: &[String]) -> Result
 /// The one command here that changes nothing, so it neither takes the
 /// `install_workspace` guard — there is no install to guard — nor rewrites
 /// `uf.lock`. Asking why a package is installed must not install anything.
+/// `uf ls`, `uf audit` and `uf search`: read the project, change nothing.
+///
+/// The same shape as [`why`] and for the same reason — the manager's own
+/// output is the answer, so uf says who it is about to ask and then gets out
+/// of the way. What differs is only which operation, and whether there are
+/// operands.
+///
+/// A manager with no such command is reported rather than substituted. uf
+/// could run npm's `search` for a bun project and it would even work; it would
+/// also be uf choosing a package manager the project did not, which is the one
+/// thing a manager-agnostic tool must not do. See
+/// [`uf_pm::ManagerRunError::Unsupported`].
+pub(crate) fn query(
+    cwd: &Utf8Path,
+    ui: &mut Ui,
+    title: &str,
+    operation: Operation<'_>,
+    operands: &[String],
+) -> Result<()> {
+    let resolved = load_config(cwd)?;
+    let detection = detect_package_manager(&resolved.root);
+    let (manager, substituted) = installable(&detection);
+
+    let invocation = uf_pm::invocation_for(manager, operation, operands, true)?;
+    let project = project_label(&resolved.root).to_string();
+    let manager_label = manager.to_string();
+    let source = chosen_by(&detection.source, substituted);
+    let command = invocation.to_string();
+    let title = title.to_owned();
+    ui.render(|renderer, out| {
+        renderer.banner(out, &title, Some(&project));
+        renderer.blank(out);
+        renderer.key_values(
+            out,
+            2,
+            &[
+                KeyValue::new("manager", &manager_label),
+                KeyValue::toned("chosen by", &source, Tone::Muted),
+                KeyValue::toned("command", &command, Tone::Path),
+            ],
+        );
+        renderer.blank(out);
+    });
+
+    run_operation(&resolved.root, operation, operands, true).map_err(|error| {
+        failed_hint(
+            error,
+            &format!("{manager_label} reported a problem; its output is above"),
+        )
+    })?;
+    Ok(())
+}
+
 pub(crate) fn why(cwd: &Utf8Path, ui: &mut Ui, package: &str) -> Result<()> {
     let resolved = load_config(cwd)?;
     let detection = detect_package_manager(&resolved.root);

--- a/crates/uf_cli/src/commands/task.rs
+++ b/crates/uf_cli/src/commands/task.rs
@@ -401,7 +401,10 @@ pub(crate) fn exec_package(
 
     let detection = detect_package_manager(&resolved.root);
     let manager = fetchable(detection.package_manager);
-    let mut invocation = command_for(manager, Operation::DlxExec);
+    // Every manager has a fetch-and-run, which is what `fetchable` guarantees:
+    // it maps a manager without one onto the one uf would use instead.
+    let mut invocation = command_for(manager, Operation::DlxExec)
+        .expect("every fetchable manager has a fetch-and-run command");
     invocation.args.push(Cow::Owned(package.to_owned()));
     invocation
         .args

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -315,6 +315,15 @@ fn run(cli: Cli, target: Option<&str>, ui: &mut Ui) -> Result<()> {
         Commands::Use { runtime } => commands::pm::use_runtime(&cwd, ui, &runtime),
         Commands::Upgrade => commands::pm::upgrade(&cwd, ui),
         Commands::Why { package } => commands::pm::why(&cwd, ui, &package),
+        Commands::Ls { args } => {
+            commands::pm::query(&cwd, ui, "uf ls", uf_pm::Operation::List, &args)
+        }
+        Commands::Audit { args } => {
+            commands::pm::query(&cwd, ui, "uf audit", uf_pm::Operation::Audit, &args)
+        }
+        Commands::Search { terms } => {
+            commands::pm::query(&cwd, ui, "uf search", uf_pm::Operation::Search, &terms)
+        }
     }
 }
 

--- a/crates/uf_cli/tests/every_command.rs
+++ b/crates/uf_cli/tests/every_command.rs
@@ -80,6 +80,12 @@ const COVERAGE: &[(&str, &str)] = &[
     ("update", "dependencies.rs: runs the package manager"),
     ("upgrade", "workflow.rs: resolves new versions"),
     ("use", "workflow.rs: rewrites the config"),
+    ("ls", "dependencies.rs: asks the package manager"),
+    ("audit", "dependencies.rs: asks the package manager"),
+    (
+        "search",
+        "dependencies.rs: asks the package manager, or says it cannot",
+    ),
     ("why", "dependencies.rs: asks the package manager"),
     // Last, because `uf --help` prints clap's own `help` last.
     ("help", "here"),

--- a/crates/uf_pm/src/command.rs
+++ b/crates/uf_pm/src/command.rs
@@ -113,11 +113,20 @@ pub enum Operation<'a> {
     Update,
     /// Explain why a package is present in the dependency tree.
     Why,
+    /// List the installed dependency tree.
+    List,
+    /// Audit the installed tree against the registry's advisories.
+    Audit,
+    /// Search the registry; the caller appends the terms.
+    ///
+    /// The first operation the table cannot answer for every manager: yarn and
+    /// bun have no search. That is why [`command_for`] returns an [`Option`].
+    Search,
 }
 
 impl Operation<'_> {
     /// Every operation, with a representative payload, for exhaustive testing.
-    pub const ALL: [Self; 12] = [
+    pub const ALL: [Self; 15] = [
         Self::Install,
         Self::InstallFrozen,
         Self::Add {
@@ -138,6 +147,9 @@ impl Operation<'_> {
         Self::DlxExec,
         Self::Update,
         Self::Why,
+        Self::List,
+        Self::Audit,
+        Self::Search,
     ];
 
     /// Whether this operation can cause a dependency's install scripts to run.
@@ -154,7 +166,31 @@ impl Operation<'_> {
             | Self::Add { .. }
             | Self::Remove
             | Self::Update => true,
-            Self::Run { .. } | Self::Exec | Self::DlxExec | Self::Why => false,
+            Self::Run { .. }
+            | Self::Exec
+            | Self::DlxExec
+            | Self::Why
+            | Self::List
+            | Self::Audit
+            | Self::Search => false,
+        }
+    }
+
+    /// The operation's name, for a message about a manager that has no command
+    /// for it.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Install | Self::InstallFrozen => "install",
+            Self::Add { .. } => "add",
+            Self::Remove => "remove",
+            Self::Run { .. } => "run",
+            Self::Exec | Self::DlxExec => "exec",
+            Self::Update => "update",
+            Self::Why => "why",
+            Self::List => "ls",
+            Self::Audit => "audit",
+            Self::Search => "search",
         }
     }
 }
@@ -182,10 +218,16 @@ impl fmt::Display for Invocation {
     }
 }
 
-/// Map a package manager operation onto the command that performs it.
+/// Map a package manager operation onto the command that performs it, or
+/// [`None`] when the manager has no command for it.
+///
+/// [`None`] is a real answer rather than a gap to fill in later: yarn and bun
+/// have no registry search, and the only honest thing uf can do is say so.
+/// Falling back to another manager would run a program the project did not
+/// choose, which is the one thing a package-manager-agnostic tool must not do.
 #[must_use]
-pub fn command_for(manager: PackageManager, operation: Operation<'_>) -> Invocation {
-    let spec = command_spec(manager, operation);
+pub fn command_for(manager: PackageManager, operation: Operation<'_>) -> Option<Invocation> {
+    let spec = command_spec(manager, operation)?;
     let mut args = InvocationArgs::with_capacity(spec.args.len() + 1);
     args.extend(spec.args.iter().copied().map(Cow::Borrowed));
 
@@ -193,10 +235,10 @@ pub fn command_for(manager: PackageManager, operation: Operation<'_>) -> Invocat
         args.push(Cow::Owned(task.to_owned()));
     }
 
-    Invocation {
+    Some(Invocation {
         program: spec.program,
         args,
-    }
+    })
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -205,11 +247,21 @@ struct CommandSpec {
     args: &'static [&'static str],
 }
 
-const fn spec(program: &'static str, args: &'static [&'static str]) -> CommandSpec {
-    CommandSpec { program, args }
+const fn spec(program: &'static str, args: &'static [&'static str]) -> Option<CommandSpec> {
+    Some(CommandSpec { program, args })
 }
 
-fn command_spec(manager: PackageManager, operation: Operation<'_>) -> CommandSpec {
+/// The manager has no command for this operation.
+///
+/// Not a fallback and never a substitution: a package manager that quietly ran
+/// a different one is how a lockfile comes to be written by something the
+/// project did not choose. The caller is told which manager and which
+/// operation, and says so.
+const fn unsupported() -> Option<CommandSpec> {
+    None
+}
+
+fn command_spec(manager: PackageManager, operation: Operation<'_>) -> Option<CommandSpec> {
     match manager {
         PackageManager::Uf => uf_spec(operation),
         PackageManager::Npm => npm_spec(operation),
@@ -223,7 +275,7 @@ fn command_spec(manager: PackageManager, operation: Operation<'_>) -> CommandSpe
 /// uf's own contract. `uf install` is lockfile-deterministic either way, and
 /// `uf exec` always resolves through the content-addressed store, so `Exec` and
 /// `DlxExec` coincide.
-const fn uf_spec(operation: Operation<'_>) -> CommandSpec {
+const fn uf_spec(operation: Operation<'_>) -> Option<CommandSpec> {
     match operation {
         Operation::Install => spec("uf", &["install"]),
         Operation::InstallFrozen => spec("uf", &["install", "--frozen-lockfile"]),
@@ -244,10 +296,13 @@ const fn uf_spec(operation: Operation<'_>) -> CommandSpec {
         Operation::Exec | Operation::DlxExec => spec("uf", &["exec"]),
         Operation::Update => spec("uf", &["update"]),
         Operation::Why => spec("uf", &["why"]),
+        Operation::List => spec("uf", &["ls"]),
+        Operation::Audit => spec("uf", &["audit"]),
+        Operation::Search => spec("uf", &["search"]),
     }
 }
 
-const fn npm_spec(operation: Operation<'_>) -> CommandSpec {
+const fn npm_spec(operation: Operation<'_>) -> Option<CommandSpec> {
     match operation {
         Operation::Install
         | Operation::Add {
@@ -271,10 +326,13 @@ const fn npm_spec(operation: Operation<'_>) -> CommandSpec {
         Operation::DlxExec => spec("npx", &["--yes"]),
         Operation::Update => spec("npm", &["update"]),
         Operation::Why => spec("npm", &["explain"]),
+        Operation::List => spec("npm", &["ls"]),
+        Operation::Audit => spec("npm", &["audit"]),
+        Operation::Search => spec("npm", &["search"]),
     }
 }
 
-const fn pnpm_spec(operation: Operation<'_>) -> CommandSpec {
+const fn pnpm_spec(operation: Operation<'_>) -> Option<CommandSpec> {
     match operation {
         Operation::Install => spec("pnpm", &["install"]),
         Operation::InstallFrozen => spec("pnpm", &["install", "--frozen-lockfile"]),
@@ -296,12 +354,18 @@ const fn pnpm_spec(operation: Operation<'_>) -> CommandSpec {
         Operation::DlxExec => spec("pnpm", &["dlx"]),
         Operation::Update => spec("pnpm", &["update"]),
         Operation::Why => spec("pnpm", &["why"]),
+        Operation::List => spec("pnpm", &["list"]),
+        Operation::Audit => spec("pnpm", &["audit"]),
+        // Added in pnpm 11. An older pnpm answers with its own "unknown
+        // command", which names the manager and the version, and is a better
+        // message than one uf could write about a version it did not check.
+        Operation::Search => spec("pnpm", &["search"]),
     }
 }
 
 /// Yarn 1.x has neither `exec` nor `dlx`: `yarn run <bin>` runs a project binary
 /// and `npx` is the only fetch-and-run available.
-const fn yarn_classic_spec(operation: Operation<'_>) -> CommandSpec {
+const fn yarn_classic_spec(operation: Operation<'_>) -> Option<CommandSpec> {
     match operation {
         Operation::Install => spec("yarn", &["install"]),
         Operation::InstallFrozen => spec("yarn", &["install", "--frozen-lockfile"]),
@@ -311,12 +375,16 @@ const fn yarn_classic_spec(operation: Operation<'_>) -> CommandSpec {
         Operation::DlxExec => spec("npx", &["--yes"]),
         Operation::Update => spec("yarn", &["upgrade"]),
         Operation::Why => spec("yarn", &["why"]),
+        Operation::List => spec("yarn", &["list"]),
+        Operation::Audit => spec("yarn", &["audit"]),
+        // Yarn 1 has no registry search, and neither does Yarn 2+.
+        Operation::Search => unsupported(),
     }
 }
 
 /// Both Yarn editions spell the dependency maps the same way, which is why
 /// `Add` is the one row the editions share a function for.
-const fn yarn_add(kind: DependencyKind) -> CommandSpec {
+const fn yarn_add(kind: DependencyKind) -> Option<CommandSpec> {
     match kind {
         DependencyKind::Prod => spec("yarn", &["add"]),
         DependencyKind::Dev => spec("yarn", &["add", "--dev"]),
@@ -326,7 +394,7 @@ const fn yarn_add(kind: DependencyKind) -> CommandSpec {
 }
 
 /// Yarn 2+ renamed the frozen install to `--immutable` and the update to `yarn up`.
-const fn yarn_berry_spec(operation: Operation<'_>) -> CommandSpec {
+const fn yarn_berry_spec(operation: Operation<'_>) -> Option<CommandSpec> {
     match operation {
         Operation::Install => spec("yarn", &["install"]),
         Operation::InstallFrozen => spec("yarn", &["install", "--immutable"]),
@@ -337,10 +405,16 @@ const fn yarn_berry_spec(operation: Operation<'_>) -> CommandSpec {
         Operation::DlxExec => spec("yarn", &["dlx"]),
         Operation::Update => spec("yarn", &["up"]),
         Operation::Why => spec("yarn", &["why"]),
+        // `yarn list` is Yarn 1's; Berry replaced it with `yarn info`, whose
+        // `--all` is the whole project rather than the current workspace.
+        Operation::List => spec("yarn", &["info", "--all"]),
+        // Berry keeps the registry commands under `yarn npm`.
+        Operation::Audit => spec("yarn", &["npm", "audit"]),
+        Operation::Search => unsupported(),
     }
 }
 
-const fn bun_spec(operation: Operation<'_>) -> CommandSpec {
+const fn bun_spec(operation: Operation<'_>) -> Option<CommandSpec> {
     match operation {
         Operation::Install => spec("bun", &["install"]),
         Operation::InstallFrozen => spec("bun", &["install", "--frozen-lockfile"]),
@@ -361,6 +435,10 @@ const fn bun_spec(operation: Operation<'_>) -> CommandSpec {
         Operation::DlxExec => spec("bunx", &[]),
         Operation::Update => spec("bun", &["update"]),
         Operation::Why => spec("bun", &["why"]),
+        Operation::List => spec("bun", &["pm", "ls"]),
+        Operation::Audit => spec("bun", &["audit"]),
+        // Bun has no registry search.
+        Operation::Search => unsupported(),
     }
 }
 

--- a/crates/uf_pm/src/command/tests.rs
+++ b/crates/uf_pm/src/command/tests.rs
@@ -1,7 +1,18 @@
 use super::*;
 
 fn rendered(manager: PackageManager, operation: Operation<'_>) -> String {
-    command_for(manager, operation).to_string()
+    supported(manager, operation).to_string()
+}
+
+/// The invocation, or a panic naming the pair that has none.
+///
+/// Most of this file is about *which* command a manager runs, and every pair
+/// it asserts on has one. The pairs that do not are
+/// `search_is_unsupported_where_the_manager_has_none`'s, which asks the
+/// opposite question.
+fn supported(manager: PackageManager, operation: Operation<'_>) -> Invocation {
+    command_for(manager, operation)
+        .unwrap_or_else(|| panic!("{manager} has no command for {operation:?}"))
 }
 
 const fn add(kind: DependencyKind) -> Operation<'static> {
@@ -255,7 +266,9 @@ fn bun_maps_every_operation() {
 fn every_manager_and_operation_pair_maps_to_an_allowlisted_program() {
     for manager in PackageManager::ALL {
         for operation in Operation::ALL {
-            let invocation = command_for(manager, operation);
+            let Some(invocation) = command_for(manager, operation) else {
+                continue;
+            };
             assert!(
                 PROGRAMS.contains(&invocation.program),
                 "{manager} {operation:?} escaped the program allowlist"
@@ -267,8 +280,8 @@ fn every_manager_and_operation_pair_maps_to_an_allowlisted_program() {
 #[test]
 fn frozen_installs_differ_from_plain_installs_for_every_manager() {
     for manager in PackageManager::ALL {
-        let install = command_for(manager, Operation::Install);
-        let frozen = command_for(manager, Operation::InstallFrozen);
+        let install = supported(manager, Operation::Install);
+        let frozen = supported(manager, Operation::InstallFrozen);
         assert_ne!(install, frozen, "{manager} has no distinct frozen install");
     }
 }
@@ -283,7 +296,7 @@ fn every_dependency_kind_maps_to_its_own_command_for_every_manager() {
     for manager in PackageManager::ALL {
         let mut seen: Vec<(DependencyKind, Invocation)> = Vec::new();
         for kind in DependencyKind::ALL {
-            let invocation = command_for(manager, add(kind));
+            let invocation = supported(manager, add(kind));
             for (earlier, previous) in &seen {
                 assert_ne!(
                     *previous, invocation,
@@ -308,15 +321,21 @@ fn a_dependency_kind_names_its_manifest_field() {
     assert_eq!(DependencyKind::Peer.manifest_field(), "peerDependencies");
 }
 
-/// The read-only operation is the only one that must not be told to ignore
-/// scripts, because it installs nothing and the flag is not its vocabulary.
+/// The read-only operations are the ones that must not be told to ignore
+/// scripts, because they install nothing and the flag is not their vocabulary.
 #[test]
 fn only_the_operations_that_install_can_run_scripts() {
     for operation in Operation::ALL {
         let installs = operation.installs_packages();
         let expected = !matches!(
             operation,
-            Operation::Run { .. } | Operation::Exec | Operation::DlxExec | Operation::Why
+            Operation::Run { .. }
+                | Operation::Exec
+                | Operation::DlxExec
+                | Operation::Why
+                | Operation::List
+                | Operation::Audit
+                | Operation::Search
         );
         assert_eq!(installs, expected, "{operation:?}");
     }
@@ -325,7 +344,7 @@ fn only_the_operations_that_install_can_run_scripts() {
 #[test]
 fn run_appends_the_task_as_the_final_argument() {
     for manager in PackageManager::ALL {
-        let invocation = command_for(manager, Operation::Run { task: "test:unit" });
+        let invocation = supported(manager, Operation::Run { task: "test:unit" });
         assert_eq!(
             invocation.args.last().map(Cow::as_ref),
             Some("test:unit"),
@@ -336,7 +355,7 @@ fn run_appends_the_task_as_the_final_argument() {
 
 #[test]
 fn a_hostile_task_name_stays_a_single_argument() {
-    let invocation = command_for(
+    let invocation = supported(
         PackageManager::Pnpm,
         Operation::Run {
             task: "build; rm -rf /",
@@ -350,14 +369,14 @@ fn a_hostile_task_name_stays_a_single_argument() {
 
 #[test]
 fn an_empty_task_name_is_still_one_argument() {
-    let invocation = command_for(PackageManager::Npm, Operation::Run { task: "" });
+    let invocation = supported(PackageManager::Npm, Operation::Run { task: "" });
 
     assert_eq!(invocation.args.as_slice(), ["run", ""]);
 }
 
 #[test]
 fn a_non_ascii_task_name_survives_intact() {
-    let invocation = command_for(PackageManager::Bun, Operation::Run { task: "ビルド" });
+    let invocation = supported(PackageManager::Bun, Operation::Run { task: "ビルド" });
 
     assert_eq!(invocation.args.last().map(Cow::as_ref), Some("ビルド"));
 }
@@ -366,7 +385,9 @@ fn a_non_ascii_task_name_survives_intact() {
 fn mapped_invocations_never_allocate_beyond_the_inline_capacity() {
     for manager in PackageManager::ALL {
         for operation in Operation::ALL {
-            let invocation = command_for(manager, operation);
+            let Some(invocation) = command_for(manager, operation) else {
+                continue;
+            };
             assert!(
                 !invocation.args.spilled(),
                 "{manager} {operation:?} spilled"
@@ -414,6 +435,43 @@ fn yarn_editions_disagree_exactly_where_yarn_changed() {
             Operation::Exec,
             Operation::DlxExec,
             Operation::Update,
+            // Yarn 1's `yarn list` became `yarn info` in Berry, and Berry put
+            // the registry commands under `yarn npm`.
+            Operation::List,
+            Operation::Audit,
         ]
     );
+}
+
+/// The pairs the table cannot answer, named rather than counted.
+///
+/// A manager that gains the command is a change to this list, which is the
+/// point: "yarn has no search" should stop being true the day it stops being
+/// true, and nothing else in the crate would notice.
+#[test]
+fn search_is_unsupported_where_the_manager_has_none() {
+    let without = PackageManager::ALL
+        .into_iter()
+        .filter(|manager| command_for(*manager, Operation::Search).is_none())
+        .collect::<Vec<_>>();
+
+    // In `PackageManager::ALL`'s own order.
+    assert_eq!(without, [PackageManager::Bun, YARN_BERRY, YARN_CLASSIC]);
+}
+
+/// And search is the only one, so every other operation is answerable by every
+/// manager uf supports.
+#[test]
+fn search_is_the_only_operation_a_manager_can_lack() {
+    for manager in PackageManager::ALL {
+        for operation in Operation::ALL {
+            if matches!(operation, Operation::Search) {
+                continue;
+            }
+            assert!(
+                command_for(manager, operation).is_some(),
+                "{manager} has no command for {operation:?}"
+            );
+        }
+    }
 }

--- a/crates/uf_pm/src/run.rs
+++ b/crates/uf_pm/src/run.rs
@@ -144,6 +144,21 @@ pub enum ManagerRunError {
         /// Why it was refused, and what to write instead.
         reason: String,
     },
+    /// The project's manager has no command for what was asked.
+    ///
+    /// Reported rather than worked around. uf could run a different manager's
+    /// equivalent, and that is exactly the substitution a project chose its
+    /// manager to avoid — the replacement would resolve against its own
+    /// registry configuration and could write its own lockfile.
+    #[error("{manager} has no `{operation}`: {hint}")]
+    Unsupported {
+        /// The manager the project uses.
+        manager: String,
+        /// The uf operation it cannot perform.
+        operation: &'static str,
+        /// What to do instead.
+        hint: String,
+    },
 }
 
 /// Install `root`'s dependencies with the package manager that drives it.
@@ -215,6 +230,22 @@ pub fn run_operation(
     })
 }
 
+/// What to do about an operation the project's manager does not have.
+///
+/// One sentence per operation, naming the managers that do have it — the
+/// reader's next question is always "then what", and "your package manager
+/// cannot" is only half an answer.
+fn unsupported_hint(operation: Operation<'_>) -> String {
+    match operation {
+        Operation::Search => {
+            "npm and pnpm can search the registry; `uf exec --yes npm search` runs npm's \
+             without changing what this project installs with"
+        }
+        _ => "no package manager uf knows spells this one differently",
+    }
+    .to_owned()
+}
+
 /// The exact command `run_operation` would spawn.
 ///
 /// Separate from the spawn so that what uf is about to run can be asserted on,
@@ -229,7 +260,12 @@ pub fn invocation_for(
     operands: &[String],
     allow_scripts: bool,
 ) -> Result<Invocation, ManagerRunError> {
-    let mut invocation = command_for(manager, operation);
+    let mut invocation =
+        command_for(manager, operation).ok_or_else(|| ManagerRunError::Unsupported {
+            manager: manager.to_string(),
+            operation: operation.name(),
+            hint: unsupported_hint(operation),
+        })?;
 
     // A dependency's `postinstall` is the supply-chain hole uf's own resolver
     // was going to close by never running one. Delegating to a manager that

--- a/crates/uf_pm/src/run/tests.rs
+++ b/crates/uf_pm/src/run/tests.rs
@@ -130,8 +130,14 @@ fn a_read_only_query_is_never_told_to_ignore_scripts() {
 fn an_operand_is_always_the_last_argument() {
     for manager in PackageManager::ALL {
         for operation in Operation::ALL {
-            let invocation = invocation_for(manager, operation, &operands(&["lodash"]), false)
-                .expect("a package name is passable");
+            let invocation = match invocation_for(manager, operation, &operands(&["lodash"]), false)
+            {
+                Ok(invocation) => invocation,
+                // The manager has no such command, which is what
+                // `search_is_unsupported_where_the_manager_has_none` asserts.
+                Err(ManagerRunError::Unsupported { .. }) => continue,
+                Err(error) => panic!("{manager} {operation:?}: {error}"),
+            };
             assert!(PROGRAMS.contains(&invocation.program));
             assert_eq!(
                 invocation.args.last().map(std::borrow::Cow::as_ref),

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -666,6 +666,43 @@ lockfile — `npm explain`, `pnpm why`, `yarn why`, `bun why` — so the chain
 printed is the chain that was actually installed. It writes nothing at all, not
 even `uf.lock`.
 
+### uf ls [NAME...]
+
+Lists the installed tree, through the same manager — `npm ls`, `pnpm list`,
+`yarn list` on Yarn 1, `yarn info --all` on Yarn 2+, `bun pm ls`. A package
+name narrows it.
+
+### uf audit [NAME...]
+
+Audits the installed tree against the registry's advisories: `npm audit`,
+`pnpm audit`, `yarn audit`, `yarn npm audit` on Yarn 2+, `bun audit`.
+
+### uf search TERM...
+
+Searches the registry. **npm and pnpm can; Yarn and bun cannot**, and uf says
+so rather than running a manager the project did not choose:
+
+<figure className="terminal">
+
+```
+error: bun has no `search`: npm and pnpm can search the registry;
+`uf exec --yes npm search` runs npm's without changing what this project
+installs with
+```
+
+</figure>
+
+That refusal is the design rather than a gap. A tool that quietly reached for
+another manager would resolve against that manager's registry configuration and
+could write its own lockfile, which is the one thing a manager-agnostic front
+end must not do.
+
+Each of the three takes package names and no flags. A manager's own flags are
+its own surface — reached with `uf exec` — because uf cannot know which of them
+only read: `pnpm audit --fix` rewrites a lockfile.
+
+`uf uninstall` is `uf remove`, which npm and pnpm both spell that way.
+
 ## Environment
 
 ### uf use TOOLCHAIN


### PR DESCRIPTION
Closes [#490](https://github.com/ubugeeei-prod/uf/issues/490), [#491](https://github.com/ubugeeei-prod/uf/issues/491), [#492](https://github.com/ubugeeei-prod/uf/issues/492), [#493](https://github.com/ubugeeei-prod/uf/issues/493). Part of [#488](https://github.com/ubugeeei-prod/uf/issues/488).

| | npm | pnpm | yarn 1 | yarn 2+ | bun |
| --- | --- | --- | --- | --- | --- |
| `uf ls` | `npm ls` | `pnpm list` | `yarn list` | `yarn info --all` | `bun pm ls` |
| `uf audit` | `npm audit` | `pnpm audit` | `yarn audit` | `yarn npm audit` | `bun audit` |
| `uf search` | `npm search` | `pnpm search` | — | — | — |

`uf uninstall` is `uf remove`, which npm and pnpm both spell that way.

## Search is the first hole in the table, and that is the interesting part

Yarn has no registry search and neither does bun. So `command_for` returns an `Option` and `invocation_for` turns `None` into `ManagerRunError::Unsupported`:

```
$ uf search flow-parser        # in a bun project
error: bun has no `search`: npm and pnpm can search the registry;
`uf exec --yes npm search` runs npm's without changing what this
project installs with
```

Running npm's search for a bun project would have worked, and would have been uf choosing a package manager the project did not — resolving against another manager's registry configuration, one `--fix` away from writing another manager's lockfile. `uf explain search` says `none — bun has no search` for the same reason.

Two tests hold that shape: one **names** the pairs with no command, so a manager that gains search is a change to a list rather than silence; the other asserts search is the only such pair, so the next hole has to be declared rather than appear.

## No flags

The three take package names and nothing else. A manager's own flags are its own surface — `uf exec` reaches them — because uf cannot know which of them only read: `pnpm audit --fix` rewrites a lockfile. It also keeps the exit codes apart, which `an_argument_uf_cannot_parse_could_not_run` asserts: `uf ls --oops` is 2, uf failing to parse its own argument, not 1 from a manager uf handed a word to.

## Verified

`uf ls`, `uf audit` and `uf search flow-parser` against a real npm project, and the refusal against a project whose `packageManager` is bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791352810&installation_model_id=422833&pr_number=525&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F525&signature=77a0b7c44cb180022a23a8e80fd0c48599b24bf0e1e4d23c0956eb05bde99f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->