### PR TITLE
ci(semver): compute the crates that cannot be compared, rather than listing them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,7 @@ jobs:
       # that cannot report `skipped`. See #367.
       - run: ./target/release/uf run ci:gate
       - run: ./target/release/uf run ci:gate:test
+      - run: ./target/release/uf run ci:semver:test
       - run: ./target/release/uf run ci:runtimes
       - run: ./target/release/uf run ci:runtimes:test
 

--- a/tools/ci/semver-exclude.sh
+++ b/tools/ci/semver-exclude.sh
@@ -4,13 +4,20 @@
 # There are two reasons a crate cannot be compared, and only one of them is
 # permanent.
 #
-# It names the `upstream/flow` submodule through a path dependency. The
+# It reaches the `upstream/flow` submodule through a path dependency. The
 # baseline is built from a copy of the crate outside the workspace, where a
 # relative path no longer resolves — which is not something a crate can fix,
-# since a path dependency is relative by definition. The list below is the
-# closure of the crates reaching `uf_flow` or `uf_check`, whether or not the
-# feature using it is enabled, and it grows as more crates print from or read
-# the parser's syntax tree. See docs/architecture.md.
+# since a path dependency is relative by definition. That is every crate whose
+# path dependencies reach `uf_flow` or `uf_check`, whether or not the feature
+# using it is enabled. See docs/architecture.md.
+#
+# The closure is **computed**, not listed. It used to be a written list with a
+# comment saying it "grows as more crates print from or read the parser's
+# syntax tree" — which is a list somebody has to remember, and #633 is what
+# happens when they do not: `uf_i18n` arrived depending on `uf_flow`, was in
+# nobody's list, and this job then failed on `cargo update` for *every* pull
+# request afterwards, including the one cutting a release. A gate that a new
+# crate breaks for everybody is worse than the break it was guarding against.
 #
 # Or it did not exist at the baseline revision. A new crate has nothing to be
 # compared against, and cargo-semver-checks ends the whole run rather than
@@ -22,7 +29,51 @@ set -eu
 
 baseline=${1:?usage: semver-exclude.sh <baseline-rev>}
 
-submodule_path='uf_check uf_cli uf_doc uf_flow uf_fmt uf_lint uf_transform'
+# The roots: the two crates that name the submodule themselves.
+roots='uf_flow uf_check'
+
+# One line per path dependency, `<crate> <dependency>`, read out of the
+# manifests. Every path dependency in this workspace is written on one line as
+# `name = { path = "../name" … }`, and the name before the `=` is what cargo
+# resolves, so that is what is read.
+#
+# `[dev-dependencies]` are skipped, and that is the whole reason this walks
+# sections rather than grepping the file. `uf_lib` and `uf_router` reach
+# `uf_flow` only through a dev-dependency, and the baseline builds fine with
+# those — excluding them would take two crates out of the gate for nothing,
+# which is the opposite of what this file is for.
+edges=$(for manifest in crates/*/Cargo.toml; do
+  awk '
+    /^\[/ { section = $0; next }
+    section == "[dev-dependencies]" { next }
+    /^name = "/ && section == "[package]" {
+      gsub(/^name = "|"$/, "", $0); crate = $0; next
+    }
+    /^[A-Za-z0-9_-]+ *= *\{ *path *= *"\.\./ {
+      dep = $1
+      if (crate != "") { print crate, dep }
+    }
+  ' "$manifest"
+done)
+
+# Transitive closure by fixed point: a crate is in when a crate it depends on
+# is. Bounded by the number of crates, because each round either adds one or
+# stops.
+submodule_path="$roots"
+while :; do
+  grown=$(printf '%s\n' "$edges" | while read -r crate dep; do
+    [ -n "$crate" ] || continue
+    for member in $submodule_path; do
+      if [ "$dep" = "$member" ]; then
+        printf '%s\n' "$crate"
+        break
+      fi
+    done
+  done)
+  next=$(printf '%s %s\n' "$submodule_path" "$grown" | tr ' ' '\n' | sed '/^$/d' | sort -u | tr '\n' ' ')
+  [ "$next" = "$(printf '%s ' $submodule_path)" ] && break
+  submodule_path="$next"
+done
 
 new=''
 for manifest in crates/*/Cargo.toml; do

--- a/tools/ci/test-semver-exclude.sh
+++ b/tools/ci/test-semver-exclude.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+# `semver-exclude.sh` against workspaces it can safely make wrong.
+#
+# The list of crates that cannot be compared used to be written down, with a
+# comment saying it "grows as more crates print from or read the parser's
+# syntax tree". #633 is what a list somebody has to remember looks like when
+# they do not: `uf_i18n` arrived with a path dependency on `uf_flow`, was in
+# nobody's list, and `Cargo Semver Checks` then failed on `cargo update` for
+# *every* pull request afterwards — including the one cutting a release. The
+# job that guards against a silent break became the break.
+#
+# So the closure is computed, and computing it is a thing that can be wrong in
+# both directions. Too narrow and the release is blocked again; too wide and
+# crates leave the gate quietly, which is worse because nothing goes red. Each
+# case below plants one shape and says which side of that line it is on.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+script="$repo_root/tools/ci/semver-exclude.sh"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-semver-exclude.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+fail() {
+  echo "test-semver-exclude: FAIL: $*" >&2
+  [ -n "${out:-}" ] && echo "  it printed: $out" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+root=""
+out=""
+
+# A crate with the dependencies named after `--`, each as a path dependency.
+# `--dev` moves the ones after it into `[dev-dependencies]`.
+crate() {
+  name="$1"
+  shift
+  mkdir -p "$root/crates/$name"
+  {
+    echo '[package]'
+    echo "name = \"$name\""
+    echo 'version = "0.0.0"'
+    echo ''
+    echo '[dependencies]'
+    section=deps
+    for dep in "$@"; do
+      if [ "$dep" = "--dev" ]; then
+        echo ''
+        echo '[dev-dependencies]'
+        section=dev
+        continue
+      fi
+      echo "$dep = { path = \"../$dep\" }"
+    done
+  } > "$root/crates/$name/Cargo.toml"
+}
+
+# A workspace in a git repository, because the check asks git what existed at
+# the baseline.
+scratch() {
+  root="$work/$1"
+  rm -rf "$root"
+  mkdir -p "$root/crates"
+  mkdir -p "$root/tools/ci"
+  cp "$script" "$root/tools/ci/semver-exclude.sh"
+  ( cd "$root" && git init --quiet && git config user.email uf@example.com \
+      && git config user.name uf )
+}
+
+commit_baseline() {
+  ( cd "$root" && git add -A && git commit --quiet -m baseline )
+}
+
+run() {
+  out="$( cd "$root" && sh tools/ci/semver-exclude.sh "$1" )"
+}
+
+# Is $1 one of the comma-separated names in $out?
+excluded() {
+  case ",$out," in
+    *",$1,"*) return 0 ;;
+  esac
+  return 1
+}
+
+# 1. The roots themselves, and a crate that names one directly.
+scratch direct
+crate uf_flow
+crate uf_check
+crate uf_fmt uf_flow
+crate uf_std
+commit_baseline
+run HEAD
+excluded uf_flow || fail "uf_flow is a root and was not excluded"
+excluded uf_check || fail "uf_check is a root and was not excluded"
+excluded uf_fmt || fail "a crate depending on uf_flow was not excluded"
+excluded uf_std && fail "uf_std reaches nothing and must stay in the gate"
+pass "excludes the roots and what depends on them, and nothing else"
+
+# 2. Transitively, which is the half a written list gets wrong first: nobody
+#    adding a dependency on `uf_fmt` thinks of themselves as adding one on the
+#    submodule.
+scratch transitive
+crate uf_flow
+crate uf_check
+crate uf_fmt uf_flow
+crate uf_lint uf_fmt
+crate uf_cli uf_lint
+crate uf_std
+commit_baseline
+run HEAD
+excluded uf_lint || fail "a crate two hops from uf_flow was not excluded"
+excluded uf_cli || fail "a crate three hops from uf_flow was not excluded"
+excluded uf_std && fail "uf_std still reaches nothing"
+pass "follows the chain however long it is"
+
+# 3. And not through `[dev-dependencies]`. `cargo update` resolves the baseline
+#    without them, so a crate that only tests against the parser builds fine —
+#    excluding it would take it out of the gate for nothing.
+scratch dev-only
+crate uf_flow
+crate uf_check
+crate uf_lib uf_std --dev uf_flow
+crate uf_std
+commit_baseline
+run HEAD
+excluded uf_lib && fail "a dev-only dependency on uf_flow must not exclude a crate"
+pass "a dev-dependency on the parser is not a reason to leave the gate"
+
+# 4. The other reason, which is temporary: a crate that did not exist at the
+#    baseline has nothing to be compared against, and cargo-semver-checks ends
+#    the whole run rather than skipping it.
+scratch new-crate
+crate uf_flow
+crate uf_check
+crate uf_std
+commit_baseline
+crate uf_brand_new
+run HEAD
+excluded uf_brand_new || fail "a crate absent from the baseline was not excluded"
+excluded uf_std && fail "a crate present at the baseline stays in the gate"
+pass "excludes a crate the baseline has never seen"
+
+# 5. A cycle. Cargo forbids one, but the closure is a fixed point and a fixed
+#    point that does not terminate is a job that hangs rather than fails, which
+#    is the worst way for this to be wrong.
+scratch cycle
+crate uf_flow
+crate uf_check
+crate uf_a uf_b
+crate uf_b uf_a
+crate uf_std
+commit_baseline
+run HEAD
+excluded uf_a && fail "a cycle that reaches nothing must not be excluded"
+pass "terminates on a cycle rather than hanging"
+
+echo "test-semver-exclude: ok"

--- a/uf.config.js
+++ b/uf.config.js
@@ -631,6 +631,18 @@ export default defineConfig({
       inputs: ["tools/ci/gate-covers-every-job.sh", "tools/ci/test-gate-covers-every-job.sh"],
     },
 
+    // The crates `cargo semver-checks` cannot compare, which is computed and
+    // therefore capable of being wrong in two directions: too narrow and the
+    // job fails for every pull request, which is what #633 did by adding a
+    // crate that reaches `uf_flow` and appeared in nobody's list; too wide and
+    // crates leave the gate with nothing going red. There is no `ci:semver`
+    // task beside this one because the check needs a baseline revision, and
+    // the workflow is the only place that knows which one.
+    "ci:semver:test": {
+      command: "tools/ci/test-semver-exclude.sh",
+      inputs: ["tools/ci/semver-exclude.sh", "tools/ci/test-semver-exclude.sh"],
+    },
+
     // And that a job which runs the workspace suite installs the runtimes the
     // suite starts. `bun_host.rs`, `deno_host.rs` and `permissions.rs` start
     // real processes and fail rather than skip when the runtime is absent —


### PR DESCRIPTION
**`Cargo Semver Checks` is currently red on every open pull request**, including #656, which is cutting `uf@0.0.0-alpha.15`:

```
error: running `cargo update` on crate `uf_i18n` failed
error: no matching package named `flow_parser`
    ... which satisfies path dependency `uf_flow` of package `uf_i18n`
error: aborting due to failure to run `cargo update`
```

## What broke

A crate that reaches the `upstream/flow` submodule through a path dependency cannot have a baseline built for it: the baseline is a copy of the crate *outside* the workspace, where a relative path no longer resolves. That is not something a crate can fix — a path dependency is relative by definition.

Those crates were named in a written list:

```sh
submodule_path='uf_check uf_cli uf_doc uf_flow uf_fmt uf_lint uf_transform'
```

under a comment saying it "grows as more crates print from or read the parser's syntax tree". That is a list somebody has to remember, and #633 is what it looks like when they do not: `uf_i18n` arrived with `uf_flow = { path = "../uf_flow" }`, went into nobody's list, and from the moment it landed the job that guards against a silent semver break *was* the break — for every pull request, not just its own.

## The change

The closure is computed from the manifests. `uf_flow` and `uf_check` are the roots, path dependencies are the edges, and the answer is the fixed point. For this workspace that is exactly the old list plus `uf_i18n`:

```
uf_check,uf_cli,uf_doc,uf_flow,uf_fmt,uf_i18n,uf_lint,uf_transform
```

and the next crate to reach the parser joins it without anybody noticing it had to.

**`[dev-dependencies]` are skipped, and that is why it walks sections rather than grepping the file.** `uf_lib` and `uf_router` reach `uf_flow` only through a dev-dependency; the baseline resolves fine without those, and excluding them would have quietly taken two crates out of the semver gate. That is the direction of this change with no red to warn anyone, so it is the one the test pins hardest.

The second half of the script — a crate that did not exist at the baseline has nothing to compare against — is untouched.

## The test it never had

`tools/ci/test-semver-exclude.sh`, in the shape `test-gate-covers-every-job.sh` established: a scratch workspace in a git repository, one planted shape per case.

```
  ok  excludes the roots and what depends on them, and nothing else
  ok  follows the chain however long it is
  ok  a dev-dependency on the parser is not a reason to leave the gate
  ok  excludes a crate the baseline has never seen
  ok  terminates on a cycle rather than hanging
```

The cycle case is there because a fixed point that does not terminate is a job that *hangs* rather than fails, which is the worst way for this to be wrong. And removing the dev-dependency skip fails the third case:

```
test-semver-exclude: FAIL: a dev-only dependency on uf_flow must not exclude a crate
  it printed: uf_check,uf_flow,uf_lib
```

which is what says the test is not decoration.

`uf run ci:semver:test` runs it on a laptop; the `Metadata` job runs it in CI, beside `ci:gate` and `ci:gate:test`.

## Why this first

Nothing else can merge until it lands — the release included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791435535&installation_model_id=422833&pr_number=657&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F657&signature=cb0630a314aafd4545f6efce672cc5d4e926bde983a42b1d35a92703eea2ee7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->