### PR TITLE
feat(pm): `uf pm approve-builds`, and the sentence npm gets instead

### DIFF
--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -578,6 +578,16 @@ pub(crate) enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// The package manager underneath: what it is allowed to do, and what it
+    /// has been told.
+    ///
+    /// `uf install`, `uf add` and the rest are the commands people run. This is
+    /// the plumbing beside them — the settings a manager reads that uf has an
+    /// opinion about.
+    Pm {
+        #[command(subcommand)]
+        command: PmCommand,
+    },
     /// Open a dependency for editing, and write the patch when you are done.
     ///
     /// `uf patch left-pad` prints a directory holding a copy of the package;
@@ -804,6 +814,31 @@ pub(crate) enum ReleaseBump {
     Patch,
     Minor,
     Major,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum PmCommand {
+    /// List the dependencies that would run code at install time, and approve
+    /// the ones you have read.
+    ///
+    /// uf passes `--ignore-scripts` to every manager by default, so no
+    /// dependency runs anything. Naming one here records it in the field your
+    /// package manager reads — `pnpm.onlyBuiltDependencies`,
+    /// `trustedDependencies`, `dependenciesMeta` — and the next install builds
+    /// exactly those.
+    ///
+    /// npm and Yarn 1 have no per-package control: `--ignore-scripts` is all of
+    /// them or none. uf says so rather than offering an approval that quietly
+    /// means "and everything else too".
+    #[command(name = "approve-builds")]
+    ApproveBuilds {
+        /// The packages to approve; none lists what is waiting.
+        #[arg(value_name = "NAME")]
+        names: Vec<String>,
+        /// Say what would be approved, and write nothing.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/uf_cli/src/commands/completion.rs
+++ b/crates/uf_cli/src/commands/completion.rs
@@ -35,6 +35,7 @@ const COMMANDS: &[&str] = &[
     "add",
     "audit",
     "build",
+    "pm",
     "patch",
     "catalog",
     "check",
@@ -104,6 +105,7 @@ const EXPLAINABLE: &[&str] = &[
     "remove",
     "update",
     "patch",
+    "pm",
     "catalog",
     "why",
     "ls",
@@ -202,6 +204,7 @@ fn candidates(words: &[String], tasks: &[&str]) -> Vec<String> {
         ["explain"] => matching(current, EXPLAINABLE.iter().copied()),
         ["env"] => matching(current, ["doctor", "use"]),
         ["catalog"] => matching(current, ["set"]),
+        ["pm"] => matching(current, ["approve-builds"]),
         _ => Vec::new(),
     }
 }

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -40,7 +40,7 @@ struct Stage {
 /// "uf" three times would be a list of nothing.
 const KNOWN: &[&str] = &[
     "dev", "build", "preview", "start", "doc", "test", "fmt", "lint", "check", "run", "exec",
-    "install", "add", "remove", "update", "patch", "catalog", "why", "upgrade", "use", "env",
+    "install", "add", "remove", "update", "patch", "pm", "catalog", "why", "upgrade", "use", "env",
     "prepare", "publish", "release", "lsp",
 ];
 
@@ -79,6 +79,13 @@ pub(crate) fn explain(cwd: &Utf8Path, ui: &mut Ui, command: &str, as_json: bool)
         // The listing is uf's own — it reads the workspace's manifests and
         // nothing else — and `uf catalog set` rewrites them and then delegates
         // an install, which is the part with a provider worth naming.
+        "pm" => query_stages(
+            &resolved,
+            Operation::Install,
+            "`uf pm approve-builds` reads node_modules for the packages that declare an install \
+             script and the root manifest for the ones this project has approved; the manager is \
+             what enforces the list, which is why the list lives in the field the manager reads",
+        ),
         "patch" => query_stages(
             &resolved,
             Operation::Patch,

--- a/crates/uf_cli/src/commands/pm.rs
+++ b/crates/uf_cli/src/commands/pm.rs
@@ -1,11 +1,13 @@
 //! `uf install`, `uf add`, `uf remove`, `uf update`, `uf why`, `uf upgrade`,
 //! and `uf use`: packages and runtimes.
 
+mod approve;
 mod catalog;
 mod deps;
 mod install;
 mod update;
 
+pub(crate) use approve::approve_builds;
 pub(crate) use catalog::{list as catalog, set as catalog_set};
 pub(crate) use deps::{add, patch, query, remove, why};
 pub(crate) use install::install;
@@ -23,6 +25,34 @@ use uf_term::{KeyValue, Status, Tone};
 
 use crate::support::{enabled, project_label, write_json_file};
 use crate::ui::Ui;
+
+/// Whether this install may let a dependency's own scripts run.
+///
+/// `pm.allowLifecycleScripts` is the blunt answer and stays the blunt answer:
+/// on means every dependency, including the ones nobody has read. The other way
+/// in is [`uf_pm::builds`]: a manager that can be handed an allow-list, with at
+/// least one name in it, gets to run exactly those, so `--ignore-scripts` comes
+/// off and the manager holds the line uf was holding.
+///
+/// Both call sites go through here rather than through
+/// `PackageManagerPlan::forbids_npm_scripts`, because a rule about running
+/// somebody else's code should have one spelling.
+///
+/// # Errors
+///
+/// When the root manifest is not JSON — the same failure the install is about
+/// to hit anyway.
+fn scripts_allowed(
+    root: &Utf8Path,
+    manager: uf_pm::PackageManager,
+    plan: &PackageManagerPlan,
+) -> Result<bool> {
+    Ok(uf_pm::builds::scripts_allowed(
+        root,
+        manager,
+        !plan.forbids_npm_scripts(),
+    )?)
+}
 
 pub(crate) fn upgrade(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
     let resolved = load_config(cwd)?;

--- a/crates/uf_cli/src/commands/pm/approve.rs
+++ b/crates/uf_cli/src/commands/pm/approve.rs
@@ -1,0 +1,341 @@
+//! `uf pm approve-builds`: which dependencies may run code when they install.
+//!
+//! The model, and why an approval is worth having at all, is in
+//! [`uf_pm::builds`]. This is the command over it: what is waiting, what the
+//! project has already said, and what this particular manager is able to
+//! enforce.
+//!
+//! # Why it names the hooks
+//!
+//! Because "approve `sharp`?" is not a question anybody can answer. The thing
+//! being approved is code that will run on the machine of everyone who installs
+//! this project, and a row that says only the package name is a review in name
+//! only. So the table carries which of `preinstall`, `install`, `postinstall`
+//! and `prepare` each package declares — `postinstall` alone is a different
+//! risk from all four.
+//!
+//! Not the script *bodies*. A minified `postinstall` is one line of four
+//! kilobytes, and printing it would let the package decide how much of your
+//! terminal it gets; the file is one `cat` away and reading it there is the
+//! review this command is asking you to do.
+//!
+//! # Why it lives under `uf pm`
+//!
+//! Because it is not something anybody runs daily. `uf install` and `uf add`
+//! are the commands; this is a setting the manager reads that uf has an opinion
+//! about, and the top level is for the verbs.
+//!
+//! # Why it refuses a name it cannot see
+//!
+//! On a security command a typo that silently does nothing is worse than an
+//! error: the reader believes they have approved something, the install keeps
+//! ignoring it, and the eventual "why doesn't `sharp` work" is debugged
+//! somewhere else entirely. So a name that is not in the tree is refused, with
+//! the names that are.
+
+use anyhow::{Result, bail};
+use camino::Utf8Path;
+use compact_str::CompactString;
+use serde_json::{Value, json};
+use uf_config::load_config;
+use uf_pm::builds::{Approvals, Buildable, approvals_for};
+use uf_pm::detect_package_manager;
+use uf_pm::installable;
+use uf_term::{Cell, Column, KeyValue, Status, Table, Tone};
+
+use crate::support::{plural, project_label};
+use crate::ui::Ui;
+
+/// How many rows the table prints.
+const ROWS_SHOWN: usize = 40;
+
+/// `uf pm approve-builds [NAME...] [--dry-run]`.
+///
+/// # Errors
+///
+/// When the project cannot be read, when a named package is not in the tree,
+/// when the manager cannot approve one package rather than all of them, or when
+/// the root manifest cannot be written.
+pub(crate) fn approve_builds(
+    cwd: &Utf8Path,
+    ui: &mut Ui,
+    names: &[String],
+    dry_run: bool,
+) -> Result<()> {
+    uf_pm::check_operands(names)?;
+    let resolved = load_config(cwd)?;
+    let root = resolved.root.clone();
+    let (manager, _) = installable(&detect_package_manager(&root));
+    let approvals = approvals_for(manager);
+    let already = uf_pm::builds::approved(&root, manager)?;
+    let waiting = uf_pm::builds::scan(&root, &already)?;
+
+    if names.is_empty() {
+        let project = project_label(&root).to_string();
+        let manager_label = manager.to_string();
+        let configured = resolved.config.pm.allow_lifecycle_scripts;
+        ui.render(|renderer, out| {
+            renderer.banner(out, "uf pm approve-builds", Some(&project));
+            renderer.blank(out);
+            render(
+                renderer,
+                out,
+                &manager_label,
+                approvals,
+                configured,
+                &waiting,
+            );
+        });
+        return Ok(());
+    }
+
+    // Every refusal before the first write: a command that approves two of
+    // three names and then fails has left the project in a state nobody asked
+    // for, on the one surface where that matters most.
+    if approvals == Approvals::AllOrNothing {
+        bail!(
+            "{manager} cannot approve one package rather than all of them: `--ignore-scripts` is \
+             every script or none, and there is no third answer to give it.\n\nuf keeps them off. \
+             Turning them all on is `pm.allowLifecycleScripts: true` in uf.config.js, which is a \
+             deliberate act with a deliberate spelling — and it approves every dependency you \
+             have, including the ones you have not read."
+        );
+    }
+    for name in names {
+        if !waiting.iter().any(|package| package.name == name.as_str()) {
+            let known = waiting
+                .iter()
+                .map(|package| package.name.as_str())
+                .collect::<Vec<_>>();
+            if known.is_empty() {
+                bail!(
+                    "nothing in this project's tree declares an install script, so there is \
+                     nothing to approve — `{name}` included. Has it been installed yet?"
+                );
+            }
+            bail!(
+                "`{name}` is not a package in this project's tree that would run code at \
+                 install time. These are: {}",
+                known.join(", ")
+            );
+        }
+    }
+
+    let named: Vec<CompactString> = names.iter().map(|name| name.as_str().into()).collect();
+    let new: Vec<&CompactString> = named
+        .iter()
+        .filter(|name| !already.contains(*name))
+        .collect();
+    let manifest = root.join("package.json");
+    let project = project_label(&root).to_string();
+    let field = approvals.field().unwrap_or("package.json").to_owned();
+    let manager_label = manager.to_string();
+    let listed: Vec<String> = new.iter().map(|name| (*name).to_string()).collect();
+    let nothing = new.is_empty();
+    let summary = plural(new.len(), "package");
+
+    ui.render(|renderer, out| {
+        renderer.banner(out, "uf pm approve-builds", Some(&project));
+        renderer.blank(out);
+        if nothing {
+            renderer.status(out, Status::Success, "already approved; nothing to write");
+            return;
+        }
+        renderer.key_values(
+            out,
+            2,
+            &[
+                KeyValue::new("manager", &manager_label),
+                KeyValue::toned("recorded in", &field, Tone::Path),
+            ],
+        );
+        renderer.blank(out);
+        renderer.bullet_list(
+            out,
+            2,
+            &listed.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+        renderer.blank(out);
+        if dry_run {
+            renderer.status(
+                out,
+                Status::Info,
+                &format!("{summary} would be approved; run without --dry-run"),
+            );
+        }
+    });
+
+    if nothing || dry_run {
+        return Ok(());
+    }
+
+    let mut all: Vec<CompactString> = already.iter().cloned().collect();
+    all.extend(named.iter().cloned());
+    all.sort();
+    all.dedup();
+    match approvals {
+        Approvals::OnlyBuilt => {
+            uf_pm::manifests::set(&manifest, &["pnpm", "onlyBuiltDependencies"], array(&all))?;
+        }
+        Approvals::Trusted => {
+            uf_pm::manifests::set(&manifest, &["trustedDependencies"], array(&all))?;
+        }
+        Approvals::DependenciesMeta => {
+            for name in &named {
+                uf_pm::manifests::set(
+                    &manifest,
+                    &["dependenciesMeta", name.as_str(), "built"],
+                    json!(true),
+                )?;
+            }
+        }
+        Approvals::AllOrNothing => unreachable!("refused above"),
+    }
+
+    ui.render(|renderer, out| {
+        renderer.status(out, Status::Success, &format!("approved {summary}"));
+        // Not run for them: approving is a decision, installing is an action,
+        // and a security command that reaches straight for the second the
+        // moment you make the first is a command that runs the script you were
+        // still thinking about.
+        renderer.status(out, Status::Info, "uf install runs their builds");
+    });
+    Ok(())
+}
+
+fn array(names: &[CompactString]) -> Value {
+    Value::Array(
+        names
+            .iter()
+            .map(|name| Value::String(name.to_string()))
+            .collect(),
+    )
+}
+
+/// Draw the listing.
+///
+/// Split out from the command so a test can render it against
+/// [`uf_term::Capabilities::plain`] and read what it says, without a tree to
+/// scan or a manager to detect.
+fn render(
+    renderer: &uf_term::Renderer,
+    out: &mut String,
+    manager: &str,
+    approvals: Approvals,
+    configured: bool,
+    waiting: &[Buildable],
+) {
+    let field = approvals.field().unwrap_or("nothing: it is all or none");
+    renderer.key_values(
+        out,
+        2,
+        &[
+            KeyValue::new("manager", manager),
+            KeyValue::toned("approvals in", field, Tone::Path),
+        ],
+    );
+    renderer.blank(out);
+
+    if configured {
+        // The one case where the table is beside the point: every script runs
+        // already, approved or not, and saying anything else here would be a
+        // report that flatters the project.
+        renderer.status(
+            out,
+            Status::Warn,
+            "pm.allowLifecycleScripts is on, so every dependency below runs its scripts — \
+             approved or not",
+        );
+        renderer.blank(out);
+    }
+
+    if waiting.is_empty() {
+        renderer.status(
+            out,
+            Status::Success,
+            "nothing in this project's tree runs code at install time",
+        );
+        return;
+    }
+
+    let pending = waiting.iter().filter(|package| !package.approved).count();
+    let bodies: Vec<String> = waiting
+        .iter()
+        .map(|package| package.scripts.join(", "))
+        .collect();
+    let mut table = Table::new(vec![
+        Column::left("package"),
+        Column::left("version"),
+        Column::left("runs"),
+        Column::left("approved"),
+    ]);
+    for (package, scripts) in waiting.iter().take(ROWS_SHOWN).zip(&bodies) {
+        table.push(vec![
+            Cell::new(package.name.as_str()),
+            Cell::toned(package.version.as_str(), Tone::Number),
+            Cell::toned(scripts, Tone::Muted),
+            if package.approved {
+                Cell::toned("yes", Tone::Good)
+            } else {
+                Cell::toned("no", Tone::Warn)
+            },
+        ]);
+    }
+    renderer.table(out, 2, &table);
+    if waiting.len() > ROWS_SHOWN {
+        renderer.blank(out);
+        renderer.status(
+            out,
+            Status::Info,
+            &format!(
+                "and {} more; --json prints all of them",
+                waiting.len() - ROWS_SHOWN
+            ),
+        );
+    }
+    renderer.blank(out);
+
+    if configured {
+        return;
+    }
+    if pending == 0 {
+        renderer.status(out, Status::Success, "every one of them is approved");
+        return;
+    }
+    renderer.status(
+        out,
+        Status::Info,
+        &format!(
+            "{} would run code at install time and {} not approved, so uf does not let {} run",
+            plural(pending, "package"),
+            if pending == 1 { "is" } else { "are" },
+            if pending == 1 { "it" } else { "them" }
+        ),
+    );
+    if approvals == Approvals::AllOrNothing {
+        // The honest sentence, rather than an approval that quietly means
+        // "and everything else too".
+        renderer.status(
+            out,
+            Status::Warn,
+            &format!(
+                "{manager} cannot approve one and not another: `--ignore-scripts` is all of them \
+                 or none"
+            ),
+        );
+        renderer.status(
+            out,
+            Status::Info,
+            "pm.allowLifecycleScripts in uf.config.js turns on every one of them, deliberately",
+        );
+        return;
+    }
+    renderer.status(
+        out,
+        Status::Info,
+        "uf pm approve-builds <name>... records the ones you have read",
+    );
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_cli/src/commands/pm/approve/tests.rs
+++ b/crates/uf_cli/src/commands/pm/approve/tests.rs
@@ -1,0 +1,131 @@
+//! What the listing says, including the sentence npm gets.
+
+use super::*;
+use uf_pm::builds::Buildable;
+use uf_term::{Capabilities, Renderer};
+
+fn plain() -> Renderer {
+    Renderer::new(Capabilities::plain())
+}
+
+fn buildable(name: &str, version: &str, scripts: &[&'static str], approved: bool) -> Buildable {
+    Buildable {
+        name: name.into(),
+        version: version.into(),
+        scripts: scripts.to_vec(),
+        approved,
+    }
+}
+
+fn drawn(manager: &str, approvals: Approvals, configured: bool, waiting: &[Buildable]) -> String {
+    let mut out = String::new();
+    render(&plain(), &mut out, manager, approvals, configured, waiting);
+    out
+}
+
+#[test]
+fn a_waiting_package_is_shown_with_what_it_would_run() {
+    let out = drawn(
+        "pnpm",
+        Approvals::OnlyBuilt,
+        false,
+        &[buildable("sharp", "0.33.5", &["postinstall"], false)],
+    );
+
+    assert!(out.contains("sharp"), "{out}");
+    assert!(out.contains("0.33.5"), "{out}");
+    assert!(out.contains("postinstall"), "{out}");
+    assert!(out.contains("pnpm.onlyBuiltDependencies"), "{out}");
+    assert!(
+        out.contains("1 package would run code at install time and is not approved"),
+        "{out}"
+    );
+    assert!(out.contains("uf pm approve-builds <name>"), "{out}");
+}
+
+#[test]
+fn an_approved_package_is_marked_and_not_counted_as_waiting() {
+    let out = drawn(
+        "pnpm",
+        Approvals::OnlyBuilt,
+        false,
+        &[buildable("sharp", "0.33.5", &["postinstall"], true)],
+    );
+
+    assert!(out.contains("every one of them is approved"), "{out}");
+    assert!(!out.contains("not approved"), "{out}");
+}
+
+/// The sentence #495 asked for: npm's "runs everything" stated rather than
+/// papered over.
+#[test]
+fn npm_is_told_it_cannot_approve_one_and_not_another() {
+    let out = drawn(
+        "npm",
+        Approvals::AllOrNothing,
+        false,
+        &[buildable("sharp", "0.33.5", &["postinstall"], false)],
+    );
+
+    assert!(out.contains("cannot approve one and not another"), "{out}");
+    assert!(out.contains("all of them or none"), "{out}");
+    assert!(out.contains("pm.allowLifecycleScripts"), "{out}");
+    // And it must not offer a command that would do nothing for this manager.
+    assert!(!out.contains("uf pm approve-builds <name>"), "{out}");
+    assert!(out.contains("nothing: it is all or none"), "{out}");
+}
+
+/// With the flag on, the table is beside the point and saying anything else
+/// would be a report that flatters the project.
+#[test]
+fn the_flag_being_on_is_said_before_the_table_rather_than_after() {
+    let out = drawn(
+        "pnpm",
+        Approvals::OnlyBuilt,
+        true,
+        &[buildable("sharp", "0.33.5", &["postinstall"], false)],
+    );
+
+    let warning = out
+        .find("pm.allowLifecycleScripts is on")
+        .expect("the warning");
+    let table = out.find("sharp").expect("the table");
+    assert!(warning < table, "{out}");
+    assert!(
+        out.contains("approved or not"),
+        "the warning does not say the approval is moot: {out}"
+    );
+    // No "so uf does not let them run" underneath, because it does.
+    assert!(!out.contains("uf does not let"), "{out}");
+}
+
+#[test]
+fn a_tree_that_runs_nothing_says_so() {
+    let out = drawn("pnpm", Approvals::OnlyBuilt, false, &[]);
+
+    assert!(
+        out.contains("nothing in this project's tree runs code at install time"),
+        "{out}"
+    );
+}
+
+/// Plural, because the sentence is read by somebody deciding whether to worry.
+#[test]
+fn several_waiting_packages_read_as_several() {
+    let out = drawn(
+        "bun",
+        Approvals::Trusted,
+        false,
+        &[
+            buildable("esbuild", "0.24.0", &["postinstall"], false),
+            buildable("sharp", "0.33.5", &["install", "postinstall"], false),
+        ],
+    );
+
+    assert!(
+        out.contains("2 packages would run code at install time and are not approved"),
+        "{out}"
+    );
+    assert!(out.contains("trustedDependencies"), "{out}");
+    assert!(out.contains("install, postinstall"), "{out}");
+}

--- a/crates/uf_cli/src/commands/pm/deps.rs
+++ b/crates/uf_cli/src/commands/pm/deps.rs
@@ -48,6 +48,7 @@ use uf_pm::{
 use uf_term::{Cell, Column, KeyValue, Renderer, Status, Table, Tone, format_duration};
 
 use super::install::{chosen_by, lockfile_label, render_change_counts, render_change_table};
+use super::scripts_allowed;
 use crate::support::{plural, project_label};
 use crate::ui::Ui;
 
@@ -303,7 +304,7 @@ pub(super) fn delegate(cwd: &Utf8Path, ui: &mut Ui, request: &Request<'_>) -> Re
         &resolved.root,
         request.operation,
         request.operands,
-        !plan.forbids_npm_scripts(),
+        scripts_allowed(&resolved.root, manager, &plan)?,
     )
     .map_err(|error| {
         failed_hint(

--- a/crates/uf_cli/src/commands/pm/install.rs
+++ b/crates/uf_cli/src/commands/pm/install.rs
@@ -48,6 +48,7 @@ use uf_term::{
     truncate_to_width,
 };
 
+use super::scripts_allowed;
 use crate::brand;
 use crate::commands::vite::resolve_host;
 use crate::support::{plural, project_label};
@@ -216,7 +217,7 @@ pub(crate) fn install(cwd: &Utf8Path, ui: &mut Ui, frozen: bool) -> Result<()> {
         let run = run_watched(
             &resolved.root,
             operation,
-            !plan.forbids_npm_scripts(),
+            scripts_allowed(&resolved.root, manager, &plan)?,
             &mut screen,
         );
         screen.close();

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -325,6 +325,11 @@ fn run(cli: Cli, target: Option<&str>, ui: &mut Ui) -> Result<()> {
                 paths,
             },
         ),
+        Commands::Pm { command } => match command {
+            cli::PmCommand::ApproveBuilds { names, dry_run } => {
+                commands::pm::approve_builds(&cwd, ui, &names, dry_run)
+            }
+        },
         Commands::Patch { target, commit } => commands::pm::patch(&cwd, ui, &target, commit),
         Commands::Catalog { command } => match command {
             None => commands::pm::catalog(&cwd, ui),

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -1346,7 +1346,7 @@ fn explain_says_which_commands_it_knows() {
         "{stderr}"
     );
     assert!(
-        stderr.contains("install, add, remove, update, patch, catalog, why, upgrade"),
+        stderr.contains("install, add, remove, update, patch, pm, catalog"),
         "{stderr}"
     );
 }

--- a/crates/uf_cli/tests/every_command.rs
+++ b/crates/uf_cli/tests/every_command.rs
@@ -84,6 +84,10 @@ const COVERAGE: &[(&str, &str)] = &[
     ("test", "here, and testing.rs for the runner"),
     ("update", "dependencies.rs: runs the package manager"),
     (
+        "pm",
+        "here, and approve/tests.rs for the listing and npm's sentence",
+    ),
+    (
         "patch",
         "dependencies.rs: asks the package manager, or names patch-package",
     ),
@@ -119,6 +123,7 @@ const READ_ONLY: &[&[&str]] = &[
     &["env", "doctor"],
     &["env", "list"],
     &["env", "gc", "--dry-run"],
+    &["pm", "approve-builds"],
     &["catalog"],
     &["explain", "dev"],
     &["fmt", "--check"],

--- a/crates/uf_pm/src/builds.rs
+++ b/crates/uf_pm/src/builds.rs
@@ -1,0 +1,342 @@
+//! Which dependencies may run code at install time.
+//!
+//! # The problem, and why uf's default is what it is
+//!
+//! A dependency with a `postinstall` script is arbitrary code, executed on the
+//! machine of everyone who installs it, before anybody has read a line of it.
+//! It is the shortest path from a compromised package to a compromised laptop,
+//! and it is the one every supply-chain incident of the last decade has used.
+//!
+//! uf's answer is `--ignore-scripts` on every install, by default, under every
+//! manager. That is safe and it is also not free: `esbuild`, `sharp` and every
+//! other package with a native binary to place will not work until their build
+//! runs. So there has to be a way to say "this one, and no others".
+//!
+//! # Where the approved set lives
+//!
+//! In the root `package.json`, in the field the project's own package manager
+//! already reads:
+//!
+//! | manager | field |
+//! | --- | --- |
+//! | pnpm | `pnpm.onlyBuiltDependencies` |
+//! | bun | `trustedDependencies` |
+//! | yarn 2+ | `dependenciesMeta.<name>.built` |
+//! | npm, yarn 1 | — |
+//!
+//! Not a file of uf's own, and not a mirror of anybody's config schema. This is
+//! uf configuring the tool it drives, which is what it does everywhere else: uf
+//! records the decision, and the manager is the thing that enforces it. A
+//! project that later stops using uf keeps a working allow-list, and one that
+//! already had one is read rather than overridden.
+//!
+//! # npm, which cannot
+//!
+//! npm has no per-package control. `--ignore-scripts` is all of them or none of
+//! them, and there is no third answer to give it. So on npm and Yarn 1 uf keeps
+//! scripts off and says so, rather than presenting an approval that quietly
+//! means "and everything else too". Turning them all on is a deliberate act
+//! with a deliberate spelling — `pm.allowLifecycleScripts` in `uf.config.js` —
+//! and `uf pm approve-builds` will not do it for you.
+//!
+//! # What the install then does
+//!
+//! `--ignore-scripts` is dropped only when the manager can enforce the
+//! allow-list itself *and* the project has recorded at least one entry. An
+//! empty list under pnpm still means no scripts, because an empty
+//! `onlyBuiltDependencies` is pnpm's way of saying exactly that; dropping the
+//! flag for it would turn "nothing is approved" into "the manager's default",
+//! which on a manager that changes its default is a silent reopening of the
+//! hole this module exists to close.
+
+use std::collections::BTreeSet;
+use std::fs;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::{CompactString, ToCompactString};
+use serde_json::Value;
+
+use crate::detect::PackageManager;
+use crate::{PackageManagerError, is_polluting_json_key};
+
+/// The manifest scripts npm and its relatives run around an install.
+///
+/// `prepare` is here because it runs on `npm install` in the package's own
+/// directory, which for a git dependency is somebody else's repository.
+pub const LIFECYCLE_SCRIPTS: [&str; 4] = ["preinstall", "install", "postinstall", "prepare"];
+
+/// How many installed packages uf will look at.
+///
+/// A tree larger than this is not a tree a person is going to review one row at
+/// a time, and walking it further only makes the command slower at the moment
+/// it has already found more than anybody will read.
+pub const MAX_SCANNED_PACKAGES: usize = 20_000;
+
+/// Where a manager records which packages may build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Approvals {
+    /// `pnpm.onlyBuiltDependencies`: an array of names.
+    OnlyBuilt,
+    /// `trustedDependencies`: an array of names, bun's own field.
+    Trusted,
+    /// `dependenciesMeta.<name>.built`: a boolean per package, Yarn 2+.
+    DependenciesMeta,
+    /// Nothing: npm and Yarn 1 are all of them or none of them.
+    AllOrNothing,
+}
+
+impl Approvals {
+    /// Whether this manager can be told about one package rather than all.
+    #[must_use]
+    pub const fn is_per_package(self) -> bool {
+        !matches!(self, Self::AllOrNothing)
+    }
+
+    /// The manifest field, as a reader would grep for it.
+    #[must_use]
+    pub const fn field(self) -> Option<&'static str> {
+        match self {
+            Self::OnlyBuilt => Some("pnpm.onlyBuiltDependencies"),
+            Self::Trusted => Some("trustedDependencies"),
+            Self::DependenciesMeta => Some("dependenciesMeta"),
+            Self::AllOrNothing => None,
+        }
+    }
+}
+
+/// Which field this manager reads.
+#[must_use]
+pub const fn approvals_for(manager: PackageManager) -> Approvals {
+    match manager {
+        PackageManager::Pnpm => Approvals::OnlyBuilt,
+        PackageManager::Bun => Approvals::Trusted,
+        PackageManager::Yarn(crate::detect::YarnEdition::Berry) => Approvals::DependenciesMeta,
+        // And uf's own resolver, which fetches nothing yet and so runs
+        // nothing: it has no field to record an approval in because it has no
+        // install script to approve.
+        PackageManager::Npm
+        | PackageManager::Uf
+        | PackageManager::Yarn(crate::detect::YarnEdition::Classic) => Approvals::AllOrNothing,
+    }
+}
+
+/// One installed package that would run code at install time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Buildable {
+    /// The package's own name, from its manifest rather than from its path.
+    pub name: CompactString,
+    /// Its version, or `0.0.0` when the manifest omits one.
+    pub version: CompactString,
+    /// Which of [`LIFECYCLE_SCRIPTS`] it declares, in that order.
+    pub scripts: Vec<&'static str>,
+    /// Whether the project has already approved it.
+    pub approved: bool,
+}
+
+/// Every installed package that declares a lifecycle script.
+///
+/// From `node_modules`, because that is where the answer is: a manifest's
+/// dependency list says what was asked for, and the tree says what arrived,
+/// including the transitive package nobody chose. Nested `node_modules` is not
+/// walked — the hoisted copy is the one that installs, which is the same
+/// simplification `uf check` makes and documents in ubugeeei-prod/uf#486.
+///
+/// Sorted by name, so two runs of the command read the same.
+///
+/// # Errors
+///
+/// When `node_modules` exists but cannot be read. A project that has not
+/// installed yet is not an error: it has nothing in its tree, which is exactly
+/// what an empty answer says.
+pub fn scan(
+    root: &Utf8Path,
+    approved: &BTreeSet<CompactString>,
+) -> Result<Vec<Buildable>, PackageManagerError> {
+    let modules = root.join("node_modules");
+    if !modules.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut found = Vec::new();
+    let mut seen = 0;
+    for entry in read_dir(&modules)? {
+        let name = entry.file_name().unwrap_or_default();
+        // `.bin`, `.package-lock.json`, `.pnpm` and friends are the manager's
+        // own bookkeeping, not packages.
+        if name.starts_with('.') {
+            continue;
+        }
+        if name.starts_with('@') {
+            for scoped in read_dir(&entry)? {
+                visit(&scoped, approved, &mut found, &mut seen)?;
+            }
+        } else {
+            visit(&entry, approved, &mut found, &mut seen)?;
+        }
+        if seen >= MAX_SCANNED_PACKAGES {
+            break;
+        }
+    }
+    found.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(found)
+}
+
+fn visit(
+    directory: &Utf8Path,
+    approved: &BTreeSet<CompactString>,
+    found: &mut Vec<Buildable>,
+    seen: &mut usize,
+) -> Result<(), PackageManagerError> {
+    if *seen >= MAX_SCANNED_PACKAGES {
+        return Ok(());
+    }
+    *seen += 1;
+    let manifest = directory.join("package.json");
+    let Ok(source) = fs::read_to_string(&manifest) else {
+        return Ok(());
+    };
+    // A manifest that does not parse is a package that will not install, and
+    // the manager's own error about it is better than one uf could write.
+    let Ok(value) = serde_json::from_str::<Value>(&source) else {
+        return Ok(());
+    };
+    let scripts: Vec<&'static str> = LIFECYCLE_SCRIPTS
+        .into_iter()
+        .filter(|script| {
+            value
+                .get("scripts")
+                .and_then(|scripts| scripts.get(*script))
+                .and_then(Value::as_str)
+                .is_some_and(|body| !body.trim().is_empty())
+        })
+        .collect();
+    if scripts.is_empty() {
+        return Ok(());
+    }
+    // From the manifest rather than from the path: a directory can be renamed,
+    // and the name the manager approves is the one the package claims.
+    let name = value
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| directory.file_name().unwrap_or_default())
+        .to_compact_string();
+    if is_polluting_json_key(&name) {
+        return Ok(());
+    }
+    found.push(Buildable {
+        approved: approved.contains(&name),
+        name,
+        version: value
+            .get("version")
+            .and_then(Value::as_str)
+            .unwrap_or("0.0.0")
+            .to_compact_string(),
+        scripts,
+    });
+    Ok(())
+}
+
+fn read_dir(directory: &Utf8Path) -> Result<Vec<Utf8PathBuf>, PackageManagerError> {
+    let entries = fs::read_dir(directory).map_err(|source| PackageManagerError::Read {
+        path: directory.to_path_buf(),
+        source,
+    })?;
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| PackageManagerError::Read {
+            path: directory.to_path_buf(),
+            source,
+        })?;
+        if let Ok(path) = Utf8PathBuf::from_path_buf(entry.path())
+            && path.is_dir()
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+/// What the root manifest already approves, in whichever field this manager
+/// reads.
+///
+/// An unreadable or absent manifest approves nothing, which is the safe answer
+/// and the true one.
+///
+/// # Errors
+///
+/// When the root manifest exists but is not JSON — the same failure an install
+/// would hit a moment later.
+pub fn approved(
+    root: &Utf8Path,
+    manager: PackageManager,
+) -> Result<BTreeSet<CompactString>, PackageManagerError> {
+    let manifest = root.join("package.json");
+    let Ok(source) = fs::read_to_string(&manifest) else {
+        return Ok(BTreeSet::new());
+    };
+    let value =
+        serde_json::from_str::<Value>(&source).map_err(|source| PackageManagerError::Parse {
+            path: manifest,
+            source,
+        })?;
+    Ok(match approvals_for(manager) {
+        Approvals::OnlyBuilt => names_in(
+            value
+                .get("pnpm")
+                .and_then(|it| it.get("onlyBuiltDependencies")),
+        ),
+        Approvals::Trusted => names_in(value.get("trustedDependencies")),
+        Approvals::DependenciesMeta => value
+            .get("dependenciesMeta")
+            .and_then(Value::as_object)
+            .map(|meta| {
+                meta.iter()
+                    .filter(|(name, _)| !is_polluting_json_key(name))
+                    .filter(|(_, entry)| entry.get("built").and_then(Value::as_bool) == Some(true))
+                    .map(|(name, _)| name.as_str().to_compact_string())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        Approvals::AllOrNothing => BTreeSet::new(),
+    })
+}
+
+fn names_in(value: Option<&Value>) -> BTreeSet<CompactString> {
+    value
+        .and_then(Value::as_array)
+        .map(|names| {
+            names
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|name| !is_polluting_json_key(name))
+                .map(ToCompactString::to_compact_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Whether an install may let dependency scripts run.
+///
+/// `true` when the project said so outright, and otherwise only when the
+/// manager can enforce an allow-list *and* the project has recorded at least
+/// one entry in it. See the module docs for why an empty list is not enough.
+///
+/// # Errors
+///
+/// When the root manifest is not JSON.
+pub fn scripts_allowed(
+    root: &Utf8Path,
+    manager: PackageManager,
+    configured: bool,
+) -> Result<bool, PackageManagerError> {
+    if configured {
+        return Ok(true);
+    }
+    if !approvals_for(manager).is_per_package() {
+        return Ok(false);
+    }
+    Ok(!approved(root, manager)?.is_empty())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_pm/src/builds/tests.rs
+++ b/crates/uf_pm/src/builds/tests.rs
@@ -1,0 +1,216 @@
+//! What is in the tree that would run code, and what the project has said
+//! about it.
+
+use super::*;
+use crate::detect::YarnEdition;
+
+const YARN_BERRY: PackageManager = PackageManager::Yarn(YarnEdition::Berry);
+const YARN_CLASSIC: PackageManager = PackageManager::Yarn(YarnEdition::Classic);
+
+fn project(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = Utf8Path::from_path(dir.path()).expect("a UTF-8 path");
+    for (path, contents) in files {
+        let file = root.join(path);
+        fs::create_dir_all(file.parent().expect("a parent")).expect("a directory");
+        fs::write(&file, contents).expect("a file");
+    }
+    dir
+}
+
+fn root_of(dir: &tempfile::TempDir) -> &Utf8Path {
+    Utf8Path::from_path(dir.path()).expect("a UTF-8 path")
+}
+
+fn nothing() -> BTreeSet<CompactString> {
+    BTreeSet::new()
+}
+
+const WITH_POSTINSTALL: &str =
+    r#"{"name":"sharp","version":"0.33.5","scripts":{"postinstall":"node install.js"}}"#;
+const HARMLESS: &str = r#"{"name":"left-pad","version":"1.3.0","scripts":{"test":"echo"}}"#;
+
+#[test]
+fn only_the_packages_that_would_run_code_are_listed() {
+    let dir = project(&[
+        ("node_modules/sharp/package.json", WITH_POSTINSTALL),
+        ("node_modules/left-pad/package.json", HARMLESS),
+        (
+            "node_modules/@scope/native/package.json",
+            r#"{"name":"@scope/native","version":"2.0.0","scripts":{"install":"make"}}"#,
+        ),
+    ]);
+
+    let found = scan(root_of(&dir), &nothing()).expect("a scan");
+
+    assert_eq!(
+        found
+            .iter()
+            .map(|package| package.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["@scope/native", "sharp"],
+        "left-pad has scripts, but none that run at install time"
+    );
+    assert_eq!(found[1].version, "0.33.5");
+    assert_eq!(found[1].scripts, vec!["postinstall"]);
+}
+
+/// An empty script body is a package that declares the hook and does nothing
+/// with it, which is not something to ask a person to approve.
+#[test]
+fn an_empty_script_is_not_a_build() {
+    let dir = project(&[(
+        "node_modules/quiet/package.json",
+        r#"{"name":"quiet","scripts":{"postinstall":"   "}}"#,
+    )]);
+
+    assert!(scan(root_of(&dir), &nothing()).expect("a scan").is_empty());
+}
+
+/// The manager's own bookkeeping lives beside the packages and is not one.
+#[test]
+fn the_managers_own_directories_are_skipped() {
+    let dir = project(&[
+        (
+            "node_modules/.pnpm/x/package.json",
+            r#"{"name":"x","scripts":{"postinstall":"echo"}}"#,
+        ),
+        ("node_modules/sharp/package.json", WITH_POSTINSTALL),
+    ]);
+
+    let found = scan(root_of(&dir), &nothing()).expect("a scan");
+
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].name, "sharp");
+}
+
+/// A directory can be renamed; the name a manager approves is the one the
+/// package claims for itself.
+#[test]
+fn the_name_comes_from_the_manifest_rather_than_the_directory() {
+    let dir = project(&[(
+        "node_modules/renamed/package.json",
+        r#"{"name":"sharp","scripts":{"postinstall":"node install.js"}}"#,
+    )]);
+
+    let found = scan(root_of(&dir), &nothing()).expect("a scan");
+
+    assert_eq!(found[0].name, "sharp");
+}
+
+#[test]
+fn a_project_that_has_not_installed_yet_is_not_an_error() {
+    let dir = project(&[("package.json", "{}")]);
+
+    assert!(scan(root_of(&dir), &nothing()).expect("a scan").is_empty());
+}
+
+#[test]
+fn approval_is_read_from_the_field_this_manager_reads() {
+    let dir = project(&[(
+        "package.json",
+        r#"{
+  "trustedDependencies": ["sharp"],
+  "pnpm": { "onlyBuiltDependencies": ["esbuild"] },
+  "dependenciesMeta": { "swc": { "built": true }, "other": { "built": false } }
+}"#,
+    )]);
+    let root = root_of(&dir);
+
+    assert_eq!(
+        approved(root, PackageManager::Bun).expect("read"),
+        ["sharp"].map(CompactString::from).into()
+    );
+    assert_eq!(
+        approved(root, PackageManager::Pnpm).expect("read"),
+        ["esbuild"].map(CompactString::from).into()
+    );
+    assert_eq!(
+        approved(root, YARN_BERRY).expect("read"),
+        ["swc"].map(CompactString::from).into(),
+        "`built: false` is a package that was considered and refused"
+    );
+    // npm has no field, so nothing is approved and nothing can be.
+    assert!(
+        approved(root, PackageManager::Npm)
+            .expect("read")
+            .is_empty()
+    );
+}
+
+#[test]
+fn a_prototype_key_is_never_an_approved_package() {
+    let dir = project(&[(
+        "package.json",
+        r#"{"trustedDependencies":["__proto__","sharp"],
+            "dependenciesMeta":{"constructor":{"built":true}}}"#,
+    )]);
+    let root = root_of(&dir);
+
+    assert_eq!(
+        approved(root, PackageManager::Bun).expect("read"),
+        ["sharp"].map(CompactString::from).into()
+    );
+    assert!(approved(root, YARN_BERRY).expect("read").is_empty());
+}
+
+#[test]
+fn a_scan_marks_what_the_project_has_already_approved() {
+    let dir = project(&[
+        ("package.json", r#"{"trustedDependencies":["sharp"]}"#),
+        ("node_modules/sharp/package.json", WITH_POSTINSTALL),
+        (
+            "node_modules/esbuild/package.json",
+            r#"{"name":"esbuild","scripts":{"postinstall":"node install.js"}}"#,
+        ),
+    ]);
+    let root = root_of(&dir);
+    let approved = approved(root, PackageManager::Bun).expect("read");
+
+    let found = scan(root, &approved).expect("a scan");
+
+    assert_eq!(found[0].name, "esbuild");
+    assert!(!found[0].approved);
+    assert_eq!(found[1].name, "sharp");
+    assert!(found[1].approved);
+}
+
+/// Three managers can be told about one package; two cannot, and saying so is
+/// the whole of what uf can honestly offer them.
+#[test]
+fn npm_and_yarn_one_are_all_or_nothing() {
+    assert!(approvals_for(PackageManager::Pnpm).is_per_package());
+    assert!(approvals_for(PackageManager::Bun).is_per_package());
+    assert!(approvals_for(YARN_BERRY).is_per_package());
+    assert!(!approvals_for(PackageManager::Npm).is_per_package());
+    assert!(!approvals_for(YARN_CLASSIC).is_per_package());
+}
+
+/// The rule the install turns on, stated as a test because getting it wrong
+/// runs somebody's `postinstall`.
+#[test]
+fn scripts_are_allowed_only_when_the_manager_can_hold_the_line() {
+    let empty = project(&[("package.json", "{}")]);
+    let listed = project(&[(
+        "package.json",
+        r#"{"pnpm":{"onlyBuiltDependencies":["esbuild"]}}"#,
+    )]);
+
+    // The project said so outright: every manager, whatever is listed.
+    for root in [root_of(&empty), root_of(&listed)] {
+        for manager in [PackageManager::Npm, PackageManager::Pnpm] {
+            assert!(
+                scripts_allowed(root, manager, true).expect("read"),
+                "{manager}"
+            );
+        }
+    }
+
+    // It did not, so the manager has to be able to enforce a list, and there
+    // has to be one. An empty `onlyBuiltDependencies` is pnpm saying "none".
+    assert!(!scripts_allowed(root_of(&empty), PackageManager::Pnpm, false).expect("read"));
+    assert!(scripts_allowed(root_of(&listed), PackageManager::Pnpm, false).expect("read"));
+    // npm cannot, at any length of list.
+    assert!(!scripts_allowed(root_of(&listed), PackageManager::Npm, false).expect("read"));
+    assert!(!scripts_allowed(root_of(&listed), YARN_CLASSIC, false).expect("read"));
+}

--- a/crates/uf_pm/src/lib.rs
+++ b/crates/uf_pm/src/lib.rs
@@ -9,6 +9,7 @@
 //! instead of forcing a migration — [`run_operation`] is where the second half
 //! actually spawns one, for every command from `uf install` to `uf why`.
 
+pub mod builds;
 pub mod command;
 pub mod delta;
 pub mod detect;
@@ -29,6 +30,7 @@ use smallvec::SmallVec;
 use thiserror::Error;
 use uf_config::UniflowedConfig;
 
+pub use crate::builds::{Approvals, Buildable, LIFECYCLE_SCRIPTS, approvals_for};
 pub use crate::command::{
     DependencyKind, Invocation, InvocationArgs, Operation, PROGRAMS, command_for,
 };

--- a/crates/uf_pm/src/manifests.rs
+++ b/crates/uf_pm/src/manifests.rs
@@ -274,6 +274,86 @@ fn restore(undo: Vec<(&Utf8PathBuf, String)>, cause: PackageManagerError) -> Pac
     }
 }
 
+/// Write `value` at a path of object keys in a manifest, creating the objects
+/// on the way down.
+///
+/// The general form of [`apply`], for the fields that are not ranges:
+/// `pnpm.onlyBuiltDependencies`, `trustedDependencies`,
+/// `dependenciesMeta.<name>.built`. There is no splice here — those are arrays
+/// and nested objects rather than one string, and there is nothing to locate
+/// unambiguously — so the manifest is re-serialised with the indentation it
+/// already had, and parsed back and compared before it is written.
+///
+/// Returns whether anything changed.
+///
+/// # Errors
+///
+/// When the manifest cannot be read, is not JSON, has a non-object where the
+/// path needs one, or cannot be written.
+pub fn set(manifest: &Utf8Path, path: &[&str], value: Value) -> Result<bool, PackageManagerError> {
+    let source = fs::read_to_string(manifest).map_err(|source| PackageManagerError::Read {
+        path: manifest.to_path_buf(),
+        source,
+    })?;
+    let mut document =
+        serde_json::from_str::<Value>(&source).map_err(|source| PackageManagerError::Parse {
+            path: manifest.to_path_buf(),
+            source,
+        })?;
+
+    let mut cursor = &mut document;
+    let Some((last, parents)) = path.split_last() else {
+        return Ok(false);
+    };
+    for key in parents {
+        let Some(object) = cursor.as_object_mut() else {
+            return Err(shape(manifest, key));
+        };
+        cursor = object
+            .entry((*key).to_owned())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    }
+    let Some(object) = cursor.as_object_mut() else {
+        return Err(shape(manifest, last));
+    };
+    if object.get(*last) == Some(&value) {
+        return Ok(false);
+    }
+    object.insert((*last).to_owned(), value);
+
+    let text = reserialize(&source, &document);
+    if !parses_to(&text, &document) {
+        return Err(PackageManagerError::Write {
+            path: manifest.to_path_buf(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the rewritten manifest is not the manifest the change described",
+            ),
+        });
+    }
+    fs::write(manifest, &text).map_err(|source| PackageManagerError::Write {
+        path: manifest.to_path_buf(),
+        source,
+    })?;
+    Ok(true)
+}
+
+/// A manifest whose shape the path cannot be written into.
+///
+/// `"pnpm": "yes"` is valid JSON and not something uf will silently replace: a
+/// manifest that says something uf did not expect is a manifest somebody wrote
+/// on purpose, and overwriting it to record an approval would be the wrong
+/// trade on the one command that exists for safety.
+fn shape(manifest: &Utf8Path, key: &str) -> PackageManagerError {
+    PackageManagerError::Write {
+        path: manifest.to_path_buf(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("`{key}` is already something other than an object"),
+        ),
+    }
+}
+
 /// Replace one `"name": "from"` pair, when there is exactly one of it.
 ///
 /// `None` when there is none or more than one — which is the answer, not a

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -718,6 +718,36 @@ does not fail the command.
 This is **not** `uf upgrade`, which is about the toolchain and the workspace
 plan rather than about your dependencies.
 
+### uf pm approve-builds [NAME...]
+
+Lists every package in the installed tree that would run code when it installs,
+with the hooks it declares and whether this project has approved it:
+
+```
+  manager       pnpm
+  approvals in  pnpm.onlyBuiltDependencies
+
+  package  version  runs         approved
+  esbuild  0.24.0   postinstall  no
+  sharp    0.33.5   postinstall  no
+
+› 2 packages would run code at install time and are not approved, so uf does not let them run
+› uf pm approve-builds <name>... records the ones you have read
+```
+
+Naming one records it. `--dry-run` says what would be approved and writes
+nothing. A name that is not in the tree is refused with the names that are — on
+a security command a typo that silently does nothing is worse than an error.
+
+The approved set lives in the root `package.json`, in the field your package
+manager already reads (`pnpm.onlyBuiltDependencies`, `trustedDependencies`,
+`dependenciesMeta`), so the manager is what enforces it. npm and Yarn 1 have no
+per-package control and are told so plainly. `docs/security.md` has the full
+reasoning, including why an empty list still means "none"
+([#495](https://github.com/ubugeeei-prod/uf/issues/495)).
+
+Approving does not install; `uf install` is what runs the builds.
+
 ### uf patch PACKAGE
 
 Opens a copy of a dependency somewhere you can edit it, and prints the

--- a/docs/security.md
+++ b/docs/security.md
@@ -83,10 +83,59 @@ decisions are:
 | Tarballs from `codeload.github.com` not hash-pinned in the lockfile | Every resolved artifact carries an integrity hash in `uf.lock`; a source without one is a hard error, not a warning | todo |
 | Binary planting through the `bin` field | `bin` targets are validated as single path segments inside the package, and shims are written only into the store's own bin directory | todo |
 | `npx`-style execution of a package the project never installed | `uf exec` runs an installed binary from `node_modules/.bin` without ceremony, and **refuses** to fetch a name that is not in the lockfile unless the caller passes `--yes`. Fetching and running an unpinned package is strictly more dangerous than a `postinstall`, so it asks at least as loudly | `crates/uf_cli/tests/cli.rs` |
-| Lifecycle scripts as an RCE vector | npm scripts are **forbidden by default** — `uf install` fails on a manifest that declares them. Project automation lives in `uf.config.js` tasks | `crates/uf_pm` |
+| Lifecycle scripts as an RCE vector | npm scripts are **forbidden by default** — `uf install` fails on a manifest that declares them, and `--ignore-scripts` goes to the manager so no *dependency* runs one either. `uf pm approve-builds` is the way back in, one package at a time; see below | `crates/uf_pm`, `uf_pm::builds` |
 | Shell injection through the `packageManager` field | Parsed by a hand-written single-pass parser with no regex (ReDoS), and `Invocation.program` comes only from a fixed program table, so no manifest text can name a program or inject an argument | `uf_pm::detect` |
 | Prototype-pollution keys in manifest JSON | `__proto__`, `constructor`, and `prototype` are reported and dropped wherever manifest JSON becomes a map | `uf_pm::detect` |
 | Terminal escape sequences in a package name, injected into a progress display that steers the cursor | Every name taken out of a manager's output is stripped of control characters and length-capped before it can be drawn, and the redrawn region cuts each row to a fixed width, so no registry text can move the cursor | `uf_pm::progress` |
+
+### Dependency install scripts
+
+A dependency with a `postinstall` script is arbitrary code, run on the machine
+of everyone who installs it, before anybody has read a line of it. uf passes
+`--ignore-scripts` to every manager by default, so none of them runs.
+
+That is safe and it is not free: `esbuild`, `sharp` and everything else with a
+native binary to place will not work until their build runs.
+`uf pm approve-builds` lists what is waiting, with the hooks each package declares, and records the
+ones you have read:
+
+```
+  package  version  runs         approved
+  esbuild  0.24.0   postinstall  no
+  sharp    0.33.5   postinstall  no
+
+› 2 packages would run code at install time and are not approved, so uf does not let them run
+```
+
+The approved set goes in the root `package.json`, in the field the project's own
+package manager already reads:
+
+| manager | field |
+| --- | --- |
+| pnpm | `pnpm.onlyBuiltDependencies` |
+| bun | `trustedDependencies` |
+| yarn 2+ | `dependenciesMeta.<name>.built` |
+| npm, yarn 1 | — |
+
+Not a file of uf's own, and not a mirror of anybody's config schema: uf records
+the decision and the manager enforces it, so a project that stops using uf keeps
+a working allow-list and one that already had a list is read rather than
+overridden. `--ignore-scripts` comes off only when the manager can enforce the
+list *and* the list has something in it — an empty `onlyBuiltDependencies` is
+pnpm's way of saying "none", and dropping the flag for it would turn that into
+"whatever the manager defaults to".
+
+**npm and Yarn 1 cannot do this.** `--ignore-scripts` is every script or none,
+and there is no third answer to give it. uf keeps them off and says so, rather
+than offering an approval that quietly means "and everything else too". Turning
+them all on is `pm.allowLifecycleScripts: true` in `uf.config.js` — a deliberate
+act with a deliberate spelling, which approves every dependency you have,
+including the ones you have not read. `uf pm approve-builds` will not do it
+for you.
+
+Approving does not install. A security command that reached for the install the
+moment you made the decision would be a command that runs the script you were
+still thinking about.
 
 ## Config and plugins
 


### PR DESCRIPTION
Closes #495. Stacked on #543; the base retargets as that merges.

A dependency with a `postinstall` script is arbitrary code, run on the machine of everyone who installs it, before anybody has read a line of it. uf passes `--ignore-scripts` to every manager, so none of them runs — which is safe, and which also means `esbuild` and `sharp` do not work until somebody says so.

## What it shows

```
  manager       pnpm
  approvals in  pnpm.onlyBuiltDependencies

  package  version  runs         approved
  esbuild  0.24.0   postinstall  no
  sharp    0.33.5   postinstall  no

› 2 packages would run code at install time and are not approved, so uf does not let them run
› uf pm approve-builds <name>... records the ones you have read
```

It names the *hooks* — `postinstall` alone is a different risk from all four — and not the script bodies. A minified `postinstall` is one line of four kilobytes, and printing it would let the package decide how much of your terminal it gets; the file is one `cat` away, and reading it there is the review this command is asking you to do.

## Where the approval lives

| manager | field |
| --- | --- |
| pnpm | `pnpm.onlyBuiltDependencies` |
| bun | `trustedDependencies` |
| yarn 2+ | `dependenciesMeta.<name>.built` |
| npm, yarn 1 | — |

The field the project's own manager already reads. Not a file of uf's own and not a mirror of anybody's config schema: uf records the decision, the manager enforces it, a project that stops using uf keeps a working allow-list, and one that already had a list is read rather than overridden.

## What the install then does

`--ignore-scripts` comes off only when the manager can enforce a list **and** the list has something in it. An empty `onlyBuiltDependencies` is pnpm's way of saying "none", and dropping the flag for it would turn that into "whatever this manager defaults to" — a silent reopening of the hole the flag closes. Both call sites now go through one `scripts_allowed`, because a rule about running somebody else's code should have one spelling.

## npm

```
! npm cannot approve one and not another: `--ignore-scripts` is all of them or none
› pm.allowLifecycleScripts in uf.config.js turns on every one of them, deliberately
```

Stated rather than papered over, which is what #495 asked for. `uf pm approve-builds sharp` on npm is an error with the same explanation — an approval that quietly meant "and everything else too" would be worse than no command.

## Why `uf pm`

Because it is not something anybody runs daily. `uf install` and `uf add` are the verbs; this is a setting the manager reads that uf has an opinion about, and the top level is for the verbs. `uf pm` is the namespace for the rest of that plumbing.

## Two smaller decisions, both because this is a security surface

- **A name not in the tree is refused**, with the names that are. A typo that silently does nothing leaves the reader believing they approved something, and the eventual "why doesn't `sharp` work" gets debugged somewhere else entirely.
- **Approving does not install.** A command that reached for the install the moment you made the decision would run the script you were still thinking about.

## Also

`uf_pm::manifests::set` is the general form of the range splice from #541, for fields that are arrays and nested objects rather than one string. It refuses to overwrite a `"pnpm"` that is already something other than an object.

`docs/security.md` gains a "Dependency install scripts" section with the whole argument, and the lifecycle-scripts row now points at it.

## Verified

uf_pm 184, uf_cli lib 298, cli 66, dependencies 14, install 5, every_command 13. `cargo fmt --check`, clippy and `uf fmt --check` clean. Exercised end to end outside the repo: the two tables above are real, `pnpm.onlyBuiltDependencies` was written into a manifest whose indentation survived, a typo'd name was refused with the real ones, and the same project detected as npm produced npm's sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791368566&installation_model_id=422833&pr_number=545&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F545&signature=4f3d602bd46dd549ea00837b2b93c0855077365ce87a79c5fe256ef0c3a52755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
