### PR TITLE
test(vite): two dev-server tests ask the operating system for their port

### DIFF
--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -3470,11 +3470,6 @@ fn wait_for_http(port: u16, path: &str, budget: Duration) -> Option<String> {
     None
 }
 
-/// One plain HTTP/1.1 request, so the test depends on nothing but the server.
-fn http_get(host: &str, port: u16, path: &str) -> String {
-    http_request(host, port, "GET", path, None)
-}
-
 /// The same, for a method and a body — which is the half a route handler is
 /// the only thing that can answer, and therefore the half a build that serves
 /// only files gets wrong.

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -3410,13 +3410,17 @@ fn server_said(said: &Mutex<String>) -> String {
 /// port stopped listening, and `http_get`'s bare `expect` reported
 /// `ConnectionRefused` and nothing about the process that had refused it.
 fn get(server: &mut Server, port: u16, path: &str, said: &Mutex<String>) -> String {
-    if TcpStream::connect(("127.0.0.1", port)).is_err() {
-        panic!(
-            "the dev server answered `/` and then stopped listening, before {path}\n{}",
+    match try_http_request("127.0.0.1", port, "GET", path, None, &[]) {
+        Ok(response) => response,
+        // The whole exchange, not just the connect. A server that has gone
+        // away mid-request resets rather than refusing, and reporting that as
+        // a bare `unwrap` on a read threw away the one thing the failure was
+        // written to carry: what the process itself said before it went.
+        Err(error) => panic!(
+            "the dev server answered `/` and then stopped answering, at {path}: {error}\n{}",
             server.evidence(said)
-        );
+        ),
     }
-    http_get("127.0.0.1", port, path)
 }
 
 /// A port nothing is listening on, released before the server binds it.
@@ -3443,14 +3447,23 @@ fn free_port() -> u16 {
 }
 
 /// Poll until the server answers, or give up.
+///
+/// The request is the probe. Connecting first and then asking looked like the
+/// careful order and was the opposite: a server that has bound its port but is
+/// not serving yet accepts the connection and resets it, so the poll would
+/// connect happily, hand the socket to a helper that unwrapped the read, and
+/// panic with `Connection reset by peer` — inside the loop written to wait for
+/// exactly that. It cost two green pull requests an hour apart.
+///
+/// So the whole exchange is fallible here, and an error is a reason to sleep
+/// rather than a reason to stop. The connect is also no longer made twice.
 fn wait_for_http(port: u16, path: &str, budget: Duration) -> Option<String> {
     let started = Instant::now();
     while started.elapsed() < budget {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            let body = http_get("127.0.0.1", port, path);
-            if !body.is_empty() {
-                return Some(body);
-            }
+        if let Ok(body) = try_http_request("127.0.0.1", port, "GET", path, None, &[])
+            && !body.is_empty()
+        {
+            return Some(body);
         }
         std::thread::sleep(Duration::from_millis(200));
     }
@@ -3487,10 +3500,29 @@ fn http_request_with(
     body: Option<&str>,
     headers: &[(&str, &str)],
 ) -> String {
-    let mut stream = TcpStream::connect((host, port)).expect("connect to the server");
-    stream
-        .set_read_timeout(Some(Duration::from_secs(60)))
-        .unwrap();
+    match try_http_request(host, port, method, path, body, headers) {
+        Ok(response) => response,
+        Err(error) => panic!("{method} {path} on {host}:{port} did not complete: {error}"),
+    }
+}
+
+/// The same exchange, for a caller that has a reason to expect it to fail.
+///
+/// [`wait_for_http`] is that caller: while a server is coming up, a connect
+/// that succeeds and a read that is reset are the same event seen half a
+/// millisecond apart, and a poll cannot tell them apart by connecting first.
+/// Everything above this returns the response or panics, because by then the
+/// server has answered once and a failure is the test's finding.
+fn try_http_request(
+    host: &str,
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+    headers: &[(&str, &str)],
+) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect((host, port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(60)))?;
     // The body's headers only when there is a body: a `GET` carrying
     // `Content-Length: 0` is legal and is still not the request a browser
     // makes, and this is the request every other assertion here is made about.
@@ -3513,11 +3545,10 @@ fn http_request_with(
         } else {
             entity
         }
-    )
-    .unwrap();
+    )?;
     let mut response = String::new();
-    stream.read_to_string(&mut response).unwrap();
-    response
+    stream.read_to_string(&mut response)?;
+    Ok(response)
 }
 
 /// The whole claim, end to end: one file, an empty directory, a served page.

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -793,78 +793,67 @@ fn dev_reports_a_contract_violation_when_one_appears() {
     }
     let root = project_with_a_clean_server_component();
     let helper = root.join("app/greeting.js");
-    let mut refused = Vec::new();
+    let said = Mutex::new(String::new());
 
-    for attempt in 1..=PORT_ATTEMPTS {
-        let port = free_port();
-        let said = Mutex::new(String::new());
-
-        let served = std::thread::scope(|scope| {
-            let mut server =
-                Server::start(&root, &["dev", "--port", &port.to_string()], scope, &said);
-            if wait_for_http(port, "/", Duration::from_secs(90)).is_none() {
-                refused.push(format!(
-                    "attempt {attempt} on port {port}: {}",
-                    server.evidence(&said)
-                ));
-                drop(server);
-                return false;
-            }
-
-            // A clean project says nothing. Asserted after the server has
-            // answered a request, which is well after the start-up analysis.
-            assert!(
-                !said_contains(&said, "server components"),
-                "a project with no violations must not report any:\n{}",
-                server_said(&said)
-            );
-
-            fs::write(&helper, HELPER_THAT_TOUCHES_THE_BROWSER).unwrap();
-            let reported = wait_for_said(
-                &said,
-                "rsc/client-only-api-in-server",
-                Duration::from_secs(30),
-            );
-            assert!(
-                reported,
-                "the dev server did not report the violation that appeared:\n{}",
+    std::thread::scope(|scope| {
+        // See the note in `dev_answers_the_fixture_the_way_a_build_does`.
+        let mut server = Server::start(&root, &["dev", "--port", "0"], scope, &said);
+        let Some(port) = server.bound_port(&said, Duration::from_secs(90)) else {
+            panic!(
+                "the dev server never announced a port\n{}",
                 server.evidence(&said)
             );
-            let text = server_said(&said);
-            assert!(
-                text.contains("app/greeting.js"),
-                "the report must name the module:\n{text}"
-            );
-            assert!(
-                text.contains("localStorage"),
-                "the report must name the API:\n{text}"
-            );
-
-            // And it goes away again: a report that only ever accumulates is a
-            // report nobody can use to tell whether they fixed it.
-            fs::write(&helper, CLEAN_HELPER).unwrap();
-            let cleared = wait_for_said(
-                &said,
-                "the server-component contract holds",
-                Duration::from_secs(30),
-            );
-            assert!(
-                cleared,
-                "the dev server never said the violation was gone:\n{}",
+        };
+        if wait_for_http(port, "/", Duration::from_secs(90)).is_none() {
+            panic!(
+                "the dev server announced port {port} and did not answer on it\n{}",
                 server.evidence(&said)
             );
-            true
-        });
-
-        if served {
-            return;
         }
-    }
 
-    panic!(
-        "the dev server never answered, on {PORT_ATTEMPTS} different ports\n{}",
-        refused.join("\n\n")
-    );
+        // A clean project says nothing. Asserted after the server has
+        // answered a request, which is well after the start-up analysis.
+        assert!(
+            !said_contains(&said, "server components"),
+            "a project with no violations must not report any:\n{}",
+            server_said(&said)
+        );
+
+        fs::write(&helper, HELPER_THAT_TOUCHES_THE_BROWSER).unwrap();
+        let reported = wait_for_said(
+            &said,
+            "rsc/client-only-api-in-server",
+            Duration::from_secs(30),
+        );
+        assert!(
+            reported,
+            "the dev server did not report the violation that appeared:\n{}",
+            server.evidence(&said)
+        );
+        let text = server_said(&said);
+        assert!(
+            text.contains("app/greeting.js"),
+            "the report must name the module:\n{text}"
+        );
+        assert!(
+            text.contains("localStorage"),
+            "the report must name the API:\n{text}"
+        );
+
+        // And it goes away again: a report that only ever accumulates is a
+        // report nobody can use to tell whether they fixed it.
+        fs::write(&helper, CLEAN_HELPER).unwrap();
+        let cleared = wait_for_said(
+            &said,
+            "the server-component contract holds",
+            Duration::from_secs(30),
+        );
+        assert!(
+            cleared,
+            "the dev server never said the violation was gone:\n{}",
+            server.evidence(&said)
+        );
+    });
 }
 
 /// Whether the server has said `needle` yet, waiting up to `budget` for it.
@@ -1329,11 +1318,21 @@ impl Drop for Server {
 /// times and prints three servers' reasons, which is more than the one line
 /// this used to give.
 ///
-/// [`dev_serves_the_docs_site_through_vite`] no longer needs it: `uf dev
-/// --port 0` asks the operating system for a port through the process that
-/// then holds it, and prints the answer, so there is no window to lose. The
-/// commands that have no such flag are still here, and this is still the best
-/// available answer for them.
+/// Most of the `uf dev` tests no longer need it: `uf dev --port 0` asks the
+/// operating system for a port *through the process that then holds it*, and
+/// prints the answer, so there is no window to lose. Three of them have moved
+/// — the two here and [`dev_serves_the_docs_site_through_vite`] — after this
+/// race failed CI five times in one afternoon, three of those on
+/// `Port … is already in use` after all three attempts lost, which is what a
+/// loaded runner does to a window this wide.
+///
+/// What is left needs a port it can name twice.
+/// [`dev_rereads_an_env_file_that_changed_under_it`] asserts across a
+/// **restart**: `--port` carries `--strict-port`, so a server that came back
+/// on the same number is the property being tested, and `--port 0` would give
+/// it a different one and turn a real regression into a passing test. The
+/// commands with no such flag are in the same position. For those this is
+/// still the best available answer.
 const PORT_ATTEMPTS: usize = 3;
 
 /// The port in the first `http://host:port` URL a server has printed, if any.
@@ -1528,36 +1527,28 @@ fn dev_answers_the_fixture_the_way_a_build_does() {
     // of them wrote.
     let _served = served_lock();
     let root = served_app_root();
-    let mut refused = Vec::new();
+    let said = Mutex::new(String::new());
 
-    for attempt in 1..=PORT_ATTEMPTS {
-        let port = free_port();
-        let said = Mutex::new(String::new());
-
-        let served = std::thread::scope(|scope| {
-            let mut server =
-                Server::start(&root, &["dev", "--port", &port.to_string()], scope, &said);
-            if let Some(body) = wait_for_http(port, "/", Duration::from_secs(90)) {
-                assert_dev_served(&mut server, port, &said, &body);
-                return true;
-            }
-            refused.push(format!(
-                "attempt {attempt} on port {port}: {}",
+    std::thread::scope(|scope| {
+        // `--port 0` rather than a port chosen here: asking the operating
+        // system *through the process that will hold the socket* leaves no
+        // window for anything else on the machine to take it. See
+        // [`Server::bound_port`].
+        let mut server = Server::start(&root, &["dev", "--port", "0"], scope, &said);
+        let Some(port) = server.bound_port(&said, Duration::from_secs(90)) else {
+            panic!(
+                "the dev server never announced a port\n{}",
                 server.evidence(&said)
-            ));
-            drop(server);
-            false
-        });
-
-        if served {
-            return;
-        }
-    }
-
-    panic!(
-        "the dev server never answered `served-app`, on {PORT_ATTEMPTS} different ports\n{}",
-        refused.join("\n\n")
-    );
+            );
+        };
+        let Some(body) = wait_for_http(port, "/", Duration::from_secs(90)) else {
+            panic!(
+                "the dev server announced port {port} and never answered `served-app`\n{}",
+                server.evidence(&said)
+            );
+        };
+        assert_dev_served(&mut server, port, &said, &body);
+    });
 }
 
 /// Everything `uf dev` has to answer for `served-app`, once it is listening.


### PR DESCRIPTION
`Port 41551 is already in use` failed CI **five times this afternoon** — three of those after all three `PORT_ATTEMPTS` lost the same race. Each one costs a full ~12-minute pipeline on a pull request that is otherwise green, on a queue that merges serially, so this has been one of the larger drags on throughput today.

## The race

`PORT_ATTEMPTS`' own comment already describes it: a port is chosen by binding zero and dropping the listener, and between that and `uf dev` binding it, anything on the machine can take it. On a loaded runner with several pipelines in flight, "anything" is another job in this same repository — and three attempts is not enough.

The comment also already names the fix, and calls it the one the issue prefers to a retry:

> `uf dev --port 0` asks the operating system for a port through the process that then holds it, and prints the answer, so there is no window to lose.

`dev_serves_the_docs_site_through_vite` was using it. Two more move to it now, and their retry loops go with the race:

- `dev_answers_the_fixture_the_way_a_build_does`
- `dev_reports_a_contract_violation_when_one_appears`

Each loses a `for attempt in 1..=PORT_ATTEMPTS`, a `refused` vector and a summary panic, and gains a `bound_port` that cannot lose.

## What stays, and why it is written down now

`dev_rereads_an_env_file_that_changed_under_it` keeps the retry. It asserts across a **restart**: `--port` carries `--strict-port`, so the server coming back on the same number *is* the property being tested. `--port 0` would hand the restart a different port and turn a real regression into a passing test.

That was implicit before; the `PORT_ATTEMPTS` comment now says it, along with the count of failures that prompted the move, so the next person deciding whether to convert the last one has the reason in front of them rather than a plausible-looking edit to make.

## Verification

`cargo test -p uf_cli --test vite` — 52 passed, 0 failed, locally.

Refs #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791447738&installation_model_id=422833&pr_number=669&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F669&signature=c722125d456e64d50465b59e9c1b45fad09d9ab5019fcc3e210ba6eb57a367e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->