### PR TITLE
perf(lint, transform): the effects rule reads the lowered tree, not the Babel one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,6 +3763,7 @@ dependencies = [
  "uf_config",
  "uf_flow",
  "uf_infra",
+ "uf_profiler",
  "uf_react_compiler",
  "uf_router",
  "uf_transform",

--- a/crates/uf_lint/Cargo.toml
+++ b/crates/uf_lint/Cargo.toml
@@ -22,6 +22,10 @@ thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+# For `examples/alloc_report.rs`: the counting allocator behind the figures in
+# ubugeeei-prod/uf#668, so the next person to touch the linter's hot path can
+# take them again rather than trust them.
+uf_profiler = { path = "../uf_profiler" }
 
 [[bench]]
 name = "lint"

--- a/crates/uf_lint/examples/alloc_report.rs
+++ b/crates/uf_lint/examples/alloc_report.rs
@@ -1,0 +1,52 @@
+//! What `uf lint` costs, in allocations and bytes, for ubugeeei-prod/uf#668.
+//!
+//! The counterpart to `uf_transform`'s example of the same name, one level up:
+//! that one measures the Babel tree, this one measures the linter that asks for
+//! it. Run it as
+//! `cargo run --release --example alloc_report -p uf_lint -- <file>`.
+
+use uf_config::UniflowedConfig;
+use uf_lint::SourceFile;
+use uf_profiler::{AllocSnapshot, CountingAllocator, Window};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator::new();
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| String::from("packages/router/internal/runtime.js"));
+    let source = std::fs::read_to_string(&path).expect("read the module");
+    let file = SourceFile {
+        path: path.clone(),
+        source,
+    };
+    let config = UniflowedConfig::default();
+    println!("{path}: {} bytes", file.source.len());
+
+    // Warm up: the first run pays for whatever is initialised once.
+    let _ = uf_lint::lint_source(&file, &config).expect("lints");
+
+    CountingAllocator::enable();
+    let window = Window::open();
+    let before = AllocSnapshot::capture();
+    let runs = 5;
+    for _ in 0..runs {
+        let report = uf_lint::lint_source(&file, &config).expect("lints");
+        std::hint::black_box(&report);
+    }
+    let after = AllocSnapshot::capture();
+    drop(window);
+    CountingAllocator::disable();
+
+    let delta = after.delta_from(&before);
+    println!("allocs / run   {}", delta.allocations / runs);
+    println!(
+        "bytes / run    {:.2} MiB",
+        delta.bytes_allocated as f64 / runs as f64 / (1024.0 * 1024.0)
+    );
+    println!(
+        "peak           {:.2} MiB",
+        delta.peak_above_baseline as f64 / (1024.0 * 1024.0)
+    );
+}

--- a/crates/uf_lint/src/runner/react_tree.rs
+++ b/crates/uf_lint/src/runner/react_tree.rs
@@ -117,20 +117,29 @@ pub(crate) fn run_react_tree_rules(
         let (Some(level), Some(line)) = (level, scan.lines.get(index)) else {
             continue;
         };
-        // The AST counts columns in UTF-16 code units and a diagnostic carries
-        // bytes, so the conversion reads the line out of the *unmasked* source:
-        // `mask_inline_comments` replaces a comment byte for byte, which keeps
-        // every offset but not every character.
+        // A diagnostic carries bytes, and the conversion reads the line out of
+        // the *unmasked* source: `mask_inline_comments` replaces a comment byte
+        // for byte, which keeps every offset but not every character.
         let text = source
             .get(line.offset..line.offset + line.text.len())
             .unwrap_or(line.text);
+        // The two rules read two trees now, and the trees count columns
+        // differently: the Flow translator's `loc` counts code points, and
+        // `babel::finalize` recomputes them as UTF-16 code units. Both are the
+        // same number until a line holds an astral character, and then they are
+        // not — so the unit is chosen by which tree the finding came from
+        // rather than assumed to be one of them.
+        let column = match finding.kind {
+            FindingKind::DerivedState => byte_column_of_code_point(text, finding.column),
+            FindingKind::RedundantMemo => byte_column(text, finding.column),
+        };
         push_at(
             diagnostics,
             scan,
             rule,
             level,
             index,
-            byte_column(text, finding.column),
+            column,
             finding.message,
         );
     }
@@ -171,16 +180,27 @@ fn analyse(
     };
 
     let work = || {
-        let (file, _) = uf_transform::babel_ast(source).ok()?;
+        // Parsed and lowered, and converted to Babel's shape only if the memo
+        // rule is the one asking. `to_babel` is 184,472 allocations of the
+        // 575,198 this file used to cost — a third of the tree's price — and
+        // `react/no-derived-state-effect` never needed what it buys. See
+        // ubugeeei-prod/uf#668.
+        //
+        // Lowered, not raw: `component` and `match` are Flow's own syntax, and
+        // this rule reads functions and calls. After the lowering a component
+        // *is* a `FunctionDeclaration`, which is the tree the rule was always
+        // written against.
+        let (program, _) = uf_transform::lowered_ast(source).ok()?;
         let mut found = Vec::new();
         if wants_effects {
-            found.extend(derived_state_effects(&file));
+            found.extend(derived_state_effects(&program));
         }
         // An error here is a bug in uf rather than in the module — the tree
         // did not fit the compiler's own schema — and it says nothing about
         // the effects the other rule already found, so it costs that rule
         // nothing.
         if wants_memo
+            && let Ok(file) = uf_transform::babel_from_lowered(program, source)
             && let Ok(redundant) = uf_transform::redundant_memoization(&file, source, &options)
         {
             found.extend(redundant.into_iter().map(|memo| TreeFinding {
@@ -218,6 +238,9 @@ fn compiler_mode(config: &UniflowedConfig) -> ReactCompilerMode {
 }
 
 /// Byte offset within `line` of the `column`-th UTF-16 code unit.
+///
+/// What `react/no-redundant-memo` needs: it reads the Babel tree, whose `loc`
+/// `babel::finalize` recomputed in UTF-16 units.
 fn byte_column(line: &str, column: u32) -> usize {
     let mut units = 0u32;
     for (offset, character) in line.char_indices() {
@@ -227,6 +250,18 @@ fn byte_column(line: &str, column: u32) -> usize {
         units += u32::try_from(character.len_utf16()).unwrap_or(u32::MAX);
     }
     line.len()
+}
+
+/// Byte offset within `line` of the `column`-th code point.
+///
+/// What `react/no-derived-state-effect` needs: it reads the lowered ESTree
+/// tree, and the Flow translator's `loc` columns count code points. The two
+/// agree on every line that is entirely BMP and part company on one that is
+/// not — an emoji before an effect would put the caret one column early.
+fn byte_column_of_code_point(line: &str, column: u32) -> usize {
+    line.char_indices()
+        .nth(column as usize)
+        .map_or(line.len(), |(offset, _)| offset)
 }
 
 // --- react/no-derived-state-effect -----------------------------------------
@@ -370,12 +405,15 @@ impl SetterScope {
 }
 
 /// Node types whose `body` is a function body.
-const FUNCTIONS: [&str; 5] = [
+///
+/// Three, not Babel's five: ESTree has no `ClassMethod` or `ObjectMethod`. A
+/// class method is a `MethodDefinition` and an object method a `Property`, and
+/// in both the function itself is the `FunctionExpression` underneath — which
+/// is the node that carries the body, and is already here.
+const FUNCTIONS: [&str; 3] = [
     "ArrowFunctionExpression",
-    "ClassMethod",
     "FunctionDeclaration",
     "FunctionExpression",
-    "ObjectMethod",
 ];
 
 /// Every function in `file` that declares a `useState` setter, with the span
@@ -531,9 +569,10 @@ fn identifiers_in<'a>(node: &'a Value, out: &mut Vec<&'a str>) {
                     Some("MemberExpression" | "OptionalMemberExpression") if key_is_a_name => {
                         "property"
                     }
-                    Some("ObjectProperty" | "ObjectMethod" | "ClassMethod") if key_is_a_name => {
-                        "key"
-                    }
+                    // `Property` and `MethodDefinition` are ESTree's spelling
+                    // of what Babel calls `ObjectProperty`, `ObjectMethod` and
+                    // `ClassMethod`.
+                    Some("Property" | "MethodDefinition") if key_is_a_name => "key",
                     _ => "",
                 };
                 pending.extend(
@@ -672,14 +711,11 @@ fn dependency_names(node: &Value) -> Option<Vec<&str>> {
 }
 
 /// Expression node types that are pure however they are combined.
-const PURE_LITERALS: [&str; 6] = [
-    "BigIntLiteral",
-    "BooleanLiteral",
-    "NullLiteral",
-    "NumericLiteral",
-    "RegExpLiteral",
-    "StringLiteral",
-];
+///
+/// One name, because ESTree has one: a string, a number, a boolean, `null`, a
+/// regular expression and a bigint are all `Literal`, and it is `to_babel`
+/// that splits them into the six Babel spells them with.
+const PURE_LITERALS: [&str; 1] = ["Literal"];
 
 /// Unary operators that read their operand and nothing else.
 ///
@@ -758,10 +794,15 @@ fn identifier_name(node: &Value) -> Option<&str> {
     node.get("name")?.as_str()
 }
 
+/// The span's start, from the ESTree `range` pair.
+///
+/// `start` and `end` as their own fields are Babel's; `babel::finalize` splits
+/// `range` into them. This tree has not been through it.
 fn span_start(node: &Value) -> Option<u64> {
-    node.get("start")?.as_u64()
+    node.get("range")?.as_array()?.first()?.as_u64()
 }
 
+/// The span's end, from the same pair.
 fn span_end(node: &Value) -> Option<u64> {
-    node.get("end")?.as_u64()
+    node.get("range")?.as_array()?.get(1)?.as_u64()
 }

--- a/crates/uf_lint/src/tests/react_tree.rs
+++ b/crates/uf_lint/src/tests/react_tree.rs
@@ -358,3 +358,29 @@ fn a_non_flow_file_is_not_parsed() {
         .is_empty()
     );
 }
+
+/// The caret lands on the hook even when the line holds an astral character.
+///
+/// The two rules read two trees, and the trees count columns differently: the
+/// Flow translator's `loc` counts code points, and `babel::finalize` recomputes
+/// them as UTF-16 code units. `react/no-derived-state-effect` moved to the
+/// lowered ESTree tree to avoid paying for the Babel conversion it never used
+/// (ubugeeei-prod/uf#668), so it reads code points now — and converting one as
+/// if it were the other puts the caret a column early on any line with an
+/// emoji in it, which is invisible until somebody writes one.
+///
+/// The comment before the hook is deliberate: `mask_inline_comments` replaces a
+/// comment byte for byte, so the masked line is the same length and the
+/// conversion has to read the *unmasked* source to see the character at all.
+#[test]
+fn an_astral_character_before_the_hook_does_not_move_the_caret() {
+    let diagnostics = derived(
+        "component Name(first: string, last: string) {\n  const [full, setFull] = useState(\"\");\n  /* \u{1f600} */ useEffect(() => {\n    setFull(first + \" \" + last);\n  }, [first, last]);\n  return <p>{full}</p>;\n}\n",
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    // `  /* ` is five bytes, the emoji is four, ` */ ` is four: `useEffect`
+    // starts at byte fourteen, one-based. Counted as UTF-16 the emoji is two
+    // units rather than one and the answer comes out thirteen.
+    assert_eq!((diagnostics[0].line, diagnostics[0].column), (6, 14));
+}

--- a/crates/uf_transform/src/lib.rs
+++ b/crates/uf_transform/src/lib.rs
@@ -197,10 +197,48 @@ pub const FLOW_EXTENSIONS: [&str; 4] = [".js", ".jsx", ".mjs", ".cjs"];
 /// [`uf_flow::parse`] says how much that costs and why the ceiling is where it
 /// is.
 pub fn babel_ast(source: &str) -> Result<(Value, lower::Lowered), TransformError> {
-    let mut program = estree::parse(source)?;
-    let lowered = lower::lower(&mut program, source)?;
+    let (program, lowered) = lowered_ast(source)?;
     let file = babel::to_babel(program, source)?;
     Ok((file, lowered))
+}
+
+/// [`babel_ast`] stopping one stage early: parsed and lowered, not converted.
+///
+/// The tree is ESTree as the Flow parser renders it, with Flow's own syntax
+/// already desugared — a `component` is a function here, and a `match` is a
+/// conditional — but with ESTree's names rather than Babel's: literals are
+/// `Literal` and not `StringLiteral`, an object's entries are `Property` and
+/// not `ObjectProperty`, a span is `range` and not `start`/`end`, and a `loc`
+/// column counts code points where Babel's counts UTF-16 units.
+///
+/// It exists because the conversion is a third of the cost of `babel_ast` and
+/// not every caller needs what it buys. `uf_lint`'s `react/no-derived-state-
+/// effect` asks about effects, setters and the expressions between them, all
+/// of which this tree already answers; only `react/no-redundant-memo` needs
+/// Babel's shape, because the official React Compiler crate reads it. See
+/// ubugeeei-prod/uf#668.
+///
+/// # Errors
+///
+/// [`TransformError::SourceTooLarge`], [`TransformError::Syntax`] and
+/// [`TransformError::Lowering`], exactly as [`babel_ast`] raises them.
+///
+/// # Call this from a thread with `uf_flow::PARSE_STACK_BYTES` of stack
+///
+/// For the reason [`babel_ast`] gives.
+pub fn lowered_ast(source: &str) -> Result<(Value, lower::Lowered), TransformError> {
+    let mut program = estree::parse(source)?;
+    let lowered = lower::lower(&mut program, source)?;
+    Ok((program, lowered))
+}
+
+/// The rest of [`babel_ast`], for a caller that already has [`lowered_ast`].
+///
+/// # Errors
+///
+/// [`TransformError::Lowering`] when the tree does not fit Babel's schema.
+pub fn babel_from_lowered(program: Value, source: &str) -> Result<Value, TransformError> {
+    babel::to_babel(program, source)
 }
 
 /// Transform one Flow module to JavaScript.


### PR DESCRIPTION
Refs #668. This is that issue's **option 1** — "run the rules on the native tree rather than the Babel one" — for the rule it is available on.

`react/no-derived-state-effect` asked `uf_transform::babel_ast` for a tree and then never used the third of it that costs the most.

| file | before | after | |
| --- | ---: | ---: | ---: |
| `packages/router/internal/runtime.js` (effects, no memo hooks) | 626,456 | 441,986 | **−29.4%** |
| `packages/ui/toggle-group.js` (memo hooks) | 199,833 | 199,833 | unchanged |

`babel::to_babel` is 184,472 allocations of the 575,198 a 111 KiB module costs: it renames every node to Babel's spelling, splits `range` into `start`/`end`, recomputes every `loc` in UTF-16 units and assigns a `_nodeId`. This rule asks about effects, `useState` setters, and the expressions between them — all of which the tree already answers one stage earlier.

The conversion still happens for `react/no-redundant-memo`, which genuinely needs Babel's shape because the official React Compiler crate reads it. That the second row above is *identical* rather than merely close is the check that the split went where I thought it did.

## Lowered, not raw

`component` and `match` are Flow's own syntax, and this rule reads functions and calls — so it has to run after the desugaring, where a component **is** a `FunctionDeclaration`. That is the tree the rule was always written against; it just used to arrive with Babel's names on it.

`lowered_ast` and `babel_from_lowered` are `babel_ast` split at that seam, and `babel_ast` is now the two of them called in order.

## What changed in the rule

Less than it sounds, because Babel's AST is largely a renaming of ESTree's:

- six literal node types (`StringLiteral`, `NumericLiteral`, …) collapse to `Literal`
- `ObjectProperty` / `ObjectMethod` / `ClassMethod` become `Property` / `MethodDefinition` — and drop out of the function list entirely, because in ESTree the function underneath them is a `FunctionExpression` that was already in it
- a span is `range: [a, b]` rather than `start` and `end`

I dumped the lowered tree and read its node kinds before writing any of this, rather than inferring them from `to_babel`'s mapping.

## The one that could have shipped silently

A `loc` column counts **code points** in the translator's tree and **UTF-16 code units** after `babel::finalize`. Those agree on every line that is entirely BMP — so all 29 existing tests would have passed either way, and the caret would sit one column early on any line with an emoji on it.

The two rules now read two trees with two column units, so the unit is chosen by which tree the finding came from rather than assumed to be one of them. `an_astral_character_before_the_hook_does_not_move_the_caret` puts an emoji in a comment in front of the hook and fails by exactly one column if they are confused — verified by swapping the conversion back:

```
test an_astral_character_before_the_hook_does_not_move_the_caret ... FAILED
```

The comment placement is deliberate: `mask_inline_comments` replaces a comment byte for byte, so the masked line is the same length and the conversion has to read the *unmasked* source to see the character at all.

30 `react_tree` tests pass, 316 in `uf_lint`, 83 in `uf_transform`.

`crates/uf_lint/examples/alloc_report.rs` is where the figures come from — the counterpart to `uf_transform`'s of the same name.

## Not closing #668

Still 441,986 allocations for one module, and `estree::parse` is now the largest phase at 254,481 — that one is the vendored translator rendering the parse as `serde_json::Value`, which is the issue's option 2 and the shape rather than the waste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791460876&installation_model_id=422833&pr_number=676&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F676&signature=90bd2b495dbde9152053002279f374d91a2ceeadf4b6503be86d6b8e77d6636c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lint diagnostic positioning when source code contains emoji or other astral characters.
  - Updated React lint analysis to use more accurate source locations across supported syntax, improving reported line and column information.

- **Developer Tools**
  - Added an allocation-reporting example to measure linting memory usage for a selected source file, including allocation counts, memory consumption, and peak usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->