### PR TITLE
fix(release): promote-latest handed npm the plan file as stdin

### DIFF
--- a/tools/release/promote-latest.sh
+++ b/tools/release/promote-latest.sh
@@ -5,6 +5,7 @@
 #   npm login
 #   tools/release/promote-latest.sh           # show the plan, then move them
 #   tools/release/promote-latest.sh --yes     # without the question
+#   tools/release/promote-latest.sh --otp=123456   # for a run with no terminal
 #
 # `publish.yml` publishes a prerelease on the `alpha` tag and never on
 # `latest`, which is the right rule and stays: a prerelease must not displace a
@@ -71,10 +72,20 @@ cd "$repo_root"
 
 check_only=false
 assume_yes=false
+# One code for the whole run.
+#
+# `npm dist-tag add` on a 2FA account asks for a one-time password per write,
+# and there are seventeen. Interactively npm handles that itself — it keeps the
+# terminal and either prompts or opens a browser — so this is for the case
+# where it cannot: a run with no terminal, and the `--otp` npm's own docs give
+# for exactly that. `UF_NPM_OTP` is the same value from the environment, so a
+# code never has to be a shell argument, where it would land in a history file.
+otp="${UF_NPM_OTP:-}"
 for argument in "$@"; do
   case "$argument" in
     --check) check_only=true ;;
     -y | --yes) assume_yes=true ;;
+    --otp=*) otp="${argument#--otp=}" ;;
     *) echo "promote-latest: unknown option: $argument" >&2; exit 2 ;;
   esac
 done
@@ -244,11 +255,38 @@ if [ "$assume_yes" != true ]; then
   esac
 fi
 
+# On file descriptor 3, not on stdin.
+#
+# `done <"$plan"` redirects stdin for the *whole loop*, so every `npm` in it
+# inherits the plan file instead of the terminal — and `npm dist-tag add` on a
+# 2FA account needs the terminal: it asks for a one-time password, or prints a
+# URL and waits for the browser. With the file on stdin it can do neither and
+# fails immediately with `EOTP`, on the first name, having moved nothing. That
+# is what happened on `uf@0.0.0-alpha.12`.
 moved=0
-while read -r name version; do
+failed=0
+failures=""
+while read -r name version <&3; do
   echo "promote-latest: ${name}@${version} -> latest"
-  npm dist-tag add "${name}@${version}" latest
-  moved=$((moved + 1))
-done <"$plan"
+  # Not `set -e`'s business. Seventeen writes with one authentication between
+  # them: a code that expires on the ninth must not throw away the eight that
+  # worked, or the report of which they were. The command is idempotent and the
+  # plan is read from the registry, so the recovery is to run it again — and
+  # the names already moved will not be in the next plan.
+  if npm dist-tag add "${name}@${version}" latest ${otp:+--otp="$otp"}; then
+    moved=$((moved + 1))
+  else
+    failed=$((failed + 1))
+    failures="${failures}  ${name}@${version}
+"
+  fi
+done 3<"$plan"
 
 printf '\npromote-latest: %s moved.\n' "$moved"
+if [ "$failed" -gt 0 ]; then
+  printf 'promote-latest: %s did not move:\n%s' "$failed" "$failures" >&2
+  printf '\nRun it again — it reads the plan from the registry, so the names\n'  >&2
+  printf 'that moved are not in the next one. If npm asked for a one-time\n'      >&2
+  printf 'password, `--otp=<code>` passes one to every write in the run.\n'       >&2
+  exit 1
+fi

--- a/tools/release/test-promote-latest.sh
+++ b/tools/release/test-promote-latest.sh
@@ -124,7 +124,23 @@ if [ -z "$name" ] || [ "$name" = "$spec" ] || [ -z "$version" ]; then
   exit 1
 fi
 [ "${4:-}" = latest ] || { echo "npm error the tag to add is missing: ${4:-}" >&2; exit 1; }
+# What real npm does when it needs a one-time password: it reads the terminal.
+# With the plan file on stdin — which is what `done <"$plan"` did — it reads a
+# line of the plan instead, and the write it thinks it confirmed is a line
+# nobody typed. The stub writes down what it found so a test can say so.
+if [ -n "${NPM_READS_STDIN:-}" ]; then
+  if read -r stolen; then
+    echo "stdin: ${stolen}" >> "$NPM_LOG"
+  else
+    echo "stdin: none" >> "$NPM_LOG"
+  fi
+fi
 [ -n "${NPM_REFUSES:-}" ] && { echo "npm error code E403" >&2; exit 1; }
+# One name refuses, the rest do not, so a run can be checked for carrying on.
+case "${NPM_REFUSES_ONLY:-}" in
+  "") ;;
+  "$name") echo "npm error code EOTP" >&2; exit 1 ;;
+esac
 echo "+latest: ${spec}"
 EOF
   chmod +x "${work}/${world}/npm"
@@ -300,6 +316,56 @@ grep -q '^  behind ' "${work}/refused.log" \
   || fail "refused: the plan was not printed before the move was attempted:
 $(cat "${work}/refused.log")"
 pass "npm refusing a move fails the run"
+
+# 12. The plan is read on a descriptor of its own, so npm keeps the terminal.
+#
+#     `done <"$plan"` redirected stdin for the whole loop, and `npm dist-tag
+#     add` on a 2FA account needs stdin: it asks for a one-time password, or
+#     prints a URL and waits. With the plan file there it can do neither, and
+#     `uf@0.0.0-alpha.12` failed on the first of seventeen names having moved
+#     nothing.
+make_registry behind
+: > "${work}/stdin.npm"
+NPM_LOG="${work}/stdin.npm" NPM_READS_STDIN=1 PATH="${work}/behind:$PATH" \
+  sh "$script" --yes < /dev/null > "${work}/stdin.log" 2>&1 \
+  || fail "stdin: the run failed:
+$(cat "${work}/stdin.log")"
+grep -q '^stdin: none$' "${work}/stdin.npm" \
+  || fail "stdin: npm was handed something to read:
+$(cat "${work}/stdin.npm")"
+pass "the plan is read on its own descriptor, so npm keeps stdin"
+
+# 13. One name refusing does not throw away the others, and the summary says
+#     which one it was. Seventeen writes with one authentication between them:
+#     a code that expires on the ninth must not lose the eight that worked.
+: > "${work}/partial.npm"
+if NPM_LOG="${work}/partial.npm" NPM_REFUSES_ONLY=@uniflowed/config PATH="${work}/behind:$PATH" \
+  sh "$script" --yes > "${work}/partial.log" 2>&1; then
+  fail "partial: a refusal should still fail the run:
+$(cat "${work}/partial.log")"
+fi
+grep -q 'did not move' "${work}/partial.log" \
+  || fail "partial: the summary did not name what failed:
+$(cat "${work}/partial.log")"
+grep -q '@uniflowed/config@' "${work}/partial.log" \
+  || fail "partial: the failing name was not printed:
+$(cat "${work}/partial.log")"
+# And the sixteen after it still moved, which is the point.
+[ "$(grep -c '^+latest: ' "${work}/partial.log")" -ge 16 ] \
+  || fail "partial: the refusal stopped the rest:
+$(cat "${work}/partial.log")"
+pass "a name that refuses is named, and does not stop the run"
+
+# 14. `--otp` reaches npm, for a run with no terminal to ask.
+: > "${work}/otp.npm"
+NPM_LOG="${work}/otp.npm" PATH="${work}/behind:$PATH" \
+  sh "$script" --yes --otp=123456 > "${work}/otp.log" 2>&1 \
+  || fail "otp: the run failed:
+$(cat "${work}/otp.log")"
+grep -q -- '--otp=123456' "${work}/otp.npm" \
+  || fail "otp: the code did not reach npm:
+$(cat "${work}/otp.npm")"
+pass "--otp reaches every write in the run"
 
 # 12. An unknown option is a usage error rather than a run that quietly does
 #     something else. `--check` and `--yes` differ by whether anything is


### PR DESCRIPTION
The `EOTP` on `uf@0.0.0-alpha.12` was not about the one-time password.

```
promote-latest: @uniflowed/config@0.0.0-alpha.11 -> latest
npm error code EOTP
npm error This operation requires a one-time password.
npm error Open this URL in your browser to authenticate: …
```

`done <"$plan"` redirects stdin for the **whole loop**, so every `npm` inside it inherited the plan file instead of the terminal. `npm dist-tag add` on a 2FA account needs the terminal — it asks for a code, or prints a URL and waits for the browser — and with a text file there it can do neither. So it failed on the first of seventeen names, every time, having moved nothing.

Worse than failing: had npm read that stdin instead of refusing it, it would have taken a line of the plan as the answer to a prompt nobody saw.

## Three changes

- **The plan is read on descriptor 3.** npm keeps stdin, and the interactive authentication it already knows how to do works.
- **A name that fails no longer ends the run.** Seventeen writes with one authentication between them: a code that expires on the ninth must not throw away the eight that worked, or the report of which they were. The summary names what did not move and says to run it again — which resumes, because the plan is read from the registry and the names that moved are not in the next one.
- **`--otp=<code>`**, and `UF_NPM_OTP` for a code that should not land in a shell history, for a run with no terminal to ask.

## The test that matters

The npm stub gains an npm that reads its own stdin and writes down what it found. The assertion is that it found nothing — which fails against the old loop and passes against this one.

Fifteen tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791360773&installation_model_id=422833&pr_number=537&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F537&signature=f4fa9387f0aece4242db058e468f6fc261890b38141d5c8b7f1a6f7452033ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->