### PR TITLE
ci(semver): the crates that cannot be compared are computed, not listed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,7 @@ jobs:
       - run: ./target/release/uf run ci:gate:test
       - run: ./target/release/uf run ci:runtimes
       - run: ./target/release/uf run ci:runtimes:test
+      - run: ./target/release/uf run semver:exclude:test
 
   upstream-integrations:
     name: Upstream Integrations

--- a/tools/ci/semver-exclude.sh
+++ b/tools/ci/semver-exclude.sh
@@ -7,10 +7,21 @@
 # It names the `upstream/flow` submodule through a path dependency. The
 # baseline is built from a copy of the crate outside the workspace, where a
 # relative path no longer resolves — which is not something a crate can fix,
-# since a path dependency is relative by definition. The list below is the
-# closure of the crates reaching `uf_flow` or `uf_check`, whether or not the
-# feature using it is enabled, and it grows as more crates print from or read
-# the parser's syntax tree. See docs/architecture.md.
+# since a path dependency is relative by definition. That is the closure of
+# the crates reaching `uf_flow` or `uf_check`, whether or not the feature
+# using it is enabled. See docs/architecture.md.
+#
+# The closure is **computed**, and it used to be a list somebody added to.
+# That list went stale the moment `uf_i18n` was added: it reaches `uf_flow`,
+# it was new so the second half below excluded it, and the release after that
+# the baseline caught up and it rejoined a gate it can never pass. The job
+# then failed on every pull request, at `uf_i18n` — which is alphabetically
+# first among the crates the list was missing, so `uf_lib` and `uf_router`
+# were latent behind it and would have been next.
+#
+# A hand-maintained list of what to check is the same shape as the bug
+# ubugeeei-prod/uf#590 fixed for the CI gate and ubugeeei-prod/uf#425 for
+# `uf explain`. This reads the manifests instead.
 #
 # Or it did not exist at the baseline revision. A new crate has nothing to be
 # compared against, and cargo-semver-checks ends the whole run rather than
@@ -22,7 +33,31 @@ set -eu
 
 baseline=${1:?usage: semver-exclude.sh <baseline-rev>}
 
-submodule_path='uf_check uf_cli uf_doc uf_flow uf_fmt uf_lint uf_transform'
+# The two crates that name the submodule directly. Everything else joins by
+# depending on one of them, at any depth.
+seed='uf_flow uf_check'
+
+names=$(sed -n 's/^name = "\(.*\)"$/\1/p' crates/*/Cargo.toml)
+
+submodule_path=$seed
+while : ; do
+  added=''
+  for manifest in crates/*/Cargo.toml; do
+    name=$(sed -n 's/^name = "\(.*\)"$/\1/p' "$manifest" | head -1)
+    [ -n "$name" ] || continue
+    # Already in?
+    case " $submodule_path " in *" $name "*) continue ;; esac
+    for excluded in $submodule_path; do
+      # A path dependency on an excluded crate, in any dependency table.
+      if grep -qE "^$excluded = \{[^}]*path = " "$manifest"; then
+        added="$added $name"
+        break
+      fi
+    done
+  done
+  [ -n "$added" ] || break
+  submodule_path="$submodule_path$added"
+done
 
 new=''
 for manifest in crates/*/Cargo.toml; do

--- a/tools/ci/test-semver-exclude.sh
+++ b/tools/ci/test-semver-exclude.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+# `semver-exclude.sh`, against a workspace with a defect planted in it.
+#
+# The list it used to print was maintained by hand and went stale the moment a
+# crate was added that reaches `uf_flow`. These cases are the shapes that
+# staleness took, so it cannot take them again.
+set -eu
+
+root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
+
+work="${TMPDIR:-/tmp}/uf-semver-exclude-test.$$"
+rm -rf "$work"
+mkdir -p "$work/crates" "$work/tools/ci"
+trap 'rm -rf "$work"' EXIT
+cp "$root/tools/ci/semver-exclude.sh" "$work/tools/ci/"
+( cd "$work" && git init -q . && git config user.email t@t && git config user.name t )
+
+write() {
+  name=$1; shift
+  mkdir -p "$work/crates/$name"
+  {
+    echo '[package]'
+    echo "name = \"$name\""
+    echo '[dependencies]'
+    for dep in "$@"; do echo "$dep = { path = \"../$dep\" }"; done
+  } > "$work/crates/$name/Cargo.toml"
+}
+
+failures=0
+expect() {
+  want=$1; why=$2
+  got=$( cd "$work" && sh tools/ci/semver-exclude.sh "$BASE" )
+  if [ "$got" != "$want" ]; then
+    echo "FAIL: $why" >&2
+    echo "  wanted: $want" >&2
+    echo "  got:    $got" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+write uf_flow
+write uf_check uf_flow
+write uf_infra
+write uf_assets uf_infra
+( cd "$work" && git add -A && git commit -qm base )
+BASE=$(cd "$work" && git rev-parse HEAD)
+
+echo "the seed and its direct dependents, and nothing else"
+expect "uf_check,uf_flow" "uf_assets reaches neither"
+
+echo "a crate that reaches uf_flow through two hops joins"
+write uf_fmt uf_flow
+write uf_router uf_fmt
+( cd "$work" && git add -A && git commit -qm two-hops )
+BASE=$(cd "$work" && git rev-parse HEAD)
+expect "uf_check,uf_flow,uf_fmt,uf_router" "the closure is transitive, not one level"
+
+echo "a crate that did not exist at the baseline is excluded too"
+write uf_i18n uf_flow
+expect "uf_check,uf_flow,uf_fmt,uf_i18n,uf_router" "new at HEAD, absent at the baseline"
+
+echo "and stays excluded once the baseline catches up, because it reaches uf_flow"
+( cd "$work" && git add -A && git commit -qm caught-up )
+BASE=$(cd "$work" && git rev-parse HEAD)
+expect "uf_check,uf_flow,uf_fmt,uf_i18n,uf_router" "this is the case that broke the job"
+
+echo "a new crate that reaches nothing rejoins the gate by itself"
+write uf_term
+expect "uf_check,uf_flow,uf_fmt,uf_i18n,uf_router,uf_term" "new, so excluded for now"
+( cd "$work" && git add -A && git commit -qm term )
+BASE=$(cd "$work" && git rev-parse HEAD)
+expect "uf_check,uf_flow,uf_fmt,uf_i18n,uf_router" "the baseline has it and it reaches nothing"
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures case(s) failed" >&2
+  exit 1
+fi
+echo "semver-exclude: every case behaved"

--- a/uf.config.js
+++ b/uf.config.js
@@ -656,6 +656,18 @@ export default defineConfig({
       inputs: ["tools/ci/workspace-suite-runtimes.sh", "tools/ci/test-workspace-suite-runtimes.sh"],
     },
 
+    // And that the crates `cargo semver-checks` cannot compare are computed
+    // rather than listed. That list was maintained by hand and went stale the
+    // moment `uf_i18n` was added: it reaches `uf_flow` through a path
+    // dependency, so its baseline copy cannot resolve `upstream/flow`, and
+    // once the baseline caught up it rejoined a gate it can never pass. The
+    // job then failed on every pull request, at `uf_i18n` — with `uf_lib` and
+    // `uf_router` latent behind it, alphabetically.
+    "semver:exclude:test": {
+      command: "tools/ci/test-semver-exclude.sh",
+      inputs: ["tools/ci/semver-exclude.sh", "tools/ci/test-semver-exclude.sh"],
+    },
+
     manifests: {
       command:
         "node -e \"for (const f of require('node:fs').globSync('packages/*/package.json')) JSON.parse(require('node:fs').readFileSync(f, 'utf8'))\"",
@@ -707,6 +719,7 @@ export default defineConfig({
         "ci:gate:test",
         "ci:runtimes",
         "ci:runtimes:test",
+        "semver:exclude:test",
         // `docs:verify` rather than the four checks under it, because that is
         // what the `Docs build` job runs and this list is the whole of
         // `uf run` in `.github/workflows/`. It reaches `docs:links`,


### PR DESCRIPTION
**`Cargo Semver Checks` is currently failing on every open pull request.** It
released #637 and #638 from the merge queue within three minutes of each other,
and it will do the same to the rest.

## Why

The baseline is built from a copy of each crate *outside* the workspace, where
a relative path dependency no longer resolves. So a crate that reaches
`uf_flow` or `uf_check` — and through them the `upstream/flow` submodule — can
never be compared, and `semver-exclude.sh` exists to say so. It carried that
closure as a list somebody adds to:

```sh
submodule_path='uf_check uf_cli uf_doc uf_flow uf_fmt uf_lint uf_transform'
```

`uf_i18n` (#633) reaches `uf_flow`. It was new, so the script's *other* half —
the computed one — excluded it and the job stayed green. When the baseline
caught up it rejoined a gate it can never pass:

```
required by package `uf_flow v0.0.0-alpha.14 (…/semver-checks/target/…)`
    ... which satisfies path dependency `uf_flow` of package `uf_i18n`
```

`uf_lib` and `uf_router` reach `uf_flow` too and were never in the list either.
The run stops at the first crate it cannot resolve and `uf_i18n` sorts before
both, so they were latent behind it.

## The fix

The closure is read from the manifests, seeded with the two crates that name
the submodule directly, and iterated to a fixed point. On this tree:

```
uf_check uf_cli uf_doc uf_flow uf_fmt uf_i18n uf_lib uf_lint uf_router uf_transform
```

— the old seven plus exactly the three that were missing. Nothing that does not
reach `uf_flow` is excluded, so no coverage is given up.

A hand-maintained list of what to check is the same shape as the bug **#590**
fixed for the CI gate's `needs:` and **#425** for `uf explain`. This is the
third; the pattern is worth naming.

## The test

`tools/ci/test-semver-exclude.sh`, six cases against scratch workspaces with a
real git history, wired into `uf run ci` and the `Metadata` job:

- the seed and its dependents, and nothing else;
- the closure is **transitive**, not one level (`uf_router` → `uf_fmt` → `uf_flow`);
- a crate absent at the baseline is excluded;
- **and stays excluded once the baseline catches up, because it reaches `uf_flow`** — the case that broke the job;
- a new crate that reaches nothing is excluded now and **rejoins by itself** when the baseline has it.

## Verification

```
uf run semver:exclude:test   exit 0   (6 cases)
uf run ci:gate               exit 0
uf run scripts:parse         exit 0
uf fmt --check               exit 0
semver-exclude.sh HEAD~1     the ten above
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791435659&installation_model_id=422833&pr_number=658&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F658&signature=c9a7052048c387c755924d48fae141754019c5031c16bb7035f286149b5ef105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->