### PR TITLE
fix(server, docs): a symlink cannot leave a served directory, and the CVE history is checked rather than asserted

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -182,6 +182,46 @@ the allow-list in the first commit rather than after one.
 - `cargo-fuzz` builds on every pull request that touches the workspace, and
   `tools/legal` tracks the license of every built-in dependency.
 
+## Checked against what actually happened
+
+The tables above are structural decisions. This section is the other direction:
+the published failures of the two frameworks uf is closest to, each one asked of
+uf's own code, with the answer and where to verify it. A row here is a claim
+about a specific file, not a posture.
+
+| Their failure | uf's answer | Where |
+| --- | --- | --- |
+| **[CVE-2025-29927](https://nvd.nist.gov/vuln/detail/CVE-2025-29927)** — Next.js middleware bypassed by a request header (`x-middleware-subrequest`) the framework used to talk to itself | No request header steers control flow anywhere in the request path. The only one read at all is `Host`, and it sets the URL's authority rather than skipping a layer. There is no internal channel to forge because uf passes none | `packages/server/standalone.js`, `packages/server/fetch.js` |
+| **[CVE-2024-34351](https://nvd.nist.gov/vuln/detail/CVE-2024-34351)** — Next.js server-action SSRF through a forged `Host` | A server action needs three things a cross-site caller cannot have: `POST` with a `uf-action` header (not a simple request, so it needs a preflight nothing answers), `content-type: application/json` (which no `<form>` can produce), and `Origin` equal to `Host`. `Origin: null` is refused rather than matched. `X-Forwarded-Host` is never consulted — a proxy that rewrites `Host` turns actions into `403`s, which is the right way to find out | `packages/router/internal/action-endpoint.js` |
+| **[CVE-2023-46298](https://nvd.nist.gov/vuln/detail/CVE-2023-46298)** — Next.js cached a personalised SSR response and served it to everybody | The route cache stores nothing when the render read the request, nothing when the response carries `Set-Cookie`, and nothing for a status that is not `200`. The "read the request" test is a comparison of request-state reads across the render, so a component inside a `<Suspense>` boundary that reads a cookie counts as much as the shell | `packages/server/fetch.js`, `tests/library/cache.test.js` |
+| **[CVE-2025-32421](https://nvd.nist.gov/vuln/detail/CVE-2025-32421)** — Next.js cache confusion between a page and its data route | uf has no parallel data route to confuse a page with, and the key is the method, the path and the search string together | `packages/server/internal/cache-key.js` |
+| Absolute URLs built from a forged `Host` and then cached, so a poisoned entry advertises the attacker's origin in `canonical` and `og:url` | `metadataBase` is a site-wide setting, not a per-request value: a route module cannot see the host it is served from, so there is nothing per-request to poison | `packages/router/internal/runtime.js` |
+| **[CVE-2021-37699](https://nvd.nist.gov/vuln/detail/CVE-2021-37699)** — open redirect from a path the framework normalised | A redirect is a status and a `Location` the application wrote; uf synthesises none from user input | — |
+| **[CVE-2018-6341](https://nvd.nist.gov/vuln/detail/CVE-2018-6341)** — React DOM server-side attribute injection | The renderer is React's own, and uf adds no attribute path around it. `Metadata` values reach `<meta content>` as React children, which React escapes | `packages/router/internal/runtime.js` |
+| Path traversal in static file serving | Decoded, NUL refused, `path.resolve`, and then required to be the root or under it — the check after normalisation rather than before | `packages/server/node.js` |
+| **Symlink escape** from a served directory | The file that is opened is realpath'd and required to be inside the realpath'd root, so a link that reads as inside and points outside is a 404 — indistinguishable from a file that is not there. A link that stays inside still works | `packages/server/node.js`, `tests/library/serve.test.js` |
+
+## Supply chain
+
+Where the code comes from, asked with the same directness.
+
+| Attack | uf's answer | Where |
+| --- | --- | --- |
+| A dependency runs code at install time | `--ignore-scripts` to every manager, always, by default. Getting one package back is `uf pm approve-builds <name>`, recorded in the field the project's own manager reads; the flag comes off only when the manager can enforce a list *and* the list has something in it | `crates/uf_pm/src/builds.rs` |
+| A package's own manifest declares scripts | `uf install` refuses the workspace before anything is fetched. Project automation is `uf.config.js` tasks | `crates/uf_pm` |
+| A tarball's bytes are not the bytes that were resolved | Every artefact carries an integrity hash in `uf.lock`; a source without one is a hard error. SHA-1 is refused outright — a check that can be forged is a check in name only | `crates/uf_env/src/archive.rs` |
+| Fetching and running a package the project never installed | `uf exec` refuses a name that is not in the lockfile without `--yes`. It is strictly more dangerous than a `postinstall`, so it asks at least as loudly | `crates/uf_cli/tests/cli.rs` |
+| A registry read leaks credentials | Packument reads are HTTPS only — `http://` refused, loopback included — a URL with an authority is refused outright, and curl is given `--proto =https --proto-redir =https` so a `301` cannot undo either | `crates/uf_pm/src/registry.rs` |
+| uf's own npm publish uses a long-lived token | It does not have one. Publishing is OIDC trusted publishing, bound to `publish.yml`; there is no npm token in the repository or its secrets | `.github/workflows/publish.yml` |
+| A compromised GitHub Action | Every action is pinned to a commit SHA and `zizmor` gates the workflows in CI | `.github/workflows/` |
+| **A compromised release host** | **Not answered yet.** `install.sh` verifies a SHA-256 that it downloads from the same host as the archive, so it proves transit and not origin. [#551](https://github.com/ubugeeei-prod/uf/issues/551) | — |
+| **A package published by a taken-over account** | **Not answered yet.** npm publishes provenance attestations and uf reads none of them; an integrity hash says the bytes are what uf resolved, not that they came from the source the package claims. [#552](https://github.com/ubugeeei-prod/uf/issues/552) | — |
+| **Dependency confusion** | **Not answered yet.** A scope cannot be bound to a registry, so a private name has nothing stopping a public answer. [#553](https://github.com/ubugeeei-prod/uf/issues/553) | — |
+
+The rows that say "not answered yet" are the point of both tables. A list where
+every row says "handled" is a list nobody checked, and the three above are open
+issues rather than sentences.
+
 ## Reporting
 
 Security reports go to the repository's private vulnerability reporting. Do not

--- a/packages/server/node.js
+++ b/packages/server/node.js
@@ -53,7 +53,7 @@
 // way when it is deployed.
 
 import { createReadStream } from "node:fs";
-import { stat } from "node:fs/promises";
+import { realpath, stat } from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -258,6 +258,11 @@ export function createStaticHandler(options: {|
   readonly root: string,
 |}): (request: Request) => Promise<Response | null> {
   const rootDir = path.resolve(options.root);
+  // Resolved once, lazily: the root is fixed for the life of the handler, and a
+  // checkout reached through a symlink — which is every macOS `/tmp` — would
+  // otherwise fail its own containment test. Lazily because this is a
+  // constructor and it cannot await.
+  let realRoot: string | null = null;
 
   return async function serveStatic(request: Request): Promise<Response | null> {
     const method = request.method.toUpperCase();
@@ -268,6 +273,9 @@ export function createStaticHandler(options: {|
 
     const resolved = path.resolve(rootDir, `.${pathname}`);
     if (resolved !== rootDir && !resolved.startsWith(rootDir + path.sep)) return null;
+
+    realRoot ??= (await realpathOrNull(rootDir)) ?? rootDir;
+    const root = realRoot;
 
     // `/guide/` and `/guide` are the same prerendered document, and neither
     // spelling is the one a person types. `<path>.html` is last because a
@@ -281,6 +289,21 @@ export function createStaticHandler(options: {|
     for (const candidate of candidates) {
       const info = await statFile(candidate);
       if (info == null || !info.isFile()) continue;
+      // The containment check above is textual, and a symlink is how a path
+      // that reads as inside the root opens a file outside it. `dist/` is
+      // written by the build, but `public/` is copied verbatim from whatever
+      // the author — or a dependency's install script — put there, so the
+      // check has to be made again on the value that is actually opened.
+      // ubugeeei-prod/uf#550; the same shape as the tarball traversals in
+      // `docs/security.md`, at the serving end.
+      //
+      // A link that stays inside the root still works, because that is a thing
+      // people do on purpose. One that leaves is a 404, indistinguishable from
+      // a file that is not there — which is what it should look like.
+      const opened = await realpathOrNull(candidate);
+      if (opened == null || (opened !== root && !opened.startsWith(root + path.sep))) {
+        continue;
+      }
       const headers = {
         "content-type":
           CONTENT_TYPES[path.extname(candidate).toLowerCase()] ?? "application/octet-stream",
@@ -304,6 +327,21 @@ function decodePathname(pathname: string): string | null {
     return decoded.includes("\0") ? null : decoded;
   } catch {
     // A percent escape that is not one. There is no file behind it.
+    return null;
+  }
+}
+
+/**
+ * `fs.realpath`, or `null` when the path cannot be resolved.
+ *
+ * A broken symlink, a component that is not a directory, or a permission the
+ * process does not have all end here — and all of them mean the same thing to
+ * the caller: this is not a file to serve.
+ */
+async function realpathOrNull(file: string): Promise<string | null> {
+  try {
+    return await realpath(file);
+  } catch {
     return null;
   }
 }

--- a/tests/library/serve.test.js
+++ b/tests/library/serve.test.js
@@ -247,6 +247,34 @@ describe("the static handler", () => {
     }
   });
 
+  /**
+   * ubugeeei-prod/uf#550: the containment check was textual, so a path that
+   * read as inside the root opened a file outside it.
+   *
+   * `dist/` is written by the build, but `public/` is copied verbatim from
+   * whatever the author — or a dependency's install script — put there. The
+   * same shape as the tarball traversals in `docs/security.md`, at the serving
+   * end rather than the extraction end.
+   */
+  it("refuses a symlink that leaves the root, and serves one that does not", async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "uf-outside-"));
+    fs.writeFileSync(path.join(outside, "secret.txt"), "the private key");
+
+    const root = directoryWith({ "inside.txt": "public", "deep/target.txt": "also public" });
+    fs.symlinkSync(path.join(outside, "secret.txt"), path.join(root, "escape.txt"));
+    fs.symlinkSync(path.join(root, "deep/target.txt"), path.join(root, "stays.txt"));
+    const serveStatic = createStaticHandler({ root });
+
+    expect(await serveStatic(request("/escape.txt"))).toBe(null);
+    // Indistinguishable from a file that is not there, which is what it should
+    // look like: a 404 that differed would say whether the target exists.
+    expect(await serveStatic(request("/nothing-at-all.txt"))).toBe(null);
+    // A link that stays inside still works, because that is a thing people do
+    // on purpose.
+    expect(await (await serveStatic(request("/stays.txt")))?.text()).toBe("also public");
+    expect(await (await serveStatic(request("/inside.txt")))?.text()).toBe("public");
+  });
+
   it("declines a path that is not a file, so the application can render it", async () => {
     const serveStatic = createStaticHandler({ root: directoryWith({}) });
     expect(await serveStatic(request("/posts/hello"))).toBe(null);


### PR DESCRIPTION
Closes #550. Files #551, #552, #553.

`docs/security.md` was a list of structural decisions — good ones, but all in one direction. This adds the other: the published failures of the two frameworks uf is closest to, each asked of uf's own code, with the answer and the file to verify it in.

## What was already answered, and answered well

| Their failure | uf |
| --- | --- |
| **CVE-2025-29927** — Next.js middleware bypassed by a header the framework used to talk to itself | No request header steers control flow anywhere in the request path. The only one read is `Host`, and it sets the URL's authority rather than skipping a layer. There is no internal channel to forge because uf passes none |
| **CVE-2024-34351** — server-action SSRF through a forged `Host` | Three independent refusals: a `uf-action` header (not a simple request, so it needs a preflight nothing answers), `application/json` (which no `<form>` can produce), and `Origin` equal to `Host`. `Origin: null` refused rather than matched; `X-Forwarded-Host` never consulted |
| **CVE-2023-46298** — a personalised SSR response cached and served to everybody | Stores nothing that read the request, nothing carrying `Set-Cookie`, nothing that is not a 200 — and the request-read test spans the whole render, so a component inside a `<Suspense>` boundary counts as much as the shell |
| **CVE-2025-32421** — cache confusion between a page and its data route | No parallel data route to confuse it with |
| Absolute URLs from a forged `Host`, then cached | `metadataBase` is site-wide, not per-request. A route module cannot see the host it is served from, so there is nothing per-request to poison |

## What was not

Static serving did the containment check the right way round — decode, refuse NUL, `path.resolve`, then require the result to be under the root. That defeats `../`, encoded `../` and a NUL truncation. It does not defeat a **symlink**: the path is textually inside, `stat` follows the link, and the bytes come from wherever it points.

`dist/` is written by the build. `public/` is copied verbatim from whatever the author — or a dependency's install script — put there.

The file that is opened is now realpath'd and required to be inside the realpath'd root. A link that leaves is a `404`, indistinguishable from a file that is not there; a link that stays inside still works, because that is a thing people do on purpose. The root is realpath'd too, and once — otherwise every macOS `/tmp` checkout would fail its own test.

The test plants both links and **fails without the fix** (verified: `19 passed, 1 failed` with the check removed, `20 passed` with it).

## Supply chain, on the same terms

A second table, and three of its rows say "not answered yet" with an issue number:

- **#551** — `install.sh` verifies a SHA-256 it downloads from the same host as the archive. That catches a truncated download; it does not catch whoever owns the host. Integrity without origin, which is the xz shape.
- **#552** — npm publishes provenance attestations and uf reads none. An integrity hash says the bytes are what uf resolved, not that they came from the source the package claims.
- **#553** — a scope cannot be bound to a registry, so a private name has nothing stopping a public answer.

The rows that say "not answered yet" are the point of both tables. A list where every row says "handled" is a list nobody checked.

## Verified

`uf test tests/library` 1,952 passed / 0 failed / 1 skipped, `uf lint` at the same 14 warnings, `uf fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791371983&installation_model_id=422833&pr_number=556&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F556&signature=731cb643c557b0fb7d3811378b34ae904f532eb5d0bdb65cdae11efa57343b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->