### PR TITLE
chore(release): uf@0.0.0-alpha.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,86 @@
 # Changelog
 
+## uf@0.0.0-alpha.13
+
+_2026-09-08_
+
+The pipeline stops merging things it did not check. Every job in `ci.yml`
+depends on `Toolchain`, and a job whose dependency fails is not run — it is
+*skipped*, which GitHub counts as a required check being satisfied. So a
+`main` that did not compile was merged on 2026-09-06 with five green ticks,
+and again on 2026-09-07. The gate job that fails unless every job actually
+succeeded is now a required context, and `ci:gate` checks the gate itself:
+a job added to the pipeline and left out of the gate's `needs:` is refused by
+name, because a hand-maintained list of what to check is the same shape as the
+bug it was written to fix.
+
+Bun runs. `@uniflowed/host`'s preload returned `undefined` from Bun's
+`onLoad`, which Bun rejects, so no Bun project could load it at all — and the
+naive repair breaks every CommonJS dependency, because anything leaving
+`onLoad` is an ES module and there is no value that means "not mine". The
+filter carries the policy now, which also closed a divergence nobody could
+see: the hand-written list never gained `.cjs`, so Bun and Node disagreed
+about which files were Flow. There is a test that starts a real Bun process
+against the real binary, which is the first time any Bun claim in this
+repository was checked rather than asserted. The answer caches are bounded
+too — `transform` had reached 767 entries and was growing by about 330 a
+build, with nothing that ever removed one.
+
+A server action is not the only thing a browser can reach any more: `QUERY`,
+server-sent events, an upgrade a handler can accept, and a queue; OAuth as a
+contract rather than a provider; and a logger whose request id reaches a
+render. The router streams its loaders instead of awaiting them, keeps the
+site around a 404, and understands parallel and intercepting routes. A
+message's arguments are in its type. And `uf release` can no longer lose a
+commit whose subject carries no pull request number, or rewrite a changelog
+section that has already been published — both of which had happened.
+
+### Added
+
+- **ui, temporal**: the sets adopt the positioner, and the grid it does not fit (#597)
+- **server**: OAuth as a contract, and a logger with a request id a render can read (#585)
+- **hooks, router**: the address bar, and a hydration error that names the node (#582)
+- **router**: a wrapper that remounts, and two spellings refused by name (#472)
+- **i18n**: the arguments a message takes, in the type (#567)
+- **router, docs**: a navigation that is a transition, and the rest of what a page says about itself (#546)
+- **fmt**: the formatter's own options, without uf re-declaring any of them (#577)
+- **server**: QUERY, event streams, an upgrade a handler can accept, and a queue (#563)
+- **router**: the loader streams, the head is a head, and a 404 keeps the site (#566)
+- **ui**: groups in a combobox, a drag on a splitter, and the claim nobody was holding (#558)
+- **web**: the five numbers a page is judged on, read from the browser (#555)
+- **run**: a task graph, a concurrency limit, and a cache keyed on declared inputs (#466)
+- **rsc**: a `"use server"` export the browser can call (#473)
+- **temporal, web, hooks**: Temporal on every host, and the two values a render has to fix (#554)
+- **pm**: `uf approve-builds`, and the sentence npm gets instead (#545)
+- **pm**: `uf update` reports what the ranges hold back, and rewrites them (#541)
+- **cell, state**: state and derived, and no way back to cell and computed (#544)
+- **env**: one .uf, and the toolchain links out of the project (#539)
+
+### Fixed
+
+- **release**: a commit with no pull request number, and a binary older than the tree (#589)
+- **host, infra**: a bound on the answer caches, and a Bun host that runs (#594)
+- **test, query**: a stub that does not outlive its file, and a clock the collection test owns (#579)
+- **project**: a file git is told to ignore is not the project's to format (#576)
+- **lint**: a property key is a key however its variance is written (#572)
+- **react-testing, test**: an accessible name, a summary, and two surfaces that were any (#571)
+- **server, docs**: a symlink cannot leave a served directory, and the CVE (#556)
+- **lint**: four false positives, and the line scanner behind the worst of them (#548)
+- **release**: `verify-npm` failed a release that had worked (#538)
+- **release**: `promote-latest` handed npm the plan file as stdin (#537)
+
+### Documentation
+
+- **config**: a condition rather than a count, and a key that does not promise what it does not do (#578)
+
+### Internal
+
+- **gate**: the gate that covers every job, checked rather than trusted (#590)
+
+### Other
+
+- Update GitHub Sponsors username in FUNDING.yml
+
 ## uf@0.0.0-alpha.12
 
 _2026-09-07_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_assets"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "base64",
  "brotli",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "base64",
  "brotli",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "serde",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "serde",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "criterion",
  "phf",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "compact_str",
  "serde",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "serde",
  "smallvec",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "uf_task"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "base64",
  "camino",
@@ -3803,14 +3803,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "camino",
  "compact_str",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.12"
+version = "0.0.0-alpha.13"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.12",
-    "@uniflowed/config": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12",
-    "@uniflowed/router": "0.0.0-alpha.12",
-    "@uniflowed/vite": "0.0.0-alpha.12",
-    "@uniflowed/web": "0.0.0-alpha.12",
+    "@uniflowed/brand": "0.0.0-alpha.13",
+    "@uniflowed/config": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13",
+    "@uniflowed/router": "0.0.0-alpha.13",
+    "@uniflowed/vite": "0.0.0-alpha.13",
+    "@uniflowed/web": "0.0.0-alpha.13",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.12",
-        "@uniflowed/config": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12",
-        "@uniflowed/router": "0.0.0-alpha.12",
-        "@uniflowed/vite": "0.0.0-alpha.12",
-        "@uniflowed/web": "0.0.0-alpha.12",
+        "@uniflowed/brand": "0.0.0-alpha.13",
+        "@uniflowed/config": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13",
+        "@uniflowed/router": "0.0.0-alpha.13",
+        "@uniflowed/vite": "0.0.0-alpha.13",
+        "@uniflowed/web": "0.0.0-alpha.13",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -4381,64 +4381,64 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.12",
-        "@uniflowed/test": "0.0.0-alpha.12"
+        "@uniflowed/config": "0.0.0-alpha.13",
+        "@uniflowed/test": "0.0.0-alpha.13"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.12",
-        "@uniflowed/validator": "0.0.0-alpha.12"
+        "@uniflowed/react": "0.0.0-alpha.13",
+        "@uniflowed/validator": "0.0.0-alpha.13"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4446,10 +4446,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.12"
+        "@uniflowed/fetch": "0.0.0-alpha.13"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4457,19 +4457,19 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4477,120 +4477,120 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/i18n": {
       "name": "@uniflowed/i18n",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.12",
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/fetch": "0.0.0-alpha.12"
+        "@uniflowed/cell": "0.0.0-alpha.13",
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/fetch": "0.0.0-alpha.13"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.12",
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/config": "0.0.0-alpha.13",
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/hooks": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4598,7 +4598,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4606,28 +4606,28 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12",
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4637,7 +4637,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4646,19 +4646,19 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.12",
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/config": "0.0.0-alpha.13",
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/server": "0.0.0-alpha.12"
+        "@uniflowed/server": "0.0.0-alpha.13"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4667,46 +4667,46 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/cell": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12",
-        "@uniflowed/react-testing": "0.0.0-alpha.12",
-        "@uniflowed/test": "0.0.0-alpha.12"
+        "@uniflowed/mock": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13",
+        "@uniflowed/react-testing": "0.0.0-alpha.13",
+        "@uniflowed/test": "0.0.0-alpha.13"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4714,54 +4714,54 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.12"
+        "@uniflowed/host": "0.0.0-alpha.13"
       }
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.12",
-        "@uniflowed/test": "0.0.0-alpha.12"
+        "@uniflowed/react-testing": "0.0.0-alpha.13",
+        "@uniflowed/test": "0.0.0-alpha.13"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.12",
+        "@uniflowed/react": "0.0.0-alpha.13",
         "react-reconciler": "^0.33.0"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/hooks": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/hooks": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4769,18 +4769,18 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.12",
-        "@uniflowed/server": "0.0.0-alpha.12",
+        "@uniflowed/host": "0.0.0-alpha.13",
+        "@uniflowed/server": "0.0.0-alpha.13",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4795,21 +4795,21 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.12",
-        "@uniflowed/core": "0.0.0-alpha.12"
+        "@uniflowed/browser": "0.0.0-alpha.13",
+        "@uniflowed/core": "0.0.0-alpha.13"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.12",
+      "version": "0.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.12",
-        "@uniflowed/hooks": "0.0.0-alpha.12",
-        "@uniflowed/react": "0.0.0-alpha.12"
+        "@uniflowed/core": "0.0.0-alpha.13",
+        "@uniflowed/hooks": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.13"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Fine-grained reactivity: state, derived values, effects and resources, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "temporal.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.12",
-    "@uniflowed/test": "0.0.0-alpha.12"
+    "@uniflowed/config": "0.0.0-alpha.13",
+    "@uniflowed/test": "0.0.0-alpha.13"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "stream.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -25,8 +25,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.12",
-    "@uniflowed/validator": "0.0.0-alpha.12"
+    "@uniflowed/react": "0.0.0-alpha.13",
+    "@uniflowed/validator": "0.0.0-alpha.13"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.12"
+    "@uniflowed/fetch": "0.0.0-alpha.13"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,8 +27,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/i18n",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Type-safe internationalisation on MessageFormat 2: a message's arguments are checked at the call, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/cell": "0.0.0-alpha.12",
-    "@uniflowed/fetch": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/cell": "0.0.0-alpha.13",
+    "@uniflowed/fetch": "0.0.0-alpha.13"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.12",
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/config": "0.0.0-alpha.13",
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/hooks": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12",
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.12",
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/config": "0.0.0-alpha.13",
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -33,6 +33,6 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/server": "0.0.0-alpha.12"
+    "@uniflowed/server": "0.0.0-alpha.13"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -42,6 +42,6 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/cell": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,10 +22,10 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12",
-    "@uniflowed/react-testing": "0.0.0-alpha.12",
-    "@uniflowed/test": "0.0.0-alpha.12"
+    "@uniflowed/mock": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13",
+    "@uniflowed/react-testing": "0.0.0-alpha.13",
+    "@uniflowed/test": "0.0.0-alpha.13"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.12"
+    "@uniflowed/host": "0.0.0-alpha.13"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.12",
-    "@uniflowed/test": "0.0.0-alpha.12"
+    "@uniflowed/react-testing": "0.0.0-alpha.13",
+    "@uniflowed/test": "0.0.0-alpha.13"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "A React renderer whose host is a terminal, following OpenTUI, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.12",
+    "@uniflowed/react": "0.0.0-alpha.13",
     "react-reconciler": "^0.33.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -50,9 +50,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/hooks": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/hooks": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -25,8 +25,8 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.12",
-    "@uniflowed/server": "0.0.0-alpha.12",
+    "@uniflowed/host": "0.0.0-alpha.13",
+    "@uniflowed/server": "0.0.0-alpha.13",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.12",
-    "@uniflowed/core": "0.0.0-alpha.12"
+    "@uniflowed/browser": "0.0.0-alpha.13",
+    "@uniflowed/core": "0.0.0-alpha.13"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.0-alpha.13",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,8 +23,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.12",
-    "@uniflowed/hooks": "0.0.0-alpha.12",
-    "@uniflowed/react": "0.0.0-alpha.12"
+    "@uniflowed/core": "0.0.0-alpha.13",
+    "@uniflowed/hooks": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.13"
   }
 }


### PR DESCRIPTION
Thirty-one changes since `uf@0.0.0-alpha.12`, cut with the release tooling that
landed in this same range — so this is also the first release where the
changelog is written by a binary that cannot lose a commit or overwrite a
published section.

`uf release alpha` reported the one commit in the range carrying no pull
request number:

```
! 1 commit in the range carries no pull request number; nothing downstream can find it by one
    - Update GitHub Sponsors username in FUNDING.yml
```

That is #443 working. Before it, that commit was in the tarball and in nobody's
notes, and the check reported full coverage.

## What is in it

- **The pipeline stops merging things it did not check** (#590, and `CI` added
  to `main`'s required contexts). A job whose dependency fails reports
  `skipped`, and GitHub counts a skipped required check as satisfied — which
  merged a `main` that did not compile, twice.
- **Bun runs** (#594). The preload returned `undefined` from `onLoad`, which
  Bun rejects, so no Bun project could load it; the obvious repair breaks every
  CommonJS dependency. Also the first test that starts a real Bun process
  against the real binary, and a bound on the answer caches, which had reached
  767 entries and were growing by ~330 a build with nothing removing any.
- **The server grew transports and contracts** — `QUERY`, event streams, an
  upgrade a handler can accept and a queue (#563); OAuth as a contract (#585).
- **The router** streams loaders (#566), keeps the site around a 404, handles
  parallel and intercepting routes (#472), and treats navigation as a
  transition (#546).
- **Typed message arguments** for i18n (#567), **web vitals** read from the
  browser (#555), **hydration errors that name the node** (#582), and the ui
  package's **positioner and date grid** (#597).

## Verification

Run in the release worktree with the binary built from this branch's base:

```
uf run release:changelog        exit 0
uf run release:changelog:test   exit 0
uf run lockfile                 exit 0
uf run manifests                exit 0
uf run release:closure          exit 0
uf run publishable              exit 0
uf run scripts:parse            exit 0
cargo metadata --locked         exit 0
```

## After this merges

The tag is what publishes: `uf@0.0.0-alpha.13` pushed to this repository runs
`release.yml` for the four target binaries and `publish.yml` for npm. Moving
the `latest` dist-tag stays a person's step — npm exchanges the workflow's
id-token for `npm publish` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791398029&installation_model_id=422833&pr_number=600&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F600&signature=29aeb32bb95dcc4f87ba22a7481522e5967626393852d7349702844fa62807a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->