### PR TITLE
perf(check): count what a check allocates, and answer whether the cache avoids it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,6 +3590,7 @@ dependencies = [
  "thiserror",
  "uf_flow",
  "uf_infra",
+ "uf_profiler",
 ]
 
 [[package]]

--- a/crates/uf_check/Cargo.toml
+++ b/crates/uf_check/Cargo.toml
@@ -76,3 +76,7 @@ uf_flow = { path = "../uf_flow", optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+# For `examples/alloc_report.rs`: the counting allocator behind the figures in
+# ubugeeei-prod/uf#678, so the next person to touch the checker can take them
+# again rather than trust them.
+uf_profiler = { path = "../uf_profiler" }

--- a/crates/uf_check/examples/alloc_report.rs
+++ b/crates/uf_check/examples/alloc_report.rs
@@ -33,13 +33,7 @@ use uf_profiler::{AllocDelta, AllocSnapshot, CountingAllocator, Window};
 static GLOBAL: CountingAllocator = CountingAllocator::new();
 
 fn main() {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let path = args
-        .iter()
-        .find(|arg| !arg.starts_with("--"))
-        .cloned()
-        .unwrap_or_else(|| String::from("packages/router/internal/runtime.js"));
-    let batch = batch_size(&args);
+    let Arguments { path, batch, cache } = Arguments::parse(std::env::args().skip(1));
     let source = std::fs::read_to_string(&path).expect("read the module");
 
     if !uf_check::is_available() {
@@ -71,7 +65,7 @@ fn main() {
     println!("{path}: {} bytes", source.len());
     println!("batch          {batch}");
 
-    if args.iter().any(|arg| arg == "--cache") {
+    if cache {
         cache_report(&sources);
         return;
     }
@@ -183,19 +177,53 @@ fn print_delta(delta: &AllocDelta, runs: u64) {
     );
 }
 
-/// `--batch N`, defaulting to one.
-fn batch_size(args: &[String]) -> usize {
-    let mut arguments = args.iter();
-    while let Some(argument) = arguments.next() {
-        if argument == "--batch" {
-            return arguments
-                .next()
-                .and_then(|count| count.parse().ok())
-                .filter(|count| *count > 0)
-                .unwrap_or(1);
+/// What the command line said.
+struct Arguments {
+    /// The module to measure.
+    path: String,
+    /// How many copies of it to hand the checker at once.
+    batch: usize,
+    /// Whether to run the three cached calls instead of the plain report.
+    cache: bool,
+}
+
+impl Arguments {
+    /// One pass, because two cannot agree about `--batch`.
+    ///
+    /// A pass that looks for the first argument not starting with `--` reads
+    /// the `2` of `--batch 2` as the file to measure, and then fails on a
+    /// module named `2`. That is only invisible while the path is written
+    /// first, which is how it was written every time it was run by hand.
+    fn parse(arguments: impl Iterator<Item = String>) -> Self {
+        let mut path = None;
+        let mut batch = 1;
+        let mut cache = false;
+        let mut arguments = arguments.peekable();
+        while let Some(argument) = arguments.next() {
+            match argument.as_str() {
+                "--cache" => cache = true,
+                "--batch" => {
+                    // Taken whatever it says, so a mistyped count is not
+                    // silently a path as well as silently a batch of one.
+                    batch = arguments
+                        .next()
+                        .and_then(|count| count.parse().ok())
+                        .filter(|count| *count > 0)
+                        .unwrap_or(1);
+                }
+                _ => {
+                    if path.is_none() {
+                        path = Some(argument);
+                    }
+                }
+            }
+        }
+        Self {
+            path: path.unwrap_or_else(|| String::from("packages/router/internal/runtime.js")),
+            batch,
+            cache,
         }
     }
-    1
 }
 
 /// `runtime.js` for copy 0, `runtime.copy1.js` for copy 1.

--- a/crates/uf_check/examples/alloc_report.rs
+++ b/crates/uf_check/examples/alloc_report.rs
@@ -1,0 +1,218 @@
+//! What `uf check` costs, in allocations and bytes, for ubugeeei-prod/uf#678.
+//!
+//! The third of these, after `uf_transform`'s and `uf_lint`'s, and the one the
+//! other two exist to be compared against: the checker is where uf's memory
+//! goes, and until this ran nobody had counted it. Run it as
+//! `cargo run --release --example alloc_report -p uf_check -- <file>`.
+//!
+//! Three modes, because #678 asks three separate questions:
+//!
+//! * **plain** — what one module costs, which is the headline figure;
+//! * **`--batch N`** — the same module N times, which separates the cost paid
+//!   once per *call* (a builtin environment, forced as far as the batch needs
+//!   it) from the cost paid per *module*. Neither is visible on its own: a
+//!   single run reports their sum and says nothing about which is which;
+//! * **`--cache`** — the same module through one [`CheckCache`] three times,
+//!   which is the question #678 leaves open. `check_sources_cached` exists for
+//!   the caller that checks one file at a time, and a batch proving cheap says
+//!   nothing about whether the cache does. Cold, warm, and warm-after-an-edit,
+//!   because the third is the one an editor actually asks for and it is not
+//!   the second: a record's key is over the file's own text, so a keystroke
+//!   makes a key nothing has been filed under.
+//!
+//! Debug and release give identical allocation counts — the counter is in the
+//! allocator, not in the optimiser — so this can be run without a release
+//! build. Release is worth it for the wall clock and nothing else.
+
+use std::path::Path;
+
+use uf_check::{CheckCache, CheckLimits, Source, check_sources, check_sources_cached};
+use uf_profiler::{AllocDelta, AllocSnapshot, CountingAllocator, Window};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator::new();
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let path = args
+        .iter()
+        .find(|arg| !arg.starts_with("--"))
+        .cloned()
+        .unwrap_or_else(|| String::from("packages/router/internal/runtime.js"));
+    let batch = batch_size(&args);
+    let source = std::fs::read_to_string(&path).expect("read the module");
+
+    if !uf_check::is_available() {
+        // Without `upstream-typecheck` every entry point returns
+        // `CheckError::Unavailable` immediately, and the figures below would be
+        // the cost of an early return rather than of a check. Say so instead of
+        // printing zeroes that look like an improvement.
+        eprintln!("built without `upstream-typecheck`: there is no checker to measure");
+        std::process::exit(1);
+    }
+
+    // One `Source` per copy, each under its own path: the checker keys a module
+    // by the path it is filed under, so N copies of one path is one module
+    // checked N times and tells us nothing about the marginal cost.
+    let paths: Vec<String> = (0..batch)
+        .map(|index| {
+            if index == 0 {
+                path.clone()
+            } else {
+                copy_path(&path, index)
+            }
+        })
+        .collect();
+    let sources: Vec<Source<'_>> = paths
+        .iter()
+        .map(|path| Source::new(path, &source))
+        .collect();
+
+    println!("{path}: {} bytes", source.len());
+    println!("batch          {batch}");
+
+    if args.iter().any(|arg| arg == "--cache") {
+        cache_report(&sources);
+        return;
+    }
+
+    // Warm up: the first call forces the builtin environment, and that is a
+    // one-time cost of the process rather than of a check.
+    let _ = check_sources(&sources, &[], &CheckLimits::default()).expect("checks");
+
+    let runs = 3;
+    let delta = measure(runs, || {
+        let report = check_sources(&sources, &[], &CheckLimits::default()).expect("checks");
+        std::hint::black_box(&report);
+    });
+    print_delta(&delta, runs);
+}
+
+/// The three calls the cache question is actually about.
+///
+/// A cold run against an empty directory, a warm one against what it wrote, and
+/// a third with one character appended — same limits, same process. The second
+/// number is what a caller saves by holding a cache; the third is what an
+/// editor saves, which is a different number for a reason that is in the key.
+fn cache_report(sources: &[Source<'_>]) {
+    let root = tempfile::tempdir().expect("a project root to cache under");
+    let Some(cache) = CheckCache::open(root.path()) else {
+        // `CheckCache::open` returns `None` when the process cannot identify
+        // its own binary, and a cache that cannot name its compiler is off in
+        // both directions by design. Measuring it would report a cold run
+        // twice and call the cache useless.
+        eprintln!("this process cannot identify its own binary, so there is no cache to measure");
+        std::process::exit(1);
+    };
+
+    // Warm up outside the cache, so the builtin environment is forced before
+    // either measured run and neither is charged for it.
+    let _ = check_sources(sources, &[], &CheckLimits::default()).expect("checks");
+
+    let cold = measure(1, || {
+        let report = check_sources_cached(sources, &[], &CheckLimits::default(), Some(&cache))
+            .expect("checks");
+        std::hint::black_box(&report);
+    });
+    let warm = measure(1, || {
+        let report = check_sources_cached(sources, &[], &CheckLimits::default(), Some(&cache))
+            .expect("checks");
+        std::hint::black_box(&report);
+    });
+
+    // The editor's question, and the one the batch above cannot answer. A
+    // keystroke changes the file's text, the text is in the key, so the record
+    // written a moment ago is filed under a key this call does not ask for.
+    // One appended character is the smallest edit there is; a larger one cannot
+    // cost less.
+    let edited_source = format!("{}\n", sources[0].source);
+    let edited: Vec<Source<'_>> = sources
+        .iter()
+        .map(|source| Source::new(source.path, &edited_source))
+        .collect();
+    let typed = measure(1, || {
+        let report = check_sources_cached(&edited, &[], &CheckLimits::default(), Some(&cache))
+            .expect("checks");
+        std::hint::black_box(&report);
+    });
+
+    println!("cold (writes the records)");
+    print_delta(&cold, 1);
+    println!("warm (reads them back)");
+    print_delta(&warm, 1);
+    println!("edited (one character appended)");
+    print_delta(&typed, 1);
+    print_saved("cache saves   ", &cold, &warm);
+    print_saved("an edit saves ", &cold, &typed);
+}
+
+/// What the second run cost less than the first, as a share of the first.
+fn print_saved(label: &str, cold: &AllocDelta, warm: &AllocDelta) {
+    let saved = cold.allocations.saturating_sub(warm.allocations);
+    let percent = if cold.allocations == 0 {
+        0.0
+    } else {
+        saved as f64 * 100.0 / cold.allocations as f64
+    };
+    println!("{label} {saved} allocations ({percent:.1}%)");
+}
+
+/// Run `workload` `runs` times inside a counting window.
+fn measure(runs: u64, mut workload: impl FnMut()) -> AllocDelta {
+    CountingAllocator::enable();
+    let window = Window::open();
+    let before = AllocSnapshot::capture();
+    for _ in 0..runs {
+        workload();
+    }
+    let after = AllocSnapshot::capture();
+    drop(window);
+    CountingAllocator::disable();
+    after.delta_from(&before)
+}
+
+fn print_delta(delta: &AllocDelta, runs: u64) {
+    println!("allocs / run   {}", delta.allocations / runs);
+    println!(
+        "bytes / run    {:.2} MiB",
+        delta.bytes_allocated as f64 / runs as f64 / (1024.0 * 1024.0)
+    );
+    println!(
+        "peak           {:.2} MiB",
+        delta.peak_above_baseline as f64 / (1024.0 * 1024.0)
+    );
+}
+
+/// `--batch N`, defaulting to one.
+fn batch_size(args: &[String]) -> usize {
+    let mut arguments = args.iter();
+    while let Some(argument) = arguments.next() {
+        if argument == "--batch" {
+            return arguments
+                .next()
+                .and_then(|count| count.parse().ok())
+                .filter(|count| *count > 0)
+                .unwrap_or(1);
+        }
+    }
+    1
+}
+
+/// `runtime.js` for copy 0, `runtime.copy1.js` for copy 1.
+///
+/// Beside the original rather than in a temporary directory, so a relative
+/// import inside the module resolves to the same file for every copy — which
+/// is what makes them the same amount of work.
+fn copy_path(path: &str, index: usize) -> String {
+    let path = Path::new(path);
+    let extension = path.extension().and_then(|extension| extension.to_str());
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("module");
+    let name = match extension {
+        Some(extension) => format!("{stem}.copy{index}.{extension}"),
+        None => format!("{stem}.copy{index}"),
+    };
+    path.with_file_name(name).to_string_lossy().into_owned()
+}


### PR DESCRIPTION
## Summary

`crates/uf_check/examples/alloc_report.rs`, the third of these after
`uf_transform`'s and `uf_lint`'s. #678 reported the checker's figures and named
the tool that produced them; it did not exist in the repository, so the numbers
could be read and not retaken. This is that tool, and it answers the one
question #678 left open.

It reproduces the issue's headline within half a percent — 1,990,575
allocations and 333.56 MiB for `packages/router/internal/runtime.js` against
the 2,001,094 and 333.63 MiB filed — which is what makes the rest of its output
worth believing.

**`--batch N`** separates the cost paid once per call from the cost paid per
module. A second copy of that file costs 1,707,906 allocations, so the fixed
part is about 283,000 and the marginal part is 15 allocations per source byte,
both matching #678's own figures.

**`--cache`** is the open question, and the answer is two answers.

| run | allocations | bytes |
| --- | ---: | ---: |
| cold | 1,990,722 | 333.65 MiB |
| warm, file unchanged | 137,342 | 6.89 MiB |
| warm, one character appended | 1,990,721 | 333.65 MiB |

`check_sources_cached` works, and it works for the caller #678 was *not*
worried about: an unchanged file costs 137,342 allocations, 93% less, and what
is left is the per-call fixed cost that a cache over per-file records was never
going to remove.

The caller it *was* worried about saves nothing. A record's key is over the
file's own text, so a keystroke asks for a key nothing has been filed under:
one appended character costs 1,990,721 against a cold 1,990,722 — a saving of a
single allocation. That is not a defect in the cache, it is what content
addressing means, and it is why an editor wants something the cache is not.
Which is now a measured fact rather than a suspicion, and the thing #678 asked
for before anything else.

No library code changes: one example, one dev-dependency, and the lock entry
for it.

Refs #678.

## Verification

```sh
cargo run --release --example alloc_report -p uf_check -- packages/router/internal/runtime.js
cargo run --release --example alloc_report -p uf_check -- packages/router/internal/runtime.js --batch 2
cargo run --release --example alloc_report -p uf_check -- packages/router/internal/runtime.js --cache
```

Pinned nightly (`nightly-2026-08-01`), locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p uf_check --all-targets -- -D warnings`

The rest is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791469423&installation_model_id=422833&pr_number=682&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F682&signature=081b530fb108d2803f70e1e1409768e55f7a24d90a4814babc2b311ae94e02ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a diagnostic example for measuring memory allocations and peak usage while checking modules.
  - Supports single-run, repeated batch, and cache-enabled comparisons, including cold, warm, and updated-cache scenarios.
  - Reports allocation counts, memory consumption, peak usage, and cache-related savings to help evaluate checker performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->