### PR TITLE
docs(security): the threat model's rows are inside its table again

### DIFF
--- a/tests/library/docs-tables.test.js
+++ b/tests/library/docs-tables.test.js
@@ -1,0 +1,136 @@
+// @flow
+//
+// Every Markdown table row in the repository is inside a table.
+//
+// `docs/security.md` is a document made of tables: a row is a threat, the
+// decision that answers it, and the test that holds the decision — and its own
+// preamble says a row whose test does not exist yet is marked `todo` and is a
+// work item rather than a claim. So a row that has fallen out of its table is
+// not a formatting nit. It renders as a line of text with pipes in it, the
+// header that gave its three cells their meaning is gone, and the work item
+// stops being visible as one.
+//
+// That is what happened: #473 inserted two `###` prose sections into the
+// middle of the "Framework, RSC, and server actions" table, and the three rows
+// after them were left below the prose — orphaned, and one of them a stale
+// duplicate of a row the table already carried in its finished form.
+//
+// The check is structural rather than about that document: a run of lines
+// beginning with `|` has to open with a header row and a delimiter row.
+// Fenced code blocks are skipped, because a fence may legitimately contain a
+// pipe table as an example of one.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "@uniflowed/test";
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Directories that are not this repository's prose. */
+const SKIP = new Set(["node_modules", "dist", ".uf", "target", "upstream", ".git", "coverage"]);
+
+/** Every Markdown and MDX file the repository owns. */
+function documents(): Array<string> {
+  const found = [];
+  const walk = (dir: string) => {
+    for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (item.isDirectory()) {
+        if (!SKIP.has(item.name)) {
+          walk(path.join(dir, item.name));
+        }
+      } else if (item.name.endsWith(".md") || item.name.endsWith(".mdx")) {
+        found.push(path.join(dir, item.name));
+      }
+    }
+  };
+  walk(REPO);
+  return found;
+}
+
+/** `| --- | --- |`, in any of the alignment spellings. */
+const DELIMITER = /^\|[\s:|-]+\|\s*$/;
+
+/**
+ * Every run of table rows in one file that does not open with a header and a
+ * delimiter, as `{ line, text }` — the line number of the run's first row and
+ * enough of it to recognise.
+ */
+function orphanedRuns(file: string): Array<{ line: number, text: string }> {
+  const lines = fs.readFileSync(file, "utf8").split("\n");
+  const orphaned = [];
+  let run: Array<string> = [];
+  let startedAt = 0;
+  let fenced = false;
+  const close = () => {
+    if (run.length > 0 && (run.length < 2 || !DELIMITER.test(run[1]))) {
+      orphaned.push({ line: startedAt, text: run[0].slice(0, 80) });
+    }
+    run = [];
+  };
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trimStart().startsWith("```")) {
+      close();
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced) {
+      continue;
+    }
+    if (line.startsWith("|")) {
+      if (run.length === 0) {
+        startedAt = index + 1;
+      }
+      run.push(line);
+    } else {
+      close();
+    }
+  }
+  close();
+  return orphaned;
+}
+
+describe("the repository's Markdown tables", () => {
+  it("has some to check", () => {
+    // A walk that found nothing would pass every case below without looking at
+    // anything, which is the failure mode a structural check like this has.
+    expect(documents().length).toBeGreaterThan(20);
+  });
+
+  it("opens every run of table rows with a header and a delimiter", () => {
+    const orphaned = [];
+    for (const file of documents()) {
+      for (const run of orphanedRuns(file)) {
+        orphaned.push(`${path.relative(REPO, file)}:${run.line} ${run.text}`);
+      }
+    }
+    expect(orphaned).toEqual([]);
+  });
+
+  it("recognises an orphan when there is one", () => {
+    // The check has to be able to fail, and the document that motivated it is
+    // fixed — so the positive case is synthetic. It is written outside the
+    // repository on purpose: a fixture with an orphaned row *in* `docs/` would
+    // be found by the case above, and a run killed between writing and
+    // removing it would leave the suite failing for a file it wrote itself.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "uf-docs-tables-"));
+    const file = path.join(dir, "orphan.md");
+    fs.writeFileSync(
+      file,
+      ["| a | b |", "| --- | --- |", "| 1 | 2 |", "", "prose", "", "| 3 | 4 |", ""].join("\n"),
+    );
+    try {
+      expect(orphanedRuns(file)).toEqual([{ line: 7, text: "| 3 | 4 |" }]);
+      // And a fenced table is not one: a code block may show a table as an
+      // example of one.
+      const fenced = path.join(dir, "fenced.md");
+      fs.writeFileSync(fenced, ["```md", "| 3 | 4 |", "```", ""].join("\n"));
+      expect(orphanedRuns(fenced)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/library/docs-tables.test.js
+++ b/tests/library/docs-tables.test.js
@@ -50,8 +50,15 @@ function documents(): Array<string> {
   return found;
 }
 
-/** `| --- | --- |`, in any of the alignment spellings. */
-const DELIMITER = /^\|[\s:|-]+\|\s*$/;
+/**
+ * `| --- | --- |`, in any of the alignment spellings.
+ *
+ * Every cell has to contain a hyphen: a character class alone would accept
+ * `| : |` and `|   |`, which GitHub does not render as a table at all — so the
+ * check would call a run of pipes a table and pass over exactly the shape it
+ * exists to catch.
+ */
+const DELIMITER = /^\|(?:\s*:?-+:?\s*\|)+\s*$/;
 
 /**
  * Every run of table rows in one file that does not open with a header and a
@@ -72,7 +79,9 @@ function orphanedRuns(file: string): Array<{ line: number, text: string }> {
   };
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (line.trimStart().startsWith("```")) {
+    // Both fence spellings. CommonMark allows `~~~` as well as backticks, and
+    // a document that used it would have its examples read as real tables.
+    if (line.trimStart().startsWith("```") || line.trimStart().startsWith("~~~")) {
       close();
       fenced = !fenced;
       continue;
@@ -129,6 +138,14 @@ describe("the repository's Markdown tables", () => {
       const fenced = path.join(dir, "fenced.md");
       fs.writeFileSync(fenced, ["```md", "| 3 | 4 |", "```", ""].join("\n"));
       expect(orphanedRuns(fenced)).toEqual([]);
+      const tilde = path.join(dir, "tilde.md");
+      fs.writeFileSync(tilde, ["~~~md", "| 3 | 4 |", "~~~", ""].join("\n"));
+      expect(orphanedRuns(tilde)).toEqual([]);
+      // And a delimiter row with no hyphen is not a delimiter row: GitHub
+      // renders this as three lines of text, not a table.
+      const colonly = path.join(dir, "colon.md");
+      fs.writeFileSync(colonly, ["| a | b |", "| : | : |", "| 1 | 2 |", ""].join("\n"));
+      expect(orphanedRuns(colonly)).toEqual([{ line: 1, text: "| a | b |" }]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
`docs/security.md`'s preamble says what a row is:

> A row whose test does not exist on `main` yet is marked `todo`; that row is a
> work item, not a claim.

#473 inserted `### The argument boundary` and `### A server action authorizes
itself` into the middle of the "Framework, RSC, and server actions" table, and
the three rows that had been below them stayed below them — seventy lines of
prose away from their header, rendering as a paragraph with pipes in it. With
no header, the third column stops saying `todo` to a reader, and three work
items stop being visible as work items.

One of the three was also **stale**. #563 landed the real answer to
CVE-2026-44578 and put it in the table:

> uf has no proxying upgrade, and the one it does have cannot become one:
> `upgradeWebSocket(request)` upgrades the *inbound* connection … — `tests/library/transports.test.js`

while the orphaned copy still claimed *"Upgrade targets are resolved against an
allowlist"* and still said `todo`. That row is removed rather than moved; the
other two go back into the table.

## The test

`tests/library/docs-tables.test.js` states the invariant structurally rather
than about this one document: over every `.md` and `.mdx` in the repository, a
run of lines beginning with `|` opens with a header row and a delimiter row.
Fenced code blocks are skipped — a fence may legitimately show a table as an
example of one, and there is a case for that.

The synthetic positive case is written to a temporary directory rather than to
`tests/library/fixtures/`: a fixture containing an orphaned row would be found
by the case above it, and a run killed between writing and removing it would
leave the suite failing for a file it wrote itself.

Scanned over the whole repository, the check found exactly one offender — the
one this fixes.

## Verification

```
uf test tests/library/docs-tables.test.js   3 passed
  … with docs/security.md reverted:         2 passed, 1 failed
uf test#library                             2181 passed, 0 failed, 1 skipped
uf fmt --check                              exit 0
uf lint                                     exit 0
```

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791387208&installation_model_id=422833&pr_number=592&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F592&signature=67753d698b645b571b0482183ab976acab68e8a31ae2965e53fb385f9d02d4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation by consolidating threat-model entries and clarifying WebSocket upgrade behavior.
  * Corrected the associated security test reference.

* **Tests**
  * Added automated checks to verify that Markdown tables include valid headers and separators.
  * Added coverage for detecting orphaned table rows while ignoring fenced code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->