### PR TITLE
feat(lint, hooks, router, state): an effect that is not one, a memo the compiler already did, and a literal that was never conditional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,12 +3620,14 @@ dependencies = [
  "criterion",
  "phf",
  "serde",
+ "serde_json",
  "thiserror",
  "uf_config",
  "uf_flow",
  "uf_infra",
  "uf_react_compiler",
  "uf_router",
+ "uf_transform",
 ]
 
 [[package]]

--- a/crates/uf_cli/src/fix.rs
+++ b/crates/uf_cli/src/fix.rs
@@ -95,9 +95,21 @@
 //!   directive has to land before the first *statement* but after the docblock
 //!   comment that carries `@flow`, and finding that line means re-running the
 //!   comment scanner that `uf_lint` owns.
-//! - `security/*`, `fetch/no-global-override`, `react/*`,
+//! - `security/*`, `fetch/no-global-override`, most of `react/*`,
 //!   `uniflowed/no-npm-script-invocation` — these ask for a different design,
 //!   not a different spelling.
+//!
+//! # The two rules whose fix is waiting on a shape
+//!
+//! `react/no-derived-state-effect` and `react/no-redundant-memo` are the first
+//! rules here whose rewrite *is* mechanical and still cannot be spelled as a
+//! [`Fix`]. Both edits span lines and statements — deleting an effect and a
+//! `useState` and leaving one `const` behind, or unwrapping a call whose
+//! argument is a multi-line arrow — and both need text taken from the file
+//! rather than a `&'static str`. [`Fix`] is one line and one constant by
+//! design, and widening it is a change to `--fix`, `--fix-unsafe`, `uf
+//! prepare` and the editor's code actions all at once. It is the change the
+//! comment on [`Fix`] anticipates; it is not this catalogue growing a row.
 //!
 //! # Two fixes that touch the same bytes
 //!

--- a/crates/uf_config/src/lint.rs
+++ b/crates/uf_config/src/lint.rs
@@ -69,7 +69,7 @@ pub enum FlowLintParser {
 /// Each rule's full rationale, category, and one-line description live on its
 /// `uf_lint::RuleDescriptor`; `uf_lint` has a test asserting this table and that
 /// catalogue agree exactly, in both directions, so the two cannot drift apart.
-const DEFAULT_LINT_RULES: [(&str, RuleLevel); 54] = [
+const DEFAULT_LINT_RULES: [(&str, RuleLevel); 56] = [
     // --- Flow built-in lints ------------------------------------------------
     // Exactness must be stated, not inferred from a config flag.
     // Off: the ambiguity is gone. Flow has been exact-by-default since 2023 and
@@ -151,6 +151,23 @@ const DEFAULT_LINT_RULES: [(&str, RuleLevel); 54] = [
     ("react/hooks-rules", RuleLevel::Error),
     // Framework routes are wired by name; `warn` while the scaffold migrates.
     ("react/no-default-export-component", RuleLevel::Warn),
+    // An effect whose whole body writes state computed from its own
+    // dependencies. `error`, because the code is wrong rather than untidy: the
+    // component renders once with the value it had before the effect ran, and
+    // then again, so a user sees the stale one — and the fix is to move the
+    // expression into render, which is mechanical. The rule reports only the
+    // shape where that move is provably safe; `uf_lint::runner::react_tree`
+    // lists what it leaves alone and why.
+    ("react/no-derived-state-effect", RuleLevel::Error),
+    // A `useMemo`/`useCallback` the official React Compiler removed when it
+    // compiled the function around it. `warn`, not `error`: nothing is broken
+    // — the compiler already did the work, so the hand-written call is a
+    // second dependency array to keep correct rather than a defect — and
+    // deleting memoization is a refactor, which is not something a build
+    // should fail over. Off when `app.builtins.reactCompiler.enabled` is
+    // false, because then the hand-written one is the only memoization there
+    // is.
+    ("react/no-redundant-memo", RuleLevel::Warn),
     // Non-idempotent render breaks streaming SSR and hydration.
     ("react/no-render-side-effects", RuleLevel::Error),
     // Platform branches are a preference, not a correctness problem.

--- a/crates/uf_lint/Cargo.toml
+++ b/crates/uf_lint/Cargo.toml
@@ -14,8 +14,10 @@ uf_flow = { path = "../uf_flow" }
 uf_infra = { path = "../uf_infra" }
 uf_react_compiler = { path = "../uf_react_compiler" }
 uf_router = { path = "../uf_router" }
+uf_transform = { path = "../uf_transform" }
 phf.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/uf_lint/src/lib.rs
+++ b/crates/uf_lint/src/lib.rs
@@ -44,7 +44,7 @@ use crate::runner::{
     run_flow_unsafe_object_assign, run_no_npm_script_invocation, run_no_tabs,
     run_no_trailing_whitespace, run_package_no_npm_scripts, run_react_compiler_rules,
     run_react_component_syntax, run_react_hook_syntax, run_react_native_platform_split,
-    run_react_no_default_export_component, run_router_reserved_files,
+    run_react_no_default_export_component, run_react_tree_rules, run_router_reserved_files,
     run_router_unsupported_segment, run_security_no_dangerously_set_inner_html,
     run_security_no_eval, run_server_no_client_secret, run_server_no_server_only_import_in_client,
     run_server_use_client_directive_position, run_server_use_server_actions, run_structure_rules,
@@ -241,6 +241,7 @@ fn lint_file(file: &SourceFile, config: &UniflowedConfig) -> Result<Vec<Diagnost
     run_react_no_default_export_component(&scan, config, &mut diagnostics);
     run_react_compiler_rules(&scan, config, &mut diagnostics);
     run_react_native_platform_split(&scan, config, &mut diagnostics);
+    run_react_tree_rules(&scan, config, &mut diagnostics);
     run_structure_rules(&scan, config, &mut diagnostics);
 
     run_server_no_client_secret(&scan, config, &mut diagnostics);

--- a/crates/uf_lint/src/rules/framework.rs
+++ b/crates/uf_lint/src/rules/framework.rs
@@ -67,6 +67,13 @@ pub(crate) static OWN_RULES: &[RuleDescriptor] = &[
         requirement: SourceText,
         description: "call hooks only at the top level of a component, hook, or `useX` function",
     },
+    RuleDescriptor {
+        id: "react/no-derived-state-effect",
+        category: RuleCategory::React,
+        default_level: RuleLevel::Error,
+        requirement: SourceText,
+        description: "compute state derived from props or state during render, not in an effect",
+    },
     // `warn`, not `error`, for the same reason as `react/component-syntax`: this
     // is a convention the ecosystem (and uf's own `uf create app` scaffold) is
     // still migrating to, and a linter must not fail a freshly created project.
@@ -77,6 +84,13 @@ pub(crate) static OWN_RULES: &[RuleDescriptor] = &[
         default_level: RuleLevel::Warn,
         requirement: SourceText,
         description: "modules that declare components must use named exports",
+    },
+    RuleDescriptor {
+        id: "react/no-redundant-memo",
+        category: RuleCategory::React,
+        default_level: RuleLevel::Warn,
+        requirement: SourceText,
+        description: "drop a `useMemo`/`useCallback` the React Compiler already did",
     },
     RuleDescriptor {
         id: "react/no-render-side-effects",

--- a/crates/uf_lint/src/runner.rs
+++ b/crates/uf_lint/src/runner.rs
@@ -14,6 +14,7 @@ mod package;
 mod react;
 mod react_compiler;
 mod react_native;
+mod react_tree;
 mod router;
 mod security;
 mod server;
@@ -40,6 +41,7 @@ pub(crate) use react::{
 };
 pub(crate) use react_compiler::run_react_compiler_rules;
 pub(crate) use react_native::run_react_native_platform_split;
+pub(crate) use react_tree::run_react_tree_rules;
 pub(crate) use router::{run_router_reserved_files, run_router_unsupported_segment};
 pub(crate) use security::{run_security_no_dangerously_set_inner_html, run_security_no_eval};
 pub(crate) use server::{

--- a/crates/uf_lint/src/runner/flow_syntax.rs
+++ b/crates/uf_lint/src/runner/flow_syntax.rs
@@ -42,7 +42,7 @@ pub(crate) fn run_flow_syntax(
 /// the product, so a file ending in `.flow` is someone else's convention and
 /// parsing it would report syntax errors against declaration syntax uf never
 /// emits.
-fn is_flow_syntax_target(path: &str) -> bool {
+pub(super) fn is_flow_syntax_target(path: &str) -> bool {
     path.ends_with(".js")
         || path.ends_with(".jsx")
         || path.ends_with(".mjs")

--- a/crates/uf_lint/src/runner/react_tree.rs
+++ b/crates/uf_lint/src/runner/react_tree.rs
@@ -1,0 +1,767 @@
+//! The two `react/*` rules that read the module's tree rather than its lines.
+//!
+//! Every other rule in this crate answers its question from [`FileScan`] — a
+//! line, its code, the brace depth it opens at. These two cannot:
+//!
+//! * `react/no-derived-state-effect` has to know that a name is a `useState`
+//!   setter declared in the same render function, that an effect's body is one
+//!   statement and not two, and that every name in the value it stores is in
+//!   the effect's dependency array. A line scanner can see none of that.
+//! * `react/no-redundant-memo` has to know what the **official React Compiler**
+//!   did with the module, which is not a question about the source text at all.
+//!   [`uf_transform::memo`] holds that answer; this runner reports it.
+//!
+//! So both go through `uf_transform`: the official Flow parser, Flow's own
+//! lowering rules, and Babel's AST shape — the same three stages `uf build`
+//! runs, so the tree the linter reads is the tree the compiler is given.
+//!
+//! # What this costs, and when it is paid
+//!
+//! Parsing a module again is far more work than a line scan, and compiling one
+//! is more again. Four gates stand in front of it, in order of cheapness:
+//!
+//! 1. Neither rule is enabled — nothing runs.
+//! 2. The path is not Flow source — nothing runs.
+//! 3. The text holds no `useEffect`, `useMemo` or `useCallback` — nothing runs.
+//!    A module without one of those words cannot violate either rule.
+//! 4. The module is nested or chained past [`uf_flow`]'s parser ceilings —
+//!    nothing runs, because `flow/syntax` has already refused it and a linter
+//!    must not be the thing that overflows a stack on a minified bundle.
+//!
+//! Past those, the parse happens on a thread of
+//! [`PARSE_STACK_BYTES`](uf_flow::PARSE_STACK_BYTES), for the reason
+//! `uf_flow::upstream` spells out: the port's frames are large, the tree is
+//! freed where it was built, and a lint worker's own stack is not enough.
+
+use serde_json::Value;
+use uf_config::UniflowedConfig;
+use uf_infra::{FxHashMap, FxHashSet};
+use uf_transform::{ReactCompilerMode, TransformOptions};
+
+use crate::scan::FileScan;
+use crate::{Diagnostic, push_at, severity};
+
+/// `react/no-derived-state-effect`.
+const DERIVED_STATE: &str = "react/no-derived-state-effect";
+
+/// `react/no-redundant-memo`.
+const REDUNDANT_MEMO: &str = "react/no-redundant-memo";
+
+/// The effect hooks this rule reads.
+///
+/// `useEffect` only. `useLayoutEffect` is where measuring the DOM belongs, and
+/// a measurement is exactly the shape this rule must not move into render.
+const EFFECT: &str = "useEffect";
+
+/// Report the rules that need the module's tree.
+pub(crate) fn run_react_tree_rules(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let derived = severity(config, DERIVED_STATE);
+    // A project that has turned the compiler off gets no report: without it,
+    // a hand-written `useMemo` is the only memoization there is.
+    let memo = config
+        .app
+        .builtins
+        .react_compiler
+        .enabled
+        .then(|| severity(config, REDUNDANT_MEMO))
+        .flatten();
+    if derived.is_none() && memo.is_none() {
+        return;
+    }
+    if !super::flow_syntax::is_flow_syntax_target(&scan.file.path) {
+        return;
+    }
+
+    let source = &scan.file.source;
+    let wants_effects = derived.is_some() && source.contains(EFFECT);
+    let wants_memo =
+        memo.is_some() && (source.contains("useMemo") || source.contains("useCallback"));
+    if !wants_effects && !wants_memo {
+        return;
+    }
+
+    // The same ceilings `uf_flow::upstream` applies before it parses. A module
+    // over one of them has already been reported by `flow/syntax`; reaching
+    // for the parser again would only be a slower way to overflow.
+    let depths = uf_flow::depths(source);
+    if source.len() > uf_flow::MAX_PARSE_BYTES
+        || depths.brackets > uf_flow::MAX_NESTING_DEPTH
+        || depths.chain > uf_flow::MAX_CHAIN_DEPTH
+    {
+        return;
+    }
+
+    let Some(found) = analyse(scan, config, wants_effects, wants_memo) else {
+        return;
+    };
+
+    for finding in found {
+        let rule = match finding.kind {
+            FindingKind::DerivedState => DERIVED_STATE,
+            FindingKind::RedundantMemo => REDUNDANT_MEMO,
+        };
+        let level = match finding.kind {
+            FindingKind::DerivedState => derived,
+            FindingKind::RedundantMemo => memo,
+        };
+        let Some(index) = usize::try_from(finding.line)
+            .ok()
+            .and_then(|line| line.checked_sub(1))
+        else {
+            continue;
+        };
+        let (Some(level), Some(line)) = (level, scan.lines.get(index)) else {
+            continue;
+        };
+        // The AST counts columns in UTF-16 code units and a diagnostic carries
+        // bytes, so the conversion reads the line out of the *unmasked* source:
+        // `mask_inline_comments` replaces a comment byte for byte, which keeps
+        // every offset but not every character.
+        let text = source
+            .get(line.offset..line.offset + line.text.len())
+            .unwrap_or(line.text);
+        push_at(
+            diagnostics,
+            scan,
+            rule,
+            level,
+            index,
+            byte_column(text, finding.column),
+            finding.message,
+        );
+    }
+}
+
+/// Which rule a finding belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FindingKind {
+    DerivedState,
+    RedundantMemo,
+}
+
+/// One finding, positioned the way the tree positions things.
+struct TreeFinding {
+    kind: FindingKind,
+    /// 1-based line.
+    line: u32,
+    /// 0-based column, in UTF-16 code units.
+    column: u32,
+    message: String,
+}
+
+/// Parse the module and run whichever of the two rules was asked for.
+///
+/// [`None`] when the module could not be parsed or lowered — `flow/syntax`
+/// reports the first and the build reports the second, and a rule that cannot
+/// see the tree has nothing to say about it.
+fn analyse(
+    scan: &FileScan<'_>,
+    config: &UniflowedConfig,
+    wants_effects: bool,
+    wants_memo: bool,
+) -> Option<Vec<TreeFinding>> {
+    let source = &scan.file.source;
+    let options = TransformOptions {
+        react_compiler: compiler_mode(config),
+        ..TransformOptions::new(scan.file.path.clone())
+    };
+
+    let work = || {
+        let (file, _) = uf_transform::babel_ast(source).ok()?;
+        let mut found = Vec::new();
+        if wants_effects {
+            found.extend(derived_state_effects(&file));
+        }
+        // An error here is a bug in uf rather than in the module — the tree
+        // did not fit the compiler's own schema — and it says nothing about
+        // the effects the other rule already found, so it costs that rule
+        // nothing.
+        if wants_memo
+            && let Ok(redundant) = uf_transform::redundant_memoization(&file, source, &options)
+        {
+            found.extend(redundant.into_iter().map(|memo| TreeFinding {
+                kind: FindingKind::RedundantMemo,
+                line: memo.line,
+                column: memo.column,
+                message: format!(
+                    "the React Compiler memoizes this already; `{}` here is a second dependency array to keep correct",
+                    memo.hook
+                ),
+            }));
+        }
+        Some(found)
+    };
+
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .stack_size(uf_flow::PARSE_STACK_BYTES)
+            .spawn_scoped(scope, work)
+            .ok()?
+            .join()
+            .ok()?
+    })
+}
+
+/// The mode uf would compile this project's modules in.
+///
+/// A `match` rather than a default, so that a mode added to `uf.config.js`
+/// cannot reach the compiler here under the wrong name: `uf lint` and
+/// `uf build` have to ask the compiler the same question.
+fn compiler_mode(config: &UniflowedConfig) -> ReactCompilerMode {
+    match config.app.builtins.react_compiler.mode {
+        uf_config::ReactCompilerMode::Syntax => ReactCompilerMode::Syntax,
+    }
+}
+
+/// Byte offset within `line` of the `column`-th UTF-16 code unit.
+fn byte_column(line: &str, column: u32) -> usize {
+    let mut units = 0u32;
+    for (offset, character) in line.char_indices() {
+        if units >= column {
+            return offset;
+        }
+        units += u32::try_from(character.len_utf16()).unwrap_or(u32::MAX);
+    }
+    line.len()
+}
+
+// --- react/no-derived-state-effect -----------------------------------------
+
+/// Every effect in `file` whose whole body is one write of state derived from
+/// its own dependencies.
+///
+/// # What is reported
+///
+/// All of these have to hold, and the list is short because each item removes
+/// a way the rule could be wrong:
+///
+/// * the call is `useEffect`, with exactly two arguments;
+/// * the first is an arrow with no parameters and no `async`;
+/// * its body is exactly one expression statement — so there is no cleanup to
+///   return, and nothing else the effect also does;
+/// * that expression calls a setter destructured from a `useState` in an
+///   enclosing function, with exactly one argument;
+/// * the second argument is a non-empty array of plain identifiers;
+/// * the argument to the setter is built from those identifiers, literals and
+///   operators, and mentions at least one of them.
+///
+/// The last condition is what makes the value computable during render: an
+/// expression over the effect's own dependencies, with no call and no property
+/// read in it, is total and pure, and React's ["You Might Not Need an
+/// Effect"](https://react.dev/learn/you-might-not-need-an-effect) is about
+/// exactly that shape.
+///
+/// # What is deliberately not reported
+///
+/// * **A property read.** `setItems(data.items)` and `setWidth(box.offsetWidth)`
+///   are the same three tokens, and the first belongs in render while the
+///   second must not go there — a layout read during render is a bug uf's own
+///   `react/no-render-side-effects` exists to catch. The source text does not
+///   say which is which, so the rule stops here rather than guessing.
+/// * **A call.** `setSorted(items.slice().sort())` may be pure and may not be;
+///   nothing in the tree says.
+/// * **A reset to a constant.** `setSelection(null)` on `[items]` is the
+///   article's *other* shape, and its fix — a `key`, or a comparison against
+///   the previous prop — is a redesign rather than moving one expression, so
+///   it is not something a rule at `error` should insist on.
+/// * **An effect with no dependency array, or an empty one.** Neither derives
+///   anything from anything.
+/// * **`useLayoutEffect`.** That is where measuring belongs.
+/// * **A setter that is not a `useState` binding.** `onChange(value)` is a
+///   prop being called, which is what an effect is *for*.
+/// * **A value the state itself feeds.** When a dependency is computed, through
+///   however many bindings, from the state this effect writes, the render-time
+///   rewrite is `const x = f(x)` — a circular definition, not a simpler
+///   program. `@uniflowed/hooks`' `useTimeAgo` is one: the schedule it stores
+///   chooses the clock whose tick decides the next schedule, and the effect is
+///   what breaks that cycle across renders. See [`SetterScope::feeds_back`].
+fn derived_state_effects(file: &Value) -> Vec<TreeFinding> {
+    let scopes = setter_scopes(file);
+    let mut found = Vec::new();
+    let mut pending = vec![file];
+
+    while let Some(node) = pending.pop() {
+        match node {
+            Value::Array(items) => pending.extend(items),
+            Value::Object(map) => {
+                if let Some(at) = derived_state_effect(node, &scopes) {
+                    found.push(TreeFinding {
+                        kind: FindingKind::DerivedState,
+                        line: at.0,
+                        column: at.1,
+                        message: String::from(
+                            "this effect only stores a value derived from its dependencies; compute it during render instead",
+                        ),
+                    });
+                }
+                pending.extend(map.values());
+            }
+            _ => {}
+        }
+    }
+
+    found.sort_by_key(|finding| (finding.line, finding.column));
+    found
+}
+
+/// One `useState` binding: `const [value, setValue] = useState(…)`.
+///
+/// `value` is [`None`] when the first element is not a plain identifier —
+/// `const [, setValue]` is written on purpose when nothing reads the state, and
+/// the feedback test below has nothing to look for then.
+struct StateBinding {
+    value: Option<String>,
+    setter: String,
+}
+
+/// One function body: the `useState` bindings declared directly in it, and what
+/// every binding declared anywhere in it reads.
+struct SetterScope {
+    start: u64,
+    end: u64,
+    state: Vec<StateBinding>,
+    /// Name of a binding declared in this body, to the names its initialiser
+    /// reads. The edges of the graph [`SetterScope::feeds_back`] searches.
+    reads: FxHashMap<String, Vec<String>>,
+}
+
+impl SetterScope {
+    /// The binding `setter` writes, when this body declares one.
+    fn binding(&self, setter: &str) -> Option<&StateBinding> {
+        self.state.iter().find(|held| held.setter == setter)
+    }
+
+    /// Whether `state` is what any of `deps` is ultimately computed from.
+    ///
+    /// A walk over [`SetterScope::reads`] rather than a name comparison,
+    /// because the dependency is rarely the state itself: `@uniflowed/hooks`'
+    /// `useTimeAgo` stores a schedule, the schedule chooses a tick, the tick
+    /// drives a clock, and the clock's reading is what the effect stores back.
+    /// Only the last of those four is the effect's dependency, and the cycle is
+    /// the reason the effect has to exist — moving the expression into render
+    /// would define the value in terms of itself.
+    ///
+    /// Over-connected on purpose: an identifier that merely *appears* in an
+    /// initialiser counts as read, so a spurious edge costs a report the rule
+    /// would otherwise make and never a report it should not. That is the right
+    /// direction for a rule at `error`.
+    fn feeds_back<'a>(&'a self, deps: &[&'a str], state: &str) -> bool {
+        let mut seen: FxHashSet<&str> = FxHashSet::default();
+        let mut pending: Vec<&str> = deps.to_vec();
+
+        while let Some(name) = pending.pop() {
+            if name == state {
+                return true;
+            }
+            if !seen.insert(name) {
+                continue;
+            }
+            if let Some(reads) = self.reads.get(name) {
+                pending.extend(reads.iter().map(String::as_str));
+            }
+        }
+
+        false
+    }
+}
+
+/// Node types whose `body` is a function body.
+const FUNCTIONS: [&str; 5] = [
+    "ArrowFunctionExpression",
+    "ClassMethod",
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "ObjectMethod",
+];
+
+/// Every function in `file` that declares a `useState` setter, with the span
+/// the setter is in scope over.
+///
+/// The `useState` bindings are read from the statements *directly* in the body,
+/// which is not a shortcut: the rules of hooks put every `useState` there, and
+/// a `setX` bound anywhere else is not a state setter this rule may assume
+/// anything about. The reads graph is collected from the whole body, because a
+/// binding declared inside a block still closes the cycle the graph is there to
+/// find.
+fn setter_scopes(file: &Value) -> Vec<SetterScope> {
+    let mut scopes = Vec::new();
+    let mut pending = vec![file];
+
+    while let Some(node) = pending.pop() {
+        match node {
+            Value::Array(items) => pending.extend(items),
+            Value::Object(map) => {
+                if let Some(node_type) = map.get("type").and_then(Value::as_str)
+                    && FUNCTIONS.contains(&node_type)
+                    && let (Some(start), Some(end)) = (span_start(node), span_end(node))
+                {
+                    let body = map.get("body");
+                    let state = declared_state(body);
+                    if !state.is_empty() {
+                        scopes.push(SetterScope {
+                            start,
+                            end,
+                            state,
+                            reads: declared_reads(body),
+                        });
+                    }
+                }
+                pending.extend(map.values());
+            }
+            _ => {}
+        }
+    }
+
+    scopes
+}
+
+/// The `useState` bindings a block statement's own declarations make.
+fn declared_state(body: Option<&Value>) -> Vec<StateBinding> {
+    let mut state = Vec::new();
+    let Some(statements) = body
+        .filter(|body| body.get("type").and_then(Value::as_str) == Some("BlockStatement"))
+        .and_then(|body| body.get("body"))
+        .and_then(Value::as_array)
+    else {
+        return state;
+    };
+
+    for statement in statements {
+        if statement.get("type").and_then(Value::as_str) != Some("VariableDeclaration") {
+            continue;
+        }
+        let Some(declarators) = statement.get("declarations").and_then(Value::as_array) else {
+            continue;
+        };
+        for declarator in declarators {
+            if !calls_hook(declarator.get("init"), "useState") {
+                continue;
+            }
+            let id = declarator.get("id");
+            if id.and_then(|id| id.get("type")).and_then(Value::as_str) != Some("ArrayPattern") {
+                continue;
+            }
+            // `const [value, setValue] = useState(…)`: the setter is the
+            // second element, and only the second.
+            let element = |at: usize| {
+                id.and_then(|id| id.get("elements"))
+                    .and_then(Value::as_array)
+                    .and_then(|elements| elements.get(at))
+                    .and_then(identifier_name)
+            };
+            if let Some(setter) = element(1) {
+                state.push(StateBinding {
+                    value: element(0).map(str::to_owned),
+                    setter: setter.to_owned(),
+                });
+            }
+        }
+    }
+
+    state
+}
+
+/// Every binding declared anywhere in `body`, and the names its initialiser
+/// reads.
+///
+/// A name declared twice keeps the union of both initialisers' reads, which is
+/// the conservative answer: shadowing is not tracked, so a scope that redeclares
+/// a name is read as if either initialiser could be the one that matters.
+fn declared_reads(body: Option<&Value>) -> FxHashMap<String, Vec<String>> {
+    let mut reads: FxHashMap<String, Vec<String>> = FxHashMap::default();
+    let mut pending = match body {
+        Some(body) => vec![body],
+        None => return reads,
+    };
+
+    while let Some(node) = pending.pop() {
+        match node {
+            Value::Array(items) => pending.extend(items),
+            Value::Object(map) => {
+                if map.get("type").and_then(Value::as_str) == Some("VariableDeclarator")
+                    && let Some(id) = map.get("id")
+                {
+                    let mut bound = Vec::new();
+                    identifiers_in(id, &mut bound);
+                    let mut initialiser = Vec::new();
+                    if let Some(init) = map.get("init") {
+                        identifiers_in(init, &mut initialiser);
+                    }
+                    for name in bound {
+                        reads
+                            .entry(name.to_owned())
+                            .or_default()
+                            .extend(initialiser.iter().map(|read| (*read).to_owned()));
+                    }
+                }
+                pending.extend(map.values());
+            }
+            _ => {}
+        }
+    }
+
+    reads
+}
+
+/// Every identifier `node` reads, appended to `out`.
+///
+/// Property names are not reads: `now.getTime()` reads `now`, and counting
+/// `getTime` would join two bindings that only share a method name. Object
+/// literal keys are skipped for the same reason.
+///
+/// Iterative, like the other walks here, because the depth of the tree is the
+/// module author's to choose.
+fn identifiers_in<'a>(node: &'a Value, out: &mut Vec<&'a str>) {
+    let mut pending = vec![node];
+
+    while let Some(node) = pending.pop() {
+        match node {
+            Value::Array(items) => pending.extend(items),
+            Value::Object(map) => {
+                if let Some(name) = identifier_name(node) {
+                    out.push(name);
+                    continue;
+                }
+                let key_is_a_name = map.get("computed") != Some(&Value::Bool(true));
+                let skipped = match map.get("type").and_then(Value::as_str) {
+                    Some("MemberExpression" | "OptionalMemberExpression") if key_is_a_name => {
+                        "property"
+                    }
+                    Some("ObjectProperty" | "ObjectMethod" | "ClassMethod") if key_is_a_name => {
+                        "key"
+                    }
+                    _ => "",
+                };
+                pending.extend(
+                    map.iter()
+                        .filter(|(field, _)| field.as_str() != skipped)
+                        .map(|(_, child)| child),
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Whether `node` is a call to `hook`, written bare or under `React.`.
+fn calls_hook(node: Option<&Value>, hook: &str) -> bool {
+    let Some(node) =
+        node.filter(|node| node.get("type").and_then(Value::as_str) == Some("CallExpression"))
+    else {
+        return false;
+    };
+    let Some(callee) = node.get("callee") else {
+        return false;
+    };
+    match callee.get("type").and_then(Value::as_str) {
+        Some("Identifier") => identifier_name(callee) == Some(hook),
+        Some("MemberExpression") if callee.get("computed") != Some(&Value::Bool(true)) => {
+            callee.get("object").and_then(identifier_name) == Some("React")
+                && callee.get("property").and_then(identifier_name) == Some(hook)
+        }
+        _ => false,
+    }
+}
+
+/// The position of a derived-state effect's `useEffect`, when `node` is one.
+fn derived_state_effect(node: &Value, scopes: &[SetterScope]) -> Option<(u32, u32)> {
+    if node.get("type").and_then(Value::as_str)? != "CallExpression" {
+        return None;
+    }
+    if !calls_hook(Some(node), EFFECT) {
+        return None;
+    }
+    let arguments = node.get("arguments").and_then(Value::as_array)?;
+    let [effect, dependencies] = arguments.as_slice() else {
+        return None;
+    };
+
+    // `() => …`, and nothing that takes a parameter or awaits.
+    if effect.get("type").and_then(Value::as_str)? != "ArrowFunctionExpression"
+        || !effect
+            .get("params")
+            .and_then(Value::as_array)
+            .is_some_and(|params| params.is_empty())
+        || effect.get("async") == Some(&Value::Bool(true))
+    {
+        return None;
+    }
+
+    let deps = dependency_names(dependencies)?;
+    let call = effect_body(effect.get("body")?)?;
+    if call.get("type").and_then(Value::as_str)? != "CallExpression" {
+        return None;
+    }
+
+    // The setter has to be a `useState` binding of a function this call
+    // stands inside. A name that is merely spelled `setX` is not one: it may
+    // be a prop, a store action, or a helper, and calling one of those from an
+    // effect is what an effect is for.
+    //
+    // The innermost enclosing declaration wins, because that is the one the
+    // name resolves to: two components in a module may each bind `setValue`,
+    // and only one of them holds this effect.
+    let setter = call.get("callee").and_then(identifier_name)?;
+    let start = span_start(node)?;
+    let scope = scopes
+        .iter()
+        .filter(|scope| {
+            scope.start <= start && start <= scope.end && scope.binding(setter).is_some()
+        })
+        .min_by_key(|scope| scope.end - scope.start)?;
+
+    let [value] = call.get("arguments").and_then(Value::as_array)?.as_slice() else {
+        return None;
+    };
+    if !derives_from(value, &deps) {
+        return None;
+    }
+
+    // A dependency the state itself feeds: the render-time rewrite would be
+    // circular, so the effect is the design rather than a mistake.
+    if let Some(state) = scope.binding(setter).and_then(|held| held.value.as_deref())
+        && scope.feeds_back(&deps, state)
+    {
+        return None;
+    }
+
+    let at = node.get("callee")?.get("loc")?.get("start")?;
+    Some((
+        u32::try_from(at.get("line")?.as_u64()?).ok()?,
+        u32::try_from(at.get("column")?.as_u64()?).ok()?,
+    ))
+}
+
+/// The single expression an effect's body evaluates, if that is all it does.
+///
+/// A block of one expression statement, or an arrow with a concise body.
+/// Anything longer is an effect that also does something else, and anything
+/// that returns is an effect with a cleanup.
+fn effect_body(body: &Value) -> Option<&Value> {
+    if body.get("type").and_then(Value::as_str)? != "BlockStatement" {
+        return Some(body);
+    }
+    let [statement] = body.get("body").and_then(Value::as_array)?.as_slice() else {
+        return None;
+    };
+    if statement.get("type").and_then(Value::as_str)? != "ExpressionStatement" {
+        return None;
+    }
+    statement.get("expression")
+}
+
+/// The names in a dependency array, when every element is a plain identifier.
+///
+/// [`None`] for an empty array, a missing one, or one holding anything else —
+/// `[data.id]` says the effect re-runs on the *field*, which is a different
+/// claim from "derived from `data`", and the rule does not make claims it
+/// cannot check.
+fn dependency_names(node: &Value) -> Option<Vec<&str>> {
+    if node.get("type").and_then(Value::as_str)? != "ArrayExpression" {
+        return None;
+    }
+    let elements = node.get("elements").and_then(Value::as_array)?;
+    if elements.is_empty() {
+        return None;
+    }
+    elements.iter().map(identifier_name).collect()
+}
+
+/// Expression node types that are pure however they are combined.
+const PURE_LITERALS: [&str; 6] = [
+    "BigIntLiteral",
+    "BooleanLiteral",
+    "NullLiteral",
+    "NumericLiteral",
+    "RegExpLiteral",
+    "StringLiteral",
+];
+
+/// Unary operators that read their operand and nothing else.
+///
+/// `delete` is not here: it writes.
+const PURE_UNARY: [&str; 6] = ["!", "+", "-", "typeof", "void", "~"];
+
+/// Whether `value` is an expression over `deps` that render could compute.
+///
+/// True only when every leaf is either a literal or one of `deps`, every node
+/// between them is an operator, and at least one dependency is actually read —
+/// a constant is not derived from anything.
+fn derives_from(value: &Value, deps: &[&str]) -> bool {
+    let mut mentions = false;
+    let mut pending = vec![value];
+
+    while let Some(node) = pending.pop() {
+        let Some(node_type) = node.get("type").and_then(Value::as_str) else {
+            return false;
+        };
+        if PURE_LITERALS.contains(&node_type) {
+            continue;
+        }
+        match node_type {
+            "Identifier" => match identifier_name(node) {
+                Some(name) if deps.contains(&name) => mentions = true,
+                _ => return false,
+            },
+            "TemplateLiteral" => match node.get("expressions").and_then(Value::as_array) {
+                Some(expressions) => pending.extend(expressions),
+                None => return false,
+            },
+            "BinaryExpression" | "LogicalExpression" => {
+                match (node.get("left"), node.get("right")) {
+                    (Some(left), Some(right)) => pending.extend([left, right]),
+                    _ => return false,
+                }
+            }
+            "ConditionalExpression" => {
+                match (
+                    node.get("test"),
+                    node.get("consequent"),
+                    node.get("alternate"),
+                ) {
+                    (Some(test), Some(consequent), Some(alternate)) => {
+                        pending.extend([test, consequent, alternate]);
+                    }
+                    _ => return false,
+                }
+            }
+            "UnaryExpression" => {
+                let operator = node.get("operator").and_then(Value::as_str);
+                match (
+                    operator.is_some_and(|op| PURE_UNARY.contains(&op)),
+                    node.get("argument"),
+                ) {
+                    (true, Some(argument)) => pending.push(argument),
+                    _ => return false,
+                }
+            }
+            "ParenthesizedExpression" => match node.get("expression") {
+                Some(expression) => pending.push(expression),
+                None => return false,
+            },
+            _ => return false,
+        }
+    }
+
+    mentions
+}
+
+/// The name of an `Identifier` node.
+fn identifier_name(node: &Value) -> Option<&str> {
+    if node.get("type").and_then(Value::as_str)? != "Identifier" {
+        return None;
+    }
+    node.get("name")?.as_str()
+}
+
+fn span_start(node: &Value) -> Option<u64> {
+    node.get("start")?.as_u64()
+}
+
+fn span_end(node: &Value) -> Option<u64> {
+    node.get("end")?.as_u64()
+}

--- a/crates/uf_lint/src/tests.rs
+++ b/crates/uf_lint/src/tests.rs
@@ -16,6 +16,7 @@ mod input;
 mod package;
 mod react;
 mod react_native;
+mod react_tree;
 mod router;
 mod security;
 mod server;

--- a/crates/uf_lint/src/tests/react.rs
+++ b/crates/uf_lint/src/tests/react.rs
@@ -214,3 +214,31 @@ fn a_default_export_outside_a_template_is_still_this_modules() {
 
     assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
 }
+
+/// ubugeeei-prod/uf#477: a hook called in an object literal is not a
+/// conditional call.
+///
+/// The reproduction from the issue, reported through `uf lint` rather than
+/// through the validator, because that is where a reader met it: ten store
+/// selections gathered into one object gave ten errors, in a rule a project
+/// cannot switch off on its own.
+#[test]
+fn hooks_rules_accepts_a_hook_called_in_an_object_literal() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\nimport { useState } from \"react\";\n\nexport hook useThing(): { a: number, b: number } {\n  const bag = {\n    a: useState(0)[0],\n    b: useState(1)[0],\n  };\n\n  return bag;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+/// And the same literal inside a condition is still a conditional call.
+#[test]
+fn hooks_rules_still_rejects_an_object_literal_built_conditionally() {
+    let diagnostics = lint_js(
+        "react/hooks-rules",
+        "// @flow\nimport { useState } from \"react\";\n\nexport hook useThing(flag: boolean): { a: number } | null {\n  if (flag) {\n    return { a: useState(0)[0] };\n  }\n  return null;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+}

--- a/crates/uf_lint/src/tests/react_tree.rs
+++ b/crates/uf_lint/src/tests/react_tree.rs
@@ -1,0 +1,360 @@
+//! The two `react/*` rules that read the module's tree: the effect that should
+//! not be an effect, and the memoization the React Compiler already did.
+//!
+//! Every rule here is tested from both sides. A linter is only as useful as the
+//! reports a reader can act on, so a fixture that must fire is worth exactly as
+//! much as one that must not.
+
+use super::*;
+
+const DERIVED_STATE: &str = "react/no-derived-state-effect";
+const REDUNDANT_MEMO: &str = "react/no-redundant-memo";
+
+/// A module that imports the hooks it uses, so each fixture is a real module.
+fn module(body: &str) -> String {
+    format!(
+        "// @flow\nimport {{useCallback, useEffect, useLayoutEffect, useMemo, useState}} from \"react\";\n\n{body}"
+    )
+}
+
+fn derived(body: &str) -> Vec<Diagnostic> {
+    lint_js(DERIVED_STATE, &module(body))
+}
+
+fn memo(body: &str) -> Vec<Diagnostic> {
+    lint_js(REDUNDANT_MEMO, &module(body))
+}
+
+// --- react/no-derived-state-effect: what it reports -------------------------
+
+#[test]
+fn an_effect_that_only_stores_a_value_built_from_its_dependencies_is_reported() {
+    // React's own opening example in "You Might Not Need an Effect".
+    let diagnostics = derived(
+        "component Name(first: string, last: string) {\n  const [full, setFull] = useState(\"\");\n  useEffect(() => {\n    setFull(first + \" \" + last);\n  }, [first, last]);\n  return <p>{full}</p>;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (6, 3));
+    assert!(
+        diagnostics[0].message.contains("during render"),
+        "{}",
+        diagnostics[0].message
+    );
+}
+
+#[test]
+fn a_concise_body_is_the_same_effect() {
+    let diagnostics = derived(
+        "component Mirror(a: number) {\n  const [b, setB] = useState(0);\n  useEffect(() => setB(a), [a]);\n  return <p>{b}</p>;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+}
+
+#[test]
+fn a_ternary_and_a_template_are_still_expressions_over_the_dependencies() {
+    let diagnostics = derived(
+        "component Label(count: number, name: string) {\n  const [text, setText] = useState(\"\");\n  useEffect(() => {\n    setText(count > 1 ? `${name}s` : name);\n  }, [count, name]);\n  return <p>{text}</p>;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+}
+
+#[test]
+fn a_hook_declaration_is_read_the_same_way_as_a_component() {
+    let diagnostics = derived(
+        "hook useDouble(a: number): number {\n  const [b, setB] = useState(0);\n  useEffect(() => {\n    setB(a * 2);\n  }, [a]);\n  return b;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+}
+
+// --- react/no-derived-state-effect: what it must not report -----------------
+
+#[test]
+fn a_setter_that_is_not_a_use_state_binding_is_not_derived_state() {
+    // `onChange` is a prop, and calling a prop from an effect is what effects
+    // are for. Nothing in the name says otherwise, so the binding does.
+    let diagnostics = derived(
+        "component Field(value: string, setValue: (v: string) => void) {\n  useEffect(() => {\n    setValue(value);\n  }, [value]);\n  return null;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_setter_declared_in_another_component_is_not_in_scope() {
+    let diagnostics = derived(
+        "component Owner() {\n  const [value, setValue] = useState(0);\n  return <p>{value}</p>;\n}\n\ncomponent Other(a: number) {\n  useEffect(() => {\n    setValue(a);\n  }, [a]);\n  return null;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn an_effect_that_also_does_something_else_is_left_alone() {
+    let diagnostics = derived(
+        "component Name(first: string) {\n  const [full, setFull] = useState(\"\");\n  useEffect(() => {\n    setFull(first);\n    track(first);\n  }, [first]);\n  return <p>{full}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn an_effect_with_a_cleanup_is_left_alone() {
+    let diagnostics = derived(
+        "component Name(first: string) {\n  const [full, setFull] = useState(\"\");\n  useEffect(() => {\n    setFull(first);\n    return () => setFull(\"\");\n  }, [first]);\n  return <p>{full}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_property_read_is_left_alone() {
+    // `data.items` and `box.offsetWidth` are the same three tokens, and the
+    // second must *not* move into render — reading layout there is the bug
+    // `react/no-render-side-effects` exists to catch. Nothing in the source
+    // says which one this is, so the rule says nothing.
+    let diagnostics = derived(
+        "component List(data: Data) {\n  const [items, setItems] = useState([]);\n  useEffect(() => {\n    setItems(data.items);\n  }, [data]);\n  return <ul>{items}</ul>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_call_is_left_alone() {
+    let diagnostics = derived(
+        "component List(items: Array<string>) {\n  const [sorted, setSorted] = useState([]);\n  useEffect(() => {\n    setSorted(sort(items));\n  }, [items]);\n  return <ul>{sorted}</ul>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_reset_to_a_constant_is_left_alone() {
+    // The article's other shape. Its fix is a `key` or a comparison against
+    // the previous prop, which is a redesign rather than moving an
+    // expression, so a rule that blocks a build must not insist on it.
+    let diagnostics = derived(
+        "component Table(items: Array<string>) {\n  const [selection, setSelection] = useState(null);\n  useEffect(() => {\n    setSelection(null);\n  }, [items]);\n  return <ul>{items}</ul>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_value_that_is_not_a_dependency_is_left_alone() {
+    let diagnostics = derived(
+        "component Odd(a: number, b: number) {\n  const [c, setC] = useState(0);\n  useEffect(() => {\n    setC(b);\n  }, [a]);\n  return <p>{c}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn an_effect_with_no_dependency_array_is_left_alone() {
+    let diagnostics = derived(
+        "component Name(first: string) {\n  const [full, setFull] = useState(\"\");\n  useEffect(() => {\n    setFull(first);\n  });\n  return <p>{full}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn an_effect_with_an_empty_dependency_array_is_left_alone() {
+    let diagnostics = derived(
+        "component Name() {\n  const [ready, setReady] = useState(false);\n  useEffect(() => {\n    setReady(true);\n  }, []);\n  return <p>{ready}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_layout_effect_is_left_alone() {
+    // Where measuring belongs, and a measurement is exactly what must not be
+    // moved into render.
+    let diagnostics = derived(
+        "component Box(width: number) {\n  const [scaled, setScaled] = useState(0);\n  useLayoutEffect(() => {\n    setScaled(width * 2);\n  }, [width]);\n  return <p>{scaled}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn an_updater_function_is_not_a_derived_value() {
+    let diagnostics = derived(
+        "component Counter(step: number) {\n  const [count, setCount] = useState(0);\n  useEffect(() => {\n    setCount((previous) => previous + step);\n  }, [step]);\n  return <p>{count}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_dependency_the_state_itself_feeds_is_left_alone() {
+    // `@uniflowed/hooks`' own `useTimeAgo`, reduced: the schedule that is
+    // stored chooses the tick, the tick drives the clock, and the clock's
+    // reading is what chooses the next schedule. `const schedule = wanted`
+    // during render would define the value in terms of itself, so the effect
+    // is what the design needs rather than a mistake — and the rule found this
+    // one by firing on it.
+    let diagnostics = derived(
+        "hook useTimeAgo(instant: number): number {\n  const [schedule, setSchedule] = useState(1000);\n  const tick = schedule;\n  const now = useNow(tick);\n  const wanted = now - instant;\n  useEffect(() => {\n    setSchedule(wanted);\n  }, [wanted]);\n  return schedule;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_dependency_that_only_shares_a_method_name_with_the_state_is_still_reported() {
+    // The feedback walk must not join two bindings through a property: `left`
+    // is read from `bounds.width`, and `width` is the state — the same word,
+    // and no path between them.
+    let diagnostics = derived(
+        "component Bar(bounds: Bounds) {\n  const [width, setWidth] = useState(0);\n  const left = bounds.width;\n  useEffect(() => {\n    setWidth(left);\n  }, [left]);\n  return <p>{width}</p>;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+}
+
+#[test]
+fn a_dependency_written_as_a_property_is_left_alone() {
+    // `[data.id]` says the effect re-runs on the field, which is a different
+    // claim from "derived from `data`".
+    let diagnostics = derived(
+        "component Row(data: Data, label: string) {\n  const [text, setText] = useState(\"\");\n  useEffect(() => {\n    setText(label);\n  }, [data.id, label]);\n  return <p>{text}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+// --- react/no-redundant-memo ------------------------------------------------
+
+#[test]
+fn a_memo_the_compiler_removed_is_reported() {
+    let diagnostics = memo(
+        "component List(items: Array<string>) {\n  const sorted = useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (5, 18));
+    assert!(
+        diagnostics[0].message.contains("useMemo"),
+        "{}",
+        diagnostics[0].message
+    );
+}
+
+#[test]
+fn a_callback_the_compiler_removed_is_reported() {
+    let diagnostics = memo(
+        "hook useHandler(id: string): () => void {\n  return useCallback(() => send(id), [id]);\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert!(
+        diagnostics[0].message.contains("useCallback"),
+        "{}",
+        diagnostics[0].message
+    );
+}
+
+#[test]
+fn the_namespaced_spelling_is_reported_at_the_hook_and_not_at_react() {
+    // `React.useMemo(…)` reported at its callee underlines `React`, which says
+    // nothing about which call is meant on a line that holds two of them.
+    let diagnostics = lint_js(
+        REDUNDANT_MEMO,
+        "// @flow\nimport * as React from \"react\";\n\ncomponent List(items: Array<string>) {\n  const sorted = React.useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (5, 24));
+}
+
+#[test]
+fn a_memo_in_a_function_the_compiler_never_touches_is_left_alone() {
+    // `syntax` mode compiles `component` and `hook` declarations. A plain
+    // function is an uncompiled boundary, and the memoization in it is the
+    // only memoization there is.
+    let diagnostics = memo(
+        "export function List(props: {items: Array<string>}) {\n  const sorted = useMemo(() => props.items.slice(), [props.items]);\n  return <ul>{sorted}</ul>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_memo_the_compiler_could_not_preserve_is_left_alone() {
+    // A missing dependency makes the compiler refuse the whole function rather
+    // than drop a memo whose guarantees it cannot reproduce — so the report
+    // this rule would have made is exactly the report that would be wrong.
+    let diagnostics = memo(
+        "component Sum(a: number, b: number) {\n  const total = useMemo(() => a + b, [a]);\n  return <p>{total}</p>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_function_that_opted_out_of_the_compiler_keeps_its_memoization() {
+    let diagnostics = memo(
+        "component List(items: Array<string>) {\n  \"use no memo\";\n  const sorted = useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\n",
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn a_project_with_the_compiler_switched_off_keeps_its_memoization() {
+    // Nothing removes it, so it is not redundant — and a rule that said
+    // otherwise would be telling a reader to delete the only memoization the
+    // build produces.
+    let mut config = only(REDUNDANT_MEMO);
+    config.app.builtins.react_compiler.enabled = false;
+    let file = at(
+        "app/index.js",
+        &module(
+            "component List(items: Array<string>) {\n  const sorted = useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\n",
+        ),
+    );
+
+    let diagnostics = lint_source(&file, &config).expect("lint").diagnostics;
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+// --- Both rules -------------------------------------------------------------
+
+#[test]
+fn a_module_that_names_neither_hook_is_not_parsed_at_all() {
+    // The gate that keeps the parse off the common path. It is behaviour
+    // rather than an optimisation detail: a module with no `useEffect`,
+    // `useMemo` or `useCallback` in it cannot violate either rule, and one
+    // that fails to parse must be reported by `flow/syntax` and nothing else.
+    let broken = "// @flow\ncomponent Page( {\n";
+
+    assert!(lint_js(DERIVED_STATE, broken).is_empty());
+    assert!(lint_js(REDUNDANT_MEMO, broken).is_empty());
+}
+
+#[test]
+fn a_module_that_does_not_parse_reports_nothing_here() {
+    let broken = "// @flow\nimport {useEffect, useMemo, useState} from \"react\";\ncomponent Page( {\n  useEffect(() => setA(1), [a]);\n";
+
+    assert!(lint_js(DERIVED_STATE, broken).is_empty());
+    assert!(lint_js(REDUNDANT_MEMO, broken).is_empty());
+}
+
+#[test]
+fn a_non_flow_file_is_not_parsed() {
+    assert!(
+        lint_one(
+            DERIVED_STATE,
+            "app/page.md",
+            "useEffect(() => setA(1), [a]);\n"
+        )
+        .is_empty()
+    );
+}

--- a/crates/uf_react_compiler/src/scope.rs
+++ b/crates/uf_react_compiler/src/scope.rs
@@ -9,11 +9,32 @@
 //!   may not, and being inside one of them means a token is no longer in
 //!   render.
 //! * *Is this token at the top level of that function?* — the frame's recorded
-//!   [`Frame::depth`] against the current one. A `{` that is not a JSX
-//!   container raises the depth, so a hook inside `if`, inside a loop, or
-//!   inside a callback is exactly the case where the two disagree.
+//!   [`Frame::depth`] against the current one. A `{` that opens something the
+//!   surrounding statement may run zero or many times raises the depth, so a
+//!   hook inside `if`, inside a loop, or inside a callback is exactly the case
+//!   where the two disagree.
+//!
+//! # Which braces nest and which do not
+//!
+//! Not every `{` conditions what is inside it. Three do not, and
+//! [`ScopeKind::nests`] is the list:
+//!
+//! | Brace | Runs |
+//! | --- | --- |
+//! | `if (…) { … }`, a loop body, `try { … }`, a callback | zero or many times |
+//! | `<p>{ … }</p>` — a JSX expression container | once, where it stands |
+//! | `value={ … }` — a JSX attribute | once, where it stands |
+//! | `const bag = { … }` — an object literal | once, where it stands |
+//!
+//! The last two used to raise the depth, and a hook called in either was
+//! reported as a conditional call — which it is not: the literal is the
+//! initialiser of a top-level `const`, so every call in it runs, in order, on
+//! every render, which is the whole of what the rule guarantees. See
+//! ubugeeei-prod/uf#477.
 
 use uf_rsc::{Token, TokenKind};
+
+use crate::syntax::{is_assignment, is_jsx_attribute_value};
 
 /// What kind of `{ ... }` a frame on the stack represents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -31,9 +52,13 @@ pub enum ScopeKind {
     UseFunction,
     /// Any other function, arrow, or class body.
     Function,
-    /// A JSX expression container, which nests neither scope nor hook depth.
+    /// A JSX expression container or attribute value, which nests neither
+    /// scope nor hook depth.
     Jsx,
-    /// A block, an object literal, or anything else.
+    /// An object literal, which is an expression the enclosing statement
+    /// evaluates exactly once where it stands.
+    ObjectLiteral,
+    /// A block, or anything else.
     Block,
 }
 
@@ -44,6 +69,17 @@ impl ScopeKind {
             self,
             Self::Component | Self::Hook | Self::UseFunction | Self::Function
         )
+    }
+
+    /// Whether the brace raises hook-nesting depth.
+    ///
+    /// False for the two kinds of brace that open an *expression* the enclosing
+    /// statement evaluates exactly once: a JSX container or attribute, and an
+    /// object literal. A hook called inside either runs on every render, in the
+    /// same order, which is precisely the condition `react/hooks-rules` exists
+    /// to check — so counting them would report a call that is not conditional.
+    pub const fn nests(self) -> bool {
+        !matches!(self, Self::Jsx | Self::ObjectLiteral)
     }
 
     /// Whether hooks may be called directly in this frame.
@@ -181,12 +217,20 @@ impl ScopeStack {
         if named {
             self.pending_body = None;
         }
+        // Read before `self.pending` is borrowed, and passed down rather than
+        // looked up inside [`classify`]: a `{` after a `:` is a property value
+        // when — and only when — it stands inside an object literal, and a free
+        // function has no way to know that.
+        let in_object_literal = self
+            .frames
+            .last()
+            .is_some_and(|frame| frame.kind == ScopeKind::ObjectLiteral);
         let kind = if named || self.parens == 0 {
             self.pending
                 .take()
-                .unwrap_or_else(|| classify(source, tokens, index))
+                .unwrap_or_else(|| classify(source, tokens, index, in_object_literal))
         } else {
-            classify(source, tokens, index)
+            classify(source, tokens, index, in_object_literal)
         };
         self.push(kind);
         kind
@@ -207,7 +251,7 @@ impl ScopeStack {
     }
 
     fn push(&mut self, kind: ScopeKind) {
-        if kind != ScopeKind::Jsx {
+        if kind.nests() {
             self.depth += 1;
         }
         self.frames.push(Frame {
@@ -221,7 +265,7 @@ impl ScopeStack {
     /// Close the innermost frame.
     pub fn close(&mut self) {
         if let Some(frame) = self.frames.pop()
-            && frame.kind != ScopeKind::Jsx
+            && frame.kind.nests()
         {
             self.depth = self.depth.saturating_sub(1);
         }
@@ -252,14 +296,19 @@ impl ScopeStack {
 /// every brace inside a parameter list or an argument list, where the pending
 /// answer belongs to the declaration still being read.
 ///
-/// Three cases matter, and the rest is a block. `<div>{…}` is a JSX expression
+/// Four cases matter, and the rest is a block. `<div>{…}` is a JSX expression
 /// container and nests neither scope nor hook depth. A brace after `=>`, or
 /// after the parameter list of a `function` expression, is a function body even
 /// when it is an argument to something else: `items.map((item) => { … })` has
 /// to be a function, or a `return` inside it would be blamed on the component
-/// around it. Everything else is a block, which is the safe answer — an object
-/// literal counted as a block only makes the top-level test stricter.
-fn classify(source: &str, tokens: &[Token], index: usize) -> ScopeKind {
+/// around it. An object literal — see [`opens_an_object_literal`] — is an
+/// expression the enclosing statement evaluates once. Everything else is a
+/// block.
+///
+/// `in_object_literal` says whether the innermost open frame is an object
+/// literal, which is the one thing the caller knows and the token stream does
+/// not; it decides the `:` row of [`opens_an_object_literal`].
+fn classify(source: &str, tokens: &[Token], index: usize, in_object_literal: bool) -> ScopeKind {
     let Some(previous) = index.checked_sub(1).and_then(|at| tokens.get(at)) else {
         return ScopeKind::Block;
     };
@@ -284,6 +333,14 @@ fn classify(source: &str, tokens: &[Token], index: usize) -> ScopeKind {
     {
         return ScopeKind::Function;
     }
+    // `value={…}` on a JSX element, and `<T = {…}>` in a type parameter list.
+    // Both are read once where they stand, and the second is not code at all.
+    if is_jsx_attribute_value(tokens, index) {
+        return ScopeKind::Jsx;
+    }
+    if opens_an_object_literal(source, tokens, index, in_object_literal) {
+        return ScopeKind::ObjectLiteral;
+    }
     // A container the JSX text runs into: `<p>hello {name}</p>`. The brace
     // follows a word rather than the `>` that ended the opening tag, and it
     // still nests nothing — so a hook called there was reported as being
@@ -292,6 +349,52 @@ fn classify(source: &str, tokens: &[Token], index: usize) -> ScopeKind {
         return ScopeKind::Jsx;
     }
     ScopeKind::Block
+}
+
+/// Whether the `{` at `index` opens an object literal.
+///
+/// Answered from the token in front of it, and the list is closed because the
+/// grammar's is: an object literal stands where an *expression* may stand, and
+/// the places a brace can follow and still be one are an initialiser or
+/// assignment, an argument list, an array, a `return`, a comma, and the `:` of
+/// a property whose value is another object.
+///
+/// | | before | opens |
+/// | --- | --- | --- |
+/// | `const bag = { … }` | `=` | an object literal |
+/// | `f({ … })` | `(` | an object literal |
+/// | `[{ … }]` | `[` | an object literal |
+/// | `f(a, { … })` | `,` | an object literal |
+/// | `return { … }` | `return` | an object literal |
+/// | `{ outer: { … } }` | `:` | an object literal, inside one |
+/// | `case 1: { … }` | `:` | a block, outside one |
+/// | `if (flag) { … }` | `)` | a block |
+/// | `{ method() { … } }` | `)` | a block, which under-describes a method body
+///   and still keeps it nesting |
+///
+/// [`is_assignment`] is what the `=` row asks, because two other `=`s can
+/// stand there and neither introduces a value: a comparison, and the `=` of a
+/// JSX attribute — which [`classify`] has already answered above this.
+///
+/// The `:` row is why `in_object_literal` is a parameter: a label and a `case`
+/// clause both put a block after a colon, and neither can appear inside an
+/// object literal, so the enclosing frame settles it.
+fn opens_an_object_literal(
+    source: &str,
+    tokens: &[Token],
+    index: usize,
+    in_object_literal: bool,
+) -> bool {
+    let Some(at) = index.checked_sub(1) else {
+        return false;
+    };
+    match tokens[at].kind {
+        TokenKind::Punct(b'=') => is_assignment(tokens, at),
+        TokenKind::Punct(b'(' | b'[' | b',') => true,
+        TokenKind::Punct(b':') => in_object_literal,
+        TokenKind::Ident => ident_at(source, tokens, at) == Some("return"),
+        _ => false,
+    }
 }
 
 /// Whether a `{` following the token at `at` can open a block.

--- a/crates/uf_react_compiler/src/syntax.rs
+++ b/crates/uf_react_compiler/src/syntax.rs
@@ -40,6 +40,25 @@ pub fn is_assignment(tokens: &[Token], index: usize) -> bool {
     !inside_a_tag(tokens, index)
 }
 
+/// Whether the `{` at `index` is the value of a JSX attribute.
+///
+/// `value={…}` and `onClick={…}` put a brace after an `=` that
+/// [`is_assignment`] already refuses to call a write, for the same reason: the
+/// `=` belongs to a tag. What the *scope* stack needs from that answer is
+/// different — an attribute value is an expression the element evaluates
+/// exactly once where it stands, so it conditions nothing inside it, and
+/// counting it as a block reported a hook called in
+/// `value={useMemo(() => …, [x])}` as a conditional call.
+///
+/// The other `=` inside an unclosed `<…>` is the default of a type parameter,
+/// `<T = { a: number }>`. That is not code at all, so the same answer is the
+/// right one there.
+pub fn is_jsx_attribute_value(tokens: &[Token], index: usize) -> bool {
+    index
+        .checked_sub(1)
+        .is_some_and(|at| tokens[at].is_punct(b'=') && inside_a_tag(tokens, at))
+}
+
 /// Whether the token at `index` stands inside an unclosed `<…>`.
 ///
 /// Two things are written that way and neither is a write: a JSX attribute —

--- a/crates/uf_react_compiler/src/tests/hooks.rs
+++ b/crates/uf_react_compiler/src/tests/hooks.rs
@@ -490,3 +490,114 @@ fn a_hook_inside_a_try_block_is_still_rejected() {
         [Finding::HookNotAtTopLevel, Finding::HookNotAtTopLevel]
     );
 }
+
+// --- An expression the statement evaluates once (ubugeeei-prod/uf#477) -------
+//
+// An object literal, a JSX container and a JSX attribute are all read exactly
+// once where they stand, so a hook called in one runs on every render in the
+// same order. Each of the accepting tests below is paired with a rejecting one
+// that puts the same literal somewhere the statement may not reach, because a
+// brace that stopped nesting everywhere would be a hole rather than a fix.
+
+#[test]
+fn a_hook_called_in_an_object_literal_is_accepted() {
+    // ubugeeei-prod/uf#477's own reproduction: a controller hook that builds
+    // its state as one object of store selections. Every call runs, in order,
+    // on every render.
+    accepts(
+        "hook useThing(): { a: number, b: number } {\n  const bag = {\n    a: useState(0)[0],\n    b: useState(1)[0],\n  };\n\n  return bag;\n}\n",
+    );
+}
+
+#[test]
+fn a_hook_called_in_a_nested_object_literal_is_accepted() {
+    accepts(
+        "component Page() {\n  const chrome = { header: { title: useTitle() } };\n  return <h1>{chrome.header.title}</h1>;\n}\n",
+    );
+}
+
+#[test]
+fn a_hook_called_in_an_object_literal_argument_is_accepted() {
+    accepts("component Page() {\n  render({ value: useValue() });\n  return null;\n}\n");
+}
+
+#[test]
+fn a_hook_called_in_an_object_literal_in_an_array_is_accepted() {
+    accepts(
+        "component Page() {\n  const rows = [{ value: useValue() }];\n  return <ul>{rows}</ul>;\n}\n",
+    );
+}
+
+#[test]
+fn a_hook_called_in_a_returned_object_literal_is_accepted() {
+    accepts("hook useThing(): { a: number } {\n  return { a: useState(0)[0] };\n}\n");
+}
+
+#[test]
+fn a_hook_called_in_a_jsx_attribute_is_accepted() {
+    accepts(
+        "component Page(items: Array<string>) {\n  return <Ctx.Provider value={useMemo(() => items, [items])} />;\n}\n",
+    );
+}
+
+#[test]
+fn a_hook_called_in_an_object_literal_inside_a_condition_is_rejected() {
+    // The literal does not nest; the `if` it stands in does.
+    assert_eq!(
+        findings(
+            "component Page(flag: boolean) {\n  if (flag) {\n    const bag = { a: useState(0)[0] };\n    return bag.a;\n  }\n  return null;\n}\n"
+        ),
+        [Finding::HookNotAtTopLevel]
+    );
+}
+
+#[test]
+fn a_hook_called_in_an_object_literal_inside_a_callback_is_rejected() {
+    // The callback is a plain function, and a plain function may not call
+    // hooks at all — the literal inside it changes nothing about that.
+    assert_eq!(
+        findings(
+            "component List(items: Array<string>) {\n  items.forEach(() => {\n    const bag = { a: useState(0)[0] };\n    return bag;\n  });\n  return null;\n}\n"
+        ),
+        [Finding::HookOutsideComponent]
+    );
+}
+
+#[test]
+fn a_hook_called_in_an_object_method_is_rejected() {
+    // `{ read() { … } }` puts a brace after a `)`, which is neither a JSX
+    // attribute nor a property value, so it keeps nesting and the call inside
+    // it is still reported. The finding under-describes it — a method body is
+    // a function, so the call is outside a component rather than merely nested
+    // — but the answer that matters is that a brace that stopped nesting
+    // everywhere would be a hole, and this one does not.
+    assert_eq!(
+        findings(
+            "component Page() {\n  const api = { read() { return useState(0); } };\n  return api.read;\n}\n"
+        ),
+        [Finding::HookNotAtTopLevel]
+    );
+}
+
+#[test]
+fn a_hook_called_in_a_switch_case_block_is_rejected() {
+    // `case 1: {` also puts a brace after a `:`, and that one is a block. It
+    // is told apart from a property value by what encloses it: a `case` cannot
+    // stand inside an object literal.
+    assert_eq!(
+        findings(
+            "component Page(mode: number) {\n  switch (mode) {\n    case 1: {\n      const [a] = useState(0);\n      return a;\n    }\n  }\n  return null;\n}\n"
+        ),
+        [Finding::HookNotAtTopLevel]
+    );
+}
+
+#[test]
+fn a_hook_called_in_a_labelled_block_is_rejected() {
+    assert_eq!(
+        findings(
+            "component Page() {\n  setup: {\n    const [a] = useState(0);\n    return a;\n  }\n}\n"
+        ),
+        [Finding::HookNotAtTopLevel]
+    );
+}

--- a/crates/uf_transform/src/compiler.rs
+++ b/crates/uf_transform/src/compiler.rs
@@ -117,7 +117,12 @@ pub fn compile(
     }
 }
 
-fn plugin_options(
+/// The options uf drives the official compiler with, for every caller.
+///
+/// One function rather than one per entry point: `uf build` and the
+/// redundant-memoization question in [`crate::memo`] must ask the compiler the
+/// same thing, or the linter would report a memoization the build then keeps.
+pub(crate) fn plugin_options(
     source: &str,
     options: &TransformOptions,
 ) -> Result<PluginOptions, TransformError> {

--- a/crates/uf_transform/src/lib.rs
+++ b/crates/uf_transform/src/lib.rs
@@ -41,13 +41,16 @@ pub mod compiler;
 pub mod emit;
 pub mod estree;
 pub mod lower;
+pub mod memo;
 pub mod print;
 pub mod scope;
 
+use serde_json::Value;
 use thiserror::Error;
 
 pub use crate::compiler::{CompilerDiagnostic, ReactCompilerMode};
 pub use crate::estree::MAX_SOURCE_BYTES;
+pub use crate::memo::{RedundantMemo, redundant_memoization};
 
 /// How one module is transformed.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -171,15 +174,42 @@ pub fn is_flow_module(id: &str) -> bool {
 /// File extensions uf treats as Flow source.
 pub const FLOW_EXTENSIONS: [&str; 4] = [".js", ".jsx", ".mjs", ".cjs"];
 
+/// The module as the React Compiler sees it: parsed with the official Flow
+/// parser, lowered, and rendered in Babel's AST shape.
+///
+/// Stages one to three of [`transform`], with the JavaScript left unprinted.
+/// It is a public entry point because a caller can want the tree and nothing
+/// else: `uf lint` asks the compiler what it did with a module's hand-written
+/// memoization (see [`memo`]) and never emits a byte of code.
+///
+/// The [`lower::Lowered`] beside it carries the one fact the later stages need
+/// and the tree does not say: whether the module declares anything the
+/// compiler would compile in `syntax` mode.
+///
+/// # Errors
+///
+/// [`TransformError::SourceTooLarge`], [`TransformError::Syntax`] and
+/// [`TransformError::Lowering`], exactly as [`transform`] raises them.
+///
+/// # Call this from a thread with `uf_flow::PARSE_STACK_BYTES` of stack
+///
+/// The Flow parser is recursive descent and freeing its tree recurses too;
+/// [`uf_flow::parse`] says how much that costs and why the ceiling is where it
+/// is.
+pub fn babel_ast(source: &str) -> Result<(Value, lower::Lowered), TransformError> {
+    let mut program = estree::parse(source)?;
+    let lowered = lower::lower(&mut program, source)?;
+    let file = babel::to_babel(program, source)?;
+    Ok((file, lowered))
+}
+
 /// Transform one Flow module to JavaScript.
 ///
 /// # Errors
 ///
 /// See [`TransformError`].
 pub fn transform(source: &str, options: &TransformOptions) -> Result<Transformed, TransformError> {
-    let mut program = estree::parse(source)?;
-    let lowered = lower::lower(&mut program, source)?;
-    let file = babel::to_babel(program, source)?;
+    let (file, lowered) = babel_ast(source)?;
 
     let (file, compiler_diagnostics, compiled_functions) =
         if options.react_compiler == ReactCompilerMode::Off || !lowered.may_compile {

--- a/crates/uf_transform/src/memo.rs
+++ b/crates/uf_transform/src/memo.rs
@@ -1,0 +1,433 @@
+//! What the official React Compiler did with a module's hand-written
+//! memoization.
+//!
+//! A `useMemo` or a `useCallback` in a component uf compiles is usually noise:
+//! the compiler memoizes what needs memoizing, and the hand-written one is a
+//! second dependency array to keep correct. It is not *always* noise, and that
+//! is the whole difficulty — a callback whose identity crosses into a function
+//! the compiler declined, or a memo whose dependencies the compiler cannot
+//! reproduce, is load-bearing.
+//!
+//! So this does not guess. It runs the compiler and looks at what came back.
+//!
+//! 1. Every `useMemo`/`useCallback` call in the module is recorded, with the
+//!    position its name is written at.
+//! 2. The module is compiled, exactly as `uf build` compiles it — the same
+//!    [`plugin_options`](crate::compiler::plugin_options), so the linter cannot
+//!    report a memoization the build then keeps.
+//! 3. A call is redundant when it stood inside a function the compiler reported
+//!    `CompileSuccess` for **and** is gone from the compiled output. The
+//!    compiler's `DropManualMemoization` pass removes a manual memo only when
+//!    its own reactive scopes reproduce it; where they cannot, the function
+//!    fails `ValidatePreservedManualMemoization` and is not compiled at all,
+//!    and the call is still standing in the output.
+//!
+//! Which means every case that has to stay silent stays silent for a reason
+//! the compiler gave, not one uf inferred:
+//!
+//! | Written in | Compiler said | Reported |
+//! | --- | --- | --- |
+//! | a `component` or `hook` uf compiles | `CompileSuccess`, call gone | yes |
+//! | a plain `function` (`syntax` mode compiles neither) | nothing | no |
+//! | a function carrying `"use no memo"` | `CompileSkip` | no |
+//! | a memo whose dependencies are incomplete | `CompileError` | no |
+//! | a function the compiler bailed on for any other reason | not a success | no |
+//!
+//! # Cost
+//!
+//! This compiles the module, which is far more work than a lint rule usually
+//! does. The caller is expected to ask only when the module's text contains
+//! `useMemo` or `useCallback` at all, and [`redundant_memoization`] returns
+//! early — before the compiler runs — when the tree holds neither.
+
+use react_compiler::entrypoint::{CompileResult, LoggerEvent, compile_program};
+use react_compiler_ast::File;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::compiler::plugin_options;
+use crate::{TransformError, TransformOptions, scope};
+
+/// The two calls a developer writes to memoize by hand.
+///
+/// `useEffect`'s dependency array is not memoization and `useRef` is not
+/// either; these two are the pair the compiler's `DropManualMemoization` pass
+/// removes, and this list has to match it or uf would report a call the
+/// compiler left alone.
+const MANUAL_MEMO: [&str; 2] = ["useCallback", "useMemo"];
+
+/// One hand-written memoization the official React Compiler made redundant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedundantMemo {
+    /// `"useMemo"` or `"useCallback"`.
+    pub hook: &'static str,
+    /// 1-based line the hook's name is written on.
+    pub line: u32,
+    /// 0-based column of the hook's name, in UTF-16 code units — the unit
+    /// Babel's `loc` counts and source maps use.
+    pub column: u32,
+    /// Name of the compiled function the call stood in, when the compiler
+    /// reported one.
+    pub function: Option<String>,
+}
+
+/// Every hand-written memoization in `file` that the official React Compiler
+/// removed.
+///
+/// `file` is the module's Babel tree, from [`crate::babel_ast`], and `source`
+/// and `options` are the ones the module would be built with — the compiler
+/// reads the source text for its suppression comments and the options decide
+/// which functions it compiles at all.
+///
+/// # Errors
+///
+/// [`TransformError::Internal`] when the tree does not deserialize into the
+/// compiler's AST or its result does not serialize back, which is a bug in uf
+/// rather than in the module. A compiler error that is *about* the module is
+/// not an error here: it means nothing was compiled, so nothing is redundant,
+/// and the answer is an empty list.
+///
+/// # Call this from a thread with `uf_flow::PARSE_STACK_BYTES` of stack
+///
+/// The compiler recurses through the tree, and so does dropping it.
+pub fn redundant_memoization(
+    file: &Value,
+    source: &str,
+    options: &TransformOptions,
+) -> Result<Vec<RedundantMemo>, TransformError> {
+    let written = manual_memo_calls(file);
+    if written.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let ast: File = serde_json::from_value(file.clone()).map_err(|error| {
+        TransformError::Internal(format!("Babel AST rejected by the React Compiler: {error}"))
+    })?;
+    let plugin = plugin_options(source, options)?;
+    let scope = scope::analyze(file);
+
+    let (compiled, events) = match compile_program(ast, scope, plugin) {
+        CompileResult::Success { ast, events, .. } => (ast, events),
+        // The compiler asked for this one to be fatal. Nothing was compiled,
+        // so nothing is redundant — and the build reports it, not the linter.
+        CompileResult::Error { .. } => return Ok(Vec::new()),
+    };
+
+    let succeeded: Vec<CompiledFunction> = events.iter().filter_map(compiled_function).collect();
+    // No function compiled, or the compiler changed nothing: every manual memo
+    // in the module is still doing its job.
+    let (Some(compiled), false) = (compiled, succeeded.is_empty()) else {
+        return Ok(Vec::new());
+    };
+
+    let output = serde_json::to_value(compiled).map_err(|error| {
+        TransformError::Internal(format!("compiled AST could not be serialized: {error}"))
+    })?;
+    let kept = manual_memo_calls(&output);
+
+    Ok(written
+        .into_iter()
+        .filter_map(|call| {
+            let function = succeeded
+                .iter()
+                .find(|function| function.contains(call.at))?;
+            // Still in the output: the compiler left this one alone even
+            // though the function around it compiled, so it is not uf's to
+            // call redundant.
+            if kept.iter().any(|other| other.at == call.at) {
+                return None;
+            }
+            Some(RedundantMemo {
+                hook: call.hook,
+                line: call.at.line,
+                column: call.at.column,
+                function: function.name.clone(),
+            })
+        })
+        .collect())
+}
+
+/// A position in the module, as Babel's `loc` and the compiler's events both
+/// spell it: a 1-based line and a 0-based UTF-16 column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Position {
+    line: u32,
+    column: u32,
+}
+
+impl Position {
+    /// Read a `{ "line": …, "column": … }` object.
+    fn from_json(value: &Value) -> Option<Self> {
+        Some(Self {
+            line: u32::try_from(value.get("line")?.as_u64()?).ok()?,
+            column: u32::try_from(value.get("column")?.as_u64()?).ok()?,
+        })
+    }
+}
+
+/// One `useMemo`/`useCallback` call, identified by where its name is written.
+///
+/// The position is the identity: the same call has the same position in the
+/// tree the compiler was handed and in the tree it gave back, because both are
+/// rendered from the author's own bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ManualMemo {
+    hook: &'static str,
+    at: Position,
+}
+
+/// A function the compiler reported `CompileSuccess` for.
+struct CompiledFunction {
+    name: Option<String>,
+    start: Position,
+    end: Position,
+}
+
+impl CompiledFunction {
+    fn contains(&self, at: Position) -> bool {
+        self.start <= at && at <= self.end
+    }
+}
+
+/// The function a `CompileSuccess` event describes, if the event is one.
+fn compiled_function(event: &LoggerEvent) -> Option<CompiledFunction> {
+    let LoggerEvent::CompileSuccess {
+        fn_loc: Some(location),
+        fn_name,
+        ..
+    } = event
+    else {
+        return None;
+    };
+    Some(CompiledFunction {
+        name: fn_name.clone(),
+        start: Position {
+            line: location.start.line,
+            column: location.start.column,
+        },
+        end: Position {
+            line: location.end.line,
+            column: location.end.column,
+        },
+    })
+}
+
+/// Every `useMemo`/`useCallback` call in a Babel tree, in tree order.
+///
+/// Iterative rather than recursive on purpose: this runs over a tree whose
+/// depth is bounded only by the parser's ceilings, and the walk should not be
+/// the thing that needs a large stack.
+///
+/// Both spellings count — `useMemo(…)` and `React.useMemo(…)` — because the
+/// compiler removes both, and reading only the first would leave uf silent
+/// about a call the compiler had already dropped.
+fn manual_memo_calls(file: &Value) -> Vec<ManualMemo> {
+    let mut found = Vec::new();
+    let mut pending = vec![file];
+
+    while let Some(node) = pending.pop() {
+        match node {
+            Value::Array(items) => pending.extend(items),
+            Value::Object(map) => {
+                if map.get("type").and_then(Value::as_str) == Some("CallExpression")
+                    && let Some(callee) = map.get("callee")
+                    && let Some((hook, name)) = manual_memo_callee(callee)
+                    && let Some(at) = name.get("loc").and_then(|loc| loc.get("start"))
+                    && let Some(at) = Position::from_json(at)
+                {
+                    found.push(ManualMemo { hook, at });
+                }
+                pending.extend(map.values());
+            }
+            _ => {}
+        }
+    }
+
+    found
+}
+
+/// The hook a callee names, when it names one of [`MANUAL_MEMO`], with the
+/// node that spells the name.
+///
+/// The name rather than the callee, because that is what a reader is looking
+/// for: `React.useMemo(…)` reported at its callee underlines `React`, which
+/// says nothing about which call is meant when a line holds two of them. It is
+/// also a stable identity across the compile — the property keeps its position
+/// in the output tree exactly as the callee would.
+fn manual_memo_callee(callee: &Value) -> Option<(&'static str, &Value)> {
+    let named = |value: &Value| {
+        let name = value.get("name")?.as_str()?;
+        MANUAL_MEMO.iter().copied().find(|hook| *hook == name)
+    };
+    match callee.get("type").and_then(Value::as_str)? {
+        "Identifier" => Some((named(callee)?, callee)),
+        // `React.useMemo(…)`, and only that: a member call on anything else is
+        // a method that happens to share a name.
+        "MemberExpression" if callee.get("computed") != Some(&Value::Bool(true)) => {
+            let object = callee.get("object")?;
+            if object.get("type").and_then(Value::as_str)? != "Identifier"
+                || object.get("name").and_then(Value::as_str)? != "React"
+            {
+                return None;
+            }
+            let property = callee.get("property")?;
+            Some((named(property)?, property))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ReactCompilerMode, babel_ast, transform};
+
+    /// `source` compiled the way `uf build` compiles it.
+    fn built(source: &str) -> String {
+        let options = TransformOptions {
+            react_compiler: ReactCompilerMode::Syntax,
+            ..TransformOptions::new("app.js")
+        };
+        transform(source, &options)
+            .expect("the module compiles")
+            .code
+    }
+
+    /// What the compiler made redundant in `source`, as `(hook, line)` pairs.
+    fn redundant(source: &str) -> Vec<(&'static str, u32)> {
+        let (file, _) = babel_ast(source).expect("the module parses and lowers");
+        let options = TransformOptions {
+            react_compiler: ReactCompilerMode::Syntax,
+            ..TransformOptions::new("app.js")
+        };
+        redundant_memoization(&file, source, &options)
+            .expect("the compiler answers")
+            .into_iter()
+            .map(|memo| (memo.hook, memo.line))
+            .collect()
+    }
+
+    #[test]
+    fn a_memo_in_a_compiled_component_is_redundant() {
+        assert_eq!(
+            redundant(
+                "import {useMemo} from 'react';\ncomponent List(items: Array<string>) {\n  const sorted = useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\n"
+            ),
+            [("useMemo", 3)]
+        );
+    }
+
+    #[test]
+    fn a_callback_in_a_compiled_hook_is_redundant() {
+        assert_eq!(
+            redundant(
+                "import {useCallback} from 'react';\nhook useHandler(id: string): () => void {\n  return useCallback(() => send(id), [id]);\n}\n"
+            ),
+            [("useCallback", 3)]
+        );
+    }
+
+    #[test]
+    fn a_memo_in_a_function_the_compiler_does_not_compile_is_left_alone() {
+        // `syntax` mode compiles `component` and `hook` declarations and
+        // nothing else, so this one is still the only memoization there is.
+        assert_eq!(
+            redundant(
+                "import {useMemo} from 'react';\nexport function List(props: {items: Array<string>}) {\n  const sorted = useMemo(() => props.items.slice(), [props.items]);\n  return <ul>{sorted}</ul>;\n}\n"
+            ),
+            []
+        );
+    }
+
+    #[test]
+    fn a_memo_in_a_function_that_opted_out_is_left_alone() {
+        assert_eq!(
+            redundant(
+                "import {useMemo} from 'react';\ncomponent List(items: Array<string>) {\n  'use no memo';\n  const sorted = useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\n"
+            ),
+            []
+        );
+    }
+
+    #[test]
+    fn a_memo_the_compiler_could_not_preserve_is_left_alone() {
+        // Missing dependency: the compiler refuses the function rather than
+        // dropping a memo whose guarantees it cannot reproduce.
+        assert_eq!(
+            redundant(
+                "import {useMemo} from 'react';\ncomponent Sum(a: number, b: number) {\n  const total = useMemo(() => a + b, [a]);\n  return <p>{total}</p>;\n}\n"
+            ),
+            []
+        );
+    }
+
+    #[test]
+    fn one_module_can_hold_both_answers() {
+        let found = redundant(
+            "import {useMemo} from 'react';\ncomponent List(items: Array<string>) {\n  const sorted = useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\nexport function Plain(props: {items: Array<string>}) {\n  const sorted = useMemo(() => props.items.slice(), [props.items]);\n  return <ul>{sorted}</ul>;\n}\n",
+        );
+        assert_eq!(found, [("useMemo", 3)]);
+    }
+
+    #[test]
+    fn a_module_with_no_manual_memoization_never_reaches_the_compiler() {
+        assert_eq!(
+            redundant("component Page() {\n  return <p>hello</p>;\n}\n"),
+            []
+        );
+    }
+
+    #[test]
+    fn the_react_namespaced_spelling_is_read_too() {
+        assert_eq!(
+            redundant(
+                "import * as React from 'react';\ncomponent List(items: Array<string>) {\n  const sorted = React.useMemo(() => items.slice(), [items]);\n  return <ul>{sorted}</ul>;\n}\n"
+            ),
+            [("useMemo", 3)]
+        );
+    }
+
+    /// The claim the rule makes, checked rather than argued.
+    ///
+    /// `react/no-redundant-memo` tells a reader to delete a call. What makes
+    /// that safe is not that the compiler *dropped* the call — it drops one it
+    /// then reproduces — but that the module without it compiles to the same
+    /// program. So compile both and compare the output, which is the only form
+    /// of the claim a reader would care about: the memoization survives, the
+    /// cache is the same size, and the only line that changes is the import
+    /// that is now unused.
+    #[test]
+    fn deleting_a_reported_memo_compiles_to_the_same_program() {
+        let with = "import {useMemo} from 'react';\nhook useInstant(clockAt: number): number {\n  return useMemo(() => expensive(clockAt), [clockAt]);\n}\n";
+        let without =
+            "hook useInstant(clockAt: number): number {\n  return expensive(clockAt);\n}\n";
+        assert_eq!(redundant(with), [("useMemo", 3)]);
+
+        let kept: Vec<String> = built(with)
+            .lines()
+            .filter(|line| !line.contains("from \"react\""))
+            .map(str::to_owned)
+            .collect();
+        let dropped: Vec<String> = built(without)
+            .lines()
+            .filter(|line| !line.contains("from \"react\""))
+            .map(str::to_owned)
+            .collect();
+
+        assert_eq!(kept, dropped);
+        assert!(
+            kept.iter().any(|line| line.contains("_c(2)")),
+            "the compiler still memoizes: {kept:?}"
+        );
+    }
+
+    #[test]
+    fn a_method_that_shares_the_name_is_not_memoization() {
+        assert_eq!(
+            redundant(
+                "component Page(cache: Cache) {\n  const value = cache.useMemo(1);\n  return <p>{value}</p>;\n}\n"
+            ),
+            []
+        );
+    }
+}

--- a/packages/hooks/render.js
+++ b/packages/hooks/render.js
@@ -212,10 +212,11 @@ export hook useRenderEnvelope(): RenderEnvelope | null {
 export hook useRenderedAt(): Instant {
   const found = useRenderEnvelope();
   const at = found?.at;
-  // The number, not the instant, in the dependency: `Instant` is a new object
-  // every render and depending on it would rebuild this on every one.
+  // The number, not the instant, is what the memoization keys on: `Instant` is
+  // a new object every render, so a scope that depended on one would rebuild
+  // this on every render rather than on every change of clock.
   const clockAt = at ?? currentClock().now();
-  return React.useMemo(() => Temporal.Instant.fromEpochMilliseconds(clockAt), [clockAt]);
+  return Temporal.Instant.fromEpochMilliseconds(clockAt);
 }
 
 /**
@@ -243,9 +244,9 @@ export hook useRenderTimeZone(): string {
  * two sides.
  *
  * The stream is stateful, so a component that draws from it during render draws
- * different numbers on a re-render. Draw in a `useMemo` keyed by what the
- * numbers are for, or in an event, and never in the body of a component React
- * may render twice.
+ * different numbers on a re-render. Draw into a `const` keyed by what the
+ * numbers are for — which the React Compiler memoizes — or in an event, and
+ * never twice in the body of a component React may render twice.
  *
  * Outside a provider the seed is a constant rather than the host's, which looks
  * like the wrong default and is the right one: two renders with no envelope
@@ -257,18 +258,19 @@ export hook useRenderTimeZone(): string {
 export hook useRandom(label: string): Random {
   const found = useRenderEnvelope();
   const seed = found?.seed;
-  return React.useMemo(() => seededRandom(seed ?? "uf").fork(label), [seed, label]);
+  return seededRandom(seed ?? "uf").fork(label);
 }
 
 /**
  * `items`, shuffled the same way on both sides of a hydration.
  *
- * The shuffle is a `useMemo` over the seed, the label and the items, so it is
- * one shuffle rather than one per render — which matters for more than speed:
- * a fresh draw on every render would reorder the list under the reader every
- * time anything else on the page changed.
+ * The shuffle is memoized over the seed, the label and the items — by the React
+ * Compiler, which is where uf's memoization comes from — so it is one shuffle
+ * rather than one per render. That matters for more than speed: a fresh draw on
+ * every render would reorder the list under the reader every time anything else
+ * on the page changed.
  */
 export hook useShuffled<T>(items: $ReadOnlyArray<T>, label: string): Array<T> {
   const random = useRandom(label);
-  return React.useMemo(() => shuffled(items, random), [items, random]);
+  return shuffled(items, random);
 }

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -15,10 +15,8 @@ import {
   createContext,
   startTransition,
   use,
-  useCallback,
   useContext,
   useEffect,
-  useMemo,
   useState,
   useSyncExternalStore,
 } from "react";
@@ -1530,9 +1528,9 @@ component RouteErrorView(module: ?ErrorModule, error: RouteError, reset: () => v
  */
 component ResolvedErrorPage() {
   const { resolved, router } = useRouterState();
-  const reset = useCallback(() => {
+  const reset = () => {
     router.refresh().catch(() => {});
-  }, [router]);
+  };
 
   if (resolved.error == null) {
     // Unreachable: this module is only ever the page of a resolved error route.
@@ -1850,7 +1848,7 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
   const [resolved, setResolved] = useState<ResolvedRoute>(initial);
   const [pending, setPending] = useState<boolean>(false);
 
-  const navigate = useCallback(async (to: string, options?: NavigateOptions): Promise<void> => {
+  const navigate = async (to: string, options?: NavigateOptions): Promise<void> => {
     if (!isBrowser()) {
       return;
     }
@@ -1899,7 +1897,7 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
       setPending(false);
       throw error;
     }
-  }, []);
+  };
 
   useEffect(() => {
     if (!isBrowser()) {
@@ -1930,59 +1928,53 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
     };
   }, []);
 
-  const router = useMemo<Router>(
-    () => ({
-      push: (to, options) => navigate(to, options),
-      replace: (to) => navigate(to, { replace: true }),
-      prefetch: async (to) => {
-        if (!isBrowser()) {
-          return;
-        }
-        const target = new URL(to, window.location.href);
-        const matched = matchRoute(routeTable().routes, target.pathname);
-        const load = matched?.route.page;
-        if (matched == null || load == null) {
-          return;
-        }
-        await Promise.all([
-          loadOnce(load),
-          ...matched.route.layouts.map((layout) => loadOnce(layout)),
-        ]);
-      },
-      refresh: async () => {
-        if (!isBrowser()) {
-          return;
-        }
-        const nextResolved = await resolveMatch(
-          routeTable(),
-          window.location.pathname + window.location.search,
-        );
-        // No view transition, and it is the one place that is right: a refresh
-        // is the same URL resolved again, so a transition would animate a page
-        // into itself — a cross-fade between two frames of the same thing,
-        // which is a flicker with a name.
-        startTransition(() => {
-          setResolved(nextResolved);
-        });
-      },
-      back: () => {
-        if (isBrowser()) {
-          window.history.back();
-        }
-      },
-      forward: () => {
-        if (isBrowser()) {
-          window.history.forward();
-        }
-      },
-    }),
-    [navigate],
-  );
+  const router: Router = {
+    push: (to, options) => navigate(to, options),
+    replace: (to) => navigate(to, { replace: true }),
+    prefetch: async (to) => {
+      if (!isBrowser()) {
+        return;
+      }
+      const target = new URL(to, window.location.href);
+      const matched = matchRoute(routeTable().routes, target.pathname);
+      const load = matched?.route.page;
+      if (matched == null || load == null) {
+        return;
+      }
+      await Promise.all([
+        loadOnce(load),
+        ...matched.route.layouts.map((layout) => loadOnce(layout)),
+      ]);
+    },
+    refresh: async () => {
+      if (!isBrowser()) {
+        return;
+      }
+      const nextResolved = await resolveMatch(
+        routeTable(),
+        window.location.pathname + window.location.search,
+      );
+      // No view transition, and it is the one place that is right: a refresh
+      // is the same URL resolved again, so a transition would animate a page
+      // into itself — a cross-fade between two frames of the same thing,
+      // which is a flicker with a name.
+      startTransition(() => {
+        setResolved(nextResolved);
+      });
+    },
+    back: () => {
+      if (isBrowser()) {
+        window.history.back();
+      }
+    },
+    forward: () => {
+      if (isBrowser()) {
+        window.history.forward();
+      }
+    },
+  };
 
-  const value = useMemo<RouterState>(
-    () => ({ resolved, router, pending }),
-    [resolved, router, pending],
-  );
+  const value: RouterState = { resolved, router, pending };
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
 }
 

--- a/packages/state/index.js
+++ b/packages/state/index.js
@@ -644,9 +644,9 @@ export hook useResetAtom<T>(
   store?: Store,
 ): () => void {
   const setter = useSetAtom<T, SetAction<T> | Reset>(target, store);
-  return React.useCallback(() => {
+  return () => {
     setter(RESET);
-  }, [setter]);
+  };
 }
 
 /**
@@ -665,18 +665,16 @@ export hook useResetAtom<T>(
  * component that holds this callback is subscribed to nothing.
  *
  * The identity of what comes back changes when `callback` does, so a handler
- * written inline is a new function every render. Wrap it in `useCallback` when
- * that matters — the same rule as every other hook that takes a function.
+ * written inline is a new function every render unless something memoizes it —
+ * which, inside a `component` the React Compiler compiled, it does. The same
+ * rule as every other hook that takes a function.
  */
 export hook useAtomCallback<Args extends $ReadOnlyArray<mixed>, Result>(
   callback: (get: Getter, set: Setter, ...args: Args) => Result,
   store?: Store,
 ): (...args: Args) => Result {
   const instance = useStoreInstance(store);
-  return React.useCallback(
-    (...args: Args) => callback(instance.get, instance.set, ...args),
-    [callback, instance],
-  );
+  return (...args: Args) => callback(instance.get, instance.set, ...args);
 }
 
 /**


### PR DESCRIPTION
Three `react/*` changes to the linter: one false positive removed, and two rules
added that answer their question from the module's tree rather than from its
lines — one of them by asking the official React Compiler what it did.

Closes #477
Closes #522
Closes #523

## `react/hooks-rules`: an object literal is not a condition (#477)

A hook called in an object literal was reported as a conditional call:

```js
export hook useThing(): { a: number, b: number } {
  const bag = {
    a: useState(0)[0], // error[react/hooks-rules]
    b: useState(1)[0], // error[react/hooks-rules]
  };
  return bag;
}
```

It is not conditional. The literal is the initialiser of a top-level `const`, so
every call in it runs, in order, on every render — which is the whole of what
the rule guarantees.

`uf_react_compiler`'s scope stack counted every `{` that was not a JSX
expression container as nesting. It now distinguishes the braces that open an
*expression the enclosing statement evaluates exactly once* — a JSX container, a
JSX attribute value, an object literal — from the ones that open something the
statement may run zero or many times. `ScopeKind::nests` is that list, and
`opens_an_object_literal` answers the object-literal case from the token in
front of the brace, with the enclosing frame settling the one ambiguous row
(`{ outer: { … } }` versus `case 1: { … }`).

**Still rejected**, each with a test: the same literal inside an `if`, inside a
callback, an object *method* body (`{ read() { … } }` — a brace after `)`, which
keeps nesting), a `switch` case block, and a labelled block. A brace that
stopped nesting everywhere would be a hole rather than a fix.

## `react/no-derived-state-effect` — `error` (#522)

The opening shape of ["You Might Not Need an
Effect"](https://react.dev/learn/you-might-not-need-an-effect): an effect whose
whole body writes state computed from its own dependencies.

```js
const [full, setFull] = useState("");
useEffect(() => {
  setFull(first + " " + last); // error[react/no-derived-state-effect]
}, [first, last]);
```

`error`, because the component renders once with the value it had before the
effect ran and then again — a user sees the stale one — and the fix is to move
one expression into render.

The rule reports only where that move is provably safe: a `useEffect` with two
arguments, a parameterless non-`async` arrow whose body is exactly one
expression statement, a setter destructured from a `useState` of an enclosing
function, a non-empty dependency array of plain identifiers, and a stored value
built only from those identifiers, literals and pure operators.

**Deliberately silent**, each with a test:

| Shape | Why |
| --- | --- |
| `setItems(data.items)` | `data.items` and `box.offsetWidth` are the same three tokens, and a layout read must *not* move into render |
| `setSorted(sort(items))` | nothing in the tree says `sort` is pure |
| `setSelection(null)` on `[items]` | the article's *other* shape; its fix is a `key` or a redesign, not moving an expression |
| `useLayoutEffect` | where measuring belongs |
| no dependency array, or an empty one | neither derives anything from anything |
| `setValue` that is a prop | calling a prop from an effect is what an effect is *for* |
| `setCount((previous) => previous + step)` | an updater is not a derived value |
| `[data.id]` as a dependency | a claim about the field, not about `data` |
| a dependency the state itself feeds | see below |

That last row is this repository's own finding, and it is the reason the rule
grew a graph walk (`SetterScope::feeds_back`). `@uniflowed/hooks`' `useTimeAgo`
stores a schedule; the schedule chooses a tick, the tick drives a clock, and the
clock's reading is what chooses the next schedule. The effect's dependency is
four bindings away from the state it writes, and `const schedule = wanted`
during render would define the value in terms of itself. The rule now walks the
reads of every binding in the enclosing body and stays silent when the state is
reachable from a dependency. Over-connected on purpose: a spurious edge costs a
report, never a wrong one.

## `react/no-redundant-memo` — `warn` (#523)

uf runs the official React Compiler on every module, so a hand-written `useMemo`
or `useCallback` in a compiled `component` or `hook` is usually a second
dependency array to keep correct. Usually, not always — and the difference is
not something to approximate. `ubugeeei-redundancy.md` is explicit that uf uses
the official compiler rather than a replacement for its optimizations, so the
rule asks it.

`uf_transform::memo` records every `useMemo`/`useCallback` in the module,
compiles it through the *same* `plugin_options` `uf build` uses — factored out
for exactly this reason, so the linter cannot report a memoization the build
then keeps — and reports a call only when it stood inside a function the
compiler logged `CompileSuccess` for **and** is gone from the compiled output.
Every silent case is silent for a reason the compiler gave:

| Written in | Compiler said | Reported |
| --- | --- | --- |
| a `component`/`hook` uf compiles | `CompileSuccess`, call gone | yes |
| a plain `function` (`syntax` mode compiles neither) | nothing | no |
| a function carrying `"use no memo"` | `CompileSkip` | no |
| a memo with an incomplete dependency array | `CompileError` | no |
| any other bail-out | not a success | no |

Off entirely when `app.builtins.reactCompiler.enabled` is `false`, because then
the hand-written one is the only memoization there is.

`warn`, not `error`: nothing is broken, and deleting memoization is a refactor
rather than something a build should fail over.

`deleting_a_reported_memo_compiles_to_the_same_program` checks the claim rather
than arguing it — it compiles the module with and without the reported call and
compares the output.

## What the new rules found here

`uf lint` was 0 errors and 14 warnings. The rules added one error and nine
warnings; all ten are dealt with in this branch, and none of them with a
suppression.

**The error was a false positive** — `@uniflowed/hooks`' `useTimeAgo`, the
feedback loop described above. Fixed in the rule, with a regression test cut
down from the real hook.

**The nine warnings were real**, in three modules:

- `packages/hooks/render.js` — `useRenderedAt`, `useRandom`, `useShuffled`
- `packages/router/internal/runtime.js` — `ResolvedErrorPage`'s `reset`, and
  `RouterProvider`'s `navigate`, `router` and `value`
- `packages/state/index.js` — `useResetAtom`, `useAtomCallback`

All nine are removed. Each of the three modules was compiled before and after
and the emitted JavaScript is **byte-identical apart from the now-unused
import** — the compiler's reactive scopes were already producing the same cache
of the same size, including for the two context values and the callback that
crosses into a `RouteErrorView` prop. The doc comments that argued for the
hand-written memoization were rewritten to say where the memoization actually
comes from, rather than deleted.

## Cost, and where it is paid

Both rules parse the module again, and one compiles it. Four gates stand in
front of that, in order of cheapness: neither rule enabled, the path is not Flow
source, the text holds no `useEffect`/`useMemo`/`useCallback`, or the module is
past `uf_flow`'s parser ceilings (where `flow/syntax` has already refused it).
Past those, the parse runs on a thread with `uf_flow::PARSE_STACK_BYTES`. `uf
lint` over this repository — 421 files, 43 of them naming `useEffect` and 52
naming `useMemo` or `useCallback` — finishes in half a second.

## Deliberately left out

**A `--fix` for either rule.** #522 asks for one where the rewrite is
mechanical, and it is; it still cannot be spelled as a `Fix`, which is one line
and one `&'static str` by design. Deleting a `useState` and an effect and
leaving a `const` behind spans lines and statements and needs text taken from
the file. Widening `Fix` changes `--fix`, `--fix-unsafe`, `uf prepare` and the
editor's code actions at once; that is its own change, and `crates/uf_cli/src/fix.rs`
now says so where it lists the rules that have no fix and why.

**`useEffect(() => setX(f(props)), [props])`**, the example in #522's own text.
`f` may read the DOM or a clock, and nothing in the tree says which — so at
`error` severity the rule stops at expressions over its dependencies. Widening
it needs purity information the linter does not have.

## Checked

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test -p uf_lint` (281), `cargo test -p uf_transform` (71),
`cargo test -p uf_react_compiler` (197), `cargo test --workspace`,
`uf fmt --check`, `uf lint` (0 errors, 14 warnings — the baseline) and
`uf test#library` (2432 passed, 0 failed) all pass. The six `uf_cli --test vite`
tests that fail here fail for want of a loopback socket the sandbox will not
bind, and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791402091&installation_model_id=422833&pr_number=606&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F606&signature=bbfeb81ee71c490b7d2c7e9b7220ee3d2be0136890dd7b7acbafd4f29344daaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->