### PR TITLE
ci(publish): the runtimes the workspace suite starts, in every job that runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,8 @@ jobs:
       # that cannot report `skipped`. See #367.
       - run: ./target/release/uf run ci:gate
       - run: ./target/release/uf run ci:gate:test
+      - run: ./target/release/uf run ci:runtimes
+      - run: ./target/release/uf run ci:runtimes:test
 
   upstream-integrations:
     name: Upstream Integrations

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,18 @@ on:
   push:
     tags:
       - "uf@*"
+  # And by hand, for the release that half-sent. `uf@0.0.0-alpha.14` was tagged,
+  # its binaries were built and released, and this job failed before publishing
+  # anything — so the tag existed, the GitHub release existed, and npm had
+  # nothing. A tag-only trigger leaves no way out of that but a second tag for
+  # code that has not changed. The version is the tag to publish, without the
+  # `uf@` prefix, and the checkout below uses it.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, without the uf@ prefix"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -20,6 +32,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # The tag on a push; the tag the operator named on a dispatch. Not
+          # the default branch: a re-run has to publish the code that was
+          # released, not whatever has merged since.
+          ref: ${{ inputs.version && format('uf@{0}', inputs.version) || github.ref }}
       - run: tools/upstream/sync.sh
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
@@ -43,6 +59,20 @@ jobs:
         with:
           bun-version: latest
       - run: bun --version
+      # And Deno, for `crates/uf_cli/tests/deno_host.rs`. Those tests fail
+      # rather than skip when the runtime is absent — deliberately, so that a
+      # host claim nobody checked cannot be green — and this job runs the same
+      # suite, so a runtime missing here is a publish that cannot happen.
+      #
+      # It was missing here. `uf@0.0.0-alpha.14` was tagged, its four binaries
+      # were built and released, and this job failed on six Deno tests before
+      # publishing a single package: a release with a tag, a GitHub release and
+      # nothing on npm. `tools/ci/workspace-suite-runtimes.sh` is why the next
+      # runtime cannot be added to one workflow and not the other.
+      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
+        with:
+          deno-version: v1.x
+      - run: deno --version
       - run: cargo test --workspace
       # Only the packages in `tools/release/published-packages.txt`, which is
       # the set that is implemented.

--- a/tools/ci/test-workspace-suite-runtimes.sh
+++ b/tools/ci/test-workspace-suite-runtimes.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env sh
+# `workspace-suite-runtimes.sh`, against pipelines with a defect planted in
+# them. A check nobody has watched fail is a check nobody knows the shape of.
+set -eu
+
+root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
+check="$root/tools/ci/workspace-suite-runtimes.sh"
+
+work="${TMPDIR:-/tmp}/uf-suite-runtimes-test.$$"
+rm -rf "$work"
+mkdir -p "$work/.github/workflows" "$work/crates/uf_cli/tests" "$work/tools/ci"
+trap 'rm -rf "$work"' EXIT
+cp "$check" "$work/tools/ci/"
+
+# The three test files the check keys off. Their contents do not matter; the
+# check asks whether they exist, because a runtime is required exactly when
+# something starts it.
+: > "$work/crates/uf_cli/tests/bun_host.rs"
+: > "$work/crates/uf_cli/tests/deno_host.rs"
+: > "$work/crates/uf_cli/tests/permissions.rs"
+
+failures=0
+
+# `case` "$1" describes the defect; the rest is the workflow to write.
+plant() {
+  cat > "$work/.github/workflows/pipeline.yml"
+}
+
+expect() {
+  want="$1"
+  why="$2"
+  if ( cd "$work" && sh tools/ci/workspace-suite-runtimes.sh >"$work/out" 2>&1 ); then
+    got=0
+  else
+    got=1
+  fi
+  if [ "$got" != "$want" ]; then
+    echo "FAIL: $why (wanted exit $want, got $got)" >&2
+    sed 's/^/    /' "$work/out" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+names() {
+  if ! grep -q "$1" "$work/out"; then
+    echo "FAIL: the message does not name '$1'" >&2
+    sed 's/^/    /' "$work/out" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+echo "a job with all three runtimes passes"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+      - uses: denoland/setup-deno@v2
+      - uses: actions/setup-node@v7
+      - run: cargo test --workspace
+YAML
+expect 0 "all three present"
+
+echo "a missing runtime is named, with the file that starts it"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v7
+      - run: cargo test --workspace
+YAML
+expect 1 "deno missing"
+names "without deno"
+names "crates/uf_cli/tests/deno_host.rs"
+
+echo "the suite reached through uf run rust:test counts"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+      - run: ./target/release/uf run rust:test
+YAML
+expect 1 "rust:test is the same command"
+
+echo "the suite reached through uf run ci counts"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./target/release/uf run ci
+YAML
+expect 1 "ci depends on rust:test"
+
+echo "uf run ci:gate is not uf run ci"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./target/release/uf run ci:gate
+      - run: ./target/release/uf run ci:gate:test
+  suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+      - uses: denoland/setup-deno@v2
+      - uses: actions/setup-node@v7
+      - run: cargo test --workspace
+YAML
+expect 0 "a task whose name merely begins with ci is not the suite"
+
+echo "a comment naming the command is prose, not a step"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      # A check that is in the pipeline and not in `uf run ci` is a check a
+      # contributor cannot run before pushing.
+      - run: echo nothing
+  suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+      - uses: denoland/setup-deno@v2
+      - uses: actions/setup-node@v7
+      - run: cargo test --workspace
+YAML
+expect 0 "a comment is not a command"
+
+echo "a runtime with no test file is not required"
+rm "$work/crates/uf_cli/tests/deno_host.rs"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v7
+      - run: cargo test --workspace
+YAML
+expect 0 "nothing starts deno, so nothing needs it"
+: > "$work/crates/uf_cli/tests/deno_host.rs"
+
+echo "a pipeline that runs no suite is refused rather than passing silently"
+plant <<'YAML'
+name: Pipeline
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo clippy --workspace
+YAML
+expect 1 "a check that checks nothing has stopped being a check"
+names "stopped checking anything"
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures case(s) failed" >&2
+  exit 1
+fi
+echo "workspace-suite-runtimes: every case behaved"

--- a/tools/ci/workspace-suite-runtimes.sh
+++ b/tools/ci/workspace-suite-runtimes.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env sh
+# Every job that runs the workspace test suite installs the runtimes it starts.
+#
+# `crates/uf_cli/tests/{bun_host,deno_host,permissions}.rs` start real Bun,
+# Deno and Node processes, and they **fail rather than skip** when the runtime
+# is absent. That is the policy working — a host claim nobody checked must not
+# be green — but it makes `cargo test --workspace` runnable only in a job that
+# installed all three.
+#
+# `publish.yml` was not such a job. `uf@0.0.0-alpha.14` was tagged, its four
+# binaries were built and released, and the publish job failed on six Deno
+# tests before publishing a single package: a tag, a GitHub release, and
+# nothing on npm. Deno had been added to `ci.yml`'s suite-running jobs and not
+# to the third one, which lives in another file.
+#
+# So the rule is checked rather than remembered, from the side that cannot be
+# forgotten: find the jobs that run the suite — directly, or through
+# `uf run rust:test` or `uf run ci`, which are the same command — and then look
+# for each runtime's setup step. A workflow added later that runs the suite is
+# caught the first time it does.
+#
+# No temporary files: this runs in `Metadata`, which installs nothing, and on a
+# machine whose `mktemp` may be refused.
+set -eu
+
+root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
+cd "$root"
+
+# name : the action that installs it : the test file that starts it.
+# A runtime whose test file does not exist is not required yet.
+# A literal tab, taken once. Nesting `$(printf '\t')` inside the `$( … )`
+# below is a parse error on bash 3.2, which is `/bin/sh` on macOS — and
+# `scripts:parse` runs `sh -n` with whatever `sh` is, so a script that only
+# parses under dash is a script that fails somebody's check.
+TAB=$(printf '\t')
+
+RUNTIMES="bun:oven-sh/setup-bun:crates/uf_cli/tests/bun_host.rs
+deno:denoland/setup-deno:crates/uf_cli/tests/deno_host.rs
+node:actions/setup-node:crates/uf_cli/tests/permissions.rs"
+
+# One pass, emitting `RUNS <workflow> <job>` and
+# `MISSING <workflow> <job> <runtime> <file>`, so the results survive the
+# subshell a pipeline puts the loop in.
+#
+# It is a function rather than the body of the `$( … )` below, and that is not
+# style: bash 3.2 — `/bin/sh` on macOS — cannot parse a `case` inside a command
+# substitution, and `scripts:parse` runs `sh -n` with whatever `sh` is.
+scan() {
+  for workflow in .github/workflows/*.yml; do
+    # One line per job: name, a tab, then its whole body flattened. A job starts
+    # at two-space indentation under `jobs:`; everything more indented is part
+    # of it.
+    awk '
+      /^jobs:/ { in_jobs = 1; next }
+      !in_jobs { next }
+      /^[^ ]/  { in_jobs = 0; next }
+      /^  [A-Za-z0-9_-]+:/ {
+        if (job != "") printf "%s\t%s\n", job, body
+        job = $1; sub(/:$/, "", job); body = ""; next
+      }
+      # Only what the job *does*. A comment mentioning `uf run ci` is prose,
+      # and reading it as a command is how this check first reported four jobs
+      # that run no suite at all.
+      /^ *#/ { next }
+      /run:|uses:/ { body = body " " $0 }
+      END { if (job != "") printf "%s\t%s\n", job, body }
+    ' "$workflow" | while IFS="$TAB" read -r job body; do
+      case "$body" in
+        *"cargo test --workspace"* | *"uf run rust:test"*) ;;
+        *"uf run ci "* | *"uf run ci") ;;
+        *) continue ;;
+      esac
+      echo "RUNS $workflow $job"
+      for runtime in $RUNTIMES; do
+        name=${runtime%%:*}
+        rest=${runtime#*:}
+        action=${rest%%:*}
+        needed_by=${rest#*:}
+        [ -f "$needed_by" ] || continue
+        case "$body" in
+          *"$action"*) ;;
+          *) echo "MISSING $workflow $job $name $needed_by" ;;
+        esac
+      done
+    done
+  done
+}
+
+findings=$(scan)
+
+echo "$findings" | grep '^RUNS ' | while read -r _ workflow job; do
+  echo "$workflow: '$job' runs the workspace suite"
+done
+
+if ! echo "$findings" | grep -q '^RUNS '; then
+  echo "no job runs the workspace suite — this check has stopped checking anything" >&2
+  exit 1
+fi
+
+if echo "$findings" | grep -q '^MISSING '; then
+  echo >&2
+  echo "$findings" | grep '^MISSING ' | while read -r _ workflow job name needed_by; do
+    echo "$workflow: '$job' runs the workspace suite without $name." >&2
+    echo "  $needed_by starts it, and fails rather than skips when it is absent." >&2
+  done
+  echo >&2
+  echo "a job runs the workspace suite without a runtime the suite starts" >&2
+  exit 1
+fi
+
+echo "every job running the workspace suite installs the runtimes it starts"

--- a/uf.config.js
+++ b/uf.config.js
@@ -631,6 +631,31 @@ export default defineConfig({
       inputs: ["tools/ci/gate-covers-every-job.sh", "tools/ci/test-gate-covers-every-job.sh"],
     },
 
+    // And that a job which runs the workspace suite installs the runtimes the
+    // suite starts. `bun_host.rs`, `deno_host.rs` and `permissions.rs` start
+    // real processes and fail rather than skip when the runtime is absent —
+    // deliberately, so a host claim nobody checked cannot be green — which
+    // makes `cargo test --workspace` runnable only where all three are
+    // installed.
+    //
+    // `publish.yml` was not such a job. `uf@0.0.0-alpha.14` was tagged, its
+    // four binaries were built and released, and the publish job failed on six
+    // Deno tests before publishing a single package: a tag, a GitHub release,
+    // and nothing on npm. Deno had been added to `ci.yml`'s two suite-running
+    // jobs and not to the third, which lives in another file. See #634.
+    "ci:runtimes": {
+      command: "tools/ci/workspace-suite-runtimes.sh",
+      inputs: [
+        ".github/workflows/*.yml",
+        "crates/uf_cli/tests/*.rs",
+        "tools/ci/workspace-suite-runtimes.sh",
+      ],
+    },
+    "ci:runtimes:test": {
+      command: "tools/ci/test-workspace-suite-runtimes.sh",
+      inputs: ["tools/ci/workspace-suite-runtimes.sh", "tools/ci/test-workspace-suite-runtimes.sh"],
+    },
+
     manifests: {
       command:
         "node -e \"for (const f of require('node:fs').globSync('packages/*/package.json')) JSON.parse(require('node:fs').readFileSync(f, 'utf8'))\"",
@@ -680,6 +705,8 @@ export default defineConfig({
         "release:changelog:test",
         "ci:gate",
         "ci:gate:test",
+        "ci:runtimes",
+        "ci:runtimes:test",
         // `docs:verify` rather than the four checks under it, because that is
         // what the `Docs build` job runs and this list is the whole of
         // `uf run` in `.github/workflows/`. It reaches `docs:links`,


### PR DESCRIPTION
`uf@0.0.0-alpha.14` was tagged an hour ago. `release.yml` built and released its
four binaries. `publish.yml` failed before publishing a single package:

```
---- a_uf_package_cannot_be_imported_on_deno stdout ----
thread 'a_uf_package_cannot_be_imported_on_deno' panicked at crates/uf_cli/tests/support/mod.rs:212:5:
this test needs `deno` on PATH and there is none, so it would prove nothing

test result: FAILED. 1 passed; 6 failed
##[error]Process completed with exit code 101.
```

So the release has a tag, a GitHub release with four archives and their
checksums, and `npm install @uniflowed/react@0.0.0-alpha.14` answers `ETARGET`.

## Why

#617 added `crates/uf_cli/tests/deno_host.rs`, which starts a real Deno and
**fails rather than skips** when the runtime is absent. That is the policy
working — its own comment says a host claim nobody checked must not be green —
and it makes `cargo test --workspace` runnable only in a job that installed
Deno.

Deno went into `ci.yml`'s two suite-running jobs. There is a third, in another
file: `publish.yml`'s `npm` job runs the same command before publishing, and
already had Node and Bun added for exactly this reason, each with a comment
saying so. It did not get Deno.

## What this does

**Deno in `publish.yml`**, with the reason on the step.

**A `workflow_dispatch` on `publish.yml`**, taking the version to publish, with
a checkout `ref` that resolves to that tag. A tag-only trigger leaves no way out
of a half-sent release but a second tag for code that has not changed; this
publishes what was actually released rather than whatever has merged since.

**`tools/ci/workspace-suite-runtimes.sh`**, wired into `uf run ci` and the
`Metadata` job. Every job that runs the workspace suite — directly, or through
`uf run rust:test` or `uf run ci` — has to install the runtimes the suite
starts. The requirement is derived from the tests, not from a list somebody
maintains: a runtime whose test file does not exist is not required, and a
fourth runtime is covered the day something starts it. On the missing case it
names the job, the runtime and the file that starts it.

## Evidence

Reverting only the `publish.yml` change:

```
.github/workflows/publish.yml: 'npm' runs the workspace suite without deno.
  crates/uf_cli/tests/deno_host.rs starts it, and fails rather than skips when it is absent.

a job runs the workspace suite without a runtime the suite starts
```

Restoring it passes, and reports the three jobs it checked:

```
.github/workflows/ci.yml: 'test' runs the workspace suite
.github/workflows/ci.yml: 'upstream-typecheck' runs the workspace suite
.github/workflows/publish.yml: 'npm' runs the workspace suite
every job running the workspace suite installs the runtimes it starts
```

Two things the first version of the check got wrong are now cases in
`tools/ci/test-workspace-suite-runtimes.sh`: a comment mentioning `uf run ci`
is prose rather than a command, and `uf run ci:gate` is not `uf run ci`.
Between them they made it report four jobs that run no suite at all. Also
covered: a missing runtime is named with its file, `uf run rust:test` and
`uf run ci` both count, a runtime with no test file is not required, and a
pipeline where nothing runs the suite is **refused** rather than passing
silently — a check that has stopped checking anything must say so.

The script parses under `sh -n` on both dash and bash 3.2 (`/bin/sh` on macOS,
which cannot parse a `case` inside a command substitution — the scan is a
function for that reason, with the reason on the line).

## Verification

```
uf run ci:runtimes        exit 0
uf run ci:runtimes:test   exit 0   (13 cases)
uf run ci:gate            exit 0
uf run ci:gate:test       exit 0
uf run scripts:parse      exit 0
uf fmt --check            exit 0
```

## After this lands

`uf@0.0.0-alpha.14`'s packages are still not on npm. The new
`workflow_dispatch` is how to finish it: run **Publish** with version
`0.0.0-alpha.14`, which republishes the code that was tagged.

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791419045&installation_model_id=422833&pr_number=635&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F635&signature=bb282b79afd6197c93259f2874b374851b844ff6bd3546d511511f8957558f8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->