### PR TITLE
chore(release): uf@0.0.0-alpha.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## uf@0.0.0-alpha.14
+
+_2026-09-07_
+
+Twenty-one changes, and the ones worth reading first are the two that were
+wrong in a way nothing could see.
+
+`@uniflowed/test` could not be imported on Bun at all. `ref()`/`unref()` set a
+flag on Node and *count* on Bun, and the transform service said what it wanted
+on every request rather than on the transition — so two sibling imports left
+the host referenced for ever, and every program that imports the test package
+is fifteen modules. This lands a week after the Bun host was made to load at
+all, which is the argument for the test that now starts a real Bun process
+rather than a claim in a README.
+
+Every React Compiler finding pointed at the wrong line, and a quarter of them
+did not exist. The position fell back to a field this compiler never populates,
+so all 173 findings named their `component` or `hook` keyword; the plugin's
+de-duplication then collapsed them to 119 lines, and the 54 it dropped were
+distinct sites — five different ref reads in one component. Findings also could
+not name their function, so all 173 said `a function`. They name 74 distinct
+functions now.
+
+`uf check` gives the same answer twice. The wall-clock inference budget is
+gone: a file the clock aborted was written to no record, so the next run
+inferred it again, off the clock that time, and reported errors the first run
+had thrown away. What bounds the checker now is work — recursion depth, type
+expansion, source bytes — and four cold runs over the same tree that varied by
+1.77× from machine load are why.
+
+And a build that emits no server refuses a callable server action instead of
+shipping a wired button and a 404; `uf build --adapter static` says which route
+handler, which middleware, which unprerendered route and which action stand in
+the way. Draft mode survives the request it was enabled in. `lint.rules` merges
+into uf's table instead of replacing it, so naming one rule no longer switches
+the other fifty-three off. The manual's "next page" reaches the end.
+
+### Added
+
+- **router, cli**: the files a route is, and a render anchor nobody has to wire (#616)
+- **lint, config**: accessibility and markup rules, a guard that does not refine, and a rule table that stopped being one (#623)
+- **runtime, config, test**: a permission set uf owns, and a host table that is checked (#617)
+- **server, router**: draft mode that survives the request, and every refusal said out loud (#615)
+- **ui, form**: the other three menus, the Enter a checkbox owes its form, and one place that computes aria-describedby (#613)
+- **build, config**: what a build produces, the two settings that decide it, and a builder that is a provider (#609)
+- **tui**: the mouse, routed by a grid the painter records (#608)
+- **lint, hooks, router, state**: an effect that is not one, a memo the compiler already did, and a literal that was never conditional (#606)
+- **pm, config, release**: provenance, a scope bound to one registry, and an origin the release host cannot forge (#604)
+- **vite, dev, router**: one renderer, a watched environment, and a channel from the browser (#602)
+
+### Fixed
+
+- **test**: a tick over work that did not happen, and four more the runner told itself (#605)
+- **cli**: one list of what `uf explain` describes, rather than two that drifted (#624)
+- **test, cli, host**: `expect`'s last any, the port `uf dev` bound, and a Bun host that could not load the test package (#622)
+- **transform, vite**: a React Compiler finding that names its function and points at itself (#611)
+- **hooks**: `useHash` hears a `pushState` it did not make (#610)
+- **check**: one record per file, an answer per batch, and no clock in the answer (#603)
+- **prepare, lint, test**: a path a run names survives `.gitignore` (#601)
+- **router**: every extension the build runs is a route, and a name it cannot run is not (#580)
+- **docs**: the manual lists State once, so "next page" reaches the end (#587)
+
+### Documentation
+
+- **security**: the threat model's rows are inside its table again (#592)
+
+### Internal
+
+- **docs, security, vite**: every link the build wrote resolves, and a scan that is uf's own (#595)
+
 ## uf@0.0.0-alpha.13
 
 _2026-09-08_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_assets"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "base64",
  "brotli",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "base64",
  "brotli",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "serde",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "serde",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "criterion",
  "phf",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "base64",
  "camino",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "compact_str",
  "serde",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "serde",
  "smallvec",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "uf_task"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "base64",
  "camino",
@@ -3808,14 +3808,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "camino",
  "compact_str",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.13"
+version = "0.0.0-alpha.14"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.13",
-    "@uniflowed/config": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13",
-    "@uniflowed/router": "0.0.0-alpha.13",
-    "@uniflowed/vite": "0.0.0-alpha.13",
-    "@uniflowed/web": "0.0.0-alpha.13",
+    "@uniflowed/brand": "0.0.0-alpha.14",
+    "@uniflowed/config": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14",
+    "@uniflowed/router": "0.0.0-alpha.14",
+    "@uniflowed/vite": "0.0.0-alpha.14",
+    "@uniflowed/web": "0.0.0-alpha.14",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.13",
-        "@uniflowed/config": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13",
-        "@uniflowed/router": "0.0.0-alpha.13",
-        "@uniflowed/vite": "0.0.0-alpha.13",
-        "@uniflowed/web": "0.0.0-alpha.13",
+        "@uniflowed/brand": "0.0.0-alpha.14",
+        "@uniflowed/config": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14",
+        "@uniflowed/router": "0.0.0-alpha.14",
+        "@uniflowed/vite": "0.0.0-alpha.14",
+        "@uniflowed/web": "0.0.0-alpha.14",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -4381,65 +4381,65 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.13",
-        "@uniflowed/test": "0.0.0-alpha.13"
+        "@uniflowed/config": "0.0.0-alpha.14",
+        "@uniflowed/test": "0.0.0-alpha.14"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.13",
-        "@uniflowed/ui": "0.0.0-alpha.13",
-        "@uniflowed/validator": "0.0.0-alpha.13"
+        "@uniflowed/react": "0.0.0-alpha.14",
+        "@uniflowed/ui": "0.0.0-alpha.14",
+        "@uniflowed/validator": "0.0.0-alpha.14"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4447,10 +4447,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.13"
+        "@uniflowed/fetch": "0.0.0-alpha.14"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4458,19 +4458,19 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4478,120 +4478,120 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/i18n": {
       "name": "@uniflowed/i18n",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.13",
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/fetch": "0.0.0-alpha.13"
+        "@uniflowed/cell": "0.0.0-alpha.14",
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/fetch": "0.0.0-alpha.14"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.13",
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/config": "0.0.0-alpha.14",
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/hooks": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4599,7 +4599,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4607,28 +4607,28 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13",
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4638,7 +4638,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4647,20 +4647,20 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.13",
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/config": "0.0.0-alpha.14",
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.13",
-        "@uniflowed/server": "0.0.0-alpha.13"
+        "@uniflowed/hooks": "0.0.0-alpha.14",
+        "@uniflowed/server": "0.0.0-alpha.14"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4669,46 +4669,46 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/cell": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13",
-        "@uniflowed/react-testing": "0.0.0-alpha.13",
-        "@uniflowed/test": "0.0.0-alpha.13"
+        "@uniflowed/mock": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14",
+        "@uniflowed/react-testing": "0.0.0-alpha.14",
+        "@uniflowed/test": "0.0.0-alpha.14"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4716,54 +4716,54 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.13"
+        "@uniflowed/host": "0.0.0-alpha.14"
       }
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.13",
-        "@uniflowed/test": "0.0.0-alpha.13"
+        "@uniflowed/react-testing": "0.0.0-alpha.14",
+        "@uniflowed/test": "0.0.0-alpha.14"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.13",
+        "@uniflowed/react": "0.0.0-alpha.14",
         "react-reconciler": "^0.33.0"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/hooks": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/hooks": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4771,18 +4771,18 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.13",
-        "@uniflowed/server": "0.0.0-alpha.13",
+        "@uniflowed/host": "0.0.0-alpha.14",
+        "@uniflowed/server": "0.0.0-alpha.14",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4797,21 +4797,21 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.13",
-        "@uniflowed/core": "0.0.0-alpha.13"
+        "@uniflowed/browser": "0.0.0-alpha.14",
+        "@uniflowed/core": "0.0.0-alpha.14"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.13",
+      "version": "0.0.0-alpha.14",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.13",
-        "@uniflowed/hooks": "0.0.0-alpha.13",
-        "@uniflowed/react": "0.0.0-alpha.13"
+        "@uniflowed/core": "0.0.0-alpha.14",
+        "@uniflowed/hooks": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.14"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Fine-grained reactivity: state, derived values, effects and resources, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "temporal.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.13",
-    "@uniflowed/test": "0.0.0-alpha.13"
+    "@uniflowed/config": "0.0.0-alpha.14",
+    "@uniflowed/test": "0.0.0-alpha.14"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "stream.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -26,9 +26,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.13",
-    "@uniflowed/ui": "0.0.0-alpha.13",
-    "@uniflowed/validator": "0.0.0-alpha.13"
+    "@uniflowed/react": "0.0.0-alpha.14",
+    "@uniflowed/ui": "0.0.0-alpha.14",
+    "@uniflowed/validator": "0.0.0-alpha.14"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.13"
+    "@uniflowed/fetch": "0.0.0-alpha.14"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,8 +27,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/i18n",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Type-safe internationalisation on MessageFormat 2: a message's arguments are checked at the call, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/cell": "0.0.0-alpha.13",
-    "@uniflowed/fetch": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/cell": "0.0.0-alpha.14",
+    "@uniflowed/fetch": "0.0.0-alpha.14"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.13",
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/config": "0.0.0-alpha.14",
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/hooks": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13",
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.13",
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/config": "0.0.0-alpha.14",
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.13",
-    "@uniflowed/server": "0.0.0-alpha.13"
+    "@uniflowed/hooks": "0.0.0-alpha.14",
+    "@uniflowed/server": "0.0.0-alpha.14"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -42,6 +42,6 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/cell": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,10 +22,10 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13",
-    "@uniflowed/react-testing": "0.0.0-alpha.13",
-    "@uniflowed/test": "0.0.0-alpha.13"
+    "@uniflowed/mock": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14",
+    "@uniflowed/react-testing": "0.0.0-alpha.14",
+    "@uniflowed/test": "0.0.0-alpha.14"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.13"
+    "@uniflowed/host": "0.0.0-alpha.14"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.13",
-    "@uniflowed/test": "0.0.0-alpha.13"
+    "@uniflowed/react-testing": "0.0.0-alpha.14",
+    "@uniflowed/test": "0.0.0-alpha.14"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "A React renderer whose host is a terminal, following OpenTUI, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.13",
+    "@uniflowed/react": "0.0.0-alpha.14",
     "react-reconciler": "^0.33.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -52,9 +52,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/hooks": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/hooks": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -33,8 +33,8 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.13",
-    "@uniflowed/server": "0.0.0-alpha.13",
+    "@uniflowed/host": "0.0.0-alpha.14",
+    "@uniflowed/server": "0.0.0-alpha.14",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.13",
-    "@uniflowed/core": "0.0.0-alpha.13"
+    "@uniflowed/browser": "0.0.0-alpha.14",
+    "@uniflowed/core": "0.0.0-alpha.14"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.13",
+  "version": "0.0.0-alpha.14",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,8 +23,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.13",
-    "@uniflowed/hooks": "0.0.0-alpha.13",
-    "@uniflowed/react": "0.0.0-alpha.13"
+    "@uniflowed/core": "0.0.0-alpha.14",
+    "@uniflowed/hooks": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.14"
   }
 }


### PR DESCRIPTION
Twenty-one changes since `uf@0.0.0-alpha.13`. The two worth reading first were
both wrong in a way nothing could see.

**`@uniflowed/test` could not be imported on Bun at all** (#622). `ref()` /
`unref()` set a flag on Node and *count* on Bun, and the transform service said
what it wanted on every request rather than on the transition — so two sibling
imports left the host referenced for ever, and every program importing the test
package is fifteen modules. It lands right after the Bun host was made to load
at all (#594), which is the argument for the test that now starts a real Bun
process instead of a claim in a README.

**Every React Compiler finding pointed at the wrong line, and a quarter of them
did not exist** (#611). The position fell back to a field this compiler never
populates, so all 173 findings named their `component` or `hook` keyword; the
plugin's de-duplication then collapsed them to 119 lines, and the 54 it dropped
were distinct sites — five different ref reads in one component. Findings also
could not name their function, so all 173 said `a function`. They name 74
distinct functions now.

Also in it:

- **`uf check` gives the same answer twice** (#603). The wall-clock inference
  budget is gone — a file the clock aborted was written to no record, so the
  next run inferred it again, off the clock, and reported errors the first run
  had thrown away. Four cold runs over one tree varied by 1.77× from load
  alone.
- **A build that emits no server refuses a callable server action** (#609,
  #621) instead of shipping a wired button and a 404 nobody sees until a click.
- **Draft mode survives the request it was enabled in** (#615), and a request
  Node's parser refuses is logged.
- **`lint.rules` merges into uf's table** instead of replacing it (#623), so
  naming one rule no longer switches the other fifty-three off — silently,
  including `flow/syntax`.
- The mouse in the terminal (#608), the other three menus and `Field` joined to
  `@uniflowed/form` (#613), a permission set uf owns across Node, Bun and Deno
  (#617), npm provenance and a scope bound to one registry (#604), and one
  render middleware in `uf dev` that answers what production answers (#602).

## About the date

This section says `_2026-09-07_` while alpha.13's says `_2026-09-08_`, and
neither is a mistake by the rule the tool follows — the date is the committer
date of the commit being released, and `%cs` renders each commit in its own
recorded timezone. alpha.13's head carried `+09:00`; this one carries `+00:00`.
#630 argues for choosing one timezone. alpha.13's published section is left
alone.

## Verification

```
uf run release:changelog        exit 0
uf run release:changelog:test   exit 0
uf run lockfile                 exit 0
uf run manifests                exit 0
uf run release:closure          exit 0
uf run publishable              exit 0
uf run scripts:parse            exit 0
cargo metadata --locked         exit 0
```

## After this merges

The tag publishes: `uf@0.0.0-alpha.14` runs `release.yml` for the four target
binaries and `publish.yml` for npm. Moving the `latest` dist-tag remains a
person's step — npm exchanges the workflow's id-token for `npm publish` and
nothing else — and `latest` is still on alpha.11 for nine names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791417234&installation_model_id=422833&pr_number=632&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F632&signature=bdfdf44ceba2626dd0b2ab5a0a5b12ef1be1c55b2bfe06dfbcb762d8b54791dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->