### PR TITLE
docs: two claims that are ahead of what uf does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,8 +100,10 @@ A server action is not the only thing a browser can reach any more: `QUERY`,
 server-sent events, an upgrade a handler can accept, and a queue; OAuth as a
 contract rather than a provider; and a logger whose request id reaches a
 render. The router streams its loaders instead of awaiting them, keeps the
-site around a 404, and understands parallel and intercepting routes. A
-message's arguments are in its type. And `uf release` can no longer lose a
+site around a 404, and recognises `@slot` and `(.)segment` — refusing each by
+name rather than serving it as a literal URL, which is the first half of
+parallel and intercepting routes and not the whole of them. A message's
+arguments are in its type. And `uf release` can no longer lose a
 commit whose subject carries no pull request number, or rewrite a changelog
 section that has already been published — both of which had happened.
 

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -15,8 +15,11 @@
 - [ ] Keep all core implementation in Rust native crates.
 - [x] Use `uf.config.js` as the single user-visible config surface.
 - [x] Prefer `.js` files with `// @flow` for user-authored Flow source.
-- [x] Default app execution to runtime-agnostic Capability JS Hosts: Node.js,
-      Deno, and Bun.
+- [ ] Default app execution to runtime-agnostic Capability JS Hosts: Node.js,
+      Deno, and Bun. Node and Bun run a uf project; Deno does not — it has no
+      Flow loader, and `uf test --host deno` refuses by name. `docs/hosts.md`
+      grades it **planned** and `uf_runtime::HOSTS` is the source of truth.
+      See #246.
 - [x] Start native `@uniflowed/test`, `@uniflowed/pm`, and `@uniflowed/rm` contracts.
 - [x] Start XDG-compliant uf runtime layout.
 - [x] Add `uf use uf@0.1.0` runtime-switch command surface.
@@ -128,7 +131,8 @@
       config loader rather than reaching a manifest and doing nothing. See #277
       and `docs/app/guide/cache`.
 - [x] Default to Node.js through the Capability JS Host contract.
-- [x] Keep Node.js, Deno, and Bun as zero-config host targets.
+- [ ] Keep Node.js, Deno, and Bun as zero-config host targets. Two of the
+      three, for the reason above.
 - [ ] Align the deferred `uf` runtime with WinterTC.
 - [ ] Execute Flow through Hermes once the Vite/host-runtime path is stable.
 - [ ] Implement Vite-backed server entry generation and RSC streaming adapters.


### PR DESCRIPTION
An audit of what forty-two pull requests actually landed overnight found two
places where a claim is ahead of the code. Both are one sentence.

**`uf@0.0.0-alpha.13`'s release notes** said the router "understands parallel
and intercepting routes". #472 recognises `@slot` and `(.)segment` and
**refuses each by name** — worth having, because before it they were served as
literal URLs — but slots, `default` and interception are not implemented, and
`ReservedRole` has no `default` at all. The sentence now says which half
landed.

This edits a published section, and that is deliberate rather than an oversight
of #457: that issue is about a *binary* replacing a section wholesale with the
wrong commits and deleting hand-written prose. This is one sentence that was
untrue when it was written, corrected in place, with the rest of the section
untouched.

**`docs/issue-roadmap.md`** ticks two boxes:

```
- [x] Default app execution to runtime-agnostic Capability JS Hosts: Node.js, Deno, and Bun.
- [x] Keep Node.js, Deno, and Bun as zero-config host targets.
```

Node and Bun run a uf project. Deno does not: it has no Flow loader,
`uf test --host deno` refuses by name, `docs/hosts.md` grades it **planned**,
and `crates/uf_cli/tests/deno_host.rs` starts a real Deno precisely to
establish that the gaps the row names are the real gaps (#617). Both are
unticked with the reason on the line and a pointer to #246.

`ubugeeei-redundancy.md` asks for Implemented, Experimental and Planned to stay
distinct, and for claims no stronger than what is actually enforced. These were
two places they had drifted.

## Not done here

- **#1's body** carries the same two ticked boxes and is behind
  `docs/issue-roadmap.md` on seventeen other lines. That is an issue body
  rather than a file in the repository; the audit commented on #1 with the
  full list rather than editing it.
- **#249's title** still says the package "ships seven" when it ships 34. Its
  body was corrected by the audit; the title is somebody else's sentence.

## Verification

```
uf run release:changelog   exit 0
uf fmt --check             exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791421269&installation_model_id=422833&pr_number=639&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F639&signature=b943b6218f092fb6adc11cf82fe905a443263b636b3a0f01d12ec9e07de17a33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->