### PR TITLE
fix(lib): the hook table had fallen six behind the package it describes

### DIFF
--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -965,8 +965,23 @@ pub fn tui_contract() -> TuiFrameworkContract {
 /// Component has no client. `useIsomorphicLayoutEffect` is the exception
 /// because it is inert on a server by construction.
 ///
-/// The list had drifted: it named `useEvent`, `useLocalStorage` and
-/// `useServerValue`, none of which the package has ever exported.
+/// The list had drifted twice, in both directions, which is why
+/// `the_hook_table_names_exactly_the_hooks_the_package_exports` now holds it
+/// rather than care does. First it named `useEvent`,
+/// `useLocalStorage` and `useServerValue`, none of which the package has ever
+/// exported. Then it fell six behind — `useEventSource`, and the five of
+/// `packages/hooks/render.js` — because a hook added to the package and to the
+/// export list above is complete as far as an editor is concerned, and this
+/// table is a second place with the same name in it.
+///
+/// The six are `(true, false)` like almost everything here, and for the two
+/// separate reasons the paragraphs above give. `useEventSource` holds a
+/// connection open from an effect and reports it through state, so it writes
+/// nothing during a render and cannot have a connection on a server.
+/// `render.js`'s five read a `RenderProvider`'s decisions through
+/// `useContext`, which is what makes both renders of a prerendered page agree
+/// — and `useContext` is the API a Server Component may not call, so the hook
+/// that is *about* rendering twice is not one a Server Component can use.
 pub fn hook_descriptors() -> Vec<HookDescriptor> {
     vec![
         HookDescriptor::new("useAnimationFrame", true, false),
@@ -983,6 +998,7 @@ pub fn hook_descriptors() -> Vec<HookDescriptor> {
         HookDescriptor::new("useElementSize", true, false),
         HookDescriptor::new("useElementState", true, false),
         HookDescriptor::new("useEventListener", true, false),
+        HookDescriptor::new("useEventSource", true, false),
         HookDescriptor::new("useFocusWithin", true, false),
         HookDescriptor::new("useGeolocation", true, false),
         HookDescriptor::new("useHash", true, false),
@@ -1006,10 +1022,15 @@ pub fn hook_descriptors() -> Vec<HookDescriptor> {
         HookDescriptor::new("usePreferredColorScheme", true, false),
         HookDescriptor::new("usePrefersReducedMotion", true, false),
         HookDescriptor::new("usePrevious", true, false),
+        HookDescriptor::new("useRandom", true, false),
+        HookDescriptor::new("useRenderEnvelope", true, false),
+        HookDescriptor::new("useRenderTimeZone", true, false),
+        HookDescriptor::new("useRenderedAt", true, false),
         HookDescriptor::new("useRerender", true, false),
         HookDescriptor::new("useScroll", true, false),
         HookDescriptor::new("useScrollLock", true, false),
         HookDescriptor::new("useSet", true, false),
+        HookDescriptor::new("useShuffled", true, false),
         HookDescriptor::new("useStableCallback", true, false),
         HookDescriptor::new("useStorage", true, false),
         HookDescriptor::new("useSupported", true, false),

--- a/crates/uf_lib/src/tests.rs
+++ b/crates/uf_lib/src/tests.rs
@@ -454,6 +454,73 @@ fn the_registry_names_exactly_what_each_package_exports() {
     assert_eq!(exempt, ["@uniflowed/react", "@uniflowed/relay"]);
 }
 
+/// `hook_descriptors()` names exactly the hooks `@uniflowed/hooks` exports.
+///
+/// The companion to [`the_registry_names_exactly_what_each_package_exports`],
+/// and it exists because that test could not see this drift. The registry's
+/// export list for `@uniflowed/hooks` was complete; the hook table beside it
+/// was six short, so an editor offering completions was right and `uf inspect`
+/// — which reports `hook_descriptors().len()` — was quietly wrong, and nothing
+/// compared the two lists that were supposed to agree.
+///
+/// Hooks and nothing else: the package also exports `RENDER_META`,
+/// `RenderProvider` and `browserWindow`, which are a string, a component and a
+/// function. A hook is a `use` followed by a capital, which is React's own rule
+/// for the name and the same one `uf_rsc`'s scanner applies.
+#[test]
+fn the_hook_table_names_exactly_the_hooks_the_package_exports() {
+    let entry = repository_root()
+        .join("packages")
+        .join("hooks")
+        .join("index.js");
+    let source = fs::read_to_string(&entry)
+        .unwrap_or_else(|error| panic!("{} cannot be read: {error}", entry.display()));
+    let exported = exported_values(&source)
+        .unwrap_or_else(|error| panic!("{} does not parse: {error}", entry.display()))
+        .unwrap_or_else(|| panic!("{} hands on another package's surface", entry.display()));
+
+    let exports_hooks: Vec<&str> = exported
+        .iter()
+        .map(String::as_str)
+        .filter(|name| is_hook_name(name))
+        .collect();
+    let described: Vec<String> = hook_descriptors()
+        .into_iter()
+        .map(|hook| hook.name.to_string())
+        .collect();
+    let mut table: Vec<&str> = described.iter().map(String::as_str).collect();
+    table.sort_unstable();
+    table.dedup();
+
+    let missing: Vec<&&str> = exports_hooks
+        .iter()
+        .filter(|name| !table.contains(name))
+        .collect();
+    let absent: Vec<&&str> = table
+        .iter()
+        .filter(|name| !exports_hooks.contains(name))
+        .collect();
+    assert!(
+        missing.is_empty() && absent.is_empty(),
+        "hook_descriptors() and @uniflowed/hooks disagree\n  \
+         the package exports and the table does not name: {missing:?}\n  \
+         the table names and the package does not export: {absent:?}"
+    );
+    // A floor as well as an equality, so a barrel that stopped parsing into
+    // anything cannot make two empty lists agree.
+    assert!(
+        exports_hooks.len() > 50,
+        "the barrel yielded almost no hooks, so this is not checking anything: {}",
+        exports_hooks.len()
+    );
+}
+
+/// React's rule for the name, which is the whole of what makes a hook one.
+fn is_hook_name(name: &str) -> bool {
+    name.strip_prefix("use")
+        .is_some_and(|rest| rest.chars().next().is_some_and(char::is_uppercase))
+}
+
 /// The components `@uniflowed/ui` ships, and the parts each one exposes.
 ///
 /// Read from `packages/ui/index.js`, which is where the parts are: a subpath


### PR DESCRIPTION
## Summary

`hook_descriptors()` says it names "every hook `@uniflowed/hooks` exports" and
named 52 of the 58. Missing: `useEventSource`, and the five of
`packages/hooks/render.js` — `useRandom`, `useRenderEnvelope`,
`useRenderTimeZone`, `useRenderedAt`, `useShuffled`.

Nothing was watching. The registry's *export list* for the same package was
complete, and `the_registry_names_exactly_what_each_package_exports` holds it
to that — so an editor's completions were right. The hook table beside it is a
second place with the same names in it and had no such test, so `uf inspect`
reported 52 hooks, and a consumer asking what a compiler may assume about
`useRenderedAt` was told nothing at all.

The six are `(idempotent_render: true, server_component_safe: false)`, for the
two reasons the function's own paragraphs already give:

* `useEventSource` opens its connection in an effect and reports it through
  state, so it writes nothing during a render and cannot have a connection on
  a server.
* `render.js`'s five read a `RenderProvider`'s decisions through `useContext` —
  which is exactly what makes both renders of a prerendered page agree on a
  clock and a seed — and `useContext` is an API a Server Component may not
  call. The hook that is *about* rendering twice is not one a Server Component
  can use.

`the_hook_table_names_exactly_the_hooks_the_package_exports` is what stops a
third drift. It parses `packages/hooks/index.js` with uf's own Flow parser, the
way its neighbour does, compares both ways round, and prints both lists on
failure:

```
hook_descriptors() and @uniflowed/hooks disagree
  the package exports and the table does not name: ["useShuffled"]
  the table names and the package does not export: []
```

(that output is from deleting an entry to check the test fails for the right
reason, not from this branch).

Found while reading #388, which proposes recording *where* each of these hooks
runs in this same file. This is not that change — but a table six names short
is a poor place to add a second fact to.

## Verification

Pinned nightly (`nightly-2026-08-01`), locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p uf_lib --all-targets -- -D warnings`
- [x] `cargo test -p uf_lib` — 32 passed, including the new test
- [x] the new test fails, with both lists named, when an entry is removed

The rest is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791469847&installation_model_id=422833&pr_number=683&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F683&signature=5a60fa208c1f4d71cef4dc360cbbd4ee6c727575d2e7edadfadd93b17e2c8bf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->