### PR TITLE
feat(router, docs): a navigation that is a transition, and the rest of what a page says about itself

### DIFF
--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -250,6 +250,7 @@ pub fn builtin_modules() -> Vec<NativeModule> {
                 "useLoaderData",
                 "useRoute",
                 "useRouter",
+                "useSeo",
             ],
         ),
         NativeModule::new(

--- a/docs/app/_uf.layout.js
+++ b/docs/app/_uf.layout.js
@@ -54,6 +54,20 @@ export const metadata: Metadata = {
   // derive: it is an X handle, and this project has not said it has one. The
   // field exists — `twitter: { site: "@…" }` — for the day it does.
   twitter: { card: "summary_large_image", images: ["/brand/og.png"] },
+  // What the site is, in the vocabulary a search engine reads rather than the
+  // sentence a person does. On the layout because it describes the site, and
+  // `jsonLd` is the one metadata field that *adds* to what an outer layout
+  // declared rather than replacing it — so a page describing itself as an
+  // `Article` keeps this rather than deleting it.
+  jsonLd: [
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "uf",
+      url: "https://docs.uniflowed.dev",
+      description: "The Unified Toolchain for Flow (React).",
+    },
+  ],
 };
 
 /**

--- a/docs/app/_uf.not-found.js
+++ b/docs/app/_uf.not-found.js
@@ -7,11 +7,24 @@
 
 import * as React from "@uniflowed/react";
 import { Link } from "@uniflowed/router";
+import type { Metadata } from "@uniflowed/router";
 
 import { Eyebrow, Lede } from "./_design/parts.js";
 import { pages } from "./_design/nav.js";
 
-export const metadata: {| readonly title: string |} = { title: "Not found · uf" };
+/**
+ * `noindex` because this page is prerendered.
+ *
+ * `uf build` writes it to `dist/docs/404.html` so a static host has something
+ * to serve, which makes it a document a crawler can be handed like any other —
+ * and a "there is no page here" in a search result is a search result for a
+ * page that does not exist. The sitemap already leaves it out; this is the
+ * half that covers a crawler which found it another way.
+ */
+export const metadata: Metadata = {
+  title: "Not found · uf",
+  robots: { index: false, follow: false },
+};
 
 export default component NotFound() {
   return (

--- a/docs/app/guide/_uf.not-found.js
+++ b/docs/app/guide/_uf.not-found.js
@@ -16,11 +16,16 @@
 
 import * as React from "@uniflowed/react";
 import { Link } from "@uniflowed/router";
+import type { Metadata } from "@uniflowed/router";
 
 import { Eyebrow, Lede } from "../_design/parts.js";
 import { sections } from "../_design/nav.js";
 
-export const metadata: {| readonly title: string |} = { title: "No such page · uf" };
+/** `noindex` for the reason the site's root 404 gives. */
+export const metadata: Metadata = {
+  title: "No such page · uf",
+  robots: { index: false, follow: false },
+};
 
 export default component GuideNotFound() {
   return (

--- a/docs/app/guide/routing/_uf.page.mdx
+++ b/docs/app/guide/routing/_uf.page.mdx
@@ -293,14 +293,113 @@ a search engine that the whole section is one page.
 by a different reader — `uf build`, in Rust, writing `<loc>` into
 `sitemap.xml`. A site that has both should keep them the same.
 
+### The rest of what a page says about itself
+
+`robots` is how a page asks not to be indexed. A page that declares nothing
+gets no `<meta name="robots">` at all, because "index, follow" is what a
+document without one already means — the tag exists to say something else:
+
+```js
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+```
+
+It is usually a **layout's** field rather than a page's. A preview tree, a
+staging section or an account area is `index: false` for everything under it,
+and saying so once is the only version of that which stays true when somebody
+adds a page. `maxSnippet` and `maxImagePreview` are the other two directives,
+and they change what a result looks like rather than whether there is one.
+
+`alternates.languages` maps a language tag to that translation's URL. The set
+has to be reciprocal — every page in it lists every other one *and itself*,
+which is what makes a search engine read them as translations rather than as
+duplicates — so it is normally the same map on every page of the set, declared
+on the layout they share. `"x-default"` is a tag like any other, and names
+what a reader with no matching language should be given:
+
+```js
+export const metadata: Metadata = {
+  alternates: { languages: { en: "/guide", ja: "/ja/guide", "x-default": "/guide" } },
+};
+```
+
+`pagination` is the two ends of a sequence, as `<link rel="prev">` and
+`<link rel="next">`. Keep each page's `canonical` pointing at **itself**:
+a paginated list whose every page is canonical to page one has told a search
+engine that pages two onwards are duplicates, and everything only linked from
+them stops being reachable.
+
+`jsonLd` is structured data, one `<script type="application/ld+json">` per
+entry. It is the one field that **adds** to what an outer layout declared
+instead of replacing it, because an `Organization` on the root layout and an
+`Article` on the page are two statements about one page rather than two
+answers to one question:
+
+```js
+export const metadata: Metadata = {
+  jsonLd: [
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      headline: "Install uf",
+    },
+  ],
+};
+```
+
+The scripts render with the route rather than in `<head>`: React hoists a
+`<title>`, a `<meta>` and a `<link>`, and not a script whose body it has to
+carry. JSON-LD is read from anywhere in the document, so this costs nothing —
+it is worth knowing when reading the markup.
+
+### Metadata a component computes
+
+`metadata` and `generateMetadata` are declarations by a route module, and some
+of what a page has to say is decided further in. A pager knows which page of
+the list it is drawing; the route that renders it does not. `useSeo` is the
+same vocabulary from inside a render:
+
+```js
+import { useSeo } from "@uniflowed/router";
+
+export component Pager(page: number, of: number) {
+  const seo = useSeo({
+    pagination: {
+      prev: page > 1 ? `/posts?page=${page - 1}` : undefined,
+      next: page < of ? `/posts?page=${page + 1}` : undefined,
+    },
+  });
+
+  return <nav className="pager">{seo}…</nav>;
+}
+```
+
+It returns elements, and the caller renders them. That is not a stylistic
+choice: a hook that *wrote* to the head would have to do it in an effect, an
+effect does not run on a server, and the page would end up with tags that are
+right in a browser and missing from every crawler. Rendering is what puts a tag
+in a server-rendered head. `useHead` from `@uniflowed/web` is the browser-only
+escape hatch and says so about itself.
+
+The argument is a `Metadata`, the same type a route exports, so there is one
+vocabulary rather than two. What the hook adds over writing the tags by hand is
+`metadataBase` — the root layout declared it, a component three levels down
+cannot know it, and the relative URLs written here are resolved against it.
+
 | Field | Emits |
 | --- | --- |
 | `title` | `<title>` |
 | `description` | `<meta name="description">` |
 | `metadataBase` | nothing on its own; resolves the URLs below |
 | `canonical` | `<link rel="canonical">` and `og:url` |
-| `openGraph.title`, `.description`, `.images` | `og:title`, `og:description`, one `og:image` each |
-| `twitter.card`, `.site`, `.creator`, `.title`, `.description`, `.images` | `twitter:*`, under `name` rather than `property` |
+| `robots.index`, `.follow`, `.maxSnippet`, `.maxImagePreview` | one `<meta name="robots">`, only for what is declared |
+| `alternates.languages` | one `<link rel="alternate" hreflang>` each |
+| `pagination.prev`, `.next` | `<link rel="prev">`, `<link rel="next">` |
+| `jsonLd` | one `<script type="application/ld+json">` each; accumulates down the tree |
+| `openGraph.title`, `.description` | `og:title`, `og:description`, falling back to `title` and `description` |
+| `openGraph.type`, `.siteName`, `.images`, `.imageAlt` | `og:type` (`website` by default), `og:site_name`, one `og:image` each, `og:image:alt` |
+| `twitter.card`, `.site`, `.creator`, `.title`, `.description`, `.images`, `.imageAlt` | `twitter:*`, under `name` rather than `property` |
 
 ## Navigating
 
@@ -325,6 +424,47 @@ renders would have done on its own. Nothing about writing the link changes,
 and the page it lands on is the same page; the difference is a full load
 rather than a transition. `useRouter().push()` and the back button do the same
 thing for the same reason.
+
+### View transitions
+
+Every client navigation goes through `document.startViewTransition` where the
+browser has one. There is nothing to switch on: without a stylesheet the
+browser's default cross-fade is what a reader gets, and a browser that has no
+such method navigates exactly the way it did before.
+
+A route can name its transition, so one stylesheet can animate an arrival in
+the manual differently from an arrival anywhere else. The name reaches CSS as
+an attribute on the document element, set for as long as the transition runs:
+
+```js
+// app/guide/_uf.layout.js
+export const viewTransition = "manual";
+```
+
+```css
+html[data-uf-view-transition="manual"]::view-transition-old(root) {
+  animation: 120ms ease-out both fade-out;
+}
+```
+
+A page's own name wins over its layout's, which is the nearest-declaration rule
+`metadata` already follows. A layout is usually the right place: a section that
+animates one way throughout should say so once.
+
+**`prefers-reduced-motion` is honoured by the router**, not by the application.
+A reader who asked their system for less motion gets the cut they asked for,
+and there is no way for an application to override it — an application able to
+would eventually.
+
+`transition={false}` on a `Link`, or `{ transition: false }` on
+`useRouter().push()`, makes one navigation a cut. It is for a navigation that
+is a change of state rather than a change of place: a tab within a page, a
+filter written into the query string. `router.refresh()` never transitions,
+because it resolves the same URL again and a transition there would cross-fade
+a page into itself.
+
+None of this reaches the server. A transition is a client-only concern, and a
+prerendered document says nothing about one.
 
 ## Middleware
 

--- a/packages/router/index.js
+++ b/packages/router/index.js
@@ -19,6 +19,7 @@ export type {
   AppProps,
   ErrorBoundary,
   ErrorModule,
+  JsonLd,
   LayoutModule,
   LinkPrefetch,
   LoaderArgs,
@@ -28,6 +29,7 @@ export type {
   NotFoundBoundary,
   PageModule,
   ResolvedRoute,
+  Robots,
   RouteError,
   RouteInfo,
   RouteMatch,
@@ -65,6 +67,7 @@ export {
   useLoaderData,
   useRoute,
   useRouter,
+  useSeo,
 } from "./internal/runtime.js";
 
 /** Props a page receives. */

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -22,6 +22,14 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+// The one thing in this module that only a browser can do, and the reason it
+// is imported here rather than from `../client.js`: a view transition needs
+// the DOM updated inside the callback it was handed, and `startTransition`
+// schedules. "View transitions", below, is the argument. Importing `react-dom`
+// costs the server bundle nothing it did not already have — `internal/stream.js`
+// imports `react-dom/server` — and this entry touches no document while it is
+// being evaluated.
+import { flushSync } from "react-dom";
 
 // The id of the script the loader data is embedded in. It moved out of the
 // head and into the tree with ubugeeei-prod/uf#373 — see [`loaderDataScript`]
@@ -95,6 +103,22 @@ export type PageModule = {
     | $ReadOnlyArray<RouteParams>
     | Promise<$ReadOnlyArray<RouteParams>>,
   readonly frontmatter?: { readonly title?: string, readonly description?: string, ... },
+  /**
+   * What a stylesheet calls the transition this route arrives under.
+   *
+   * Not a switch. Every client navigation opts into a view transition where
+   * the browser has one, and this is how one arrival is told from another —
+   * the name reaches CSS as an attribute on the document element for as long
+   * as the transition runs:
+   *
+   *     html[data-uf-view-transition="manual"]::view-transition-old(root) { … }
+   *
+   * A layout may declare one too, and then it covers every route under it; the
+   * page's own wins. That is the rule `metadata` already follows, and there is
+   * no reason for a second one — "the nearest declaration" is how everything
+   * else in a route module is resolved.
+   */
+  readonly viewTransition?: string,
   ...
 };
 
@@ -103,6 +127,8 @@ export type LayoutModule = {
   readonly default?: RouteComponent,
   readonly Layout?: RouteComponent,
   readonly metadata?: Metadata,
+  /** A transition name for every route under this layout; see [`PageModule`]. */
+  readonly viewTransition?: string,
   ...
 };
 
@@ -146,6 +172,41 @@ export type LoadingModule = {
  */
 export type TwitterCard = "summary" | "summary_large_image" | "app" | "player";
 
+/**
+ * What a crawler may do with a page.
+ *
+ * Four fields rather than the whole `robots` vocabulary, and the omissions are
+ * the argument. `index` and `follow` are the two directives a page has an
+ * opinion about; `maxSnippet` and `maxImagePreview` are the two that change
+ * what a result *looks* like and have no other spelling. `nosnippet` is not
+ * here because `maxSnippet: 0` is the same instruction, and a type with two
+ * ways to say one thing is a type somebody will eventually ask which of them
+ * wins.
+ *
+ * Every field is optional and every one is only emitted when it is declared,
+ * because "index, follow" is what a document with no `robots` meta already
+ * says — the tag exists to say something else.
+ */
+export type Robots = {
+  readonly index?: boolean,
+  readonly follow?: boolean,
+  /** The longest snippet a result may quote; `0` is none, `-1` is no limit. */
+  readonly maxSnippet?: number,
+  readonly maxImagePreview?: "none" | "standard" | "large",
+};
+
+/**
+ * One JSON-LD object, as a page hands it over.
+ *
+ * `mixed` values rather than a schema.org type, because there is no useful
+ * middle: the vocabulary is hundreds of types deep, it grows without asking
+ * anyone, and a partial transcription of it would reject correct documents far
+ * more often than it caught wrong ones. What this type does claim is the part
+ * uf is answerable for — that the thing is an object, and therefore that it
+ * serialises into one `<script>`.
+ */
+export type JsonLd = { readonly [string]: mixed };
+
 /** Document metadata a page or layout declares. */
 export type Metadata = {
   readonly title?: string,
@@ -172,6 +233,69 @@ export type Metadata = {
    * under a second section — is one page, and this is how it says so.
    */
   readonly canonical?: string,
+  /**
+   * What a crawler may do with this page. See [`Robots`].
+   *
+   * The one field here that is usually declared on a *layout*: a staging
+   * section, a preview tree or an account area is `index: false` for
+   * everything under it, and saying so once is the only version of that which
+   * stays true when a page is added.
+   */
+  readonly robots?: Robots,
+  /**
+   * The other addresses this same page is published at.
+   *
+   * `languages` maps a BCP 47 tag to that translation's URL and becomes one
+   * `<link rel="alternate" hreflang>` each. The set has to be reciprocal —
+   * every page in it lists every other one *and itself*, which is what makes a
+   * search engine read them as translations rather than as duplicates — so it
+   * is usually the same map on every page of the set, declared on the layout
+   * they share. `"x-default"` is a tag like any other here, and names what a
+   * reader whose language is not in the set should be given.
+   *
+   * Nested under `alternates` rather than sitting at the top level as
+   * `languages`, because `alternate` is the link relation and a language is
+   * only one kind of alternate; the outer name is a fact about the wire rather
+   * than a shape invented here.
+   */
+  readonly alternates?: {
+    readonly languages?: { readonly [string]: string },
+  },
+  /**
+   * The pages either side of this one in a sequence.
+   *
+   * `<link rel="prev">` and `<link rel="next">`, resolved against
+   * `metadataBase` like every other URL here. A page four of a list, and a
+   * chapter in the middle of a manual, are the same statement: this document
+   * is one of a series and here is where the series continues.
+   *
+   * `canonical` still belongs to the page itself. Pointing every page of a
+   * paginated list at page one is the mistake this pair exists to make
+   * unnecessary — it tells a search engine that pages two onwards are
+   * duplicates of page one, and everything only reachable from them stops
+   * being reachable at all.
+   */
+  readonly pagination?: {
+    readonly prev?: string,
+    readonly next?: string,
+  },
+  /**
+   * Structured data, as JSON-LD.
+   *
+   * One `<script type="application/ld+json">` per entry. Unlike everything
+   * else here it *accumulates* down the tree rather than being replaced by the
+   * nearest declaration: an `Organization` on the root layout and an `Article`
+   * on the page are two statements about one page, not two answers to one
+   * question, and replacing would mean a page that describes itself silently
+   * deletes the site's description of itself.
+   *
+   * The scripts are rendered with the rest of the route rather than hoisted
+   * into `<head>`, because React hoists `<title>`, `<meta>` and `<link>` and
+   * not a script it has to keep the body of. JSON-LD is read from anywhere in
+   * the document, so this costs nothing; it is worth knowing when reading the
+   * markup.
+   */
+  readonly jsonLd?: $ReadOnlyArray<JsonLd>,
   readonly openGraph?: {
     /**
      * The title a share card shows.
@@ -406,6 +530,16 @@ export type ResolvedRoute = {|
    */
   readonly deferred: ?Promise<mixed>,
   readonly metadata: Metadata,
+  /**
+   * What a stylesheet calls the transition this route arrives under, or `null`
+   * when neither the page nor a layout above it named one.
+   *
+   * Resolved with the route rather than looked up at the moment of the
+   * navigation, because by then the answer is a property of the destination's
+   * modules and those are exactly what has just been loaded. A server render
+   * carries it and never reads it; see "View transitions".
+   */
+  readonly viewTransition: ?string,
   readonly status: 200 | 401 | 403 | 404 | 500,
   /**
    * Set when this resolution *is* the error page: the loader threw, or the
@@ -845,6 +979,7 @@ async function resolveRoute(
     data,
     deferred,
     metadata,
+    viewTransition: resolveViewTransition(page, layouts),
     status: 200,
     error: null,
     errorBoundary: await boundary,
@@ -1032,6 +1167,10 @@ async function resolveError(
     data: undefined,
     deferred: null,
     metadata: declared.title != null ? declared : { ...declared, title: errorTitle(routeError) },
+    // The boundary's own layouts may name one; the page cannot, because the
+    // page here is this module's. An error arriving under the section's
+    // transition is the same answer as a page arriving under it.
+    viewTransition: resolveViewTransition({}, layouts),
     status: routeErrorStatus(routeError),
     error: routeError,
     // All of the boundary's layouts are above it, and no inner boundary is
@@ -1101,6 +1240,7 @@ async function resolveNotFound(
     data: undefined,
     deferred: null,
     metadata,
+    viewTransition: resolveViewTransition(page, layouts),
     status: 404,
     error: null,
     // A not-found page is a page: one that throws is contained like any other.
@@ -1112,15 +1252,31 @@ async function resolveNotFound(
   };
 }
 
+/**
+ * The route's metadata: each declaration merged over the ones outside it.
+ *
+ * Per key, so a page that declares only `canonical` keeps the title its layout
+ * set — with one exception, and it is deliberate. `jsonLd` is gathered along
+ * the way instead of merged, because a nearer declaration of it is an addition
+ * rather than a correction; [`Metadata`] has the argument.
+ */
 async function resolveMetadata(
   page: PageModule,
   layouts: $ReadOnlyArray<LayoutModule>,
   args: MetadataArgs,
 ): Promise<Metadata> {
   let merged: Metadata = {};
+  let structured: $ReadOnlyArray<JsonLd> = [];
+  const take = (declared: Metadata) => {
+    if (declared.jsonLd != null) {
+      structured = [...structured, ...declared.jsonLd];
+    }
+    merged = { ...merged, ...declared };
+  };
+
   for (const layout of layouts) {
     if (layout.metadata != null) {
-      merged = { ...merged, ...layout.metadata };
+      take(layout.metadata);
     }
   }
   if (page.frontmatter != null) {
@@ -1132,12 +1288,42 @@ async function resolveMetadata(
     };
   }
   if (page.metadata != null) {
-    merged = { ...merged, ...page.metadata };
+    take(page.metadata);
   }
   if (typeof page.generateMetadata === "function") {
-    merged = { ...merged, ...(await page.generateMetadata(args)) };
+    take(await page.generateMetadata(args));
   }
-  return merged;
+  return structured.length === 0 ? merged : { ...merged, jsonLd: structured };
+}
+
+/** A module that may name the transition its route arrives under. */
+type Transitioning = { readonly viewTransition?: string, ... };
+
+/**
+ * What a stylesheet calls this route's arrival: the nearest declaration wins.
+ *
+ * The same walk `resolveMetadata` does one function above, and stated as its
+ * own function rather than folded into that one because the two answer
+ * different questions and only one of them is a document. Layouts are root
+ * first, so overwriting as it descends leaves the innermost, and the page has
+ * the last word.
+ *
+ * The parameters say what is read rather than naming `PageModule` and
+ * `LayoutModule`, which is the shape `nearestBoundary` already takes for the
+ * same reason: this reads one optional field, so requiring the whole of either
+ * type would be a claim it does not need and cannot use.
+ */
+function resolveViewTransition(
+  page: Transitioning,
+  layouts: $ReadOnlyArray<Transitioning>,
+): ?string {
+  let name: ?string = null;
+  for (const layout of layouts) {
+    if (layout.viewTransition != null) {
+      name = layout.viewTransition;
+    }
+  }
+  return page.viewTransition ?? name;
 }
 
 component DefaultNotFound() {
@@ -1302,11 +1488,177 @@ class RouteErrorBoundary extends React.Component<RouteErrorBoundaryProps, RouteE
 }
 
 // ---------------------------------------------------------------------------
+// View transitions
+// ---------------------------------------------------------------------------
+//
+// A client navigation replaces the tree and the browser paints the new one,
+// which is a cut. `document.startViewTransition` is the platform's answer, and
+// it is opt-in per navigation rather than per site — so somebody has to call
+// it, and the somebody is whatever replaced the tree. That is this module.
+// Leaving it to the application would mean every application reimplementing
+// the same four decisions below, and getting the last one wrong.
+//
+// # Why `flushSync` rather than `startTransition`
+//
+// The browser captures the old frame, calls the callback, and waits on the
+// promise the callback returns before capturing the new one. So the callback
+// has to leave the DOM updated, and `startTransition` deliberately does not:
+// it schedules, and returns having changed nothing.
+//
+// The alternative was to hand the browser a promise resolved from a layout
+// effect after the commit, which keeps the render concurrent and can hang: a
+// running view transition blocks input until its callback settles, so a commit
+// React decides not to make — an interrupted transition, an unmounted provider
+// — is a frozen page with no way back. `flushSync` cannot hang.
+//
+// The cost is real and worth stating rather than discovering. Inside a
+// transition the commit is synchronous, so a route that suspends *while
+// rendering* shows its `_uf.loading.js` fallback instead of leaving the
+// previous page up until it resolves. Its modules and its loader are already
+// finished by this point — `resolveMatch` awaited both — so what is left is a
+// component suspending on something else, and it degrades to the fallback the
+// project wrote for exactly that.
+//
+// # Why not React's `<ViewTransition>`
+//
+// It is not in a stable React. This package's peer range is `react >= 19`, and
+// reaching for a component that exists only in an experimental build would
+// turn an animation into a reason a project cannot use the router at all.
+// `startViewTransition` is the same feature one layer down, and it is in the
+// browser rather than in a dependency.
+//
+// # What must not change
+//
+// A browser without `startViewTransition` navigates exactly as it did before
+// any of this. A reader who asked for less motion gets the cut they asked for,
+// without the application having to remember to ask on their behalf. And the
+// server renders nothing about it: a transition is a client-only concern, and
+// the moment one reaches the markup it is a hydration difference instead.
+
+/**
+ * The attribute a running transition's name reaches CSS through.
+ *
+ * On the document element, because that is where the `::view-transition`
+ * pseudo-elements hang and therefore the only element a selector can reach
+ * them from.
+ */
+const VIEW_TRANSITION_ATTRIBUTE = "data-uf-view-transition";
+
+/**
+ * The part of a running transition this module reads.
+ *
+ * One property, because one is what a navigation needs: `finished` settles
+ * when the animation is over, which is when the document may stop saying which
+ * transition is running. `ready` and `updateCallbackDone` are for an
+ * application animating something itself, and a router holding them would be
+ * claiming to know what they were for.
+ */
+type ViewTransition = { readonly finished: Promise<mixed>, ... };
+
+/**
+ * The document, under the one description this module has of it.
+ *
+ * Flow's library definitions have no `startViewTransition` — the API is newer
+ * than they are — and reading it off `any` would leave the one call that
+ * performs a navigation unchecked, where a wrong type is a broken navigation
+ * rather than a broken animation. Optional, because "this browser may not have
+ * it" is the entire point.
+ *
+ * An `interface` rather than an object type, because a `Document` is a class
+ * instance and class instances are not subtypes of object types. `documentElement`
+ * is nullable for the same reason it is in Flow's own libdef: a document parsed
+ * from nothing has no root element.
+ */
+interface ViewTransitionDocument {
+  readonly startViewTransition?: (update: () => mixed) => ViewTransition;
+  readonly documentElement: HTMLElement | null;
+}
+
+/**
+ * Whether the reader has asked for less motion.
+ *
+ * Asked at the moment of the navigation rather than subscribed to, because it
+ * is not a rendered value: nothing re-renders when the preference changes, and
+ * the only question is what to do with the click that just happened.
+ * `usePrefersReducedMotion` in `@uniflowed/hooks` is the rendered form of the
+ * same query and answers a different question.
+ *
+ * `matchMedia` is optional here because a document installed by a test runner
+ * may not have one, and a media query that cannot be asked is not a reason to
+ * fail a navigation.
+ */
+function prefersReducedMotion(): boolean {
+  const query = window.matchMedia?.("(prefers-reduced-motion: reduce)");
+  return query != null && query.matches === true;
+}
+
+/**
+ * Apply `update`, inside a view transition where there is one to be had.
+ *
+ * Two ways out and they are one decision: with no `startViewTransition`, or
+ * with a reader who asked for less motion, this is the `startTransition` the
+ * router did before any of this existed — same commit, same concurrency, no
+ * animation.
+ *
+ * `name` is the route's, and it reaches CSS as an attribute for as long as the
+ * transition runs. The other spelling is the `types` option, which is the
+ * platform's own vocabulary for the same idea and is *newer than
+ * `startViewTransition` itself* — so passing the options object to a browser
+ * that has only the callback form is a `TypeError` thrown out of the call that
+ * performs the navigation. Naming a transition would then need a second and
+ * finer feature detection than the one for having transitions at all, and the
+ * cost of getting that one wrong is the navigation rather than the animation.
+ * One attribute needs no detection and is removed again when the transition
+ * ends.
+ */
+function withViewTransition(name: ?string, update: () => void): void {
+  const owner: ViewTransitionDocument = document;
+  const start = owner.startViewTransition?.bind(owner);
+  if (start == null || prefersReducedMotion()) {
+    startTransition(update);
+    return;
+  }
+
+  const root = owner.documentElement;
+  if (name != null && root != null) {
+    root.setAttribute(VIEW_TRANSITION_ATTRIBUTE, name);
+  }
+  const ended = () => {
+    if (name != null && root != null) {
+      root.removeAttribute(VIEW_TRANSITION_ATTRIBUTE);
+    }
+  };
+  // Both settlements do the same thing, and the rejection is not a failure:
+  // `finished` rejects when the transition is skipped — a second navigation
+  // before this one finished, a tab that went to the background — and a
+  // skipped transition has still ended. Handling it is also what keeps a
+  // routine interruption from being reported as an unhandled rejection.
+  start(() => {
+    flushSync(update);
+  }).finished.then(ended, ended);
+}
+
+// ---------------------------------------------------------------------------
 // The React binding
 // ---------------------------------------------------------------------------
 
 /** How a navigation is performed. */
-export type NavigateOptions = {| readonly replace?: boolean, readonly scroll?: boolean |};
+export type NavigateOptions = {|
+  readonly replace?: boolean,
+  readonly scroll?: boolean,
+  /**
+   * Whether this navigation may animate. Defaults to `true`, which is what
+   * every navigation does.
+   *
+   * `false` is how a caller says this one is a change of state rather than a
+   * change of place — a tab within a page, a filter written into the query
+   * string — and should be a cut. `true` does not *force* one: a browser
+   * without `startViewTransition` and a reader who asked for less motion still
+   * get the cut, because an application able to override the second would
+   * eventually override it.
+   */
+  readonly transition?: boolean,
+|};
 
 /** What `useRouter()` returns. */
 export type Router = {|
@@ -1416,10 +1768,15 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
       } else {
         window.history.pushState(null, "", next + target.hash);
       }
-      startTransition(() => {
+      const commit = () => {
         setResolved(nextResolved);
         setPending(false);
-      });
+      };
+      if (options?.transition === false) {
+        startTransition(commit);
+      } else {
+        withViewTransition(nextResolved.viewTransition, commit);
+      }
       if (options?.scroll !== false) {
         if (target.hash !== "") {
           const element = document.getElementById(target.hash.slice(1));
@@ -1451,7 +1808,10 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
         return;
       }
       resolveMatch(routeTable(), next).then((nextResolved) => {
-        startTransition(() => {
+        // The back button is a navigation, and a navigation that animates in
+        // one direction and cuts in the other would read as a bug in the
+        // animation rather than as a decision.
+        withViewTransition(nextResolved.viewTransition, () => {
           setResolved(nextResolved);
         });
       });
@@ -1489,6 +1849,10 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
           routeTable(),
           window.location.pathname + window.location.search,
         );
+        // No view transition, and it is the one place that is right: a refresh
+        // is the same URL resolved again, so a transition would animate a page
+        // into itself — a cross-fade between two frames of the same thing,
+        // which is a flicker with a name.
         startTransition(() => {
           setResolved(nextResolved);
         });
@@ -1855,9 +2219,83 @@ function absoluteUrl(value: string, base: void | string): string {
   }
 }
 
+/**
+ * The `robots` directives, as one `content` string, or `null` for none.
+ *
+ * `null` rather than an empty string, so a page that declared nothing gets no
+ * tag at all: "index, follow" is what a document with no `robots` meta already
+ * means, and writing it out tells a crawler what it had already assumed.
+ *
+ * Each declared field contributes its directive and no field implies another.
+ * `index: true` therefore emits `index` rather than nothing — the value is
+ * there to overrule a section that said otherwise, and a directive that
+ * disappeared because it agreed with the default would be a page saying
+ * something and no evidence of it in the markup.
+ */
+function robotsContent(robots: void | Robots): ?string {
+  if (robots == null) {
+    return null;
+  }
+  const directives: Array<string> = [];
+  if (robots.index != null) {
+    directives.push(robots.index ? "index" : "noindex");
+  }
+  if (robots.follow != null) {
+    directives.push(robots.follow ? "follow" : "nofollow");
+  }
+  if (robots.maxSnippet != null) {
+    directives.push(`max-snippet:${robots.maxSnippet}`);
+  }
+  if (robots.maxImagePreview != null) {
+    directives.push(`max-image-preview:${robots.maxImagePreview}`);
+  }
+  return directives.length === 0 ? null : directives.join(", ");
+}
+
+/**
+ * One JSON-LD object as the text of a `<script>`.
+ *
+ * `<` is escaped so a string inside the data holding `</script>` cannot end
+ * the element early — the same escape `server.js` applies to the embedded
+ * loader data, and for the same reason: the text is the application's and the
+ * element it lands in is terminated by a character sequence rather than by a
+ * length. `dataScript` also escapes U+2028 and U+2029; those are about a
+ * string being parsed as JavaScript source, and this one never is.
+ */
+function jsonLdText(entry: JsonLd): string {
+  return JSON.stringify(entry).replace(/</g, "\\u003c");
+}
+
+/**
+ * One JSON-LD object, as the element that carries it.
+ *
+ * A function rather than an element written inline, because the suppression
+ * needs a line of its own; `docs/app/_uf.layout.js` has the same shape for the
+ * same reason. `security/no-dangerously-set-inner-html` is about markup that
+ * came from somewhere and has to be sanitized before a browser parses it as
+ * HTML, and its escape hatch is a `@uniflowed/markdown` sanitizer — the right
+ * answer for markup and no answer at all for JSON. This string is
+ * `JSON.stringify`'s output with `<` escaped, so nothing in it can close the
+ * element, and it is never parsed as HTML. There is also no other spelling:
+ * React escapes a text child, so `{"@type":"Article"}` would reach the page as
+ * `&quot;@type&quot;`, which is not JSON-LD any more.
+ */
+function jsonLdScript(entry: JsonLd): React.Node {
+  const text = jsonLdText(entry);
+  const html = { __html: text };
+  // uf-lint-disable-next-line security/no-dangerously-set-inner-html
+  return <script key={text} type="application/ld+json" dangerouslySetInnerHTML={html} />;
+}
+
 component Head(metadata: Metadata) {
-  const { title, description, metadataBase, canonical, openGraph, twitter } = metadata;
+  const { title, description, metadataBase, canonical, robots } = metadata;
+  const { alternates, pagination, jsonLd, openGraph, twitter } = metadata;
   const href = canonical != null ? absoluteUrl(canonical, metadataBase) : null;
+  const crawler = robotsContent(robots);
+  // Read out of `alternates` once rather than through it at every use: the map
+  // is read inside a callback, and a refinement of `alternates.languages` does
+  // not survive being carried into one.
+  const languages = alternates?.languages;
   // A page that said what it is called has said what its card is called. Every
   // site that had to write both wrote the same string twice, and the second
   // one is the one that goes stale — the docs site shipped thirty pages whose
@@ -1880,7 +2318,33 @@ component Head(metadata: Metadata) {
     <>
       {title != null ? <title>{title}</title> : null}
       {description != null ? <meta name="description" content={description} /> : null}
+      {crawler != null ? <meta name="robots" content={crawler} /> : null}
       {href != null ? <link rel="canonical" href={href} /> : null}
+      {/* The set is reciprocal and includes this page, so a `hreflang` list is
+          usually the same list on every page of it — which is why it belongs
+          on the layout they share rather than on each of them.
+
+          `hrefLang` is React's spelling and it reaches the markup unchanged,
+          which is worth knowing before grepping a document for `hreflang` and
+          concluding it is missing. HTML attribute names are case-insensitive,
+          so the parser every crawler runs reads it as the same attribute; the
+          lowercase spelling is the one React warns about. */}
+      {languages != null
+        ? Object.keys(languages).map((language) => (
+            <link
+              key={language}
+              rel="alternate"
+              hrefLang={language}
+              href={absoluteUrl(languages[language], metadataBase)}
+            />
+          ))
+        : null}
+      {pagination?.prev != null ? (
+        <link rel="prev" href={absoluteUrl(pagination.prev, metadataBase)} />
+      ) : null}
+      {pagination?.next != null ? (
+        <link rel="next" href={absoluteUrl(pagination.next, metadataBase)} />
+      ) : null}
       {/* `og:url` *is* the canonical URL of the page, in Open Graph's own
           words, so one declaration answers both rather than asking a project
           to write the same URL twice and keep them in step. */}
@@ -1927,8 +2391,53 @@ component Head(metadata: Metadata) {
       {twitterImageAlt != null && twitter?.images != null ? (
         <meta name="twitter:image:alt" content={twitterImageAlt} />
       ) : null}
+      {/* Last, and not hoisted into `<head>` with the rest: React hoists a
+          `<title>`, a `<meta>` and a `<link>`, and not a script whose body it
+          would have to carry. JSON-LD is read from anywhere in the document,
+          so these render where the route does. */}
+      {jsonLd != null ? jsonLd.map(jsonLdScript) : null}
     </>
   );
+}
+
+/**
+ * Head elements a component contributes while it is rendering.
+ *
+ * `metadata` and `generateMetadata` are how a *route* says what it is, and
+ * both are resolved before anything renders — which is what makes them work
+ * for a crawler that runs no JavaScript. They are also declarations by the
+ * route module, and part of what a page has to say is decided further in: a
+ * paginated list knows its `prev` and `next` in the component that draws the
+ * pager, and a breadcrumb knows the trail it has just walked.
+ *
+ * So this returns elements rather than writing to the head. Writing would have
+ * to happen in an effect, an effect does not run on a server, and the result
+ * would be a page whose tags are right in a browser and missing from the
+ * crawler — `packages/web/head.js` is that escape hatch and says so at the top
+ * of the file. Rendering is what puts a tag in a server-rendered head, so the
+ * caller renders what comes back:
+ *
+ *     export component Pager(page: number, of: number) {
+ *       const seo = useSeo({
+ *         pagination: {
+ *           prev: page > 1 ? `/posts?page=${page - 1}` : undefined,
+ *           next: page < of ? `/posts?page=${page + 1}` : undefined,
+ *         },
+ *       });
+ *       return <nav className="pager">{seo}…</nav>;
+ *     }
+ *
+ * The argument is a `Metadata` — the same type a route exports — because there
+ * is one vocabulary for what a page says about itself, and a second one would
+ * be a second place for it to be wrong. What this adds over rendering the tags
+ * by hand is the thing a component three levels down cannot know:
+ * `metadataBase`, which the root layout declared, and against which the
+ * relative URLs written here are resolved.
+ */
+export hook useSeo(seo: Metadata): React.Node {
+  const { resolved } = useRouterState();
+  const base = seo.metadataBase ?? resolved.metadata.metadataBase;
+  return <Head metadata={base == null ? seo : { ...seo, metadataBase: base }} />;
 }
 
 /** When a `Link` loads the route it points at. */
@@ -1939,12 +2448,15 @@ export type LinkPrefetch = "off" | "intent" | "render";
  *
  * Renders a real anchor, so the link works before hydration and for a right
  * click, and takes over only a plain left click. `prefetch="intent"` (the
- * default) loads the destination's chunks on hover or focus.
+ * default) loads the destination's chunks on hover or focus, and
+ * `transition={false}` makes this one navigation a cut — most navigations are
+ * a link, so the opt-out in [`NavigateOptions`] has to be reachable from one.
  */
 export component Link(
   to: string,
   prefetch?: LinkPrefetch = "intent",
   replace?: boolean = false,
+  transition?: boolean = true,
   children?: React.Node,
   className?: string,
   onClick?: (event: SyntheticMouseEvent<HTMLAnchorElement>) => mixed,
@@ -1983,7 +2495,7 @@ export component Link(
       return;
     }
     event.preventDefault();
-    router.push(to, { replace }).catch((error) => {
+    router.push(to, { replace, transition }).catch((error) => {
       // A failed navigation falls back to the browser doing it.
       console.error(error);
       window.location.assign(to);

--- a/tests/library/metadata.test.js
+++ b/tests/library/metadata.test.js
@@ -16,8 +16,8 @@
 // silently ignored by the machine that reads it.
 
 import * as React from "@uniflowed/react";
-import { routerView } from "@uniflowed/router";
-import type { Metadata } from "@uniflowed/router";
+import { routerView, useSeo } from "@uniflowed/router";
+import type { LayoutModule, Metadata, PageModule } from "@uniflowed/router";
 import { createRenderer } from "@uniflowed/router/server";
 import { describe, expect, it } from "@uniflowed/test";
 
@@ -415,6 +415,231 @@ describe("what was already there", () => {
     );
     expect(html).toContain(
       '<meta property="og:image" content="https://docs.uniflowed.dev/og.png"/>',
+    );
+  });
+});
+
+/**
+ * The document a single route renders to, from the modules it is given.
+ *
+ * `documentFor` is the shorthand over it; a test reaches for this one when it
+ * needs a page module of its own rather than a metadata object.
+ */
+async function documentOf(page: PageModule, layout?: ?LayoutModule): Promise<string> {
+  const { prerender } = createRenderer({
+    App: routerView("./app"),
+    routes: [
+      {
+        path: "/guide",
+        params: [],
+        mdx: false,
+        file: "app/guide/_uf.page.js",
+        page: () => Promise.resolve(page),
+        layouts: layout == null ? [] : [() => Promise.resolve(layout)],
+      },
+    ],
+    notFound: [],
+    errors: [],
+  });
+
+  const result = await prerender("/guide", assets);
+  // A throw anywhere above would render the error page instead, and every
+  // `not.toContain` below would then pass for the wrong reason.
+  expect(result.status).toBe(200);
+  return result.html;
+}
+
+describe("what a page tells a crawler", () => {
+  it("says noindex, nofollow when it wants neither", async () => {
+    const html = await documentFor({ title: "a preview", robots: { index: false, follow: false } });
+
+    expect(html).toContain('<meta name="robots" content="noindex, nofollow"/>');
+  });
+
+  it("says nothing at all when the page declares nothing", async () => {
+    // "index, follow" is what a document with no `robots` meta already means,
+    // so a tag that spelled it out would tell a crawler what it had assumed.
+    const html = await documentFor({ title: "an ordinary page" });
+
+    expect(html).not.toContain('name="robots"');
+  });
+
+  it("keeps a directive that agrees with the default, because it is overruling one", async () => {
+    // A section declared `index: false` on its layout and one page under it is
+    // public. Dropping `index` for agreeing with the crawler's default would
+    // leave that page saying nothing, in a document whose own layout is the
+    // reason it had to say something.
+    const html = await documentFor({ robots: { index: true } }, { robots: { index: false } });
+
+    expect(html).toContain('<meta name="robots" content="index"/>');
+  });
+
+  it("carries the two directives that change what a result looks like", async () => {
+    const html = await documentFor({
+      title: "a page",
+      robots: { maxSnippet: 160, maxImagePreview: "large" },
+    });
+
+    expect(html).toContain(
+      '<meta name="robots" content="max-snippet:160, max-image-preview:large"/>',
+    );
+  });
+});
+
+describe("the translations of a page", () => {
+  it("is one hreflang link each, resolved against metadataBase", async () => {
+    const html = await documentFor({
+      metadataBase: "https://docs.uniflowed.dev",
+      alternates: { languages: { en: "/guide", ja: "/ja/guide" } },
+    });
+
+    expect(html).toContain(
+      '<link rel="alternate" hrefLang="en" href="https://docs.uniflowed.dev/guide"/>',
+    );
+    expect(html).toContain(
+      '<link rel="alternate" hrefLang="ja" href="https://docs.uniflowed.dev/ja/guide"/>',
+    );
+  });
+
+  it("takes x-default like any other tag, because to a crawler it is one", async () => {
+    const html = await documentFor({
+      alternates: { languages: { "x-default": "https://docs.uniflowed.dev/guide" } },
+    });
+
+    expect(html).toContain(
+      '<link rel="alternate" hrefLang="x-default" href="https://docs.uniflowed.dev/guide"/>',
+    );
+  });
+
+  it("comes down from the layout, because the set is the same on every page of it", async () => {
+    const html = await documentFor(
+      { title: "a page" },
+      { alternates: { languages: { ja: "/ja" } } },
+    );
+
+    expect(html).toContain('<link rel="alternate" hrefLang="ja" href="/ja"/>');
+  });
+
+  it("is absent from a page that has no translations", async () => {
+    const html = await documentFor({ title: "a page" });
+
+    expect(html).not.toContain('rel="alternate"');
+  });
+});
+
+describe("a page in a sequence", () => {
+  it("links to the pages either side of it", async () => {
+    const html = await documentFor({
+      metadataBase: "https://docs.uniflowed.dev",
+      canonical: "/posts?page=4",
+      pagination: { prev: "/posts?page=3", next: "/posts?page=5" },
+    });
+
+    expect(html).toContain('<link rel="prev" href="https://docs.uniflowed.dev/posts?page=3"/>');
+    expect(html).toContain('<link rel="next" href="https://docs.uniflowed.dev/posts?page=5"/>');
+  });
+
+  it("keeps its own canonical URL rather than pointing at page one", async () => {
+    // The mistake this pair exists to make unnecessary. A paginated list whose
+    // every page is canonical to page one has told a search engine that pages
+    // two onwards are duplicates, and everything only linked from them stops
+    // being reachable.
+    const html = await documentFor({
+      canonical: "https://docs.uniflowed.dev/posts?page=4",
+      pagination: { prev: "https://docs.uniflowed.dev/posts?page=3" },
+    });
+
+    expect(html).toContain(
+      '<link rel="canonical" href="https://docs.uniflowed.dev/posts?page=4"/>',
+    );
+  });
+
+  it("emits only the end it has, on the first page of a list", async () => {
+    const html = await documentFor({ pagination: { next: "/posts?page=2" } });
+
+    expect(html).toContain('<link rel="next" href="/posts?page=2"/>');
+    expect(html).not.toContain('rel="prev"');
+  });
+});
+
+describe("structured data", () => {
+  it("is one script per entry, in the vocabulary a search engine reads", async () => {
+    const html = await documentFor({
+      title: "Install · uf",
+      jsonLd: [{ "@context": "https://schema.org", "@type": "TechArticle", name: "Install uf" }],
+    });
+
+    expect(html).toContain('<script type="application/ld+json">');
+    expect(html).toContain('"@type":"TechArticle"');
+  });
+
+  it("adds to what the layout declared rather than replacing it", async () => {
+    // The one field where the nearest declaration does not win. An
+    // `Organization` on the root layout and an `Article` on the page are two
+    // statements about one page — replacing would mean a page that describes
+    // itself silently deletes the site's description of itself.
+    const html = await documentFor(
+      { jsonLd: [{ "@type": "TechArticle" }] },
+      { jsonLd: [{ "@type": "Organization" }] },
+    );
+
+    expect(html).toContain('"@type":"Organization"');
+    expect(html).toContain('"@type":"TechArticle"');
+  });
+
+  it("cannot be closed from inside its own data", async () => {
+    // The escape that matters. A `</script>` in any string in the data would
+    // end the element early, and everything after it would be markup the page
+    // never wrote — which is the whole of the injection.
+    const html = await documentFor({
+      jsonLd: [{ "@type": "Article", headline: "</script><img src=x onerror=alert(1)>" }],
+    });
+
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("\\u003c/script");
+  });
+
+  it("is absent from a page that declares none", async () => {
+    const html = await documentFor({ title: "a page" });
+
+    expect(html).not.toContain("application/ld+json");
+  });
+});
+
+describe("useSeo", () => {
+  it("puts a component's own tags in the document the server writes", async () => {
+    // The case `metadata` cannot serve: a pager knows which page of the list
+    // it is drawing, and the route module that renders it does not. The tags
+    // have to reach the *prerendered* document, because a hook that only
+    // worked in a browser would be right on screen and missing from every
+    // crawler — which is exactly what `useHead` in `@uniflowed/web` says about
+    // itself.
+    component Pager() {
+      const seo = useSeo({ pagination: { prev: "/posts?page=1", next: "/posts?page=3" } });
+      return <nav>{seo}a pager</nav>;
+    }
+
+    const html = await documentOf({ default: Pager, metadata: { title: "Posts" } });
+
+    expect(html).toContain('<link rel="prev" href="/posts?page=1"/>');
+    expect(html).toContain('<link rel="next" href="/posts?page=3"/>');
+  });
+
+  it("resolves its URLs against the metadataBase the layout declared", async () => {
+    // The one thing a component three levels down cannot know, and the reason
+    // this is a hook rather than a handful of tags written by hand.
+    component Deep() {
+      const seo = useSeo({ canonical: "/posts?page=2" });
+      return <p>{seo}deep</p>;
+    }
+
+    const html = await documentOf(
+      { default: Deep },
+      { default: SiteLayout, metadata: { metadataBase: "https://docs.uniflowed.dev" } },
+    );
+
+    expect(html).toContain(
+      '<link rel="canonical" href="https://docs.uniflowed.dev/posts?page=2"/>',
     );
   });
 });

--- a/tests/library/view-transitions.test.js
+++ b/tests/library/view-transitions.test.js
@@ -1,0 +1,385 @@
+// @flow
+//
+// A navigation that is a transition rather than a cut.
+//
+// `document.startViewTransition` is opt-in per navigation, so something has to
+// call it, and nothing in uf did: every client navigation replaced the tree and
+// the browser painted the new one. See ubugeeei-prod/uf#502.
+//
+// The router is what replaces the tree, so the router is what calls it — and
+// the interesting half of that decision is what happens when it cannot. Three
+// of the cases below are about *not* transitioning: a browser that has no such
+// method, a reader who asked for less motion, and a caller that said this
+// navigation is a change of state rather than a change of place. Each has to
+// arrive at the same page it arrived at before any of this existed, because a
+// feature that degrades into a broken link is worse than no feature.
+//
+// The transition itself is stubbed rather than run. A real one is compositor
+// work in a browser that happy-dom is not; what a test can hold the router to
+// is that it asked, that it said which transition it was asking for, and that
+// it stopped saying so afterwards.
+
+import * as React from "@uniflowed/react";
+import { act, cleanup, render, screen, userEvent } from "@uniflowed/react-testing";
+import {
+  Link,
+  RouteView,
+  RouterProvider,
+  type RouteTable,
+  resolveMatch,
+  routerView,
+} from "@uniflowed/router";
+import { createRenderer } from "@uniflowed/router/server";
+import { afterEach, describe, expect, it } from "@uniflowed/test";
+
+// Reached by path rather than by package name, the way `rsc-split.test.js`
+// reaches for the same module: the document has to exist before a stub can be
+// put on it, and `render` installs one only when it is called.
+import { installDom } from "../../packages/react-testing/internal/dom.js";
+
+component Home() {
+  return (
+    <main>
+      <h1>home</h1>
+      <Link to="/guide">go to the manual</Link>
+      <Link to="/guide" transition={false}>
+        go to the manual without animating
+      </Link>
+    </main>
+  );
+}
+
+component Guide() {
+  return <h1>the manual</h1>;
+}
+
+component GuideLayout(children: React.Node) {
+  return <div className="guide">{children}</div>;
+}
+
+/**
+ * A site with a home page and a manual, where the manual names its transition.
+ *
+ * Built fresh per test rather than shared, because the runtime caches a loaded
+ * module by the identity of the function that loads it — two tests sharing one
+ * table would share whichever page the first of them resolved.
+ */
+function site(options?: {| readonly on?: "page" | "layout" |}): RouteTable {
+  const where = options?.on ?? "page";
+  const guide = { default: Guide, viewTransition: where === "page" ? "manual" : undefined };
+  const layout = {
+    default: GuideLayout,
+    viewTransition: where === "layout" ? "manual" : undefined,
+  };
+  return {
+    routes: [
+      {
+        path: "/",
+        params: [],
+        mdx: false,
+        file: "app/_uf.page.js",
+        page: () => Promise.resolve({ default: Home }),
+        layouts: [],
+      },
+      {
+        path: "/guide",
+        params: [],
+        mdx: false,
+        file: "app/guide/_uf.page.js",
+        page: () => Promise.resolve(guide),
+        layouts: [() => Promise.resolve(layout)],
+      },
+    ],
+    notFound: [],
+    errors: [],
+  };
+}
+
+/** What one call to `startViewTransition` looked like from the router's side. */
+type Started = {|
+  /** The name on the document element at the moment the transition began. */
+  readonly named: ?string,
+  /** What was on the page once the update callback had returned. */
+  readonly painted: string,
+|};
+
+/** The one thing the router reads off a transition: that it is over. */
+type StubTransition = {| readonly finished: Promise<void> |};
+
+/**
+ * The document, as something this file can put a `startViewTransition` on.
+ *
+ * Flow's `Document` has no such property, and that a browser may not have it is
+ * the entire reason the router feature-detects it — so installing a stub has to
+ * go through a type that says it may be there. An `interface` because a
+ * `Document` is a class instance and class instances are not subtypes of object
+ * types, which is the same reason the runtime declares its own.
+ */
+interface StubDocument {
+  startViewTransition?: (update: () => mixed) => StubTransition;
+}
+
+/** The document, with the property this file installs on it declared. */
+function stubDocument(): StubDocument {
+  installDom();
+  return globalThis.document;
+}
+
+/**
+ * A `startViewTransition` that records the call and applies the update.
+ *
+ * The name is read *inside* the callback rather than afterwards, because when
+ * it is set is the whole of what it is for: a browser captures the old frame
+ * before calling back, and an attribute added after that is an attribute no
+ * `::view-transition-old` selector ever saw.
+ *
+ * `painted` is read after the callback for the mirror-image reason. A browser
+ * captures the new frame from whatever the DOM holds when the callback
+ * settles, so a router that scheduled the commit instead of performing it
+ * hands the browser two captures of the same page and calls it a transition.
+ *
+ * `finished` is settled by the caller so a test can hold the transition open
+ * and ask what the document says while it is running.
+ */
+function installViewTransitions(): {|
+  readonly started: $ReadOnlyArray<Started>,
+  readonly finish: () => Promise<void>,
+|} {
+  const started: Array<Started> = [];
+  let settle: () => void = () => {};
+  const finished = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  stubDocument().startViewTransition = (update: () => mixed) => {
+    const named = root().getAttribute("data-uf-view-transition");
+    update();
+    started.push({ named, painted: root().textContent ?? "" });
+    return { finished };
+  };
+
+  return {
+    started,
+    finish: async () => {
+      settle();
+      // Two turns: one for `finished` itself, one for the `.then` the router
+      // took off it. A single `await` would ask what the document says while
+      // the handler that changes it is still queued.
+      await finished;
+      await Promise.resolve();
+    },
+  };
+}
+
+/** Say that the reader has asked their system for less motion. */
+function installReducedMotion(matches: boolean): void {
+  installDom();
+  Object.defineProperty(globalThis.window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: matches && query.includes("prefers-reduced-motion"),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+/** The document element, which is where a transition's name is written. */
+function root(): Element {
+  const element = globalThis.document.documentElement;
+  if (element == null) {
+    throw new Error("the document has no root element");
+  }
+  return element;
+}
+
+/**
+ * Install the table and mount the site at `/`, ready to navigate.
+ *
+ * `createRenderer` is doing a second job here. The router holds one route
+ * table per process, installed by whichever entry started the app, and
+ * `RouterProvider` resolves the *next* route out of that table rather than out
+ * of a prop — so a test that only rendered the provider navigates into a
+ * router with no table at all. The runtime says so rather than silently doing
+ * nothing, which is how this was found.
+ */
+async function atHome(table: RouteTable): Promise<void> {
+  installDom();
+  createRenderer({
+    App: routerView("./app"),
+    routes: table.routes,
+    notFound: table.notFound,
+    errors: table.errors,
+  });
+  globalThis.window.history.pushState(null, "", "/");
+  const resolved = await resolveMatch(table, "/");
+  render(
+    <RouterProvider url="/" initial={resolved}>
+      <RouteView />
+    </RouterProvider>,
+  );
+}
+
+/** Follow a link, letting everything the navigation queued run. */
+async function follow(name: string): Promise<void> {
+  await act(async () => {
+    await userEvent.click(screen.getByRole("link", { name }));
+  });
+}
+
+/**
+ * The heading of the page that is on screen.
+ *
+ * By role, so "the manual arrived" cannot be satisfied by the link that points
+ * at it — which is the way a navigation that silently did nothing would pass
+ * every assertion in this file.
+ */
+function heading(): string {
+  return screen.getByRole("heading").textContent ?? "";
+}
+
+afterEach(() => {
+  cleanup();
+  // The stub is an own property put on a document that is installed once per
+  // worker and shared with every other file scheduled onto it: one left behind
+  // is one the next file runs under. `undefined` rather than `delete`, because
+  // it is what the router's own feature detection reads — a property that is
+  // not a function is a browser that does not have the API.
+  if (globalThis.document != null) {
+    stubDocument().startViewTransition = undefined;
+    root().removeAttribute("data-uf-view-transition");
+  }
+});
+
+describe("a navigation in a browser that has view transitions", () => {
+  it("goes through one", async () => {
+    const transitions = installViewTransitions();
+    await atHome(site());
+
+    await follow("go to the manual");
+
+    expect(transitions.started.length).toBe(1);
+    expect(heading()).toBe("the manual");
+  });
+
+  it("hands the browser a page that has already changed", async () => {
+    // The reason the commit inside a transition is `flushSync` and not
+    // `startTransition`: the browser captures the new frame from whatever the
+    // DOM holds when the callback settles, and a scheduled commit has changed
+    // nothing by then. Two captures of the same page is not a transition, and
+    // nothing about it looks broken — it looks like the animation not firing.
+    const transitions = installViewTransitions();
+    await atHome(site());
+
+    await follow("go to the manual");
+
+    expect(transitions.started[0].painted).toContain("the manual");
+    expect(transitions.started[0].painted).not.toContain("home");
+  });
+
+  it("says which transition it is, from the page that named it", async () => {
+    // The name is what lets one stylesheet animate an arrival into the manual
+    // differently from an arrival anywhere else. Without it a project has one
+    // transition for the whole site, which is the same as having none it can
+    // design.
+    const transitions = installViewTransitions();
+    await atHome(site());
+
+    await follow("go to the manual");
+
+    expect(transitions.started[0].named).toBe("manual");
+  });
+
+  it("takes the name from a layout, for every route under it", async () => {
+    // The rule `metadata` already follows. A section that animates the same
+    // way throughout should say so once, in the file that is the section.
+    const transitions = installViewTransitions();
+    await atHome(site({ on: "layout" }));
+
+    await follow("go to the manual");
+
+    expect(transitions.started[0].named).toBe("manual");
+  });
+
+  it("stops saying so once the transition has ended", async () => {
+    // The attribute is global state on the document element. Left behind, the
+    // next navigation animates under the previous page's name — and the page
+    // after that under one nothing on screen ever declared.
+    const transitions = installViewTransitions();
+    await atHome(site());
+    await follow("go to the manual");
+    expect(root().getAttribute("data-uf-view-transition")).toBe("manual");
+
+    await act(async () => {
+      await transitions.finish();
+    });
+
+    expect(root().getAttribute("data-uf-view-transition")).toBe(null);
+  });
+});
+
+describe("a navigation that must not transition", () => {
+  it("still arrives in a browser that has no startViewTransition", async () => {
+    // The case the whole feature is measured against. Nothing is installed, so
+    // `document.startViewTransition` is undefined — which is what every
+    // browser older than the API is, and what one that never ships it stays.
+    await atHome(site());
+
+    await follow("go to the manual");
+
+    expect(heading()).toBe("the manual");
+    expect(root().getAttribute("data-uf-view-transition")).toBe(null);
+  });
+
+  it("is a cut for a reader who asked for less motion, without being asked to be", async () => {
+    // `prefers-reduced-motion` is honoured by the router rather than by the
+    // application. An application that had to remember would forget, and the
+    // reader who set the preference is the one person who cannot see that it
+    // was forgotten.
+    const transitions = installViewTransitions();
+    installReducedMotion(true);
+    try {
+      await atHome(site());
+
+      await follow("go to the manual");
+
+      expect(transitions.started.length).toBe(0);
+      expect(heading()).toBe("the manual");
+    } finally {
+      installReducedMotion(false);
+    }
+  });
+
+  it("is a cut when the link says this one is not a change of place", async () => {
+    const transitions = installViewTransitions();
+    await atHome(site());
+
+    await follow("go to the manual without animating");
+
+    expect(transitions.started.length).toBe(0);
+    expect(heading()).toBe("the manual");
+  });
+});
+
+describe("the server", () => {
+  it("renders nothing about a transition, because a transition is not markup", async () => {
+    // A transition is a client-only concern, and the moment one reaches the
+    // markup it is a hydration difference instead: the server would write an
+    // attribute the first client render does not, on the one element React
+    // cannot re-render its way out of.
+    const { prerender } = createRenderer({
+      App: routerView("./app"),
+      routes: site().routes,
+      notFound: [],
+      errors: [],
+    });
+
+    const result = await prerender("/guide", { scripts: [], styles: [], preloads: [] });
+
+    expect(result.status).toBe(200);
+    expect(result.html).toContain("the manual");
+    expect(result.html).not.toContain("data-uf-view-transition");
+  });
+});


### PR DESCRIPTION
Two halves of the same surface in `packages/router`. A navigation replaced the tree and the browser painted the new one, which is a cut; and `Metadata` carried a title, a description, a canonical URL and a share card, which is most of what a page has to say and not all of it.

## #502 — View transitions

Every client navigation now goes through `document.startViewTransition` where the browser has one — a `Link`, `router.push()` and the back button alike. There is nothing to switch on: with no stylesheet the browser's default cross-fade is what a reader gets.

A route names its transition, so one stylesheet can animate an arrival in the manual differently from an arrival anywhere else:

```js
// app/guide/_uf.layout.js
export const viewTransition = "manual";
```

```css
html[data-uf-view-transition="manual"]::view-transition-old(root) {
  animation: 120ms ease-out both fade-out;
}
```

A page's own name wins over its layout's, which is the nearest-declaration rule `metadata` already follows rather than a second one to learn.

Opting out, for a navigation that is a change of state rather than a change of place:

```js
<Link to="/posts?sort=new" transition={false}>Newest</Link>
router.push("/posts?sort=new", { transition: false });
```

**`prefers-reduced-motion` is honoured by the router**, not by the application, and there is no way to override it. A browser without `startViewTransition` navigates exactly as it did before. `router.refresh()` never transitions — it resolves the same URL again, and a transition there is a page cross-faded into itself. The server renders nothing about any of it.

### Three decisions worth reading the file for

**`flushSync`, not `startTransition`.** The browser captures the old frame, calls back, and waits on the promise the callback returns before capturing the new one — so the callback has to leave the DOM updated, and `startTransition` schedules and returns having changed nothing. The alternative was a promise resolved from an effect after the commit: concurrent, and able to hang, because a running transition blocks input until its callback settles. The cost is stated in the file rather than left to be discovered — inside a transition the commit is synchronous, so a route that suspends *while rendering* shows its `_uf.loading.js` fallback instead of leaving the previous page up.

**An attribute, not the `types` option.** `types` is the platform's own vocabulary for naming a transition, and it is newer than `startViewTransition` itself — passing the options object to a browser that has only the callback form is a `TypeError` out of the call that performs the navigation. Naming a transition would then need a second and finer feature detection than the one for having transitions at all, and getting *that* one wrong breaks the navigation rather than the animation.

**Not React's `<ViewTransition>`.** It is not in a stable React (`react@19.2.8` exports `Activity`, `startTransition`, `useTransition` and no `ViewTransition`). This package's peer range is `react >= 19`, and depending on an experimental build would turn an animation into a reason a project cannot use the router.

## #504 — The rest of what a page says about itself

Four fields on the existing `Metadata`, each for something previously reachable only by rendering `<head>` tags by hand — an escape hatch nothing checks, nothing merges through the layouts, and nothing resolves against `metadataBase`.

```js
import type { Metadata } from "@uniflowed/router";

export const metadata: Metadata = {
  title: "Posts · page 4",
  canonical: "/posts?page=4",
  robots: { index: true, follow: true, maxImagePreview: "large" },
  alternates: { languages: { en: "/posts", ja: "/ja/posts", "x-default": "/posts" } },
  pagination: { prev: "/posts?page=3", next: "/posts?page=5" },
  jsonLd: [{ "@context": "https://schema.org", "@type": "Blog", name: "Posts" }],
};
```

- **`robots`** — `index`, `follow`, `maxSnippet`, `maxImagePreview`. Four rather than the whole vocabulary: the first two are what a page has an opinion about, and the other two change what a result *looks* like. `nosnippet` is absent because `maxSnippet: 0` is the same instruction, and a type with two ways to say one thing is one somebody will ask which of them wins. A page that declares nothing gets no tag at all — "index, follow" is what a document without one already means. Usually a layout's field: a staging tree or an account area is `noindex` for everything under it.
- **`alternates.languages`** — one `<link rel="alternate" hreflang>` per translation. The set is reciprocal (every page lists every other one *and itself*), so it is normally the same map on every page and belongs on the layout they share. `"x-default"` is a tag like any other.
- **`pagination`** — `<link rel="prev">` and `<link rel="next">`, so a paginated list has something to say other than making every page canonical to page one, which tells a search engine that pages two onwards are duplicates.
- **`jsonLd`** — one `<script type="application/ld+json">` per entry, and the **one field that accumulates down the tree** rather than being replaced by the nearest declaration. An `Organization` on the root layout and an `Article` on the page are two statements about one page, not two answers to one question.

### `useSeo`

The same vocabulary from inside a render, for the part a route module cannot know — a pager knows its own `prev` and `next`, and the page it is on does not:

```js
import { useSeo } from "@uniflowed/router";

export component Pager(page: number, of: number) {
  const seo = useSeo({
    pagination: {
      prev: page > 1 ? `/posts?page=${page - 1}` : undefined,
      next: page < of ? `/posts?page=${page + 1}` : undefined,
    },
  });

  return <nav className="pager">{seo}…</nav>;
}
```

It returns elements and the caller renders them. That is not a style choice: a hook that *wrote* to the head would have to do it in an effect, an effect does not run on a server, and the page would end up with tags that are right in a browser and missing from every crawler — `useHead` in `@uniflowed/web` is that escape hatch and says so at the top of its own file. The argument is a `Metadata`, the same type a route exports, so there is one vocabulary rather than two; what the hook adds over writing the tags by hand is `metadataBase`, which the root layout declared and a component three levels down cannot know.

## What a page emits now

The metadata above, prerendered into an app whose root layout owns the document — React hoists the `<title>`, `<meta>` and `<link>` into `<head>` and leaves the script where the route rendered it:

```html
<!doctype html>
<html lang="en"><head><meta charSet="utf-8"/><title>T</title>
<meta name="robots" content="noindex, nofollow"/>
<link rel="canonical" href="https://x.dev/guide"/>
<link rel="alternate" hrefLang="ja" href="https://x.dev/ja"/>
<link rel="prev" href="https://x.dev/a"/>
<link rel="next" href="https://x.dev/b"/>
<meta property="og:url" content="https://x.dev/guide"/>
<meta property="og:title" content="T"/>
<meta property="og:type" content="website"/>
</head><body>
<script type="application/ld+json">{"@type":"Article"}</script>
<p>a page</p></body></html>
```

`hrefLang` is React's spelling and reaches the markup unchanged; HTML attribute names are case-insensitive, so the parser every crawler runs reads it as `hreflang`, and the lowercase spelling is the one React warns about. A note in the file says so, because the alternative is somebody grepping a document for `hreflang` and concluding it is missing.

## The docs site

Both `_uf.not-found.js` files are `noindex, nofollow`. `uf build` prerenders them to `404.html` so a static host has something to serve, which makes them documents a crawler can be handed like any other; the sitemap already leaves them out, and this is the half that covers a crawler that found one another way. The root layout declares the site's `WebSite` object, which is also the worked example of the field that accumulates.

## Verification

Run from the worktree, with the prebuilt `uf` binary (`cargo` was not run — see the note below).

| Command | Result |
| --- | --- |
| `uf test tests/library` | **1977 passed, 0 failed, 1 skipped**, 51 files. Baseline before this change on the same checkout: 1951 passed, 0 failed, 1 skipped, 50 files. |
| `uf lint` | **0 errors, 14 warnings**, 378 files — the same 14 `uf.config.js` documents as the standing baseline, in files this change does not touch. |
| `uf fmt --check` | **every file is already formatted** |
| `uf check` | **1884 errors, 14 warnings.** Baseline on the same checkout: **1886**. `packages/router/internal/runtime.js` is at 23 errors both before and after, so the package gains none. |

`uf check` does not pass on `main` and is not the gate CI runs — `uf.config.js`'s `check:lib` task runs `uf lint`. The 1,886 are uf's own checker being incomplete against this repository (sixteen rules are skipped for needing type inference uf does not implement yet), concentrated in the test suite where `@uniflowed/test` and `@uniflowed/react-testing` are typed loosely (#248): `ui.test.js` alone accounts for 308. This change was measured against that baseline rather than against zero, and comes out two below it. The one error in the new test file is `Element` vs `HTMLElement` on `userEvent.click(screen.getByRole(…))`, which is the pattern every other component test in the suite uses.

**No cargo was run.** The Rust half of this repository is untouched — nothing under `crates/`, `upstream/`, `Cargo.toml` or `Cargo.lock` changed — so the Rust tests should be unaffected. `crates/uf_cli/tests/vite.rs` asserts on the docs site's built `index.html` with `contains`, and the two docs-site metadata additions are additive; the JSON-LD it writes contains no `component ` and so does not trip the "Flow syntax leaked into the document" assertion. That is reasoning, not a run — a reviewer with a built workspace should confirm it.

## Worth a follow-up

- **Generated per-route Open Graph images.** #504 names "per-route Open Graph images" and `openGraph.images` already carries them per route; what does not exist is Next's `opengraph-image.tsx` shape, where a route renders its own card at build time. That is a `uf build` feature rather than a router one, so it is out of this change's reach.
- **`og:image:width` / `og:image:height`.** They are what let a platform render a card at full size on the first share without fetching the image. They need `openGraph.images` to admit an object as well as a string, which is a second way to say one thing unless it replaces the first.
- **The docs site names no transition.** Every navigation on it now takes the browser's default cross-fade, which is the intended default. Naming one for `/guide` needs CSS in `_design/seam.css` written against something visible, and this change had no browser to look at.
- **A `<link rel="alternate">` for a feed.** `alternates` is nested rather than flat partly to leave the rel its own name; a site with an RSS feed has an alternate that is not a language, and nothing here serves it yet.

Closes #502.
Closes #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791369352&installation_model_id=422833&pr_number=546&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F546&signature=93f9e1b7d5f68501aa4ab74654c170a629016b3b0276a365f594af0b684e4a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->