### PR TITLE
chore(release): uf@0.0.0-alpha.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## uf@0.0.0-alpha.16
+
+_2026-09-08_
+
+Twenty-one changes. The one to read first is the one that made a check pass by
+checking nothing: `uf check` in an npm workspace resolved a hoisted dependency
+to nothing, so an app in a monorepo — where the dependency is installed at the
+root and not beside the project — was typed as `any` throughout and told it was
+fine. Three separate causes had to be fixed for the fix to do anything, and the
+last of them was a path resolver refusing a `..` it could not cancel, which is
+why the first two had looked like they worked.
+
+Beside it, a diagnostic now counts the columns a path *draws* rather than the
+ones its scalars would draw alone. A name built out of emoji-presentation
+sequences rendered at twice the cap meant to keep it inside one row — the same
+family as alpha.15's lead, and the same input: a name out of a clone uf did not
+write.
+
+The rest is spread evenly. A form the browser submits reaches a server action,
+and `uf dev` says which module put a component in the client bundle and why.
+Every route has a typed link, including the ones that take no parameters. A
+test can live beside the code it tests, and an accessibility audit reads the
+tree while you edit it. And `uf profile` is a profiler rather than a wall-clock
+number — hierarchical spans, a counting allocator, and a report saying where
+the time and the memory went. Its first findings are in this release: building
+a Babel tree costs 31% fewer allocations, the effects rule stopped asking for a
+tree it never used, and the formatter lost two more passes. `uf lint` over a
+111 KiB module went from 839,000 allocations to 442,000.
+
+### Added
+
+- **test, transform, vite**: a test beside the code it tests, and an audit that reads the tree (#643)
+- **router, rsc, dev**: a form the browser submits to a server action, and the chain that puts a module in the client bundle (#636)
+- **profiler**: where uf's time and memory actually go (#660)
+- **router, check**: a typed link for every route, including the ones that take no parameters (#655)
+- **build, cli**: the runtime a compiled binary embeds is the project's own, and the machine it is for (#638)
+
+### Fixed
+
+- **vite**: a dev 404 for a page says which header decided it (#677)
+- **term**: the columns a path draws, not the ones its scalars would draw alone (#672)
+- **server, vite, infra**: one rule for a prerendered document, and a policy on the site that argues for them (#652)
+- **check**: a hoisted dependency is read, so a workspace app has types at all (#667)
+- **config, testing, react-testing**: a config type a test holds, and three surfaces that named nothing (#644)
+- **config, vite**: the MDX highlighter reads the keys the reference documents (#664)
+- **term, cli, security**: a diagnostic prints four things out of a checkout, not one (#663)
+
+### Performance
+
+- **lint**: react/derived-state needs a setter, so a module with no useState is not parsed (#670)
+- **lint, transform**: the effects rule reads the lowered tree, not the Babel one (#676)
+- **transform**: 31% fewer allocations building the Babel tree (#673)
+- **fmt**: build a concat straight into the arena rather than through a Vec (#665)
+- **fmt**: compute a node's sorted children once rather than once per comment (#661)
+
+### Internal
+
+- **std**: hold the form/ui edge to a type, and say why it points that way (#674)
+- **vite**: two dev-server tests ask the operating system for their port (#669)
+- **release**: name #650 in the alpha.15 section (#662)
+- **release**: the changelog date is UTC, held by two commits an hour apart (#647)
+
 ## uf@0.0.0-alpha.15
 
 _2026-09-08_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3518,7 +3518,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_assets"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "ab_glyph",
  "base64",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "base64",
  "brotli",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "serde",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "serde",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "uf_i18n"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "serde",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "criterion",
  "phf",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "base64",
  "camino",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "uf_profiler"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "compact_str",
  "serde",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "serde",
  "smallvec",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "uf_task"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "base64",
  "camino",
@@ -3953,14 +3953,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "camino",
  "compact_str",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.15"
+version = "0.0.0-alpha.16"
 
 [workspace.dependencies]
 # Glyph outlines and coverage rasterisation, for `uf_assets::og`. Pure Rust

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.15",
-    "@uniflowed/config": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15",
-    "@uniflowed/router": "0.0.0-alpha.15",
-    "@uniflowed/vite": "0.0.0-alpha.15",
-    "@uniflowed/web": "0.0.0-alpha.15",
+    "@uniflowed/brand": "0.0.0-alpha.16",
+    "@uniflowed/config": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16",
+    "@uniflowed/router": "0.0.0-alpha.16",
+    "@uniflowed/vite": "0.0.0-alpha.16",
+    "@uniflowed/web": "0.0.0-alpha.16",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.15",
-        "@uniflowed/config": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15",
-        "@uniflowed/router": "0.0.0-alpha.15",
-        "@uniflowed/vite": "0.0.0-alpha.15",
-        "@uniflowed/web": "0.0.0-alpha.15",
+        "@uniflowed/brand": "0.0.0-alpha.16",
+        "@uniflowed/config": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16",
+        "@uniflowed/router": "0.0.0-alpha.16",
+        "@uniflowed/vite": "0.0.0-alpha.16",
+        "@uniflowed/web": "0.0.0-alpha.16",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -4392,65 +4392,65 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.15",
-        "@uniflowed/test": "0.0.0-alpha.15"
+        "@uniflowed/config": "0.0.0-alpha.16",
+        "@uniflowed/test": "0.0.0-alpha.16"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.15",
-        "@uniflowed/ui": "0.0.0-alpha.15",
-        "@uniflowed/validator": "0.0.0-alpha.15"
+        "@uniflowed/react": "0.0.0-alpha.16",
+        "@uniflowed/ui": "0.0.0-alpha.16",
+        "@uniflowed/validator": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4458,10 +4458,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.15"
+        "@uniflowed/fetch": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4469,19 +4469,19 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4489,120 +4489,120 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/i18n": {
       "name": "@uniflowed/i18n",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.15",
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/fetch": "0.0.0-alpha.15"
+        "@uniflowed/cell": "0.0.0-alpha.16",
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/fetch": "0.0.0-alpha.16"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.15",
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/config": "0.0.0-alpha.16",
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/hooks": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4610,7 +4610,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4618,28 +4618,28 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15",
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4649,7 +4649,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4658,20 +4658,20 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.15",
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/config": "0.0.0-alpha.16",
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.15",
-        "@uniflowed/server": "0.0.0-alpha.15"
+        "@uniflowed/hooks": "0.0.0-alpha.16",
+        "@uniflowed/server": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4680,46 +4680,46 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/cell": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15",
-        "@uniflowed/react-testing": "0.0.0-alpha.15",
-        "@uniflowed/test": "0.0.0-alpha.15"
+        "@uniflowed/mock": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16",
+        "@uniflowed/react-testing": "0.0.0-alpha.16",
+        "@uniflowed/test": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4727,26 +4727,26 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.15"
+        "@uniflowed/host": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "axe-core": ">=4"
@@ -4759,30 +4759,30 @@
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.15",
-        "@uniflowed/test": "0.0.0-alpha.15"
+        "@uniflowed/react-testing": "0.0.0-alpha.16",
+        "@uniflowed/test": "0.0.0-alpha.16"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.15",
+        "@uniflowed/react": "0.0.0-alpha.16",
         "react-reconciler": "^0.33.0"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/hooks": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/hooks": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4790,18 +4790,18 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.15",
-        "@uniflowed/server": "0.0.0-alpha.15",
+        "@uniflowed/host": "0.0.0-alpha.16",
+        "@uniflowed/server": "0.0.0-alpha.16",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4822,21 +4822,21 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.15",
-        "@uniflowed/core": "0.0.0-alpha.15"
+        "@uniflowed/browser": "0.0.0-alpha.16",
+        "@uniflowed/core": "0.0.0-alpha.16"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.15",
+      "version": "0.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.15",
-        "@uniflowed/hooks": "0.0.0-alpha.15",
-        "@uniflowed/react": "0.0.0-alpha.15"
+        "@uniflowed/core": "0.0.0-alpha.16",
+        "@uniflowed/hooks": "0.0.0-alpha.16",
+        "@uniflowed/react": "0.0.0-alpha.16"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Fine-grained reactivity: state, derived values, effects and resources, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "temporal.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.15",
-    "@uniflowed/test": "0.0.0-alpha.15"
+    "@uniflowed/config": "0.0.0-alpha.16",
+    "@uniflowed/test": "0.0.0-alpha.16"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "stream.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -26,9 +26,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.15",
-    "@uniflowed/ui": "0.0.0-alpha.15",
-    "@uniflowed/validator": "0.0.0-alpha.15"
+    "@uniflowed/react": "0.0.0-alpha.16",
+    "@uniflowed/ui": "0.0.0-alpha.16",
+    "@uniflowed/validator": "0.0.0-alpha.16"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.15"
+    "@uniflowed/fetch": "0.0.0-alpha.16"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,8 +27,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/i18n",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Type-safe internationalisation on MessageFormat 2: a message's arguments are checked at the call, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/cell": "0.0.0-alpha.15",
-    "@uniflowed/fetch": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/cell": "0.0.0-alpha.16",
+    "@uniflowed/fetch": "0.0.0-alpha.16"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.15",
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/config": "0.0.0-alpha.16",
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/hooks": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15",
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.15",
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/config": "0.0.0-alpha.16",
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.15",
-    "@uniflowed/server": "0.0.0-alpha.15"
+    "@uniflowed/hooks": "0.0.0-alpha.16",
+    "@uniflowed/server": "0.0.0-alpha.16"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -42,6 +42,6 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/cell": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,10 +22,10 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15",
-    "@uniflowed/react-testing": "0.0.0-alpha.15",
-    "@uniflowed/test": "0.0.0-alpha.15"
+    "@uniflowed/mock": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16",
+    "@uniflowed/react-testing": "0.0.0-alpha.16",
+    "@uniflowed/test": "0.0.0-alpha.16"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -23,7 +23,7 @@
     "worker.js"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.15"
+    "@uniflowed/host": "0.0.0-alpha.16"
   },
   "peerDependencies": {
     "axe-core": ">=4"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.15",
-    "@uniflowed/test": "0.0.0-alpha.15"
+    "@uniflowed/react-testing": "0.0.0-alpha.16",
+    "@uniflowed/test": "0.0.0-alpha.16"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "A React renderer whose host is a terminal, following OpenTUI, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.15",
+    "@uniflowed/react": "0.0.0-alpha.16",
     "react-reconciler": "^0.33.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -52,9 +52,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/hooks": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/hooks": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -33,8 +33,8 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.15",
-    "@uniflowed/server": "0.0.0-alpha.15",
+    "@uniflowed/host": "0.0.0-alpha.16",
+    "@uniflowed/server": "0.0.0-alpha.16",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.15",
-    "@uniflowed/core": "0.0.0-alpha.15"
+    "@uniflowed/browser": "0.0.0-alpha.16",
+    "@uniflowed/core": "0.0.0-alpha.16"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.15",
+  "version": "0.0.0-alpha.16",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,8 +23,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.15",
-    "@uniflowed/hooks": "0.0.0-alpha.15",
-    "@uniflowed/react": "0.0.0-alpha.15"
+    "@uniflowed/core": "0.0.0-alpha.16",
+    "@uniflowed/hooks": "0.0.0-alpha.16",
+    "@uniflowed/react": "0.0.0-alpha.16"
   }
 }


### PR DESCRIPTION
Twenty-one changes since alpha.15. The full section is in `CHANGELOG.md`; the short version:

**The one to read first** is the one that made a check pass by checking nothing. `uf check` in an npm workspace resolved a hoisted dependency to nothing, so an app in a monorepo — where the dependency is installed at the root and not beside the project — was typed as `any` throughout and told it was fine (#667). Three separate causes had to be fixed for the fix to do anything, and the last was a path resolver refusing a `..` it could not cancel, which is why the first two had looked like they worked.

**Beside it**, a diagnostic now counts the columns a path *draws* rather than the ones its scalars would draw alone (#672). A name built out of emoji-presentation sequences rendered at twice the cap meant to keep it inside one row — the same family as alpha.15's lead, and the same input: a name out of a clone uf did not write.

**Features.** A form the browser submits reaches a server action, and `uf dev` says which module put a component in the client bundle and why (#636). Every route has a typed link, including the ones that take no parameters (#655). A test can live beside the code it tests, and an accessibility audit reads the tree while you edit it (#643). `uf profile` is a profiler rather than a wall-clock number (#660).

**Performance**, all of it found with that profiler:

| | before | after |
| --- | ---: | ---: |
| `babel_ast`, 111 KiB module (#673) | 830,581 | 575,198 allocations |
| the effects rule stopped building a tree it never used (#676) | 626,456 | 441,986 |
| `uf lint`, end to end | 839,171 | **441,986** |

Two more passes came out of the formatter (#661, #665).

## What was checked before this was cut

- `uf release alpha` wrote the section **before** the bump, which is the order `bump-version.sh` verifies — run it after and it plans one version too far, invisibly.
- Workspace version and `packages/*/package.json` agree at `0.0.0-alpha.16`; both lockfiles refreshed and `cargo metadata --locked` is clean.
- `release:closure`, `publishable`, `manifests` and `lockfile` all pass on this commit.
- The queue was empty when this was cut, so nothing merges between the release commit and the tag — which is what `changelog-covers-the-release.sh` needs to hold.

After this merges: `git tag uf@0.0.0-alpha.16` on **this commit specifically**, then push the tag. `publish.yml` publishes over OIDC and `release.yml` builds the four targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791464588&installation_model_id=422833&pr_number=681&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F681&signature=21f7b4f8ae720813ec4f5adc06a20033771f1edf26203a49f800f9bd7681cfb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Forms can submit directly to server actions.
  - Added typed links for every route.
  - `uf dev` identifies the module responsible for placing a component in the client bundle.
  - Added hierarchical profiling with allocation counting.
  - Accessibility audits can read the rendered tree.

- **Bug Fixes**
  - Fixed dependency resolution for `uf check` in npm workspaces.
  - Improved path handling and diagnostic column counting.

- **Documentation**
  - Added the alpha.16 changelog and release highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->