### PR TITLE
perf(fmt): compute a node's sorted children once rather than once per comment

### DIFF
--- a/crates/uf_fmt/benches/fmt.rs
+++ b/crates/uf_fmt/benches/fmt.rs
@@ -63,9 +63,52 @@ component Panel{index}(props: Props{index}) renders React.Node {{
     source
 }
 
+/// A module that is mostly comments, which is what this repository's own
+/// source looks like and what the synthetic module above has none of.
+///
+/// Comment attachment descends the tree once per comment, so its cost is the
+/// product of the two — a module with many comments *and* many nodes is the
+/// only shape that shows it, and neither half alone does. Before the children
+/// of a visited node were cached, formatting
+/// `packages/router/internal/runtime.js` allocated 12.41 MiB; after, 7.95 MiB,
+/// with the peak unchanged. This is the bench that would notice that going
+/// away again.
+fn commented_source(components: usize) -> String {
+    let mut source = String::with_capacity(components * 1024);
+    source.push_str("// @flow\n\nimport * as React from \"react\";\n\n");
+    for index in 0..components {
+        source.push_str(&format!(
+            r#"
+/**
+ * The {index}th panel, and why it is written the way it is.
+ *
+ * A block comment above a declaration is the commonest shape there is, and
+ * the one comment attachment has to place by descending from the root.
+ */
+type Props{index} = {{|
+  // The identity, which the parent owns.
+  +id: string,
+  // How many times it has been asked to count, or nothing yet.
+  +count?: ?number,
+|}};
+
+// A leading line comment, which attaches differently from a block.
+component Panel{index}(props: Props{index}) renders React.Node {{
+  // Inside the body, where the enclosing node is not the program.
+  const [count, setCount] = React.useState<number>(props.count ?? 0); // and trailing
+  /* an inline block */
+  return <div id={{props.id}}>{{count}}</div>;
+}}
+"#
+        ));
+    }
+    source
+}
+
 fn bench_format(criterion: &mut Criterion) {
     let config = FmtConfig::default();
     let source = synthetic_source(120);
+    let commented = commented_source(120);
     let bytes = source.len() as u64;
 
     let mut group = criterion.benchmark_group("uf_fmt");
@@ -84,6 +127,12 @@ fn bench_format(criterion: &mut Criterion) {
     // Already-formatted input is the common `uf fmt --check` case.
     let formatted = format_source(&source, &config).expect("format").output;
     group.throughput(Throughput::Bytes(formatted.len() as u64));
+    group.bench_function("format heavily commented file", |bencher| {
+        bencher.iter(|| {
+            black_box(uf_fmt::format_source(black_box(&commented), black_box(&config)).unwrap())
+        });
+    });
+
     group.bench_function("format already formatted file", |bencher| {
         bencher.iter(|| black_box(format_source(black_box(&formatted), &config).expect("format")));
     });

--- a/crates/uf_fmt/src/flow/comments.rs
+++ b/crates/uf_fmt/src/flow/comments.rs
@@ -134,6 +134,7 @@ impl<'a> Comments<'a> {
             comments,
             slots: FxHashMap::default(),
             ties: Vec::new(),
+            children: FxHashMap::default(),
         };
         attacher.run();
         let printed = vec![false; attacher.comments.len()];
@@ -219,6 +220,21 @@ struct Attacher<'a, 't> {
     comments: Vec<Comment<'a>>,
     slots: FxHashMap<NodeKey, Slots>,
     ties: Vec<Context<'a>>,
+    /// Each visited node's children, spanned and sorted, computed once.
+    ///
+    /// [`Self::decorate`] descends from the root for **every** comment, and
+    /// asked for a node's children at every level of every descent — so the
+    /// root's children, which for a real module is every top-level statement,
+    /// were collected into a `Vec`, mapped into a second `Vec` and sorted once
+    /// per comment. Profiling `uf fmt` over
+    /// `packages/router/internal/runtime.js` put comment attachment at
+    /// 4.6 MiB of allocation for a 111 KiB file — more than the parser and
+    /// more than the printer, for the phase that does the least work.
+    ///
+    /// The children of a node do not change while the tree is being read, so
+    /// the answer is computed once and kept. The memory is bounded by the
+    /// tree; what it replaces was unbounded in the number of comments.
+    children: FxHashMap<NodeKey, Vec<(Span, NodeRef<'a>)>>,
 }
 
 impl<'a> Attacher<'a, '_> {
@@ -227,18 +243,19 @@ impl<'a> Attacher<'a, '_> {
             return;
         }
         let root = NodeRef::Program(self.program);
-        let contexts: Vec<Context<'a>> = (0..self.comments.len())
-            .map(|index| {
-                let (enclosing, preceding, following) =
-                    self.decorate(root, self.comments[index].span, None);
-                Context {
-                    index,
-                    enclosing,
-                    preceding,
-                    following,
-                }
-            })
-            .collect();
+        // A loop rather than a `map`, because `decorate` now caches what it
+        // reads and so needs `&mut self`.
+        let mut contexts: Vec<Context<'a>> = Vec::with_capacity(self.comments.len());
+        for index in 0..self.comments.len() {
+            let span = self.comments[index].span;
+            let (enclosing, preceding, following) = self.decorate(root, span, None);
+            contexts.push(Context {
+                index,
+                enclosing,
+                preceding,
+                following,
+            });
+        }
 
         for (position, context) in contexts.iter().enumerate() {
             let comment = self.comments[context.index];
@@ -352,22 +369,26 @@ impl<'a> Attacher<'a, '_> {
 
     /// Sorted children of `node`, with the ones that cannot carry comments
     /// replaced by their own children.
-    fn sorted_children(&self, node: NodeRef<'a>) -> Vec<(Span, NodeRef<'a>)> {
-        let mut raw = Vec::new();
-        node.children(&mut raw);
-        let mut children: Vec<(Span, NodeRef<'a>)> = raw
-            .into_iter()
-            .map(|child| (self.span(child), child))
-            .collect();
-        children.sort_by_key(|(span, _)| (span.start, span.end));
-        children
+    fn sorted_children(&mut self, node: NodeRef<'a>) -> &[(Span, NodeRef<'a>)] {
+        let key = node.key();
+        if !self.children.contains_key(&key) {
+            let mut raw = Vec::new();
+            node.children(&mut raw);
+            let mut children: Vec<(Span, NodeRef<'a>)> = raw
+                .into_iter()
+                .map(|child| (self.span(child), child))
+                .collect();
+            children.sort_by_key(|(span, _)| (span.start, span.end));
+            self.children.insert(key, children);
+        }
+        &self.children[&key]
     }
 
     /// Prettier's `decorateComment`: the enclosing, preceding and following
     /// nodes of a comment, found by descending into whichever child
     /// contains it.
     fn decorate(
-        &self,
+        &mut self,
         node: NodeRef<'a>,
         comment: Span,
         enclosing: Option<NodeRef<'a>>,
@@ -947,14 +968,14 @@ impl<'a> Attacher<'a, '_> {
     /// so gives nothing to compare a key against. See the `DeclareClass` arm
     /// of [`handle_class`](Self::handle_class).
     fn first_child_after_name(
-        &self,
+        &mut self,
         node: NodeRef<'a>,
         id: &'a ast::Identifier<uf_flow::Loc, uf_flow::Loc>,
         tparams: Option<&'a types::TypeParams<uf_flow::Loc, uf_flow::Loc>>,
     ) -> Option<NodeRef<'a>> {
         self.sorted_children(node)
-            .into_iter()
-            .map(|(_, child)| child)
+            .iter()
+            .map(|(_, child)| *child)
             .find(|child| {
                 NodeRef::Identifier(id).key() != child.key()
                     && !tparams


### PR DESCRIPTION
Comment attachment descends the tree from the root for **every** comment, and asked for a node's sorted children at every level of every descent:

```rust
fn sorted_children(&self, node: NodeRef<'a>) -> Vec<(Span, NodeRef<'a>)> {
    let mut raw = Vec::new();
    node.children(&mut raw);
    let mut children: Vec<(Span, NodeRef<'a>)> =
        raw.into_iter().map(|child| (self.span(child), child)).collect();
    children.sort_by_key(|(span, _)| (span.start, span.end));
    children
}
```

Two `Vec` allocations and a sort, per level, per comment. The root's children — for a real module, every top-level statement — were collected and sorted **once per comment in the file**.

## Found by profiling, not by reading

This is the first thing the new profiler was pointed at. `uf fmt` over `packages/router/internal/runtime.js` (111 KiB), five iterations:

```
span             hits        self       total       bytes     allocs
fmt/parse           5    88.55 ms    88.55 ms    16.0 MiB     118440
fmt/print           5    44.08 ms    44.08 ms    16.6 MiB      82565
fmt/comments        5    24.24 ms    24.24 ms    23.1 MiB      14165
fmt/render          5    23.68 ms    23.68 ms     3.5 MiB      15355
```

Comment attachment allocated **more than the parser and more than the printer**, in a fifth of their allocations — 1.6 KiB an allocation, which is the shape of a `Vec` of children being built and thrown away. Nothing about the wall-clock column would have suggested looking there; it is the third-slowest row.

## The change

A node's children do not change while the tree is being read, so they are computed once and kept, keyed on `NodeKey` — the identity `slots` is already keyed on. `decorate` and `first_child_after_name` become `&mut self`, and `run` builds its contexts in a loop rather than a `map` over `&self`.

## Measured

Release build, same 111 KiB module, five runs:

| | before | after | |
| --- | --- | --- | --- |
| time / run | 5.643 ms | 5.375 ms | **−4.7%** |
| allocations / run | 46,090 | 43,659 | **−5.3%** |
| bytes / run | 12.41 MiB | 7.95 MiB | **−36%** |
| peak above baseline | 4.84 MiB | 4.84 MiB | unchanged |

**The peak is the number that says this is not a trade.** The cache holds one entry per node visited, bounded by the tree; what it replaces was bounded by the number of comments times the depth of the descent, and none of it survived the call.

## The benchmark

`format heavily commented file` is new, and it is where the effect is plainest — the cost is the *product* of comments and nodes, so neither half alone shows it. The existing synthetic module has no comments at all; this one is shaped like this repository's own source, which is mostly comments.

```
uf_fmt/format heavily commented file   4.89 ms  ->  3.78 ms   (−23%)
```

Reverting the cache underneath it reports:

```
change: [+26.212% +29.561% +31.395%] (p = 0.00 < 0.05)
Performance has regressed.
```

which is what makes it a guard rather than a number in a commit message.

## Behaviour

None changed. `decorate` and `first_child_after_name` see the same children in the same order — the cache is keyed on node identity and the computation is unchanged. `uf_fmt`'s 97 tests pass, `cargo fmt` and `clippy` are clean.

Groundwork for `docs/roadmap.md`'s "audit hot paths for unnecessary `.clone()` calls and replace them with borrowed or arena-backed flows", which is the same question asked of a different phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791441252&installation_model_id=422833&pr_number=661&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F661&signature=01ac582f54deac7b8e4b9b375090fd5c75b66b29bd7541e94a34422a318cb838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->