### PR TITLE
fix(term): the columns a path draws, not the ones its scalars would draw alone

### DIFF
--- a/crates/uf_term/src/text.rs
+++ b/crates/uf_term/src/text.rs
@@ -89,6 +89,83 @@ pub fn display_width(text: &str) -> usize {
     width
 }
 
+/// One scalar's contribution to the rendered width, and whether a cut may
+/// land on it.
+#[derive(Clone, Copy)]
+struct Column {
+    /// What this scalar adds to the width of the whole string.
+    cost: usize,
+    /// Whether this scalar opens a cluster rather than continuing one.
+    ///
+    /// A cut may only land here. Anywhere else the scalar's rendered width
+    /// depends on what came before it, which the cut has just thrown away, and
+    /// so the width [`cost`](Self::cost) recorded and the width the terminal
+    /// draws part ways.
+    opens_cluster: bool,
+}
+
+/// What each scalar in `kept` adds to the rendered width, and where it is safe
+/// to cut.
+///
+/// The same rule [`display_width`] applies, as a per-scalar cost so a running
+/// total can use it: a variation selector has no width of its own and instead
+/// widens the narrow scalar before it, and a scalar joined by a zero-width
+/// joiner adds nothing because the cluster it continues already paid.
+///
+/// Summing [`char_width`] instead gets both wrong, and one of them unsafely.
+/// A path of `a\u{fe0f}` repeated a hundred and twenty times sums to 120 and
+/// renders as 240 — twice the bound the cap exists to hold — so a name built
+/// out of emoji-presentation sequences could wrap the row whatever the cap
+/// said. See ubugeeei-prod/uf#671.
+///
+/// The cut points come from this same pass rather than from a predicate over
+/// the scalars, because whether a scalar continues a cluster is a fact about
+/// the state machine and not about the scalar. A joiner's reach survives a
+/// variation selector — neither this function nor [`display_width`] clears
+/// `joined` on one — so `ZWJ VS16 X` leaves `X` joined, which a predicate
+/// reading only `kept[at - 1]` calls the start of a cluster and is wrong by
+/// the full width of `X`.
+///
+/// Escapes are not handled here and do not need to be: both callers drop every
+/// control character before measuring, and `\x1b` is one.
+fn columns(kept: &[char]) -> Vec<Column> {
+    let mut columns = Vec::with_capacity(kept.len());
+    let mut joined = false;
+    let mut previous_narrow = false;
+    for &ch in kept {
+        let column = match ch {
+            ZWJ => {
+                joined = true;
+                previous_narrow = false;
+                Column {
+                    cost: 0,
+                    opens_cluster: false,
+                }
+            }
+            VS16 => {
+                let widened = usize::from(previous_narrow);
+                previous_narrow = false;
+                Column {
+                    cost: widened,
+                    opens_cluster: false,
+                }
+            }
+            _ => {
+                let width = char_width(ch);
+                let column = Column {
+                    cost: if joined { 0 } else { width },
+                    opens_cluster: !joined,
+                };
+                joined = false;
+                previous_narrow = width == 1;
+                column
+            }
+        };
+        columns.push(column);
+    }
+    columns
+}
+
 /// The widest a path is drawn before it is elided.
 ///
 /// Wide enough that a real path in a real repository is never cut, and narrow
@@ -117,23 +194,33 @@ pub const MAX_PATH_WIDTH: usize = 120;
 /// directories every one of which was the same.
 pub fn push_safe_path(out: &mut String, path: &str) {
     let kept: Vec<char> = path.chars().filter(|ch| !ch.is_control()).collect();
-    let width: usize = kept.iter().copied().map(char_width).sum();
-    if width <= MAX_PATH_WIDTH {
+    let columns = columns(&kept);
+    let total: usize = columns.iter().map(|column| column.cost).sum();
+    if total <= MAX_PATH_WIDTH {
         out.extend(kept);
         return;
     }
-    let mut tail = Vec::with_capacity(kept.len());
-    let mut budget = MAX_PATH_WIDTH - 1;
-    for ch in kept.iter().rev().copied() {
-        let width = char_width(ch);
-        if width > budget {
-            break;
-        }
-        budget -= width;
-        tail.push(ch);
+    // Dropped from the front until what is left fits beside the ellipsis. The
+    // costs are read forward, because that is the direction the rule runs in —
+    // a variation selector's column belongs to the scalar before it.
+    let mut kept_width = total;
+    let mut start = 0usize;
+    while start < kept.len() && kept_width > MAX_PATH_WIDTH - 1 {
+        kept_width -= columns[start].cost;
+        start += 1;
+    }
+    // And then on to a cluster boundary, because the ellipsis is drawn in front
+    // of what is kept and a cluster's leftovers would attach themselves to it.
+    // A dangling variation selector asks for the *ellipsis* in emoji
+    // presentation and takes a second column doing it, which is how a path that
+    // measured 119 came out at 121; a scalar left behind by its joiner is
+    // charged nothing here and its full width by the terminal. Advancing only
+    // ever drops more, so the budget still holds.
+    while start < kept.len() && !columns[start].opens_cluster {
+        start += 1;
     }
     out.push('\u{2026}');
-    out.extend(tail.iter().rev());
+    out.extend(&kept[start..]);
 }
 
 /// [`push_safe_path`] as a value, for a caller that is not building a line.
@@ -160,18 +247,21 @@ pub const MAX_MESSAGE_WIDTH: usize = 512;
 /// left, because a sentence is read from its start. See ubugeeei-prod/uf#659.
 pub fn push_safe_message(out: &mut String, message: &str) {
     let kept: Vec<char> = message.chars().filter(|ch| !ch.is_control()).collect();
-    let width: usize = kept.iter().copied().map(char_width).sum();
-    if width <= MAX_MESSAGE_WIDTH {
+    let columns = columns(&kept);
+    if columns.iter().map(|column| column.cost).sum::<usize>() <= MAX_MESSAGE_WIDTH {
         out.extend(kept);
         return;
     }
+    // The ellipsis goes on the end here, so there is no cluster to land on: the
+    // scalars kept are the ones the rule already measured, in the state it
+    // measured them in. A joiner left dangling at the cut only ever makes the
+    // ellipsis cost less, never more.
     let mut budget = MAX_MESSAGE_WIDTH - 1;
-    for ch in kept {
-        let width = char_width(ch);
-        if width > budget {
+    for (ch, column) in kept.into_iter().zip(columns) {
+        if column.cost > budget {
             break;
         }
-        budget -= width;
+        budget -= column.cost;
         out.push(ch);
     }
     out.push('\u{2026}');

--- a/crates/uf_term/src/text/tests.rs
+++ b/crates/uf_term/src/text/tests.rs
@@ -358,3 +358,133 @@ fn a_message_wider_than_the_cap_is_cut_from_its_tail() {
     let padded = format!("{}short", "\x1b".repeat(2_000));
     assert_eq!(safe_message(&padded), "short");
 }
+
+/// The cap is the *rendered* width, so an emoji-presentation sequence counts.
+///
+/// `char_width` gives a variation selector zero and the narrow scalar before it
+/// one, which sums to half of what a terminal draws: `a\u{fe0f}` repeated 120
+/// times summed to 120 — exactly the cap — and rendered as 240 columns. A name
+/// built out of those could wrap the row the bound exists to hold whatever the
+/// bound said. See ubugeeei-prod/uf#671.
+#[test]
+fn an_emoji_presentation_sequence_counts_the_columns_it_draws() {
+    let path = "a\u{fe0f}".repeat(120);
+    let drawn = safe_path(&path);
+
+    assert!(
+        display_width(&drawn) <= MAX_PATH_WIDTH,
+        "{}",
+        display_width(&drawn)
+    );
+    assert!(drawn.starts_with('\u{2026}'), "it was elided: {drawn:?}");
+    // The same sequence inside the cap is left whole.
+    let short = "a\u{fe0f}".repeat(10);
+    assert_eq!(safe_path(&short), short);
+}
+
+/// A joined cluster is one cluster, and is not charged per scalar.
+///
+/// The other half of the same mistake, in the other direction: summing
+/// `char_width` charges every scalar of a zero-width-joiner sequence, so a
+/// path of them would be elided long before it filled the row.
+#[test]
+fn a_zero_width_joiner_sequence_is_charged_once() {
+    // A single rendered glyph made of three scalars joined by two joiners.
+    let family = "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}";
+    let path = format!("src/{}.js", family.repeat(20));
+    let drawn = safe_path(&path);
+
+    // Well inside the cap once the joins are counted, so nothing is elided.
+    assert_eq!(display_width(&drawn), display_width(&path));
+    assert!(!drawn.starts_with('\u{2026}'), "{drawn:?}");
+}
+
+/// And a message is measured the same way.
+#[test]
+fn a_message_counts_the_columns_it_draws_too() {
+    let message = "a\u{fe0f}".repeat(MAX_MESSAGE_WIDTH);
+    let drawn = safe_message(&message);
+
+    assert!(
+        display_width(&drawn) <= MAX_MESSAGE_WIDTH,
+        "{}",
+        display_width(&drawn)
+    );
+    assert!(drawn.ends_with('\u{2026}'), "{drawn:?}");
+}
+
+/// The per-scalar costs are [`display_width`], split up — checked exhaustively.
+///
+/// The caps read the costs forward and stop at whatever boundary the budget
+/// runs out on, so any place the two rules disagree is a place a cap is wrong
+/// about the row. Rather than trust that the second copy of the state machine
+/// matches the first by eye, every sequence of up to four scalars drawn from
+/// the interesting alphabet — narrow, wide, a variation selector, a joiner —
+/// is checked to sum to exactly what the string renders as.
+#[test]
+fn the_costs_sum_to_what_the_string_renders_as() {
+    const ALPHABET: [char; 5] = ['a', '漢', VS16, ZWJ, '\u{1f469}'];
+
+    let mut sequences: Vec<Vec<char>> = vec![Vec::new()];
+    for _ in 0..4 {
+        let mut longer = Vec::new();
+        for sequence in &sequences {
+            for &ch in &ALPHABET {
+                let mut next = sequence.clone();
+                next.push(ch);
+                longer.push(next);
+            }
+        }
+        sequences.extend(longer);
+    }
+
+    for sequence in &sequences {
+        let rendered: String = sequence.iter().collect();
+        assert_eq!(
+            columns(sequence)
+                .iter()
+                .map(|column| column.cost)
+                .sum::<usize>(),
+            display_width(&rendered),
+            "{rendered:?}"
+        );
+    }
+}
+
+/// And what the cap keeps is under the cap, whatever it had to cut through.
+///
+/// Dropping from the front can stop in the middle of a cluster, where the
+/// costs were counted against scalars that are no longer there. The one that
+/// would be unsafe — keeping a joined scalar whose joiner was dropped, which
+/// the model charged nothing and the terminal charges in full — cannot happen,
+/// because dropping a zero-cost scalar never brings the total under the budget
+/// and so never ends the loop. This holds the property rather than the reason.
+#[test]
+fn every_cut_leaves_a_path_inside_the_cap() {
+    const ALPHABET: [char; 5] = ['a', '漢', VS16, ZWJ, '\u{1f469}'];
+
+    // Long enough that the cap always bites — every scalar draws at most two
+    // columns, so twice the cap in scalars is at least the cap in columns — and
+    // seeded differently each round so the boundary lands on each kind of
+    // scalar, and on each kind of run leading up to one, in turn.
+    let mut seed = 0x2545_f491_4f6c_dd1du64;
+    for _ in 0..500 {
+        let mut path = String::with_capacity(MAX_MESSAGE_WIDTH * 8);
+        for _ in 0..MAX_MESSAGE_WIDTH * 2 {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            path.push(ALPHABET[(seed % ALPHABET.len() as u64) as usize]);
+        }
+        let drawn = safe_path(&path);
+        assert!(
+            display_width(&drawn) <= MAX_PATH_WIDTH,
+            "{} columns: {drawn:?}",
+            display_width(&drawn)
+        );
+        assert!(
+            display_width(&safe_message(&path)) <= MAX_MESSAGE_WIDTH,
+            "message: {drawn:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #671.

`safe_path` caps a drawn path at `MAX_PATH_WIDTH` and `safe_message` caps a message at `MAX_MESSAGE_WIDTH`. Both measured by summing `char_width`. `display_width` — the function that says what a terminal actually draws — does not.

```
path = "a\u{fe0f}".repeat(120)

char_width sum = 120     <- exactly MAX_PATH_WIDTH, so nothing was elided
display_width  = 240     <- what the terminal draws
```

A variation selector has no width of its own; it widens the narrow scalar before it. So a name built out of emoji-presentation sequences drew at twice the bound the cap exists to hold — and did it on exactly the input the cap was added for (#640): a name out of a checkout uf did not write. The same mistake runs the other way for a zero-width joiner, harmlessly: summing charges every scalar of a cluster that the terminal charges once, so a path of joined emoji was elided long before it filled the row.

## The half that is not in the report

`columns` is `display_width`'s rule, per scalar, so a running total can use it. That alone is not enough, and the property test is what said so — twice.

The ellipsis is drawn *in front of* what a path keeps, so the cut has to land somewhere the recorded cost still describes what will be drawn:

- A suffix that began with an orphaned variation selector asked for the **ellipsis** in emoji presentation and took a second column doing it. A path measuring 119 came out at 121.
- Advancing to a "cluster boundary" found by a predicate over the scalars was still wrong. A joiner's reach survives a variation selector — neither `columns` nor `display_width` clears `joined` on one — so `ZWJ VS16 X` leaves `X` joined, which a predicate reading only `kept[at - 1]` calls a cluster start, and is wrong by the full width of `X`. The cut points now come out of the same pass that computes the costs, because whether a scalar continues a cluster is a fact about the state machine, not about the scalar.

`safe_message` needs none of this: its ellipsis goes on the end, so the scalars it keeps are the ones the rule already measured in the state it measured them in, and a joiner left dangling at the cut only ever makes the ellipsis cost less. It is held to the property anyway.

## Tests

Three levels, and reverting either half of the fix fails them:

| | drop the boundary advance | sum `char_width` instead |
|---|---|---|
| `an_emoji_presentation_sequence_counts_the_columns_it_draws` | | ✗ |
| `a_zero_width_joiner_sequence_is_charged_once` | | ✗ |
| `a_message_counts_the_columns_it_draws_too` | | ✗ |
| `the_costs_sum_to_what_the_string_renders_as` | | ✗ |
| `every_cut_leaves_a_path_inside_the_cap` | ✗ | ✗ |

`the_costs_sum_to_what_the_string_renders_as` is exhaustive over every sequence of up to four scalars drawn from `['a', '漢', VS16, ZWJ, '👩']` — 780 cases — and pins the second copy of the state machine to the first rather than trusting that they match by eye. `every_cut_leaves_a_path_inside_the_cap` builds 500 random paths out of the same alphabet, long enough that the cap always bites, and asserts what is drawn is inside it. Together they run in 0.16s.

252 `uf_term` tests pass.

## Provenance

Reported by CodeRabbit on #652, against a file that had already left that pull request, so GitHub marked the thread outdated. The finding outlived the file — it was still true of `main` — so it was filed as #671 against the code that has it rather than resolved away there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791451097&installation_model_id=422833&pr_number=672&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F672&signature=d53b1382935362b40c9a444d16508423b8afc469e69b9ca4c214be002f69bc48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text truncation so paths and messages with emoji variation selectors and joined emoji sequences stay within the configured width limits.
  * Improved truncation boundaries to avoid cutting through grapheme clusters.

* **Tests**
  * Added coverage for emoji presentation, zero-width joiners, rendered-width calculations, and safe truncation across varied character sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->