### PR TITLE
fix(release): verify-npm failed a release that had worked

### DIFF
--- a/tools/release/verify-npm.sh
+++ b/tools/release/verify-npm.sh
@@ -206,14 +206,49 @@ for name in $packages; do
   specifiers="$specifiers @uniflowed/$name@$version"
 done
 
-# shellcheck disable=SC2086 # deliberate word splitting: one argument per package
-if npm install --no-audit --no-fund $specifiers >"$work/install.log" 2>&1; then
-  echo "  installed $(echo "$packages" | wc -l | tr -d ' ') packages"
-else
-  echo "verify-npm: install failed" >&2
-  tail -20 "$work/install.log" >&2
-  exit 1
-fi
+# Retried, for the same reason step 2 is — and it is a *different* read.
+#
+# Step 2 asks for the version document, `registry.npmjs.org/<name>/<version>`,
+# and every package answered 200. `npm install` resolves through the
+# **packument**, `registry.npmjs.org/<name>`, which is a different object
+# behind a different cache and is updated a moment later. So there is a window
+# where a version exists, is fetchable by URL, and is `ETARGET` to `npm
+# install` — and `uf@0.0.0-alpha.12` landed in it: seventeen packages published,
+# seventeen reported on the registry, and `No matching version found for
+# @uniflowed/core@0.0.0-alpha.12` from the install a second later.
+#
+# A false failure here is worse than no check. This job exists because
+# `uf@0.0.0-alpha.2` had a tag, a GitHub release and nothing on npm and nobody
+# noticed (#142); a job that goes red on a release that worked teaches people
+# to stop reading it, which puts #142 back.
+#
+# `--prefer-online` on the retries, because npm caches the packument it just
+# resolved and would otherwise re-read its own stale copy for the whole
+# retry budget.
+install_delay=2
+freshness=""
+while :; do
+  # shellcheck disable=SC2086 # deliberate word splitting: one argument per package
+  if npm install --no-audit --no-fund $freshness $specifiers >"$work/install.log" 2>&1; then
+    echo "  installed $(echo "$packages" | wc -l | tr -d ' ') packages"
+    break
+  fi
+  left="$(remaining)"
+  if [ "$left" -le 0 ]; then
+    printf 'verify-npm: install kept failing for %ss\n' "$WAIT_SECONDS" >&2
+    tail -20 "$work/install.log" >&2
+    exit 1
+  fi
+  [ "$install_delay" -gt "$left" ] && install_delay="$left"
+  printf '  waiting     %ss; the packument is behind the version document\n' \
+    "$install_delay"
+  sleep "$install_delay"
+  install_delay=$((install_delay * 2))
+  # From the second attempt on. npm caches the packument it just failed to
+  # resolve from, so a plain retry re-reads its own stale copy for the whole
+  # budget and the wait buys nothing.
+  freshness="--prefer-online"
+done
 
 for name in $packages; do
   entry="$work/node_modules/@uniflowed/$name/package.json"


### PR DESCRIPTION
`uf@0.0.0-alpha.12` published all seventeen packages, and Publish went red:

```
npm error code ETARGET
npm error notarget No matching version found for @uniflowed/core@0.0.0-alpha.12.
```

The version was there. `tools/release/verify-npm.sh` run by hand now passes — seventeen on the registry, seventeen installed — and `npm view @uniflowed/core versions` has it.

## It retries the wrong read

Step 2 asks for the **version document**, `registry.npmjs.org/<name>/<version>`, and all seventeen answered `200` well inside its budget. `npm install` resolves through the **packument**, `registry.npmjs.org/<name>` — a different object, behind a different cache, updated a moment later. So there is a window where a version exists, is fetchable by URL, and is `ETARGET` to an install. This release landed in it.

The install is retried on the same deadline now, with `--prefer-online` from the second attempt: npm caches the packument it just failed to resolve from, so a plain retry re-reads its own stale copy and the wait buys nothing.

## Why it matters more than one red run

A false failure here is worse than no check. The job exists because [#142](https://github.com/ubugeeei-prod/uf/issues/142) — `uf@0.0.0-alpha.2` had a tag, a GitHub release and nothing on npm, and nobody noticed. A job that goes red on a release that worked teaches people to stop reading it, which puts #142 back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791361435&installation_model_id=422833&pr_number=538&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F538&signature=d6ff1af50a35bb92e0f668831a6b55c464679500a1af5d33fc4b046712b43bbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->