### PR TITLE
fix(prepare, lint, test): a path a run names survives `.gitignore`

### DIFF
--- a/crates/uf_cli/src/commands/prepare.rs
+++ b/crates/uf_cli/src/commands/prepare.rs
@@ -585,6 +585,26 @@ impl Run<'_> {
             || self.generated.iter().any(|file| file.path == relative_path)
     }
 
+    /// The paths discovery is asked about by name: the staged set and this
+    /// run's generated files.
+    ///
+    /// Empty when there is no staged set, because that is the "check
+    /// everything" case and naming nothing is what widens the walk back to the
+    /// whole project. It is a list of exact paths, never a prefix, so it can
+    /// only ever *add* the files [`Self::checks`] was going to keep anyway —
+    /// it cannot widen the set the checks run over.
+    fn named_paths(&self) -> Vec<String> {
+        let staged = match &self.staged {
+            StagedFiles::Staged(files) => files.as_slice(),
+            StagedFiles::Unavailable(_) => &[],
+        };
+        staged
+            .iter()
+            .map(compact_str::CompactString::to_string)
+            .chain(self.generated.iter().map(|file| file.path.to_string()))
+            .collect()
+    }
+
     /// Why a check step had nothing to read.
     fn nothing_to_check(&self, verb: &str) -> String {
         if self.staged.is_empty_index() {
@@ -615,17 +635,20 @@ impl Run<'_> {
         if self.staged.is_empty_index() && self.generated.is_empty() {
             return Ok(());
         }
-        // The generated files by name, because they are exactly the files a
-        // project tells git to ignore — `router.js` is in this repository's own
-        // `.gitignore` — and a discovery walk that honours `.gitignore` would
-        // not find them. Naming a path is asking about it; see
-        // `uf_project::scan_selected_source_files`. Without this, `uf prepare`
-        // generated two files and then silently checked neither.
-        let named: Vec<String> = self
-            .generated
-            .iter()
-            .map(|file| file.path.to_string())
-            .collect();
+        // The staged and generated files by name, because both are files a
+        // project can legitimately tell git to ignore while this run still has
+        // to read them, and a discovery walk that honours `.gitignore` would
+        // not offer either. Naming a path is asking about it; see
+        // `uf_project::scan_selected_source_files`.
+        //
+        // * The generated ones — `router.js` is in this repository's own
+        //   `.gitignore` — because without them `uf prepare` wrote two files
+        //   and then silently checked neither.
+        // * The staged ones because git stops applying `.gitignore` to a path
+        //   the moment that path is in the index. A force-added file is as
+        //   much a part of the commit as any other, and dropping it excluded
+        //   from the checks the one file the commit is about.
+        let named = self.named_paths();
         let mut scan =
             scan_selected_source_files(&self.resolved.root, &self.resolved.config, &named)?;
         scan.unreadable

--- a/crates/uf_cli/src/commands/test.rs
+++ b/crates/uf_cli/src/commands/test.rs
@@ -21,7 +21,7 @@ use anyhow::{Context, Result, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use uf_config::env_files::ProjectEnv;
 use uf_config::load_config;
-use uf_project::{ProjectFile, scan_source_files};
+use uf_project::{ProjectFile, scan_selected_source_files};
 use uf_term::PhaseTimer;
 use uf_test::{
     Bail, Concurrency, FileStatus, HostCommand, HostKind, LockedObserver, NativeTestRunnerPlan,
@@ -139,7 +139,11 @@ pub(crate) fn test(cwd: &Utf8Path, ui: &mut Ui, args: TestArgs) -> Result<()> {
 
     let resolved = load_config(cwd)?;
     let root = resolved.root.clone();
-    let scan = scan_source_files(&root, &resolved.config)?;
+    // Named paths override `.gitignore`, as they do for `uf lint` and
+    // `uf fmt`: a suite that writes its fixture into an ignored directory —
+    // `tests/library/module-mock.test.js` does, so a killed run leaves nothing
+    // behind — still has to be runnable by name.
+    let scan = scan_selected_source_files(&root, &resolved.config, &args.paths)?;
     let unreadable = unreadable_lines(&scan.unreadable);
     let files = scan.files;
     // Before anything is run. A file uf could not read might have been a test,

--- a/crates/uf_cli/src/commands/test/watch.rs
+++ b/crates/uf_cli/src/commands/test/watch.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 use camino::Utf8Path;
 use uf_config::UniflowedConfig;
 use uf_config::env_files::ProjectEnv;
-use uf_project::{ProjectFile, scan_source_files};
+use uf_project::{ProjectFile, scan_selected_source_files};
 use uf_term::{PhaseTimer, Status};
 use uf_test::{ImportGraph, TestFilter, Watcher};
 
@@ -53,7 +53,9 @@ pub(super) fn watch(
     // not read, so a watch session either began without any or is about to be
     // told about one it did not have before. Either way it keeps watching:
     // exiting a watch loop because somebody saved a binary is hostile.
-    let mut files = scan_source_files(root, &config)?.files;
+    // The paths this session was started with, so a watch narrowed to a
+    // directory `.gitignore` names sees the same files the one-shot run does.
+    let mut files = scan_selected_source_files(root, &config, &args.paths)?.files;
     // Resolved once: a watch session that lost its host between runs would be
     // reporting a different failure than the one the user is editing towards.
     // Resolved once, with the environment the session started with: a watch
@@ -80,7 +82,7 @@ pub(super) fn watch(
             continue;
         }
 
-        let refreshed = scan_source_files(root, &config)?.files;
+        let refreshed = scan_selected_source_files(root, &config, &args.paths)?.files;
         let moved = changed_paths(&files, &refreshed);
         files = refreshed;
         prime(&mut watcher, &files);

--- a/crates/uf_cli/src/fix/files.rs
+++ b/crates/uf_cli/src/fix/files.rs
@@ -39,7 +39,7 @@ use anyhow::{Context, Result};
 use camino::Utf8Path;
 use uf_config::{ResolvedConfig, load_config};
 use uf_lint::{LintError, LintReport, SourceFile, lint_source};
-use uf_project::{ProjectFile, scan_source_files};
+use uf_project::{ProjectFile, scan_selected_source_files};
 
 use super::{FORMATTED_AWAY, Safety, apply, fix_for, plan};
 use crate::support::selects;
@@ -103,7 +103,11 @@ pub(crate) struct FixSummary {
 /// what `uf lint` would say if they ran it themselves.
 pub(crate) fn fix_project(cwd: &Utf8Path, paths: &[String], mode: FixMode) -> Result<FixSummary> {
     let resolved = load_config(cwd)?;
-    let scan = scan_source_files(&resolved.root, &resolved.config)?;
+    // The same discovery `uf lint` runs, told the same paths: a `.gitignore`d
+    // file that was named is reported by the report this run prints
+    // afterwards, so a fix pass that could not see it would print a diagnostic
+    // it had silently declined to fix.
+    let scan = scan_selected_source_files(&resolved.root, &resolved.config, paths)?;
     let mut files: Vec<ProjectFile> = scan
         .files
         .into_iter()

--- a/crates/uf_cli/tests/prepare.rs
+++ b/crates/uf_cli/tests/prepare.rs
@@ -244,6 +244,32 @@ fn a_generation_failure_stops_the_run_and_the_record_says_which_steps_never_ran(
     );
 }
 
+/// A staged file `.gitignore` names is still checked.
+///
+/// git stops applying `.gitignore` to a path the moment that path is in the
+/// index, so a force-added file is as much a part of the commit as any other.
+/// Discovery reads `.gitignore` now (ubugeeei-prod/uf#483), and a run that let
+/// it narrow the staged set would have skipped the one file the commit is
+/// about while reporting "no problems" — a hook that passes because it never
+/// opened the file is worse than no hook.
+#[test]
+fn a_staged_file_the_gitignore_names_is_still_checked() {
+    let dir = a_repository();
+    fs::write(dir.path().join("ignored.js"), LINTS_BADLY).expect("a file with a lint error");
+    let gitignore = dir.path().join(".gitignore");
+    let scaffolded = fs::read_to_string(&gitignore).expect("the scaffold's .gitignore");
+    fs::write(&gitignore, format!("{scaffolded}ignored.js\n")).expect("a .gitignore naming it");
+    git(dir.path(), &["add", "--force", "ignored.js"]);
+
+    let (code, stdout, stderr) = run(dir.path(), &["prepare"]);
+
+    assert_eq!(code, FOUND_A_PROBLEM, "{stdout}{stderr}");
+    assert!(
+        stdout.contains("security/no-eval"),
+        "the staged file was not linted:\n{stdout}"
+    );
+}
+
 /// A project with server actions: the types are written, and they are checked.
 ///
 /// `server-actions.js` and `router.js` are git-ignored in a scaffolded project,


### PR DESCRIPTION
Closes #599.

#576 taught project discovery to read `.gitignore` (closing #483) and gave `uf prepare` its generated files by name, because a scaffolded project ignores `router.js` and `server-actions.js` and the walk had stopped offering them. This is the other half: the four call sites that narrow discovery to a set of paths were still reading `scan_source_files`, the walk that can no longer offer an ignored path to anybody.

## The staged set

git stops applying `.gitignore` to a path the moment that path is in the index. That is not a corner of git, it is the rule — `.gitignore` decides what gets *added*, and a force-added file is as much a part of the commit as any other. `git status` shows it, `git diff --cached` shows it, the commit contains it.

`uf prepare` narrowed by the walk rather than by the index, so it skipped exactly that file and then reported no problems, about the one file the commit was about. A hook that passes because it never opened the file is worse than no hook: it is a signature on work that was never inspected, and nothing on screen says a path was skipped.

`a_staged_file_the_gitignore_names_is_still_checked` is the regression test — a scaffolded repository, a file with a `security/no-eval` error, that filename appended to the `.gitignore`, `git add --force`. Reverting `prepare.rs` on this merged tree and running it gives what the issue reports:

```
  ✓ discover-staged-files         1 staged file
      - ignored.js
  ✓ generate-router-types         wrote router.js
  · generate-server-action-types  this project declares no server actions
  ✓ run-lint                      1 file checked, no problems
  ✓ run-format-check              0 files of 1 need formatting

✓ prepare passed
```

Exit 0, with `ignored.js` named on one line and "no problems" three lines later — the one file it checked was `router.js`, which this run had just written and named for itself.

## The three other callers

Same walk, same drop, on paths the user typed:

- **`fix_project`.** The fix pass read the unselected walk while the report printed afterwards comes from linting again — and `uf lint` reads named paths. So `uf lint --fix src/wasm` printed a diagnostic in a file it had silently declined to fix, with the two halves of one command disagreeing about which files exist.
- **`uf test <paths>`.** A named path a `.gitignore` covers was not in the scan, so the run called a real file a typo. A suite that writes its fixture into an ignored directory — so a killed run leaves nothing behind — could not be run by name.
- **Watch mode** rescans on every change, and now rescans with the paths its session was started with, so it agrees with the one-shot run it follows rather than drifting from it after the first save.

## Nothing widens

`named_paths` is a list of exact paths, never a prefix, so it can only ever *add* files the run was already about — it cannot widen the set the checks run over. With no staged set the list is empty, and naming nothing is what keeps the walk at the whole project: that is the "check everything" case, and it still is. `uf prepare` on a tree with an unstaged ignored file still ignores it, so #483 does not regress.

The comment in `Run::scan` was rewritten rather than extended, because naming paths now has two reasons and one of them is not "these files are generated".

## Verified

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test -p uf_cli`: every suite green — lib 304, `cli` 66, `prepare` 16 (was 15), `lint_fix` 13, `testing` 29, `every_command` 13 — except the six in `tests/vite.rs` that `panic`ked with "this test needs a loopback socket and could not bind one: Operation not permitted". That is this sandbox refusing to bind loopback; they fail on `main` here too and go nowhere near this change.
- `cargo build --release --bin uf`, then against this workspace: `uf fmt --check` says every file is already formatted, and `uf lint` exits 0 at the same 14 warnings #576 reported — so nothing that was being checked stopped being checked, and nothing that was not started.
- `uf test#library` on node 24: 2431 passed, 1 failed — `standalone.test.js:410`, `expected 2 to be 1` on the socket-drain pull count, which is #593. It passes when that file is run on its own, and `packages/server` is not in this diff.

Merged `main` (835f107, #597) in before the run, so all of that is on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791398530&installation_model_id=422833&pr_number=601&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F601&signature=a74f3ba26cc9c6438d41fa677cf31bf2e7f6d56de5433c04bf7006fb62f80548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->