### PR TITLE
test(std): hold the form/ui edge to a type, and say why it points that way

### DIFF
--- a/packages/form/field.js
+++ b/packages/form/field.js
@@ -59,6 +59,22 @@
 // and it would be a worse trade: a structural match that holds until somebody
 // changes one of them.
 //
+// # The edge reads backwards, and stays until #210
+//
+// ubugeeei-prod/uf#614 is right that a headless form store depending on a
+// component library is the wrong direction, and that `docs/architecture.md`
+// asks for the two to be independently consumable. The decision recorded there
+// is to keep the edge and hold it to a *type*: Flow erases this import, so
+// nothing of `@uniflowed/ui` is loaded, bundled or run by a project that
+// installs this package — the cost is an entry in `package.json` so `uf check`
+// can resolve it, and not a component library in a form store's runtime. The
+// line that would make it a real dependency is a *value* crossing, and
+// `tests/library/published-packages.test.js` fails on one.
+//
+// The trigger to reverse it is #210. Once `@uniflowed/form` is on npm,
+// `publishable.sh` allows `ui → form`, and `FieldSource` belongs in the package
+// that produces it rather than the one that consumes it.
+//
 // # The subscription is this component's, not the form's
 //
 // `useFormState({ control, name })` rather than reading `form.formState`. A form

--- a/packages/ui/field.js
+++ b/packages/ui/field.js
@@ -108,6 +108,22 @@ import { withProps } from "./internal/merge-props.js";
  * `onBlur` and the constraint attributes a progressive form emits — spread onto
  * whatever element `Field.Control` renders, underneath the attributes the field
  * computes.
+ *
+ * # It is declared here and produced there
+ *
+ * `@uniflowed/form`'s `useFieldSource` builds one of these, so this type is the
+ * seam between the two packages — and it lives on this side only because the
+ * dependency can only run this way today: this package is on npm and that one
+ * is not, and `tools/release/publishable.sh` refuses a published package that
+ * depends on an unpublished one.
+ *
+ * That is backwards, and ubugeeei-prod/uf#614 says so. It stands because
+ * declaring the type twice trades a documented edge for silent drift — a
+ * `Field.Root` accepting a shape `useFieldSource` no longer produces would
+ * type-check on both sides and fail only where they meet — and because the
+ * import is type-only, so no project installing `@uniflowed/form` loads,
+ * bundles or runs any of this package. #210 is the trigger: once
+ * `@uniflowed/form` publishes, this moves there and `@uniflowed/ui` imports it.
  */
 export type FieldSource = {|
   readonly invalid: boolean,

--- a/tests/library/published-packages.test.js
+++ b/tests/library/published-packages.test.js
@@ -283,3 +283,113 @@ describe("what the published packages pack", () => {
     expect(missing).toEqual([]);
   });
 });
+
+/**
+ * Every `.js` file under `directory`, relative to the repository root.
+ */
+const sourcesUnder = (directory: string): Array<string> => {
+  const found = [];
+  const walk = (at: string) => {
+    for (const entry of fs.readdirSync(at, { withFileTypes: true })) {
+      const full = path.join(at, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== "node_modules") walk(full);
+      } else if (entry.name.endsWith(".js")) {
+        found.push(path.relative(repository, full));
+      }
+    }
+  };
+  walk(path.join(repository, directory));
+  return found;
+};
+
+/**
+ * The `@uniflowed/*` specifiers `source` imports, and whether each is a type.
+ *
+ * Same approach as [`relativeImports`] and for the same reason: the comment-free
+ * source, a pattern over import positions, and a test below that the pattern
+ * still matches something.
+ */
+const packageImports = (source: string): Array<{| specifier: string, type: boolean |}> => {
+  const pattern = /\bimport\s+(type\s+)?([^;]*?)\bfrom\s*["'](@uniflowed\/[^"']*)["']/g;
+  const code = withoutComments(source);
+  const found = [];
+  let match;
+  while ((match = pattern.exec(code)) !== null) {
+    // `import { type Foo }` is a type import too, and is the form uf's own
+    // formatter produces when a value from the same module is imported beside
+    // it. A clause with any binding that is *not* prefixed is a value import.
+    const clause = match[2];
+    const inlineOnly =
+      /\{/.test(clause) &&
+      clause
+        .replace(/^[^{]*\{|\}[^}]*$/g, "")
+        .split(",")
+        .map((binding) => binding.trim())
+        .filter((binding) => binding !== "")
+        .every((binding) => binding.startsWith("type "));
+    found.push({ specifier: match[3], type: match[1] != null || inlineOnly });
+  }
+  return found;
+};
+
+describe("the edges between the packages", () => {
+  it("the scan finds the imports it is looking for", () => {
+    // The same guard `the scan reads code and not prose` gives the other
+    // pattern: an assertion over an empty list passes, and would go on passing
+    // after the shape of an import changed.
+    const found = packageImports(
+      'import type { A } from "@uniflowed/ui/field";\n' +
+        'import { b } from "@uniflowed/core";\n' +
+        'import { type C, d } from "@uniflowed/react";\n' +
+        'import { type E } from "@uniflowed/hooks";\n',
+    );
+    expect(found).toEqual([
+      { specifier: "@uniflowed/ui/field", type: true },
+      { specifier: "@uniflowed/core", type: false },
+      { specifier: "@uniflowed/react", type: false },
+      { specifier: "@uniflowed/hooks", type: true },
+    ]);
+  });
+
+  // `@uniflowed/form` depends on `@uniflowed/ui` for the `FieldSource` type,
+  // and the dependency reads backwards: a headless form store should not need
+  // a component library. ubugeeei-prod/uf#614 asked for that to be a decision
+  // rather than the only thing that compiled, and the decision is to keep the
+  // edge and hold it to a type.
+  //
+  // Kept because the alternative is worse today. Duplicating the type trades a
+  // resolvable, documented edge for silent drift — `Field.Root` accepting a
+  // shape that `useFieldSource` no longer produces would type-check on both
+  // sides and fail only where they meet — and a third package to own the
+  // contract costs a name, which #560 is the standing evidence is not free.
+  //
+  // Held to a type because that is what makes it tolerable: Flow erases it, so
+  // nothing of `@uniflowed/ui` is loaded, bundled or run by a project that
+  // installs `@uniflowed/form`. The cost is an entry in `package.json` so that
+  // `uf check` can resolve it. A *value* crossing this edge would make the
+  // component library a runtime dependency of the form store, which is the
+  // thing `docs/architecture.md` requires not be true, and is the line this
+  // test draws.
+  //
+  // The trigger to reverse it is #210: once `@uniflowed/form` is on npm,
+  // `publishable.sh` allows `ui → form` and the type belongs in the package
+  // that produces it. Delete this test then.
+  it("the only thing @uniflowed/form takes from @uniflowed/ui is a type", () => {
+    const offenders = [];
+    let seen = 0;
+    for (const file of sourcesUnder("packages/form")) {
+      const source = fs.readFileSync(path.join(repository, file), "utf8");
+      for (const found of packageImports(source)) {
+        if (!found.specifier.startsWith("@uniflowed/ui")) continue;
+        seen += 1;
+        if (!found.type) offenders.push(`${file} imports a value from ${found.specifier}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+    // And the edge is still there to be checked. A rename that made this scan
+    // find nothing would leave the assertion above passing over an empty list.
+    expect(seen).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #614.

#614 asks for a decision about `@uniflowed/form` depending on `@uniflowed/ui` for the `FieldSource` type — "a decision, written down, rather than the edge standing because it was the only thing that compiled that afternoon." It lists three ways out and says none is free.

**The decision: keep the edge, and hold it to a type. #210 is the trigger to reverse it.**

## Why keep it

The two alternatives are worse *today*, not in principle.

- **Declaring the type twice** trades a documented, resolvable edge for silent drift. A `Field.Root` accepting a shape that `useFieldSource` no longer produces would type-check on both sides and fail only where they meet — which is the failure mode this repository argues against everywhere else.
- **A third package** to own the contract costs a name, and #560 is the standing evidence that a name is not free: `@uniflowed/temporal` is the package with the Temporal front door and it still cannot be installed.

## Why "held to a type" is the part that matters

The edge does read backwards — a headless form store should not need a component library, and `docs/architecture.md` asks for the two to be independently consumable. What makes the current shape tolerable rather than merely legal is that Flow **erases** the import: no project installing `@uniflowed/form` loads, bundles, or runs any of `@uniflowed/ui`. The cost is an entry in `package.json` so `uf check` can resolve the type.

The line that would make it a real dependency is a **value** crossing. That was an intention; it is now a test.

```
✗ the edges between the packages > the only thing @uniflowed/form takes from @uniflowed/ui is a type
    expected ["packages/form/field.js imports a value from @uniflowed/ui/field"] to equal []
```

The test scans every module under `packages/form`, reports the offending file by name, and also asserts the edge is still found at all — so a rename cannot leave it quietly passing over an empty list. That is the same guard `the scan reads code and not prose` gives the neighbouring scan, for the same reason, and it reuses that file's `withoutComments` so a specifier inside a comment is not mistaken for an import.

## The trigger, on both copies

`#210` is named on the declaration in `packages/ui/field.js` and on the import in `packages/form/field.js`, with what changes when it lands: once `@uniflowed/form` is on npm, `publishable.sh` allows `ui → form`, `FieldSource` moves to the package that produces it, and this test is deleted.

No behaviour changes here — the code was correct either way, as #614 says. What changes is that the shape is now a decision with a stated trigger and a test that holds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791455077&installation_model_id=422833&pr_number=674&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F674&signature=2f8bc6b85887014c3dd361199b1ce3fb1d6ebc281c7396883ffde074a62e3090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->