### PR TITLE
feat(pm): `uf catalog`, one version for a workspace that declares it everywhere

### DIFF
--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -578,6 +578,19 @@ pub(crate) enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Show the versions a workspace shares, and change one everywhere.
+    ///
+    /// A package more than one manifest declares is a catalogue entry, and the
+    /// range they agree on is its value. `uf catalog` prints them and every
+    /// package whose manifests *dis*agree; `uf catalog set` makes them agree.
+    ///
+    /// pnpm's `catalog:` is a specifier only pnpm can resolve, so uf does not
+    /// invent a fifth one: it reports how many a project has and leaves pnpm to
+    /// resolve them. See ubugeeei-prod/uf#496.
+    Catalog {
+        #[command(subcommand)]
+        command: Option<CatalogCommand>,
+    },
     /// Re-read the workspace and record the package and runtime plan.
     ///
     /// It fetches nothing and it does not replace the uf binary, in spite of
@@ -773,6 +786,22 @@ pub(crate) enum ReleaseBump {
     Patch,
     Minor,
     Major,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum CatalogCommand {
+    /// Declare one range for a package in every manifest that has it.
+    Set {
+        /// The package.
+        #[arg(value_name = "NAME")]
+        name: String,
+        /// The range, for example `^19.0.0`.
+        #[arg(value_name = "RANGE")]
+        range: String,
+        /// Say what would change, and change nothing.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/uf_cli/src/commands/completion.rs
+++ b/crates/uf_cli/src/commands/completion.rs
@@ -35,6 +35,7 @@ const COMMANDS: &[&str] = &[
     "add",
     "audit",
     "build",
+    "catalog",
     "check",
     "init",
     "new",
@@ -101,6 +102,7 @@ const EXPLAINABLE: &[&str] = &[
     "add",
     "remove",
     "update",
+    "catalog",
     "why",
     "ls",
     "audit",
@@ -197,6 +199,7 @@ fn candidates(words: &[String], tasks: &[&str]) -> Vec<String> {
         ["create"] => matching(current, CREATE_KINDS.iter().copied()),
         ["explain"] => matching(current, EXPLAINABLE.iter().copied()),
         ["env"] => matching(current, ["doctor", "use"]),
+        ["catalog"] => matching(current, ["set"]),
         _ => Vec::new(),
     }
 }

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -40,8 +40,8 @@ struct Stage {
 /// "uf" three times would be a list of nothing.
 const KNOWN: &[&str] = &[
     "dev", "build", "preview", "start", "doc", "test", "fmt", "lint", "check", "run", "exec",
-    "install", "add", "remove", "update", "why", "upgrade", "use", "env", "prepare", "publish",
-    "release", "lsp",
+    "install", "add", "remove", "update", "catalog", "why", "upgrade", "use", "env", "prepare",
+    "publish", "release", "lsp",
 ];
 
 pub(crate) fn explain(cwd: &Utf8Path, ui: &mut Ui, command: &str, as_json: bool) -> Result<()> {
@@ -75,6 +75,15 @@ pub(crate) fn explain(cwd: &Utf8Path, ui: &mut Ui, command: &str, as_json: bool)
             &resolved,
             Operation::Update,
             "moves the lockfile to the newest versions the manifest ranges already allow",
+        ),
+        // The listing is uf's own — it reads the workspace's manifests and
+        // nothing else — and `uf catalog set` rewrites them and then delegates
+        // an install, which is the part with a provider worth naming.
+        "catalog" => dependency_stages(
+            &resolved,
+            Operation::Install,
+            "`uf catalog` reads the manifests and reports; `uf catalog set` rewrites the range \
+             in each of them and the manager installs what they now say",
         ),
         "why" => why_stages(&resolved),
         "ls" => query_stages(

--- a/crates/uf_cli/src/commands/pm.rs
+++ b/crates/uf_cli/src/commands/pm.rs
@@ -1,10 +1,12 @@
 //! `uf install`, `uf add`, `uf remove`, `uf update`, `uf why`, `uf upgrade`,
 //! and `uf use`: packages and runtimes.
 
+mod catalog;
 mod deps;
 mod install;
 mod update;
 
+pub(crate) use catalog::{list as catalog, set as catalog_set};
 pub(crate) use deps::{add, query, remove, why};
 pub(crate) use install::install;
 pub(crate) use update::update;

--- a/crates/uf_cli/src/commands/pm/catalog.rs
+++ b/crates/uf_cli/src/commands/pm/catalog.rs
@@ -1,0 +1,420 @@
+//! `uf catalog`: one version, named once, for a workspace that declares it
+//! everywhere.
+//!
+//! # The decision this command is (ubugeeei-prod/uf#496)
+//!
+//! pnpm has *catalogs*: `pnpm-workspace.yaml` names a version once, and every
+//! package writes `"react": "catalog:"`. Nothing else has the concept — npm,
+//! yarn and bun read `catalog:` as a specifier they cannot resolve and refuse
+//! the install.
+//!
+//! That left two ways to have a `uf catalog`, and both were wrong:
+//!
+//! **A passthrough to pnpm** is a command that does nothing in four projects
+//! out of five, which is not a command uf should ship.
+//!
+//! **uf's own `catalog:`, resolved before the manager sees the manifests**,
+//! means uf rewriting everybody's `package.json` on the way into an install and
+//! putting it back afterwards. That is uf standing between the manifests and
+//! the installer — the thing `docs/red-lines.md` exists to prevent — and it is
+//! unsafe besides: a `^C` half way through leaves a workspace full of manifests
+//! nobody wrote.
+//!
+//! So uf does not invent a fifth catalogue, and it does not resolve anything
+//! behind a manager's back. It offers the thing catalogs are actually *for*,
+//! in a form all five managers already understand: **one place to change a
+//! version, and a check that every package agrees.**
+//!
+//! - The catalogue is the workspace itself. A package declared by more than one
+//!   manifest is a catalogue entry, and the range they agree on is its value.
+//! - `uf catalog` prints it, and prints every package whose manifests disagree
+//!   — which is the bug a catalogue exists to prevent, and the one nothing
+//!   currently reports.
+//! - `uf catalog set NAME RANGE` writes that range into every manifest that
+//!   declares `NAME`, and installs. One place to change a version, on npm,
+//!   pnpm, yarn and bun alike.
+//!
+//! What this gives up against pnpm's version is the indirection: a manifest
+//! here says `^19.0.0` rather than `catalog:`. What it buys is that the file
+//! says what will be installed, on every manager, with nothing in between —
+//! and that `uf catalog set` is one command rather than an edit plus a hope.
+//!
+//! A project that already uses pnpm's catalogs keeps them. uf reads `catalog:`
+//! as a range it does not rewrite, reports how many there are, and leaves
+//! pnpm to resolve them, because pnpm can.
+
+use anyhow::{Context, Result, bail};
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::{CompactString, ToCompactString};
+use uf_config::load_config;
+use uf_infra::FxHashMap;
+use uf_pm::Operation;
+use uf_pm::manifests::{Changes, Declaration};
+use uf_term::{Cell, Column, Status, Table, Tone};
+
+use crate::support::{plural, project_label};
+use crate::ui::Ui;
+
+/// How many rows either table prints before it stops listing them.
+const ROWS_SHOWN: usize = 40;
+
+/// `uf catalog`.
+///
+/// # Errors
+///
+/// When the project or one of its manifests cannot be read.
+pub(crate) fn list(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
+    let resolved = load_config(cwd)?;
+    let project = project_label(&resolved.root).to_string();
+    let entries = entries(&resolved.root, &uf_pm::manifests::declarations(&resolved.root)?);
+
+    ui.render(|renderer, out| {
+        renderer.banner(out, "uf catalog", Some(&project));
+        renderer.blank(out);
+        render(renderer, out, &entries);
+    });
+    Ok(())
+}
+
+/// `uf catalog set NAME RANGE [--dry-run]`.
+///
+/// # Errors
+///
+/// When the range is not one that can go in a manifest, when no manifest
+/// declares the package, or when a manifest cannot be rewritten.
+pub(crate) fn set(
+    cwd: &Utf8Path,
+    ui: &mut Ui,
+    name: &str,
+    range: &str,
+    dry_run: bool,
+) -> Result<()> {
+    // The name reaches a package manager's argv and the range reaches a JSON
+    // string in a file the project cannot install without; both are checked
+    // before either is written.
+    uf_pm::check_operands(std::slice::from_ref(&name.to_owned()))?;
+    if range.trim().is_empty() || range.chars().any(char::is_control) {
+        bail!("`{range}` is not a range that can go in a manifest");
+    }
+
+    let resolved = load_config(cwd)?;
+    let project = project_label(&resolved.root).to_string();
+    let declared = uf_pm::manifests::declarations(&resolved.root)?;
+    let affected: Vec<&Declaration> = declared
+        .iter()
+        .filter(|declaration| declaration.name == name)
+        .collect();
+    if affected.is_empty() {
+        bail!("no manifest in this workspace declares `{name}`");
+    }
+
+    let mut moving: Vec<(String, CompactString)> = Vec::new();
+    let mut changes: FxHashMap<Utf8PathBuf, Changes> = FxHashMap::default();
+    for declaration in &affected {
+        if declaration.range == range {
+            continue;
+        }
+        moving.push((
+            relative(&resolved.root, &declaration.manifest),
+            declaration.range.clone(),
+        ));
+        changes
+            .entry(declaration.manifest.clone())
+            .or_default()
+            .insert(
+                (declaration.field, declaration.name.clone()),
+                range.to_compact_string(),
+            );
+    }
+
+    let rows: Vec<Vec<Cell<'_>>> = moving
+        .iter()
+        .take(ROWS_SHOWN)
+        .map(|(manifest, was)| {
+            vec![
+                Cell::toned(manifest.as_str(), Tone::Path),
+                Cell::toned(was.as_str(), Tone::Muted),
+                Cell::toned(range, Tone::Number),
+            ]
+        })
+        .collect();
+    let nothing = moving.is_empty();
+    let name_owned = name.to_owned();
+    let summary = format!(
+        "{} in {}",
+        plural(moving.len(), "declaration"),
+        plural(changes.len(), "manifest")
+    );
+    ui.render(|renderer, out| {
+        renderer.banner(out, "uf catalog set", Some(&project));
+        renderer.blank(out);
+        if nothing {
+            renderer.status(
+                out,
+                Status::Success,
+                &format!("every manifest already declares {name_owned} at {range}"),
+            );
+            return;
+        }
+        let mut table = Table::new(vec![
+            Column::left("manifest"),
+            Column::left("was"),
+            Column::left("becomes"),
+        ]);
+        for row in &rows {
+            table.push(row.clone());
+        }
+        renderer.table(out, 2, &table);
+        renderer.blank(out);
+        if dry_run {
+            renderer.status(
+                out,
+                Status::Info,
+                &format!("{summary} would change; run without --dry-run"),
+            );
+        }
+    });
+
+    if nothing || dry_run {
+        return Ok(());
+    }
+
+    for (manifest, changes) in &changes {
+        uf_pm::manifests::apply(manifest, changes)
+            .with_context(|| format!("could not rewrite {}", relative(&resolved.root, manifest)))?;
+    }
+    ui.render(|renderer, out| {
+        renderer.status(out, Status::Success, &format!("wrote {summary}"));
+        renderer.blank(out);
+    });
+
+    // The manifests say something new, so the lockfile has to be made to agree.
+    super::deps::delegate(
+        cwd,
+        ui,
+        &super::deps::Request {
+            heading: "uf catalog set",
+            operation: Operation::Install,
+            operands: &[],
+            retry: "uf install".to_owned(),
+            announced: true,
+        },
+    )
+}
+
+/// One package more than one manifest declares.
+struct Entry {
+    name: CompactString,
+    /// Every manifest that declares it, and at what.
+    declared: Vec<(String, CompactString)>,
+}
+
+impl Entry {
+    /// The one range they all say, when they all say one.
+    fn agreed(&self) -> Option<&CompactString> {
+        let first = &self.declared.first()?.1;
+        self.declared
+            .iter()
+            .all(|(_, range)| range == first)
+            .then_some(first)
+    }
+}
+
+/// What the whole command has to say.
+struct Catalogue {
+    entries: Vec<Entry>,
+    manifests: usize,
+    /// Declarations that are pnpm's `catalog:`, which pnpm resolves itself.
+    pnpm_catalog: usize,
+}
+
+/// Every package that more than one manifest declares.
+///
+/// One manifest declaring a package is not a catalogue entry — there is nothing
+/// for it to agree with, and a workspace's whole dependency list is not a
+/// catalogue. Two is where the question "do these say the same thing" starts
+/// having an answer.
+fn entries(root: &Utf8Path, declared: &[Declaration]) -> Catalogue {
+    let mut by_name: FxHashMap<CompactString, Vec<(String, CompactString)>> = FxHashMap::default();
+    let mut manifests: Vec<&Utf8PathBuf> = Vec::new();
+    let mut pnpm_catalog = 0;
+    for declaration in declared {
+        if !manifests.contains(&&declaration.manifest) {
+            manifests.push(&declaration.manifest);
+        }
+        if declaration.range.starts_with("catalog:") {
+            pnpm_catalog += 1;
+        }
+        by_name
+            .entry(declaration.name.clone())
+            .or_default()
+            .push((relative(root, &declaration.manifest), declaration.range.clone()));
+    }
+
+    let mut entries: Vec<Entry> = by_name
+        .into_iter()
+        .filter(|(_, declared)| declared.len() > 1)
+        .map(|(name, mut declared)| {
+            declared.sort();
+            Entry { name, declared }
+        })
+        .collect();
+    // Disagreements first, then by name: the rows that need a decision are the
+    // rows worth putting at the top.
+    entries.sort_by(|left, right| {
+        left.agreed()
+            .is_some()
+            .cmp(&right.agreed().is_some())
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    Catalogue {
+        entries,
+        manifests: manifests.len(),
+        pnpm_catalog,
+    }
+}
+
+/// Draw it.
+fn render(renderer: &uf_term::Renderer, out: &mut String, catalogue: &Catalogue) {
+    if catalogue.manifests < 2 {
+        renderer.status(
+            out,
+            Status::Info,
+            "one manifest, so there is nothing for a catalogue to keep in step",
+        );
+        render_pnpm(renderer, out, catalogue);
+        return;
+    }
+    if catalogue.entries.is_empty() {
+        renderer.status(
+            out,
+            Status::Success,
+            &format!(
+                "no package is declared by more than one of this workspace's {}",
+                plural(catalogue.manifests, "manifest")
+            ),
+        );
+        render_pnpm(renderer, out, catalogue);
+        return;
+    }
+
+    let disagreeing: Vec<&Entry> = catalogue
+        .entries
+        .iter()
+        .filter(|entry| entry.agreed().is_none())
+        .collect();
+
+    renderer.heading(out, 2, "shared");
+    renderer.blank(out);
+    let counts: Vec<String> = catalogue
+        .entries
+        .iter()
+        .map(|entry| plural(entry.declared.len(), "package"))
+        .collect();
+    let mut table = Table::new(vec![
+        Column::left("package"),
+        Column::left("range"),
+        Column::left("declared in"),
+    ]);
+    for (entry, count) in catalogue.entries.iter().take(ROWS_SHOWN).zip(&counts) {
+        let (range, tone) = match entry.agreed() {
+            Some(range) => (range.as_str(), Tone::Muted),
+            // Not a range, because there isn't one — that is the finding, and
+            // the disagreements table below says what they are.
+            None => ("differs", Tone::Warn),
+        };
+        table.push(vec![
+            Cell::new(entry.name.as_str()),
+            Cell::toned(range, tone),
+            Cell::toned(count, Tone::Number),
+        ]);
+    }
+    renderer.table(out, 2, &table);
+    if catalogue.entries.len() > ROWS_SHOWN {
+        renderer.blank(out);
+        renderer.status(
+            out,
+            Status::Info,
+            &format!(
+                "and {} more; --json prints all of them",
+                catalogue.entries.len() - ROWS_SHOWN
+            ),
+        );
+    }
+    renderer.blank(out);
+
+    if !disagreeing.is_empty() {
+        renderer.heading(out, 2, "disagreements");
+        renderer.blank(out);
+        let mut table = Table::new(vec![
+            Column::left("package"),
+            Column::left("manifest"),
+            Column::left("range"),
+        ]);
+        for entry in disagreeing.iter().take(ROWS_SHOWN) {
+            for (manifest, range) in &entry.declared {
+                table.push(vec![
+                    Cell::new(entry.name.as_str()),
+                    Cell::toned(manifest.as_str(), Tone::Path),
+                    Cell::toned(range.as_str(), Tone::Warn),
+                ]);
+            }
+        }
+        renderer.table(out, 2, &table);
+        renderer.blank(out);
+        renderer.status(
+            out,
+            Status::Warn,
+            &format!(
+                "{} declared at more than one range",
+                plural(disagreeing.len(), "package")
+            ),
+        );
+        renderer.status(
+            out,
+            Status::Info,
+            &format!(
+                "uf catalog set {} <range> makes every manifest agree",
+                disagreeing[0].name
+            ),
+        );
+    } else {
+        renderer.status(
+            out,
+            Status::Success,
+            &format!(
+                "{} shared, and every manifest agrees on all of them",
+                plural(catalogue.entries.len(), "package")
+            ),
+        );
+    }
+    render_pnpm(renderer, out, catalogue);
+}
+
+/// pnpm's own catalogue, when the project has one.
+fn render_pnpm(renderer: &uf_term::Renderer, out: &mut String, catalogue: &Catalogue) {
+    if catalogue.pnpm_catalog == 0 {
+        return;
+    }
+    renderer.status(
+        out,
+        Status::Info,
+        &format!(
+            "{} written as pnpm's `catalog:`, which pnpm resolves itself",
+            plural(catalogue.pnpm_catalog, "declaration")
+        ),
+    );
+}
+
+/// A manifest as the reader knows it: `.` for the root, else its directory.
+fn relative(root: &Utf8Path, manifest: &Utf8Path) -> String {
+    let directory = manifest.parent().unwrap_or(manifest);
+    match directory.strip_prefix(root) {
+        Ok(path) if path.as_str().is_empty() => ".".to_owned(),
+        Ok(path) => path.to_string(),
+        Err(_) => directory.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_cli/src/commands/pm/catalog/tests.rs
+++ b/crates/uf_cli/src/commands/pm/catalog/tests.rs
@@ -1,0 +1,150 @@
+//! What the catalogue is, and what it says when the manifests disagree.
+
+use super::*;
+use compact_str::ToCompactString;
+use uf_term::{Capabilities, Renderer};
+
+fn plain() -> Renderer {
+    Renderer::new(Capabilities::plain())
+}
+
+fn declaration(manifest: &str, name: &str, range: &str) -> Declaration {
+    Declaration {
+        manifest: Utf8PathBuf::from(format!("/p/{manifest}")),
+        field: "dependencies",
+        name: name.to_compact_string(),
+        range: range.to_compact_string(),
+    }
+}
+
+fn catalogue(declared: &[Declaration]) -> Catalogue {
+    entries(Utf8Path::new("/p"), declared)
+}
+
+fn drawn(catalogue: &Catalogue) -> String {
+    let mut out = String::new();
+    render(&plain(), &mut out, catalogue);
+    out
+}
+
+/// A package one manifest declares has nothing to agree with, so it is not an
+/// entry — otherwise "the catalogue" would just be the dependency list.
+#[test]
+fn an_entry_is_a_package_more_than_one_manifest_declares() {
+    let declared = [
+        declaration("package.json", "react", "^18.2.0"),
+        declaration("packages/ui/package.json", "react", "^18.2.0"),
+        declaration("package.json", "vitest", "~1.0.0"),
+    ];
+
+    let catalogue = catalogue(&declared);
+
+    assert_eq!(catalogue.entries.len(), 1);
+    assert_eq!(catalogue.entries[0].name, "react");
+    assert_eq!(catalogue.entries[0].agreed().map(CompactString::as_str), Some("^18.2.0"));
+}
+
+/// The bug a catalogue exists to prevent, and the one nothing else reports.
+#[test]
+fn manifests_that_disagree_are_the_finding() {
+    let declared = [
+        declaration("package.json", "eslint", "^9.0.0"),
+        declaration("packages/ui/package.json", "eslint", "^8.57.0"),
+    ];
+
+    let catalogue = catalogue(&declared);
+    assert!(catalogue.entries[0].agreed().is_none());
+
+    let out = drawn(&catalogue);
+    assert!(out.contains("disagreements"), "{out}");
+    assert!(out.contains("differs"), "the shared table hid the finding: {out}");
+    assert!(out.contains("^9.0.0") && out.contains("^8.57.0"), "{out}");
+    assert!(out.contains("1 package declared at more than one range"), "{out}");
+    assert!(out.contains("uf catalog set eslint <range>"), "{out}");
+}
+
+/// The rows that need a decision go first.
+#[test]
+fn a_disagreement_sorts_above_an_agreement() {
+    let declared = [
+        declaration("package.json", "aaa-agrees", "^1.0.0"),
+        declaration("packages/ui/package.json", "aaa-agrees", "^1.0.0"),
+        declaration("package.json", "zzz-differs", "^1.0.0"),
+        declaration("packages/ui/package.json", "zzz-differs", "^2.0.0"),
+    ];
+
+    let out = drawn(&catalogue(&declared));
+
+    let differs = out.find("zzz-differs").expect("the disagreement");
+    let agrees = out.find("aaa-agrees").expect("the agreement");
+    assert!(differs < agrees, "{out}");
+}
+
+#[test]
+fn a_workspace_that_agrees_says_so_rather_than_printing_an_empty_section() {
+    let declared = [
+        declaration("package.json", "react", "^18.2.0"),
+        declaration("packages/ui/package.json", "react", "^18.2.0"),
+    ];
+
+    let out = drawn(&catalogue(&declared));
+
+    assert!(out.contains("1 package shared, and every manifest agrees"), "{out}");
+    assert!(!out.contains("disagreements"), "{out}");
+}
+
+/// A single-package project has no catalogue question, and should be told that
+/// rather than "nothing is shared".
+#[test]
+fn one_manifest_is_not_a_workspace_with_nothing_shared() {
+    let declared = [
+        declaration("package.json", "react", "^18.2.0"),
+        declaration("package.json", "vitest", "~1.0.0"),
+    ];
+
+    let out = drawn(&catalogue(&declared));
+
+    assert!(out.contains("nothing for a catalogue to keep in step"), "{out}");
+}
+
+#[test]
+fn a_workspace_that_shares_nothing_says_which_nothing() {
+    let declared = [
+        declaration("package.json", "react", "^18.2.0"),
+        declaration("packages/ui/package.json", "vitest", "~1.0.0"),
+    ];
+
+    let out = drawn(&catalogue(&declared));
+
+    assert!(
+        out.contains("no package is declared by more than one of this workspace's 2 manifests"),
+        "{out}"
+    );
+}
+
+/// A pnpm project keeps its own catalogue; uf reports it and does not fight it.
+#[test]
+fn pnpms_own_catalog_is_reported_rather_than_reinterpreted() {
+    let declared = [
+        declaration("package.json", "react", "catalog:"),
+        declaration("packages/ui/package.json", "react", "catalog:"),
+        declaration("packages/ui/package.json", "vue", "catalog:react17"),
+    ];
+
+    let catalogue = catalogue(&declared);
+    assert_eq!(catalogue.pnpm_catalog, 3);
+
+    let out = drawn(&catalogue);
+    assert!(out.contains("3 declarations written as pnpm's `catalog:`"), "{out}");
+    assert!(out.contains("pnpm resolves itself"), "{out}");
+}
+
+#[test]
+fn the_root_manifest_is_a_dot_and_a_package_is_its_directory() {
+    let root = Utf8Path::new("/p");
+    assert_eq!(relative(root, Utf8Path::new("/p/package.json")), ".");
+    assert_eq!(
+        relative(root, Utf8Path::new("/p/packages/ui/package.json")),
+        "packages/ui"
+    );
+}

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -325,6 +325,14 @@ fn run(cli: Cli, target: Option<&str>, ui: &mut Ui) -> Result<()> {
                 paths,
             },
         ),
+        Commands::Catalog { command } => match command {
+            None => commands::pm::catalog(&cwd, ui),
+            Some(cli::CatalogCommand::Set {
+                name,
+                range,
+                dry_run,
+            }) => commands::pm::catalog_set(&cwd, ui, &name, &range, dry_run),
+        },
         Commands::Update {
             packages,
             latest,

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -1346,7 +1346,7 @@ fn explain_says_which_commands_it_knows() {
         "{stderr}"
     );
     assert!(
-        stderr.contains("install, add, remove, update, why, upgrade"),
+        stderr.contains("install, add, remove, update, catalog, why, upgrade"),
         "{stderr}"
     );
 }

--- a/crates/uf_cli/tests/every_command.rs
+++ b/crates/uf_cli/tests/every_command.rs
@@ -83,6 +83,10 @@ const COVERAGE: &[(&str, &str)] = &[
     ("start", "vite.rs: serves a build over a socket"),
     ("test", "here, and testing.rs for the runner"),
     ("update", "dependencies.rs: runs the package manager"),
+    (
+        "catalog",
+        "here, and catalog/tests.rs for the table and the disagreements",
+    ),
     ("upgrade", "workflow.rs: resolves new versions"),
     ("use", "workflow.rs: rewrites the config"),
     ("ls", "dependencies.rs: asks the package manager"),
@@ -111,6 +115,7 @@ const READ_ONLY: &[&[&str]] = &[
     &["env", "doctor"],
     &["env", "list"],
     &["env", "gc", "--dry-run"],
+    &["catalog"],
     &["explain", "dev"],
     &["fmt", "--check"],
     &["info"],

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -718,6 +718,61 @@ does not fail the command.
 This is **not** `uf upgrade`, which is about the toolchain and the workspace
 plan rather than about your dependencies.
 
+### uf catalog
+
+Prints the versions this workspace shares — every package more than one
+manifest declares — and, underneath, every package whose manifests *dis*agree:
+
+```
+  shared
+
+  package  range    declared in
+  eslint   differs  2 packages
+  react    differs  3 packages
+
+  disagreements
+
+  package  manifest      range
+  eslint   .             ^9.0.0
+  eslint   packages/ui   ^8.57.0
+  react    .             ^18.2.0
+  react    packages/api  ^17.0.0
+  react    packages/ui   ^18.2.0
+
+! 2 packages declared at more than one range
+› uf catalog set eslint <range> makes every manifest agree
+```
+
+That second table is the bug a catalogue exists to prevent, and nothing else
+reports it.
+
+### uf catalog set NAME RANGE
+
+Writes one range into every manifest that declares `NAME`, then installs.
+`--dry-run` prints the table and changes nothing. Only the range moves in each
+file; indentation and key order are left as they were.
+
+**Why this and not pnpm's `catalog:`.** pnpm names a version once in
+`pnpm-workspace.yaml` and lets a package write `"react": "catalog:"`. No other
+manager has the concept — npm, yarn and bun read `catalog:` as a specifier they
+cannot resolve and refuse the install. That left uf two options, and both were
+worse than this one: a passthrough to pnpm does nothing in four projects out of
+five, and resolving `catalog:` *for* the other managers means uf rewriting
+everybody's `package.json` on the way into an install and putting it back
+afterwards — uf standing between the manifests and the installer, and a
+workspace full of manifests nobody wrote if you interrupt it.
+
+So uf does not invent a fifth catalogue. It offers what catalogs are for, in a
+form all five managers already understand: one place to change a version, and a
+check that every package agrees. What you give up is the indirection — a
+manifest here says `^19.0.0` rather than `catalog:`. What you get is a file that
+says what will be installed, on every manager, and one command instead of an
+edit and a hope.
+
+A project already using pnpm's catalogs keeps them: uf counts the `catalog:`
+declarations, reports them, and leaves pnpm to resolve them, because pnpm can
+([#496](https://github.com/ubugeeei-prod/uf/issues/496)).
+
 ### uf why NAME
 
 Explains why a package is in the tree, answered by the manager out of its own


### PR DESCRIPTION
Closes #496. **Stacked on #541** — review that first; this branch's base retargets to `main` when it merges.

#496 asked for a decision: is `uf catalog` a passthrough to pnpm, or uf's own catalogue resolved before the manager sees the manifests?

**Neither.**

A passthrough does nothing in four projects out of five. And resolving `catalog:` *for* npm/yarn/bun means uf rewriting everybody's `package.json` on the way into an install and putting it back afterwards — uf standing between the manifests and the installer, which is what `docs/red-lines.md` exists to prevent, and a workspace full of manifests nobody wrote if you `^C` it.

So uf does not invent a fifth catalogue. It offers what catalogs are actually *for*, in a form all five managers already understand: **one place to change a version, and a check that every package agrees.**

## `uf catalog`

```
  shared

  package  range    declared in
  eslint   differs  2 packages
  react    differs  3 packages

  disagreements

  package  manifest      range
  eslint   .             ^9.0.0
  eslint   packages/ui   ^8.57.0
  react    .             ^18.2.0
  react    packages/api  ^17.0.0
  react    packages/ui   ^18.2.0

! 2 packages declared at more than one range
› uf catalog set eslint <range> makes every manifest agree
```

Real output from a three-package workspace. The second table is the bug a catalogue exists to prevent, and nothing else reports it.

A package only one manifest declares is not an entry — there is nothing for it to agree with, and a workspace's whole dependency list is not a catalogue.

## `uf catalog set NAME RANGE`

```
  manifest      was      becomes
  .             ^18.2.0  ^18.3.1
  packages/api  ^17.0.0  ^18.3.1
  packages/ui   ^18.2.0  ^18.3.1

✓ wrote 3 declarations in 3 manifests
```

then the manager's install. `--dry-run` prints the table and stops. Only the range moves in each file — the splice from #541 keeps indentation and key order byte for byte.

## What it gives up, and what it buys

Given up: the indirection. A manifest here says `^19.0.0`, not `catalog:`.

Bought: the file says what will be installed, on every manager, with nothing in between — and one command instead of an edit and a hope.

A project already using pnpm's catalogs keeps them. uf counts the `catalog:` declarations, reports them, and leaves pnpm to resolve them, because pnpm can.

## Verified

uf_cli lib 292, cli 66, every_command 13, output 17. Clippy clean. And end to end outside the repo — both tables above are real runs, and `set` rewrote three manifests (including one with an inline `"dependencies": { ... }` object) and installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791367064&installation_model_id=422833&pr_number=542&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F542&signature=5a013dad526b2feb7d3a4789df60ada63eb225b44e791d90f201aabc5b5f4913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->