### PR TITLE
chore(release): name #650 in the alpha.15 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2026-09-08_
 
-Nineteen changes. The one to read first is the one that was wrong in a way
+Twenty changes. The one to read first is the one that was wrong in a way
 nothing could see: a diagnostic printed a module path exactly as it came off
 the filesystem, and a repository is attacker-authored input — `uf` is run
 against a clone, and a file in it can be named `src/\x1b[2Jgotcha.js`. Registry
@@ -23,6 +23,7 @@ that replaces `uf` rather than the one that only said so.
 
 ### Added
 
+- **build, project**: the other build — a library, and what one ships (#650)
 - **i18n, cli, test**: the five refusals a message's type owes, and the catalogue a translator gets (#633)
 - **vite, router, query**: React DevTools on purpose, Strict Mode by default, and the request it was cancelling (#631)
 - **lib, cli, ui, stylex**: a readiness per component, the parts list a test reads, and the constraint a select group states (#628)


### PR DESCRIPTION
#650 landed between the alpha.15 release pull request's last sync and its merge, so the section documenting the release does not name it.

`uf@0.0.0-alpha.15` **has not been tagged yet**. Tagging with this in place keeps `changelog-covers-the-release.sh` true of the release; tagging without it turns `main` red the moment the tag exists, because the commit is in the tag's range and not in its section.

One line, and the count in the summary paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791441314&installation_model_id=422833&pr_number=662&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F662&signature=b7419e56bb57d32fe5c948a5c2230b92d9b6a1e60f1c32d751eaa5a43c3098ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->