### PR TITLE
feat(cli): uf clean, and a boundary at the network

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ reference, with every flag and exit code.
 | | |
 | --- | --- |
 | `uf new`, `uf init` | Scaffold an application into a new directory, or into this one |
+| `uf clean` | Removes what a rebuild writes again — never a lockfile, and `node_modules` only when asked |
 | `uf dev` | Vite's dev server, with React Fast Refresh through `component` declarations |
 | `uf build` | Client and server bundles, prerendered routes, a size report and the build manifest |
 | `uf preview`, `uf start` | Serve that build — through Vite, or through uf's own server with no bundler in the process |

--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -359,6 +359,19 @@ pub(crate) enum Commands {
     /// process is what keeps it from paying start-up once per asset.
     #[command(hide = true)]
     Assets,
+    /// Remove what a rebuild would write again.
+    ///
+    /// The build's output, uf's own per-project state under `.uf/`, and the
+    /// caches. Not `node_modules` unless asked, and never a lockfile: the line
+    /// is the network, and a lockfile is an input.
+    Clean {
+        /// Also remove `node_modules`, which costs a network round trip.
+        #[arg(long)]
+        deps: bool,
+        /// Print what would be removed, and remove nothing.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Lint the project without type checking it.
     Lint {
         /// Emit machine-readable JSON on stdout.

--- a/crates/uf_cli/src/commands.rs
+++ b/crates/uf_cli/src/commands.rs
@@ -6,6 +6,7 @@
 pub(crate) mod assets;
 pub(crate) mod build;
 pub(crate) mod check;
+pub(crate) mod clean;
 pub(crate) mod compile;
 pub(crate) mod completion;
 pub(crate) mod create;

--- a/crates/uf_cli/src/commands/clean.rs
+++ b/crates/uf_cli/src/commands/clean.rs
@@ -39,6 +39,7 @@ use crate::support::{plural, project_label};
 use crate::ui::Ui;
 
 /// One directory `uf clean` considered.
+#[derive(Debug)]
 struct Target {
     /// Project-relative, as the reader knows it.
     label: String,
@@ -77,10 +78,10 @@ pub(crate) fn clean(cwd: &Utf8Path, ui: &mut Ui, deps: bool, dry_run: bool) -> R
         push(&mut targets, root, "node_modules", "an install");
     }
 
-    let removed = targets
-        .iter()
-        .filter(|target| target.bytes > 0 || target.files > 0)
-        .collect::<Vec<_>>();
+    // Every target that exists, empty or not. Filtering out the empty ones
+    // reported "nothing to remove" and left the directory sitting there, which
+    // is the one outcome a reader who ran `uf clean` did not ask for.
+    let removed = targets.iter().collect::<Vec<_>>();
 
     let project = project_label(root).to_string();
     if removed.is_empty() {
@@ -163,28 +164,53 @@ pub(crate) fn clean(cwd: &Utf8Path, ui: &mut Ui, deps: bool, dry_run: bool) -> R
     Ok(())
 }
 
-/// Add `relative` to the list, measured, unless it is not there or is already
-/// inside something else on the list.
+/// Add `relative` to the list, measured, unless it is not there, is not under
+/// the project, or is already covered by something on the list.
 ///
-/// The nesting check is what keeps `dist/docs` from being counted and then
-/// removed a second time under `dist/` — where the second removal is not an
-/// error but the size in the table would be wrong, which is the number the
-/// reader is deciding on.
+/// # Why the containment check
+///
+/// `build.outDir` and `docs.outDir` come from `uf.config.js`, so `relative` is
+/// whatever a project wrote — `"../.."`, or an absolute path, are both things
+/// a person types by mistake at two in the morning. A command that deletes
+/// must not be one config typo away from deleting a directory nobody named:
+/// the resolved path has to be a strict descendant of the project root, and a
+/// target that is not is skipped rather than removed.
+///
+/// Canonicalised first, because `root/dist/../..` is a parent directory that
+/// `starts_with` alone reads as a child. The root is canonicalised too — a
+/// symlinked checkout otherwise fails its own test.
+///
+/// # Why the nesting check works in both directions
+///
+/// A project may set `build.outDir` to `dist/client` and leave `docs.outDir`
+/// at `dist`. The first is pushed, and skipping the second because it
+/// *contains* one already listed would leave `dist/docs` on disk after a
+/// `uf clean` that reported success. So a new target that contains existing
+/// ones replaces them, and one contained by an existing target is skipped —
+/// either way the list ends up as the outermost directories and nothing is
+/// counted, or missed, twice.
 fn push(targets: &mut Vec<Target>, root: &Utf8Path, relative: &str, cost: &'static str) {
     let path = root.join(relative);
     if !path.is_dir() {
         return;
     }
-    if targets
-        .iter()
-        .any(|target| path.starts_with(&target.path) || target.path.starts_with(&path))
-    {
+    let (Ok(real), Ok(real_root)) = (path.canonicalize_utf8(), root.canonicalize_utf8()) else {
+        return;
+    };
+    // Strict: the root itself is not a target, and `uf clean` in a project
+    // whose `outDir` is `"."` must not remove the project.
+    if real == real_root || !real.starts_with(&real_root) {
         return;
     }
-    let (bytes, files) = measure(&path);
+    if targets.iter().any(|target| real.starts_with(&target.path)) {
+        return;
+    }
+    targets.retain(|target| !target.path.starts_with(&real));
+
+    let (bytes, files) = measure(&real);
     targets.push(Target {
         label: relative.to_owned(),
-        path,
+        path: real,
         cost,
         bytes,
         files,

--- a/crates/uf_cli/src/commands/clean.rs
+++ b/crates/uf_cli/src/commands/clean.rs
@@ -1,0 +1,215 @@
+//! `uf clean`: remove what a rebuild would write again.
+//!
+//! # The boundary, which is the whole of the design
+//!
+//! Four kinds of thing accumulate in a uf project, and they cost different
+//! amounts to lose:
+//!
+//! | | costs | removed by |
+//! | --- | --- | --- |
+//! | `dist/` — the build's output | a rebuild | `uf clean` |
+//! | `.uf/cache/` — transform and check answers | a rebuild, slower | `uf clean` |
+//! | `.uf/` — the rest of uf's per-project state | a re-resolve | `uf clean` |
+//! | `node_modules/` and the lockfile's store | a network round trip | `--deps` |
+//!
+//! The line is drawn at the network. Everything `uf clean` removes by default,
+//! this checkout can produce again on its own; `node_modules/` cannot, and a
+//! command that deleted it because somebody wanted their `dist/` gone would be
+//! a command that turned a two-second mistake into a two-minute one on a good
+//! connection and an impossible one on a train.
+//!
+//! `uf.lock` and `package-lock.json` are never removed at all, by any flag.
+//! They are inputs — checked in, reviewed, and the reason an install is
+//! reproducible — and no amount of cleaning should make the next install
+//! resolve something different from the last one.
+//!
+//! # What it prints
+//!
+//! What it removed and how much, which is the one thing a command that deletes
+//! owes its reader. `--dry-run` prints the same table and removes nothing, so
+//! the answer to "what would this take" is available before it is taken.
+
+use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use uf_bundle::size::ByteSize;
+use uf_config::load_config;
+use uf_term::{Cell, Column, Status, Table, Tone};
+
+use crate::support::{plural, project_label};
+use crate::ui::Ui;
+
+/// One directory `uf clean` considered.
+struct Target {
+    /// Project-relative, as the reader knows it.
+    label: String,
+    path: Utf8PathBuf,
+    /// What losing it costs, in the reader's terms rather than uf's.
+    cost: &'static str,
+    bytes: u64,
+    files: u64,
+}
+
+/// `uf clean [--deps] [--dry-run]`.
+pub(crate) fn clean(cwd: &Utf8Path, ui: &mut Ui, deps: bool, dry_run: bool) -> Result<()> {
+    let resolved = load_config(cwd)?;
+    let root = &resolved.root;
+
+    let mut targets = Vec::new();
+    // The build's output first, because it is what most readers mean.
+    push(
+        &mut targets,
+        root,
+        &resolved.config.build.out_dir,
+        "a rebuild",
+    );
+    // The documentation site writes under `dist/` by default, and under its
+    // own directory when a project moved it. Pushed separately and skipped
+    // when it is already inside one that was pushed, so a nested directory is
+    // not counted twice.
+    push(
+        &mut targets,
+        root,
+        &resolved.config.docs.out_dir,
+        "a docs rebuild",
+    );
+    push(&mut targets, root, ".uf", "re-resolving and re-checking");
+    if deps {
+        push(&mut targets, root, "node_modules", "an install");
+    }
+
+    let removed = targets
+        .iter()
+        .filter(|target| target.bytes > 0 || target.files > 0)
+        .collect::<Vec<_>>();
+
+    let project = project_label(root).to_string();
+    if removed.is_empty() {
+        ui.render(|renderer, out| {
+            renderer.banner(out, "uf clean", Some(&project));
+            renderer.blank(out);
+            renderer.status(out, Status::Success, "nothing to remove");
+        });
+        return Ok(());
+    }
+
+    let total_bytes: u64 = removed.iter().map(|target| target.bytes).sum();
+    let total_files: u64 = removed.iter().map(|target| target.files).sum();
+    // Owned first, borrowed in the render: `Cell` borrows its text, and the
+    // renderer runs inside a closure the locals must outlive.
+    let cells = removed
+        .iter()
+        .map(|target| {
+            (
+                target.label.clone(),
+                plural(target.files as usize, "file"),
+                ByteSize::from_bytes(target.bytes).to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let rows = cells
+        .iter()
+        .zip(&removed)
+        .map(|((label, files, size), target)| {
+            vec![
+                Cell::toned(label, Tone::Path),
+                Cell::toned(files, Tone::Number),
+                Cell::toned(size, Tone::Number),
+                Cell::toned(target.cost, Tone::Muted),
+            ]
+        })
+        .collect::<Vec<_>>();
+
+    let summary = format!(
+        "{} in {}",
+        ByteSize::from_bytes(total_bytes),
+        plural(total_files as usize, "file")
+    );
+    let dry = dry_run;
+    ui.render(|renderer, out| {
+        renderer.banner(out, "uf clean", Some(&project));
+        renderer.blank(out);
+        let mut table = Table::new(vec![
+            Column::left("directory"),
+            Column::right("files"),
+            Column::right("size"),
+            Column::left("costs"),
+        ]);
+        for row in &rows {
+            table.push(row.clone());
+        }
+        renderer.table(out, 2, &table);
+        renderer.blank(out);
+        if dry {
+            renderer.status(
+                out,
+                Status::Info,
+                &format!("{summary} would be removed; run without --dry-run"),
+            );
+        }
+    });
+
+    if dry_run {
+        return Ok(());
+    }
+
+    for target in &removed {
+        std::fs::remove_dir_all(&target.path)
+            .with_context(|| format!("could not remove {}", target.label))?;
+    }
+
+    ui.render(|renderer, out| {
+        renderer.status(out, Status::Success, &format!("removed {summary}"));
+    });
+    Ok(())
+}
+
+/// Add `relative` to the list, measured, unless it is not there or is already
+/// inside something else on the list.
+///
+/// The nesting check is what keeps `dist/docs` from being counted and then
+/// removed a second time under `dist/` — where the second removal is not an
+/// error but the size in the table would be wrong, which is the number the
+/// reader is deciding on.
+fn push(targets: &mut Vec<Target>, root: &Utf8Path, relative: &str, cost: &'static str) {
+    let path = root.join(relative);
+    if !path.is_dir() {
+        return;
+    }
+    if targets
+        .iter()
+        .any(|target| path.starts_with(&target.path) || target.path.starts_with(&path))
+    {
+        return;
+    }
+    let (bytes, files) = measure(&path);
+    targets.push(Target {
+        label: relative.to_owned(),
+        path,
+        cost,
+        bytes,
+        files,
+    });
+}
+
+/// The size and file count under `path`.
+///
+/// Unreadable entries are skipped rather than reported: this number exists to
+/// tell a reader roughly what they are about to lose, and a directory uf cannot
+/// stat is one `remove_dir_all` will complain about in a moment with a better
+/// message than a walk could.
+fn measure(path: &Utf8Path) -> (u64, u64) {
+    let mut bytes = 0;
+    let mut files = 0;
+    for entry in walkdir::WalkDir::new(path).into_iter().flatten() {
+        if let Ok(metadata) = entry.metadata()
+            && metadata.is_file()
+        {
+            bytes += metadata.len();
+            files += 1;
+        }
+    }
+    (bytes, files)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_cli/src/commands/clean/tests.rs
+++ b/crates/uf_cli/src/commands/clean/tests.rs
@@ -106,6 +106,66 @@ fn a_nested_output_directory_is_counted_once() {
     assert_eq!(targets[0].files, 2, "both files are under dist");
 }
 
+/// And in the other order, which is the one that used to lose a directory.
+///
+/// `build.outDir: "dist/client"` with `docs.outDir` left at `dist` pushed the
+/// child first, and the parent was then skipped for containing it — so
+/// `uf clean` removed `dist/client`, reported success, and left `dist/docs`
+/// where it was.
+#[test]
+fn an_ancestor_replaces_the_children_already_listed() {
+    let dir = project();
+    let root = root_of(&dir);
+    fs::create_dir_all(root.join("dist/client")).expect("a directory");
+    fs::write(root.join("dist/client/app.js"), "1\n").expect("a file");
+    let mut targets = Vec::new();
+
+    push(&mut targets, root, "dist/client", "a rebuild");
+    push(&mut targets, root, "dist", "a docs rebuild");
+
+    assert_eq!(targets.len(), 1, "the child was left beside its parent");
+    assert!(targets[0].path.ends_with("dist"), "{:?}", targets[0].path);
+    assert_eq!(targets[0].files, 3, "every file under dist is counted");
+}
+
+/// A directory that exists and holds nothing is still a directory somebody
+/// asked to have removed.
+#[test]
+fn an_empty_output_directory_is_removed_rather_than_reported_as_nothing() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = root_of(&dir);
+    fs::write(root.join("uf.config.js"), "// @flow\nexport default {};\n").expect("a config");
+    fs::write(root.join("package.json"), "{ \"name\": \"c\" }\n").expect("a manifest");
+    fs::create_dir_all(root.join("dist")).expect("a directory");
+
+    run(root, false, false);
+
+    assert!(!root.join("dist").exists(), "an empty dist survived");
+}
+
+/// `build.outDir` comes from `uf.config.js`, and a command that deletes must
+/// not be one typo away from deleting a directory nobody named.
+#[test]
+fn a_configured_output_outside_the_project_is_refused() {
+    let outer = tempfile::tempdir().expect("a temporary directory");
+    let outer_root = root_of(&outer);
+    let root = outer_root.join("project");
+    fs::create_dir_all(&root).expect("a project directory");
+    fs::write(root.join("uf.config.js"), "// @flow\nexport default {};\n").expect("a config");
+    fs::write(root.join("package.json"), "{ \"name\": \"c\" }\n").expect("a manifest");
+    // The thing a `../..` would take with it.
+    fs::create_dir_all(outer_root.join("sibling")).expect("a directory");
+    fs::write(outer_root.join("sibling/keep.txt"), "keep\n").expect("a file");
+
+    let mut targets = Vec::new();
+    push(&mut targets, &root, "../sibling", "a rebuild");
+    push(&mut targets, &root, "..", "a rebuild");
+    push(&mut targets, &root, ".", "a rebuild");
+
+    assert!(targets.is_empty(), "{targets:?} escaped the project");
+    assert!(outer_root.join("sibling/keep.txt").is_file());
+}
+
 /// And a project with nothing to remove says so rather than failing.
 #[test]
 fn a_clean_project_is_not_an_error() {

--- a/crates/uf_cli/src/commands/clean/tests.rs
+++ b/crates/uf_cli/src/commands/clean/tests.rs
@@ -1,0 +1,118 @@
+//! What `uf clean` removes, and — mostly — what it does not.
+
+use std::fs;
+
+use super::*;
+
+/// A project with a build output, a cache, an install and a lockfile.
+fn project() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = Utf8Path::from_path(dir.path()).expect("a UTF-8 path");
+    for (path, contents) in [
+        ("uf.config.js", "// @flow\nexport default {};\n"),
+        ("package.json", "{ \"name\": \"c\", \"private\": true }\n"),
+        ("package-lock.json", "{}\n"),
+        ("uf.lock", "{}\n"),
+        ("app.js", "// @flow\nexport const a = 1;\n"),
+        ("dist/index.html", "<!doctype html>\n"),
+        ("dist/docs/index.html", "<!doctype html>\n"),
+        (".uf/cache/check/one.json", "{}\n"),
+        ("node_modules/left-pad/index.js", "module.exports = 1;\n"),
+    ] {
+        let file = root.join(path);
+        fs::create_dir_all(file.parent().expect("a parent")).expect("a directory");
+        fs::write(&file, contents).expect("a file");
+    }
+    dir
+}
+
+fn root_of(dir: &tempfile::TempDir) -> &Utf8Path {
+    Utf8Path::from_path(dir.path()).expect("a UTF-8 path")
+}
+
+fn run(root: &Utf8Path, deps: bool, dry_run: bool) {
+    // JSON mode, because these tests are about the filesystem and the human
+    // render would otherwise print a table per assertion.
+    let mut ui = Ui::new(uf_term::ColorChoice::Never, crate::ui::OutputMode::Json);
+    clean(root, &mut ui, deps, dry_run).expect("clean runs");
+}
+
+#[test]
+fn the_build_output_and_ufs_own_state_go() {
+    let dir = project();
+    let root = root_of(&dir);
+
+    run(root, false, false);
+
+    assert!(!root.join("dist").exists(), "dist survived");
+    assert!(!root.join(".uf").exists(), ".uf survived");
+}
+
+/// The line is the network: everything else can be produced from this
+/// checkout, and `node_modules` cannot.
+#[test]
+fn the_install_stays_unless_it_is_asked_for() {
+    let dir = project();
+    let root = root_of(&dir);
+
+    run(root, false, false);
+    assert!(root.join("node_modules").is_dir(), "node_modules went");
+
+    run(root, true, false);
+    assert!(!root.join("node_modules").exists(), "--deps left it");
+}
+
+/// A lockfile is an input. No flag removes one, because the next install must
+/// resolve what the last one did.
+#[test]
+fn no_flag_removes_a_lockfile() {
+    let dir = project();
+    let root = root_of(&dir);
+
+    run(root, true, false);
+
+    assert!(root.join("uf.lock").is_file(), "uf.lock went");
+    assert!(
+        root.join("package-lock.json").is_file(),
+        "package-lock.json went"
+    );
+    assert!(root.join("app.js").is_file(), "a source file went");
+}
+
+#[test]
+fn a_dry_run_removes_nothing() {
+    let dir = project();
+    let root = root_of(&dir);
+
+    run(root, true, true);
+
+    assert!(root.join("dist").is_dir());
+    assert!(root.join(".uf").is_dir());
+    assert!(root.join("node_modules").is_dir());
+}
+
+/// `dist/docs` is inside `dist`, so it is measured once rather than twice —
+/// the size in the table is what the reader decides on.
+#[test]
+fn a_nested_output_directory_is_counted_once() {
+    let dir = project();
+    let root = root_of(&dir);
+    let mut targets = Vec::new();
+
+    push(&mut targets, root, "dist", "a rebuild");
+    push(&mut targets, root, "dist/docs", "a docs rebuild");
+
+    assert_eq!(targets.len(), 1, "dist/docs was counted under its own name");
+    assert_eq!(targets[0].files, 2, "both files are under dist");
+}
+
+/// And a project with nothing to remove says so rather than failing.
+#[test]
+fn a_clean_project_is_not_an_error() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = root_of(&dir);
+    fs::write(root.join("uf.config.js"), "// @flow\nexport default {};\n").expect("a config");
+    fs::write(root.join("package.json"), "{ \"name\": \"c\" }\n").expect("a manifest");
+
+    run(root, true, false);
+}

--- a/crates/uf_cli/src/commands/completion.rs
+++ b/crates/uf_cli/src/commands/completion.rs
@@ -48,6 +48,7 @@ const COMMANDS: &[&str] = &[
     "inspect",
     "install",
     "i",
+    "clean",
     "lint",
     "ls",
     "lsp",

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -270,6 +270,7 @@ fn run(cli: Cli, target: Option<&str>, ui: &mut Ui) -> Result<()> {
             fix_mode(fix, fix_unsafe),
             &paths,
         ),
+        Commands::Clean { deps, dry_run } => commands::clean::clean(&cwd, ui, deps, dry_run),
         Commands::Lsp => commands::dev::lsp(&cwd),
         Commands::Preview { host, port, mode } => {
             commands::serve::preview(&cwd, ui, commands::serve::ServeArgs { host, port, mode })

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -1362,6 +1362,7 @@ fn explain_says_which_commands_it_knows() {
 /// `exec` left this list when it started running things: three of its four
 /// paths hand control to something else, so there is a provider to name.
 const SELF_CONTAINED: &[&str] = &[
+    "clean",
     "completion",
     "create",
     "explain",

--- a/crates/uf_cli/tests/every_command.rs
+++ b/crates/uf_cli/tests/every_command.rs
@@ -67,6 +67,8 @@ const COVERAGE: &[(&str, &str)] = &[
     ("info", "here, and output.rs for the brand surface"),
     ("inspect", "here, and inspect.rs for the resolved config"),
     ("install", "workflow.rs: runs the package manager"),
+    // Where the parser declares it, which is what `uf --help` prints.
+    ("clean", "here, and clean/tests.rs for what it removes"),
     ("lint", "here, and output.rs for the report"),
     ("lsp", "cli.rs: speaks a protocol over stdio"),
     (

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -719,7 +719,7 @@ only read: `pnpm audit --fix` rewrites a lockfile.
 ### uf clean [--deps] [--dry-run]
 
 Removes what a rebuild would write again: the build's output, the documentation
-site's if it is elsewhere, and `.uf/` — uf's own per-project state, which is the
+site's output if it is elsewhere, and `.uf/` — uf's own per-project state, which is the
 transform and check caches and the resolved config.
 
 Not `node_modules` unless `--deps` says so. **The line is the network**:
@@ -734,6 +734,10 @@ last one.
 
 It prints what it removed and how much. `--dry-run` prints the same table and
 removes nothing.
+
+A configured `outDir` outside the project is refused rather than removed:
+`build.outDir` comes from `uf.config.js`, and a command that deletes must not
+be one typo away from taking a directory nobody named.
 
 ## Environment
 

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -716,6 +716,25 @@ only read: `pnpm audit --fix` rewrites a lockfile.
 
 `uf uninstall` is `uf remove`, which npm and pnpm both spell that way.
 
+### uf clean [--deps] [--dry-run]
+
+Removes what a rebuild would write again: the build's output, the documentation
+site's if it is elsewhere, and `.uf/` — uf's own per-project state, which is the
+transform and check caches and the resolved config.
+
+Not `node_modules` unless `--deps` says so. **The line is the network**:
+everything removed by default, the checkout can produce again on its own, and a
+command that deleted the install because somebody wanted their `dist/` gone
+would turn a two-second mistake into a two-minute one.
+
+**No flag removes a lockfile.** `uf.lock` and the manager's own are inputs —
+checked in, reviewed, and the reason an install is reproducible — and no amount
+of cleaning should make the next install resolve something different from the
+last one.
+
+It prints what it removed and how much. `--dry-run` prints the same table and
+removes nothing.
+
 ## Environment
 
 ### uf use TOOLCHAIN


### PR DESCRIPTION
Closes [#497](https://github.com/ubugeeei-prod/uf/issues/497). Part of [#488](https://github.com/ubugeeei-prod/uf/issues/488).

```
uf clean              dist/, the docs output, .uf/
uf clean --deps       and node_modules/
uf clean --dry-run    the same table, and nothing removed
```

The command is easy; the boundary is the design.

**The line is the network.** Everything `uf clean` removes by default, the checkout can produce again on its own. `node_modules/` cannot, and a command that deleted it because somebody wanted their `dist/` gone would turn a two-second mistake into a two-minute one on a good connection and an impossible one on a train.

**No flag removes a lockfile.** `uf.lock` and the manager's own are inputs — checked in, reviewed, and the reason an install is reproducible. No amount of cleaning should change what the next install resolves. There is a test for exactly that, because it is the assertion that will stop somebody adding `--all`.

It prints what it removed and how much, which is what a command that deletes owes its reader, and `--dry-run` prints it beforehand. A nested output directory is measured once — `dist/docs` under `dist/` would otherwise be counted twice, and the size is the number being decided on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791353303&installation_model_id=422833&pr_number=532&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F532&signature=3c43d72c1258b3b6fde860c17b8d08ace9cf1dab3c134704cbf612bc4c84c534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `uf clean` command to remove rebuildable build output, documentation output, and `.uf/` state.
  - Added `--dry-run` to preview items before removal.
  - Added optional `--deps` to remove `node_modules`; lockfiles and source files are preserved.

- **Documentation**
  - Documented `uf clean`, its options, and reporting behavior.

- **Tests**
  - Added coverage for cleanup boundaries, dry runs, nested outputs, and empty projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->