### PR TITLE
chore(release): uf@0.0.0-alpha.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2026-09-08_
 
-Sixteen changes. The one to read first is the one that was wrong in a way
+Eighteen changes. The one to read first is the one that was wrong in a way
 nothing could see: a diagnostic printed a module path exactly as it came off
 the filesystem, and a repository is attacker-authored input — `uf` is run
 against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry
@@ -32,6 +32,7 @@ that replaces `uf` rather than the one that only said so.
 
 ### Fixed
 
+- **pm, exec**: the root pnpm refused, the links the delta dropped, and the shim Windows runs (#637)
 - **check**: the half of SubtleCrypto a signing module needs, and the CryptoKey it names (#651)
 - **term, cli, security**: a filename is text a terminal draws, not a command it runs (#649)
 - **test, server, host, tui, cli**: five defects, and the seam behind the worst of them (#642)
@@ -45,6 +46,7 @@ that replaces `uf` rather than the one that only said so.
 
 ### Internal
 
+- **semver**: compute the crates that cannot be compared, rather than listing them (#657)
 - **publish**: the verify job reads the version the publish job published (#641)
 - **publish**: the runtimes the workspace suite starts, in every job that runs it (#635)
 - **config**: the whole rule table survives naming one rule, walked entry by entry (#618)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2026-09-08_
 
-Thirteen changes. The one to read first is the one that was wrong in a way
+Fourteen changes. The one to read first is the one that was wrong in a way
 nothing could see: a diagnostic printed a module path exactly as it came off
 the filesystem, and a repository is attacker-authored input — `uf` is run
 against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry
@@ -12,7 +12,9 @@ text has been stripped of control characters since the progress display existed;
 filenames were not, in any reporter that named one.
 
 The rest is spread evenly. `uf check` reads a project's `.flowconfig` `[libs]`
-when it has one, and resolves a package to the copy Node would load. Four
+when it has one, resolves a package to the copy Node would load, and knows the
+half of `SubtleCrypto` a module that signs anything needs — it had `digest` and
+no `sign`, `importKey` or `CryptoKey`, so correct code was told it was wrong. Four
 parsers now share one option set, so a syntax error says the same thing
 whichever of them found it. `uf build --adapter static` refuses what a static
 host cannot serve rather than writing output that 404s. `OgImage` is a template
@@ -28,6 +30,7 @@ that replaces `uf` rather than the one that only said so.
 
 ### Fixed
 
+- **check**: the half of SubtleCrypto a signing module needs, and the CryptoKey it names (#651)
 - **term, cli, security**: a filename is text a terminal draws, not a command it runs (#649)
 - **test, server, host, tui, cli**: five defects, and the seam behind the worst of them (#642)
 - **fmt, transform, corpus, pm**: `for await` only over `of`, and one manifest for the corpus (#629)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2026-09-08_
 
-Fourteen changes. The one to read first is the one that was wrong in a way
+Fifteen changes. The one to read first is the one that was wrong in a way
 nothing could see: a diagnostic printed a module path exactly as it came off
 the filesystem, and a repository is attacker-authored input — `uf` is run
 against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry
@@ -23,6 +23,7 @@ that replaces `uf` rather than the one that only said so.
 
 ### Added
 
+- **vite, router, query**: React DevTools on purpose, Strict Mode by default, and the request it was cancelling (#631)
 - **lib, cli, ui, stylex**: a readiness per component, the parts list a test reads, and the constraint a select group states (#628)
 - **cli, rm**: the command that replaces uf, and the one that only said so (#627)
 - **assets**: OgImage as a template uf can draw, fonts it subsets, and icons it sprites (#625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## uf@0.0.0-alpha.15
+
+_2026-09-08_
+
+Thirteen changes. The one to read first is the one that was wrong in a way
+nothing could see: a diagnostic printed a module path exactly as it came off
+the filesystem, and a repository is attacker-authored input — `uf` is run
+against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry
+text has been stripped of control characters since the progress display existed;
+filenames were not, in any reporter that named one.
+
+The rest is spread evenly. `uf check` reads a project's `.flowconfig` `[libs]`
+when it has one, and resolves a package to the copy Node would load. Four
+parsers now share one option set, so a syntax error says the same thing
+whichever of them found it. `uf build --adapter static` refuses what a static
+host cannot serve rather than writing output that 404s. `OgImage` is a template
+uf draws, with fonts it subsets and icons it sprites. And `uf rm` is the command
+that replaces `uf` rather than the one that only said so.
+
+### Added
+
+- **lib, cli, ui, stylex**: a readiness per component, the parts list a test reads, and the constraint a select group states (#628)
+- **cli, rm**: the command that replaces uf, and the one that only said so (#627)
+- **assets**: OgImage as a template uf can draw, fonts it subsets, and icons it sprites (#625)
+- **cli, config, router**: the static target refuses what a static host cannot serve (#621)
+
+### Fixed
+
+- **term, cli, security**: a filename is text a terminal draws, not a command it runs (#649)
+- **test, server, host, tui, cli**: five defects, and the seam behind the worst of them (#642)
+- **fmt, transform, corpus, pm**: `for await` only over `of`, and one manifest for the corpus (#629)
+- **check, flow, transform**: one option set for four parsers, and uf's words for a syntax error (#645)
+- **check**: the `[libs]` a project declares, and the copy of a package Node would load (#626)
+
+### Documentation
+
+- two claims that are ahead of what uf does (#639)
+
+### Internal
+
+- **publish**: the verify job reads the version the publish job published (#641)
+- **publish**: the runtimes the workspace suite starts, in every job that runs it (#635)
+- **config**: the whole rule table survives naming one rule, walked entry by entry (#618)
+
 ## uf@0.0.0-alpha.14
 
 _2026-09-07_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2026-09-08_
 
-Eighteen changes. The one to read first is the one that was wrong in a way
+Nineteen changes. The one to read first is the one that was wrong in a way
 nothing could see: a diagnostic printed a module path exactly as it came off
 the filesystem, and a repository is attacker-authored input — `uf` is run
 against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry
@@ -46,6 +46,7 @@ that replaces `uf` rather than the one that only said so.
 
 ### Internal
 
+- **merge-queue**: the checks a batch is merged on, and the trigger they report to (#648)
 - **semver**: compute the crates that cannot be compared, rather than listing them (#657)
 - **publish**: the verify job reads the version the publish job published (#641)
 - **publish**: the runtimes the workspace suite starts, in every job that runs it (#635)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2026-09-08_
 
-Fifteen changes. The one to read first is the one that was wrong in a way
+Sixteen changes. The one to read first is the one that was wrong in a way
 nothing could see: a diagnostic printed a module path exactly as it came off
 the filesystem, and a repository is attacker-authored input — `uf` is run
 against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry
@@ -23,6 +23,7 @@ that replaces `uf` rather than the one that only said so.
 
 ### Added
 
+- **i18n, cli, test**: the five refusals a message's type owes, and the catalogue a translator gets (#633)
 - **vite, router, query**: React DevTools on purpose, Strict Mode by default, and the request it was cancelling (#631)
 - **lib, cli, ui, stylex**: a readiness per component, the parts list a test reads, and the constraint a select group states (#628)
 - **cli, rm**: the command that replaces uf, and the one that only said so (#627)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3518,7 +3518,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_assets"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "ab_glyph",
  "base64",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "base64",
  "brotli",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "serde",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "serde",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "criterion",
  "phf",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "base64",
  "camino",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "compact_str",
  "serde",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "serde",
  "smallvec",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "uf_task"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "base64",
  "camino",
@@ -3929,14 +3929,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "compact_str",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "uf_i18n"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 dependencies = [
  "camino",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.14"
+version = "0.0.0-alpha.15"
 
 [workspace.dependencies]
 # Glyph outlines and coverage rasterisation, for `uf_assets::og`. Pure Rust

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.14",
-    "@uniflowed/config": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14",
-    "@uniflowed/router": "0.0.0-alpha.14",
-    "@uniflowed/vite": "0.0.0-alpha.14",
-    "@uniflowed/web": "0.0.0-alpha.14",
+    "@uniflowed/brand": "0.0.0-alpha.15",
+    "@uniflowed/config": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15",
+    "@uniflowed/router": "0.0.0-alpha.15",
+    "@uniflowed/vite": "0.0.0-alpha.15",
+    "@uniflowed/web": "0.0.0-alpha.15",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.14",
-        "@uniflowed/config": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14",
-        "@uniflowed/router": "0.0.0-alpha.14",
-        "@uniflowed/vite": "0.0.0-alpha.14",
-        "@uniflowed/web": "0.0.0-alpha.14",
+        "@uniflowed/brand": "0.0.0-alpha.15",
+        "@uniflowed/config": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15",
+        "@uniflowed/router": "0.0.0-alpha.15",
+        "@uniflowed/vite": "0.0.0-alpha.15",
+        "@uniflowed/web": "0.0.0-alpha.15",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -4381,65 +4381,65 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.14",
-        "@uniflowed/test": "0.0.0-alpha.14"
+        "@uniflowed/config": "0.0.0-alpha.15",
+        "@uniflowed/test": "0.0.0-alpha.15"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.14",
-        "@uniflowed/ui": "0.0.0-alpha.14",
-        "@uniflowed/validator": "0.0.0-alpha.14"
+        "@uniflowed/react": "0.0.0-alpha.15",
+        "@uniflowed/ui": "0.0.0-alpha.15",
+        "@uniflowed/validator": "0.0.0-alpha.15"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4447,10 +4447,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.14"
+        "@uniflowed/fetch": "0.0.0-alpha.15"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4458,19 +4458,19 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4478,120 +4478,120 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/i18n": {
       "name": "@uniflowed/i18n",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.14",
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/fetch": "0.0.0-alpha.14"
+        "@uniflowed/cell": "0.0.0-alpha.15",
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/fetch": "0.0.0-alpha.15"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.14",
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/config": "0.0.0-alpha.15",
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/hooks": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4599,7 +4599,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4607,28 +4607,28 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14",
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4638,7 +4638,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4647,20 +4647,20 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.14",
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/config": "0.0.0-alpha.15",
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.14",
-        "@uniflowed/server": "0.0.0-alpha.14"
+        "@uniflowed/hooks": "0.0.0-alpha.15",
+        "@uniflowed/server": "0.0.0-alpha.15"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4669,46 +4669,46 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/cell": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14",
-        "@uniflowed/react-testing": "0.0.0-alpha.14",
-        "@uniflowed/test": "0.0.0-alpha.14"
+        "@uniflowed/mock": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15",
+        "@uniflowed/react-testing": "0.0.0-alpha.15",
+        "@uniflowed/test": "0.0.0-alpha.15"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4716,54 +4716,54 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.14"
+        "@uniflowed/host": "0.0.0-alpha.15"
       }
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.14",
-        "@uniflowed/test": "0.0.0-alpha.14"
+        "@uniflowed/react-testing": "0.0.0-alpha.15",
+        "@uniflowed/test": "0.0.0-alpha.15"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.14",
+        "@uniflowed/react": "0.0.0-alpha.15",
         "react-reconciler": "^0.33.0"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/hooks": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/hooks": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4771,18 +4771,18 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.14",
-        "@uniflowed/server": "0.0.0-alpha.14",
+        "@uniflowed/host": "0.0.0-alpha.15",
+        "@uniflowed/server": "0.0.0-alpha.15",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4797,21 +4797,21 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.14",
-        "@uniflowed/core": "0.0.0-alpha.14"
+        "@uniflowed/browser": "0.0.0-alpha.15",
+        "@uniflowed/core": "0.0.0-alpha.15"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.14",
+      "version": "0.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.14",
-        "@uniflowed/hooks": "0.0.0-alpha.14",
-        "@uniflowed/react": "0.0.0-alpha.14"
+        "@uniflowed/core": "0.0.0-alpha.15",
+        "@uniflowed/hooks": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.15"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Fine-grained reactivity: state, derived values, effects and resources, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "temporal.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.14",
-    "@uniflowed/test": "0.0.0-alpha.14"
+    "@uniflowed/config": "0.0.0-alpha.15",
+    "@uniflowed/test": "0.0.0-alpha.15"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "stream.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -26,9 +26,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.14",
-    "@uniflowed/ui": "0.0.0-alpha.14",
-    "@uniflowed/validator": "0.0.0-alpha.14"
+    "@uniflowed/react": "0.0.0-alpha.15",
+    "@uniflowed/ui": "0.0.0-alpha.15",
+    "@uniflowed/validator": "0.0.0-alpha.15"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.14"
+    "@uniflowed/fetch": "0.0.0-alpha.15"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,8 +27,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/i18n",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Type-safe internationalisation on MessageFormat 2: a message's arguments are checked at the call, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/cell": "0.0.0-alpha.14",
-    "@uniflowed/fetch": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/cell": "0.0.0-alpha.15",
+    "@uniflowed/fetch": "0.0.0-alpha.15"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.14",
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/config": "0.0.0-alpha.15",
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/hooks": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14",
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.14",
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/config": "0.0.0-alpha.15",
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.14",
-    "@uniflowed/server": "0.0.0-alpha.14"
+    "@uniflowed/hooks": "0.0.0-alpha.15",
+    "@uniflowed/server": "0.0.0-alpha.15"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -42,6 +42,6 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/cell": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,10 +22,10 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14",
-    "@uniflowed/react-testing": "0.0.0-alpha.14",
-    "@uniflowed/test": "0.0.0-alpha.14"
+    "@uniflowed/mock": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15",
+    "@uniflowed/react-testing": "0.0.0-alpha.15",
+    "@uniflowed/test": "0.0.0-alpha.15"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.14"
+    "@uniflowed/host": "0.0.0-alpha.15"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.14",
-    "@uniflowed/test": "0.0.0-alpha.14"
+    "@uniflowed/react-testing": "0.0.0-alpha.15",
+    "@uniflowed/test": "0.0.0-alpha.15"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "A React renderer whose host is a terminal, following OpenTUI, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.14",
+    "@uniflowed/react": "0.0.0-alpha.15",
     "react-reconciler": "^0.33.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -52,9 +52,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/hooks": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/hooks": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -33,8 +33,8 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.14",
-    "@uniflowed/server": "0.0.0-alpha.14",
+    "@uniflowed/host": "0.0.0-alpha.15",
+    "@uniflowed/server": "0.0.0-alpha.15",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.14",
-    "@uniflowed/core": "0.0.0-alpha.14"
+    "@uniflowed/browser": "0.0.0-alpha.15",
+    "@uniflowed/core": "0.0.0-alpha.15"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.14",
+  "version": "0.0.0-alpha.15",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,8 +23,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.14",
-    "@uniflowed/hooks": "0.0.0-alpha.14",
-    "@uniflowed/react": "0.0.0-alpha.14"
+    "@uniflowed/core": "0.0.0-alpha.15",
+    "@uniflowed/hooks": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.15"
   }
 }


### PR DESCRIPTION
Thirteen changes since `uf@0.0.0-alpha.14`.

`uf release alpha` wrote the changelog section and `tools/release/bump-version.sh 0.0.0-alpha.15` moved the workspace onto it — the Cargo workspace version, all fifty `packages/*` manifests and their pinned `@uniflowed/*` siblings, the docs site's manifest, and both lockfiles.

## The one to read first

A diagnostic printed a module path exactly as it came off the filesystem. A repository is attacker-authored input by the same argument the asset decoders are: `uf` is run against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry text has been stripped of control characters since the progress display existed; filenames were not, in any reporter that named one. (#649)

## The rest

- `uf check` reads a project's `.flowconfig` `[libs]` when it has one, and resolves a package to the copy Node would load (#626)
- Four parsers share one option set, so a syntax error says the same thing whichever of them found it (#645)
- `uf build --adapter static` refuses what a static host cannot serve, rather than writing output that 404s (#621)
- `OgImage` is a template uf draws, with fonts it subsets and icons it sprites (#625)
- `uf rm` is the command that replaces `uf`, rather than the one that only said so (#627)
- A readiness per component, the parts list a test reads, and the constraint a select group states (#628)
- Five defects in the test runner, server, host, TUI and CLI, and the seam behind the worst of them (#642)
- `for await` only over `of`, and one manifest for the corpus (#629)

Plus the publish pipeline's own two (#635, #641) and a config test that walks the whole rule table (#618).

## Checks run before this

```
verify-npm: checking the dependency closure of tools/release/published-packages.txt
  every @uniflowed/* dependency is itself published

changelog-covers-the-release:
  every commit in 6 released version(s) is named in the changelog
  (82 by pull request number, 1 with no number)

lockfile-in-sync: package-lock.json matches all 51 manifests
```

The changelog date is `2026-09-08`, above alpha.14's `2026-09-07` — the first release cut since the date became UTC rather than whichever timezone the merge commit happened to record.

## After this merges

`git tag uf@0.0.0-alpha.15 && git push origin uf@0.0.0-alpha.15` is what publishes: `publish.yml` sends the seventeen names over OIDC and `release.yml` builds the four target binaries and the GitHub release.

**`latest` will still be behind.** It is on alpha.11/alpha.12 across all seventeen names today, so `npm install @uniflowed/react` gives a build three releases old. The publish job's OIDC token can publish and nothing else, so moving the dist-tag is a person's step:

```bash
npm login && tools/release/promote-latest.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791433051&installation_model_id=422833&pr_number=656&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F656&signature=263dd050abb6e7b678f1075f926fef2efbfab13221807c2c23d37a9620f57634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->