### PR TITLE
perf(transform): 31% fewer allocations building the Babel tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
  "uf_check",
  "uf_flow",
  "uf_infra",
+ "uf_profiler",
 ]
 
 [[package]]

--- a/crates/uf_transform/Cargo.toml
+++ b/crates/uf_transform/Cargo.toml
@@ -37,6 +37,11 @@ similar-asserts.workspace = true
 # only one that can see every entry point.
 uf_check = { path = "../uf_check" }
 
+# For `examples/alloc_report.rs`: the counting allocator that produced the
+# figures in ubugeeei-prod/uf#668, so the next person to touch this pipeline can
+# reproduce them rather than take them on trust.
+uf_profiler = { path = "../uf_profiler" }
+
 [[bench]]
 name = "transform"
 harness = false

--- a/crates/uf_transform/examples/alloc_report.rs
+++ b/crates/uf_transform/examples/alloc_report.rs
@@ -1,0 +1,56 @@
+//! What `babel_ast` costs, in allocations and bytes, for ubugeeei-prod/uf#668.
+//!
+//! Not a test and not a bench: a number to put in a commit message, and the
+//! thing to re-run after a change to see whether it moved. Run it as
+//! `cargo run --release --example alloc_report -p uf_transform -- <file>`.
+
+use uf_profiler::{AllocSnapshot, CountingAllocator, Window};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator::new();
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| String::from("packages/router/internal/runtime.js"));
+    let source = std::fs::read_to_string(&path).expect("read the module");
+
+    // `--dump`: the tree itself, so a change meant only to cost less can be
+    // held against the tree it used to produce. `serde_json` is built with
+    // `preserve_order`, so this is sensitive to key order as well as to
+    // content — which is how the one difference this change does make was
+    // found rather than assumed away.
+    if std::env::args().any(|arg| arg == "--dump") {
+        let (file, _) = uf_transform::babel_ast(&source).expect("parses");
+        println!("{}", serde_json::to_string(&file).expect("serializes"));
+        return;
+    }
+
+    println!("{path}: {} bytes", source.len());
+
+    // Warm up: the first run pays for whatever the parser initialises once.
+    let _ = uf_transform::babel_ast(&source).expect("parses");
+
+    CountingAllocator::enable();
+    let window = Window::open();
+    let before = AllocSnapshot::capture();
+    let runs = 5;
+    for _ in 0..runs {
+        let built = uf_transform::babel_ast(&source).expect("parses");
+        std::hint::black_box(&built);
+    }
+    let after = AllocSnapshot::capture();
+    drop(window);
+    CountingAllocator::disable();
+
+    let delta = after.delta_from(&before);
+    println!("allocs / run   {}", delta.allocations / runs);
+    println!(
+        "bytes / run    {:.2} MiB",
+        delta.bytes_allocated as f64 / runs as f64 / (1024.0 * 1024.0)
+    );
+    println!(
+        "peak           {:.2} MiB",
+        delta.peak_above_baseline as f64 / (1024.0 * 1024.0)
+    );
+}

--- a/crates/uf_transform/src/babel.rs
+++ b/crates/uf_transform/src/babel.rs
@@ -65,7 +65,10 @@ impl LineTable {
 }
 
 fn convert(node: &mut Value) -> Result<Edit, TransformError> {
-    let Some(kind) = node_type(node).map(str::to_owned) else {
+    // Classified rather than owned, for the reason [`Final::of`] gives: the
+    // arms below need the node mutably, and paying a `String` per node to hold
+    // a name across that borrow is the cost this avoids.
+    let Some(kind) = node_type(node).map(Convert::of) else {
         return Ok(Edit::Keep);
     };
     // The parser attaches comments to nodes in its own shape; the compiler
@@ -74,36 +77,36 @@ fn convert(node: &mut Value) -> Result<Edit, TransformError> {
     for key in ["leadingComments", "trailingComments", "innerComments"] {
         remove_key(node, key);
     }
-    Ok(match kind.as_str() {
-        "Literal" => Edit::Replace(literal(node)),
-        "Property" => Edit::Replace(property(node)?),
-        "MethodDefinition" => Edit::Replace(method_definition(node)),
-        "PropertyDefinition" => Edit::Replace(property_definition(node)),
-        "PrivateIdentifier" => Edit::Replace(private_name(node)),
-        "ImportExpression" => Edit::Replace(import_expression(node)),
-        "ExportAllDeclaration" if !node["exported"].is_null() => {
+    Ok(match kind {
+        Convert::Literal => Edit::Replace(literal(node)),
+        Convert::Property => Edit::Replace(property(node)?),
+        Convert::MethodDefinition => Edit::Replace(method_definition(node)),
+        Convert::PropertyDefinition => Edit::Replace(property_definition(node)),
+        Convert::PrivateIdentifier => Edit::Replace(private_name(node)),
+        Convert::ImportExpression => Edit::Replace(import_expression(node)),
+        Convert::ExportAllDeclaration if !node["exported"].is_null() => {
             Edit::Replace(export_namespace(node))
         }
-        "ChainExpression" => Edit::Replace(chain(take(node, "expression"))),
-        "Program" | "BlockStatement" => {
+        Convert::ChainExpression => Edit::Replace(chain(take(node, "expression"))),
+        Convert::Block => {
             lift_directives(node);
             Edit::Keep
         }
-        "JSXText" => {
+        Convert::JsxText => {
             let value = node["value"].clone();
             let raw = take(node, "raw");
             node["extra"] = json!({ "rawValue": value, "raw": raw });
             Edit::Keep
         }
-        "ArrayExpression" => {
+        Convert::ArrayExpression => {
             remove_key(node, "trailingComma");
             Edit::Keep
         }
-        "VariableDeclaration" => {
+        Convert::VariableDeclaration => {
             remove_key(node, "__ufEnum");
             Edit::Keep
         }
-        "ClassDeclaration" | "ClassExpression" => {
+        Convert::Class => {
             if node
                 .get("decorators")
                 .and_then(Value::as_array)
@@ -113,7 +116,7 @@ fn convert(node: &mut Value) -> Result<Edit, TransformError> {
             }
             Edit::Keep
         }
-        "ImportDeclaration" => {
+        Convert::ImportDeclaration => {
             for key in ["attributes", "assertions"] {
                 if node
                     .get(key)
@@ -125,12 +128,58 @@ fn convert(node: &mut Value) -> Result<Edit, TransformError> {
             }
             Edit::Keep
         }
-        "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration" => {
+        Convert::Function => {
             remove_key(node, "expression");
             Edit::Keep
         }
         _ => Edit::Keep,
     })
+}
+
+/// The node types [`convert`] treats specially, as a value rather than a name.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Convert {
+    ArrayExpression,
+    Block,
+    ChainExpression,
+    Class,
+    ExportAllDeclaration,
+    Function,
+    ImportDeclaration,
+    ImportExpression,
+    JsxText,
+    Literal,
+    MethodDefinition,
+    PrivateIdentifier,
+    Property,
+    PropertyDefinition,
+    VariableDeclaration,
+    Other,
+}
+
+impl Convert {
+    fn of(kind: &str) -> Self {
+        match kind {
+            "ArrayExpression" => Self::ArrayExpression,
+            "Program" | "BlockStatement" => Self::Block,
+            "ChainExpression" => Self::ChainExpression,
+            "ClassDeclaration" | "ClassExpression" => Self::Class,
+            "ExportAllDeclaration" => Self::ExportAllDeclaration,
+            "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration" => {
+                Self::Function
+            }
+            "ImportDeclaration" => Self::ImportDeclaration,
+            "ImportExpression" => Self::ImportExpression,
+            "JSXText" => Self::JsxText,
+            "Literal" => Self::Literal,
+            "MethodDefinition" => Self::MethodDefinition,
+            "PrivateIdentifier" => Self::PrivateIdentifier,
+            "Property" => Self::Property,
+            "PropertyDefinition" => Self::PropertyDefinition,
+            "VariableDeclaration" => Self::VariableDeclaration,
+            _ => Self::Other,
+        }
+    }
 }
 
 fn remove_key(node: &mut Value, key: &str) {
@@ -458,17 +507,75 @@ fn comment(node: &Value) -> Value {
 /// The keys `finalize` never descends into.
 const SKIPPED: [&str; 4] = ["type", "loc", "range", "extra"];
 
+/// Overwrite an existing `loc` with a recomputed start and end.
+///
+/// `false` when there is nothing of the right shape to write into and the
+/// caller has to build one — a node the translator gave no `loc`, or one whose
+/// `loc` is not the two-point object every other node's is.
+///
+/// The keys are all present already, so every write is an assignment into a
+/// slot rather than an insert: no key is allocated and no map is grown.
+fn overwrite_position(object: &mut Map<String, Value>, start: (u32, u32), end: (u32, u32)) -> bool {
+    let Some(loc) = object.get_mut("loc").and_then(Value::as_object_mut) else {
+        return false;
+    };
+    // Babel's `loc` has no `source`, and the translator's does.
+    loc.remove("source");
+    let mut written = 0;
+    for (key, (line, column)) in [("start", start), ("end", end)] {
+        let Some(point) = loc.get_mut(key).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        // One at a time: two `get_mut` on the same map cannot be live at once,
+        // and both keys are checked before either is written so a `loc`
+        // missing one of them is left alone rather than half-updated.
+        if !(point.contains_key("line") && point.contains_key("column")) {
+            continue;
+        }
+        if let Some(slot) = point.get_mut("line") {
+            *slot = Value::from(line);
+        }
+        if let Some(slot) = point.get_mut("column") {
+            *slot = Value::from(column);
+        }
+        written += 1;
+    }
+    written == 2
+}
+
+/// The node types [`finalize`] treats specially, as a value rather than a name.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Final {
+    Call,
+    ExpressionStatement,
+    Identifier,
+    MemberExpression,
+    Other,
+}
+
+impl Final {
+    fn of(kind: &str) -> Self {
+        match kind {
+            "CallExpression" | "NewExpression" => Self::Call,
+            "ExpressionStatement" => Self::ExpressionStatement,
+            "Identifier" => Self::Identifier,
+            "MemberExpression" => Self::MemberExpression,
+            _ => Self::Other,
+        }
+    }
+}
+
 /// Assign node ids and Babel's `start`/`end`, and tidy the fields Babel
 /// omits, throughout the file.
 fn finalize(node: &mut Value, next_id: &mut u32, lines: &LineTable) {
     let Some(object) = node.as_object_mut() else {
         return;
     };
-    let Some(kind) = object
-        .get("type")
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-    else {
+    // Classified rather than owned. Reading the type borrows the node and
+    // every arm below needs it mutably, which is what `str::to_owned` was
+    // paying for: one `String` per node, for a name compared four times and
+    // dropped. See ubugeeei-prod/uf#668.
+    let Some(kind) = object.get("type").and_then(Value::as_str).map(Final::of) else {
         return;
     };
 
@@ -487,30 +594,39 @@ fn finalize(node: &mut Value, next_id: &mut u32, lines: &LineTable) {
     if let Some((start, end)) = offsets {
         let (start_line, start_column) = lines.position(u32::try_from(start).unwrap_or(u32::MAX));
         let (end_line, end_column) = lines.position(u32::try_from(end).unwrap_or(u32::MAX));
-        object.insert(
-            "loc".to_owned(),
-            json!({
-                "start": { "line": start_line, "column": start_column },
-                "end": { "line": end_line, "column": end_column },
-            }),
-        );
+        // Written into the `loc` the translator already attached, when there
+        // is one. Its columns count code points where everything downstream
+        // counts UTF-16 units, so the numbers are wrong — but the shape is
+        // exactly right, and overwriting four of them costs nothing where
+        // building a replacement cost three maps and six keys, on every node
+        // of every module. `estree::parse` asks for `include_locs`, so there
+        // is one to write into almost always. See ubugeeei-prod/uf#668.
+        if !overwrite_position(object, (start_line, start_column), (end_line, end_column)) {
+            object.insert(
+                "loc".to_owned(),
+                json!({
+                    "start": { "line": start_line, "column": start_column },
+                    "end": { "line": end_line, "column": end_column },
+                }),
+            );
+        }
     } else if let Some(loc) = object.get_mut("loc").and_then(Value::as_object_mut) {
         loc.remove("source");
     }
 
-    match kind.as_str() {
-        "ExpressionStatement" => {
+    match kind {
+        Final::ExpressionStatement => {
             object.remove("directive");
         }
-        "MemberExpression" => {
+        Final::MemberExpression => {
             object.remove("optional");
         }
-        "CallExpression" | "NewExpression" => {
+        Final::Call => {
             if object.get("optional") == Some(&Value::Bool(false)) {
                 object.remove("optional");
             }
         }
-        "Identifier" => {
+        Final::Identifier => {
             let name = object.get("name").cloned();
             if let (Some(loc), Some(name)) =
                 (object.get_mut("loc").and_then(Value::as_object_mut), name)
@@ -518,22 +634,27 @@ fn finalize(node: &mut Value, next_id: &mut u32, lines: &LineTable) {
                 loc.insert("identifierName".to_owned(), name);
             }
         }
-        _ => {}
+        Final::Other => {}
     }
 
-    let keys: Vec<String> = object
-        .keys()
-        .filter(|key| !SKIPPED.contains(&key.as_str()))
-        .cloned()
-        .collect();
-    for key in keys {
-        match object.get_mut(&key) {
-            Some(Value::Array(items)) => {
+    // Walked through the map itself. This used to collect the keys into a
+    // `Vec<String>` first — a vector and an owned copy of every key, on every
+    // node — because `get_mut` cannot run while `keys` is borrowed. `iter_mut`
+    // hands out the key and the child together and needs neither, and it is
+    // the same order, so `_nodeId` still counts the tree the way it did.
+    // On `packages/router/internal/runtime.js` this was the largest single
+    // line in ubugeeei-prod/uf#668.
+    for (key, child) in object.iter_mut() {
+        if SKIPPED.contains(&key.as_str()) {
+            continue;
+        }
+        match child {
+            Value::Array(items) => {
                 for item in items {
                     finalize(item, next_id, lines);
                 }
             }
-            Some(child @ Value::Object(_)) => finalize(child, next_id, lines),
+            Value::Object(_) => finalize(child, next_id, lines),
             _ => {}
         }
     }

--- a/crates/uf_transform/src/lower/mod.rs
+++ b/crates/uf_transform/src/lower/mod.rs
@@ -136,15 +136,17 @@ fn transform_post_at(
         return Ok(Edit::Keep);
     }
 
-    let keys: Vec<String> = object
-        .keys()
-        .filter(|key| !SKIPPED_KEYS.contains(&key.as_str()))
-        .cloned()
-        .collect();
-    for key in keys {
-        let Some(child) = object.get_mut(&key) else {
+    // Walked through the map itself. This used to collect the keys into a
+    // `Vec<String>` first — a vector and an owned copy of every key, on every
+    // node of every module — because `get_mut` cannot run while `keys` is
+    // borrowed. Nothing in the loop adds or removes a key, only writes into
+    // one, so `iter_mut` is the same walk without the copies. Both the
+    // lowering and the Babel conversion come through here, so it is paid twice
+    // a module. See ubugeeei-prod/uf#668.
+    for (key, child) in object.iter_mut() {
+        if SKIPPED_KEYS.contains(&key.as_str()) {
             continue;
-        };
+        }
         match child {
             Value::Array(items) => {
                 let mut rebuilt = Vec::with_capacity(items.len());

--- a/crates/uf_transform/src/lower/strip.rs
+++ b/crates/uf_transform/src/lower/strip.rs
@@ -56,19 +56,64 @@ pub fn lower(program: &mut Value) -> Result<(), TransformError> {
     Ok(())
 }
 
+/// The node types [`strip_node`] treats specially, as a value rather than a name.
+///
+/// The classification happens while the type is still borrowed from the node,
+/// so nothing is owned. Reading it as a `&str` and keeping it across the arms
+/// below — which all need the node mutably — is what `str::to_owned` was
+/// paying for: one `String` per node of every module, for a name that is
+/// compared and dropped. See ubugeeei-prod/uf#668.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Strip {
+    Cast,
+    Class,
+    Export,
+    ExportAll,
+    Function,
+    Import,
+    Pattern,
+    PropertyDefinition,
+    TypeOnly,
+    Other,
+}
+
+impl Strip {
+    fn of(kind: &str) -> Self {
+        if TYPE_ONLY_STATEMENTS.contains(&kind) {
+            return Self::TypeOnly;
+        }
+        match kind {
+            "AsExpression" | "AsConstExpression" | "TypeCastExpression" | "SatisfiesExpression" => {
+                Self::Cast
+            }
+            "ClassDeclaration" | "ClassExpression" => Self::Class,
+            "ExportNamedDeclaration" => Self::Export,
+            "ExportAllDeclaration" => Self::ExportAll,
+            "FunctionDeclaration" | "FunctionExpression" | "ArrowFunctionExpression" => {
+                Self::Function
+            }
+            "ImportDeclaration" => Self::Import,
+            "Identifier" | "ObjectPattern" | "ArrayPattern" | "RestElement"
+            | "AssignmentPattern" => Self::Pattern,
+            "PropertyDefinition" => Self::PropertyDefinition,
+            _ => Self::Other,
+        }
+    }
+}
+
 fn strip_node(node: &mut Value) -> Edit {
-    let Some(kind) = node_type(node).map(str::to_owned) else {
+    let Some(kind) = node_type(node).map(Strip::of) else {
         return Edit::Keep;
     };
-    if TYPE_ONLY_STATEMENTS.contains(&kind.as_str()) {
+    if kind == Strip::TypeOnly {
         return Edit::Remove;
     }
 
-    match kind.as_str() {
-        "AsExpression" | "AsConstExpression" | "TypeCastExpression" | "SatisfiesExpression" => {
+    match kind {
+        Strip::Cast => {
             return Edit::Replace(take(node, "expression"));
         }
-        "ImportDeclaration" => {
+        Strip::Import => {
             if matches!(str_field(node, "importKind"), Some("type" | "typeof")) {
                 return Edit::Remove;
             }
@@ -86,13 +131,13 @@ fn strip_node(node: &mut Value) -> Edit {
             }
             remove_key(node, "importKind");
         }
-        "ExportAllDeclaration" => {
+        Strip::ExportAll => {
             if str_field(node, "exportKind") == Some("type") {
                 return Edit::Remove;
             }
             remove_key(node, "exportKind");
         }
-        "ExportNamedDeclaration" => {
+        Strip::Export => {
             if str_field(node, "exportKind") == Some("type") {
                 return Edit::Remove;
             }
@@ -111,10 +156,10 @@ fn strip_node(node: &mut Value) -> Edit {
             }
             remove_key(node, "exportKind");
         }
-        "FunctionDeclaration" | "FunctionExpression" | "ArrowFunctionExpression" => {
+        Strip::Function => {
             strip_function(node);
         }
-        "ClassDeclaration" | "ClassExpression" => {
+        Strip::Class => {
             for key in [
                 "typeParameters",
                 "superTypeArguments",
@@ -124,7 +169,7 @@ fn strip_node(node: &mut Value) -> Edit {
                 remove_key(node, key);
             }
         }
-        "PropertyDefinition" => {
+        Strip::PropertyDefinition => {
             if node.get("declare").and_then(Value::as_bool) == Some(true) {
                 return Edit::Remove;
             }
@@ -132,7 +177,7 @@ fn strip_node(node: &mut Value) -> Edit {
                 remove_key(node, key);
             }
         }
-        "Identifier" | "ObjectPattern" | "ArrayPattern" | "RestElement" | "AssignmentPattern" => {
+        Strip::Pattern => {
             remove_key(node, "typeAnnotation");
             remove_key(node, "optional");
         }


### PR DESCRIPTION
Refs #668.

`uf lint` allocates 830,581 times and 67.79 MiB for one 111 KiB module, and 94% of it is `uf_transform::babel_ast`. #668 lays out four options and calls the pipeline's `serde_json::Value` shape the real answer. **This is none of those four** — it is the waste that has nothing to do with the shape, found by reading the three walks the tree goes through.

| | before | after | |
| --- | ---: | ---: | ---: |
| allocations / run | 830,581 | 575,198 | **−30.7%** |
| bytes / run | 67.79 MiB | 56.04 MiB | **−17.3%** |

Measured on `packages/router/internal/runtime.js` (113,734 bytes), release build, five runs after a warm-up.

## Three changes, all the same mistake

**The key list — the largest.** `transform_post_at` and `finalize` both collected every key of every node into a `Vec<String>` before walking its children, because `get_mut` cannot run while `keys` is borrowed:

```rust
let keys: Vec<String> = object.keys().filter(…).cloned().collect();
for key in keys { match object.get_mut(&key) { … } }
```

Neither loop adds or removes a key — both only write into one — so `iter_mut` is the same walk in the same order, with no vector and no copies. `transform_post` carries both the lowering *and* the Babel conversion, so this one was paid twice a module.

**The type name.** `convert`, `finalize` and `strip_node` each read the node's type as a `&str` and immediately `to_owned` it, because the arms below need the node mutably — one `String` per node per pass, for a name compared once and dropped. Classified into a `Copy` enum while it is still borrowed instead, which costs nothing and reads better at the match.

**The `loc` object.** `finalize` replaced every node's `loc` with a fresh `json!({ start, end })` — three maps and six keys, per node. The translator has already attached one of exactly that shape (`estree::parse` asks for `include_locs`); only its *numbers* are wrong, because its columns count code points where everything downstream counts UTF-16 units. Overwriting four numbers into slots that already exist allocates nothing.

## What this changes about the output

Nothing about the tree, and one thing about how it serializes — and I checked rather than assumed.

`babel_ast` was run over **all 277 modules under `packages/`**, before and after, and the trees compared as parsed JSON:

```
semantically identical: 277
semantically DIFFERENT: 0
```

Compared as *text*, all 277 differ, in exactly one way:

```
before: "loc":{"start":{"line":76,"column":0},"end":{"line":721,"column":1}}
after : "loc":{"end":{"line":721,"column":1},"start":{"line":76,"column":0}}
```

`loc`'s key order is now the translator's rather than the `json!`'s, and `serde_json` is built with `preserve_order`, so that is observable in a serialized tree.

Nothing in this repository reads a Babel tree by key order — the React Compiler crate deserializes it, and the printer, the scope analysis, the memo rule and `uf_lint`'s tree rules all address it by name — so this is a difference rather than a change in behaviour. Flagging it because it is the one thing a reviewer should decide about rather than take on trust: if you would rather the bytes stayed identical, the `loc` change is separable and worth 78k of the 255k saved.

## The reproducer is checked in

`examples/alloc_report.rs` is how the figures above were taken, and its `--dump` is how the trees were compared:

```bash
cargo run --release --example alloc_report -p uf_transform -- packages/router/internal/runtime.js
```

#668's numbers were otherwise a claim rather than something the next person could re-take, and this pipeline is going to be touched again.

## Not closing #668

The issue's real question — whether the two `react/*` rules should read the native Flow AST instead, or whether the Babel tree should stop being `serde_json::Value` — is untouched. 575,198 allocations for one module is still 5 per source byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791454625&installation_model_id=422833&pr_number=673&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F673&signature=c715d96ef3cb3329fce2fcdceacf47fed5b130391bd1b43c9cb3585a6bd63e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->