### PR TITLE
feat(vite, router): `uf dev` streams a page instead of collecting it

### DIFF
--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -1601,6 +1601,19 @@ fn assert_dev_served(server: &mut Server, port: u16, said: &Mutex<String>, body:
         )
     );
 
+    // And a page that suspends arrives in two pieces. `uf dev` used to collect
+    // the whole document, because `transformIndexHtml` is a whole-document
+    // hook — so the one server a developer actually watches was the one that
+    // did not stream, and `_uf.loading.js` looked broken. It transforms only
+    // the head now, which is all Vite's injections need. ubugeeei-prod/uf#374.
+    //
+    // The same `streamed` `uf preview` and `uf start` are held to, so the three
+    // cannot drift apart. Its own id, because the fixture keeps one promise per
+    // id and a second request for one already resolved answers at once.
+    if let Err(why) = streamed(port, "dev") {
+        panic!("{}", context(&why.0, &why.1));
+    }
+
     // A route handler, asked exactly the way a browser asks: `Accept:
     // text/html`, no extension, `GET`. That is a *document* request by every
     // test the renderer can apply to it, which is why the handler was invisible
@@ -3258,40 +3271,55 @@ fn assert_served(server: &mut Server, port: u16, said: &Mutex<String>, body: &st
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect();
+    if let Err(why) = streamed(port, &slow_id) {
+        panic!("{}", context(&why.0, &why.1));
+    }
+}
+
+/// Whether the server sent a suspending page's shell before the page itself.
+///
+/// One copy of the rule for the three servers that have to obey it. `uf preview`
+/// and `uf start` always did; `uf dev` collected the whole document because
+/// `transformIndexHtml` is a whole-document hook, which is the one place a
+/// developer would notice streaming and the one place it did not happen
+/// (ubugeeei-prod/uf#374). Now that it streams too, the assertion is shared
+/// rather than written twice and allowed to drift.
+///
+/// The failure is returned rather than panicked so each caller can say which
+/// server it was asking; the pair is the description and the evidence.
+fn streamed(port: u16, slow_id: &str) -> Result<(), (String, String)> {
     let slow = timed_get(port, &format!("/slow/{slow_id}"));
-    assert!(
-        slow.text.starts_with("HTTP/1.1 200"),
-        "{}",
-        context("did not render the suspending route", &slow.evidence())
-    );
-    let shell = slow.first_at("slow: waiting").unwrap_or_else(|| {
-        panic!(
-            "{}",
-            context("never sent the `_uf.loading.js` fallback", &slow.evidence())
-        )
-    });
-    let page = slow
-        .first_at(&format!("slow: {slow_id}"))
-        .unwrap_or_else(|| {
-            panic!(
-                "{}",
-                context("the suspended page never arrived", &slow.evidence())
-            )
-        });
-    assert!(
-        shell + STREAMING_MARGIN <= page,
-        "{}",
-        context(
-            &format!(
+    if !slow.text.starts_with("HTTP/1.1 200") {
+        return Err((
+            "did not render the suspending route".to_owned(),
+            slow.evidence(),
+        ));
+    }
+    let Some(shell) = slow.first_at("slow: waiting") else {
+        return Err((
+            "never sent the `_uf.loading.js` fallback".to_owned(),
+            slow.evidence(),
+        ));
+    };
+    let Some(page) = slow.first_at(&format!("slow: {slow_id}")) else {
+        return Err((
+            "the suspended page never arrived".to_owned(),
+            slow.evidence(),
+        ));
+    };
+    if shell + STREAMING_MARGIN > page {
+        return Err((
+            format!(
                 "sent the fallback and the page together: the fallback was {}ms in and the \
                  page {}ms in, and the page waits {}ms — so nothing streamed",
                 shell.as_millis(),
                 page.as_millis(),
                 SUSPENDING_ROUTE_DELAY.as_millis()
             ),
-            &slow.evidence()
-        )
-    );
+            slow.evidence(),
+        ));
+    }
+    Ok(())
 }
 
 /// How long `app/slow/[id]/_uf.page.js` waits before it renders.

--- a/packages/router/internal/stream.js
+++ b/packages/router/internal/stream.js
@@ -307,9 +307,15 @@ function queueDestination(queue: ChunkQueue): NodeDestination {
 async function* assembled(
   chunks: AsyncGenerator<string, void, void>,
   shell: DocumentShell,
+  transformHead?: (html: string) => Promise<string>,
 ): AsyncGenerator<string, void, void> {
   let held = "";
   let shape = "unknown";
+  // The opening chunk is the only one the hook sees, and every path below
+  // reaches exactly one of them. Awaiting here rather than at each `yield`
+  // keeps the four of them from drifting apart.
+  const opening = async (html: string): Promise<string> =>
+    transformHead == null ? html : await transformHead(html);
 
   for await (const chunk of chunks) {
     if (shape === "document-open" || shape === "shell-open") {
@@ -329,7 +335,7 @@ async function* assembled(
         continue;
       }
       shape = "shell-open";
-      yield shell.open + split.head + shell.body + split.rest;
+      yield await opening(shell.open + split.head + shell.body + split.rest);
       held = "";
       continue;
     }
@@ -337,7 +343,7 @@ async function* assembled(
     const close = held.indexOf("</head>");
     if (close !== -1) {
       shape = "document-open";
-      yield ufDoctype(held.slice(0, close) + shell.head + held.slice(close));
+      yield await opening(ufDoctype(held.slice(0, close) + shell.head + held.slice(close)));
       held = "";
       continue;
     }
@@ -345,7 +351,9 @@ async function* assembled(
     const body = held.search(/<body[\s>]/i);
     if (body !== -1) {
       shape = "document-open";
-      yield ufDoctype(`${held.slice(0, body)}<head>${shell.head}</head>${held.slice(body)}`);
+      yield await opening(
+        ufDoctype(`${held.slice(0, body)}<head>${shell.head}</head>${held.slice(body)}`),
+      );
       held = "";
     }
   }
@@ -355,14 +363,14 @@ async function* assembled(
   // `<body>` in it, or a shell that is hoistable elements all the way down.
   // There is nothing left to wait for in any of them.
   if (shape === "document") {
-    yield ufDoctype(held + shell.head);
+    yield await opening(ufDoctype(held + shell.head));
     shape = "document-open";
   } else if (shape === "shell" || shape === "unknown") {
     // `complete` is not consulted: nothing more is coming, so a run that was
     // still open is over and whatever was left of it is markup like any other.
     const split = hoisted(held);
     shape = "shell-open";
-    yield shell.open + split.head + shell.body + split.rest;
+    yield await opening(shell.open + split.head + shell.body + split.rest);
   }
   if (shape === "shell-open") {
     yield shell.close;
@@ -582,6 +590,28 @@ export type RenderOptions = {|
    * shell's own failure is not reported here — it rejects instead.
    */
   readonly onError: (error: mixed) => void,
+  /**
+   * Rewrite the opening chunk — everything up to and including the head —
+   * before it goes out.
+   *
+   * For `uf dev`, and only for it. Vite's `transformIndexHtml` rewrites asset
+   * URLs and injects `/@vite/client` and the refresh preamble, and it is a
+   * *whole document* hook, so the development server used to collect the page
+   * and transform it at the end. That made the one place a developer would
+   * notice streaming the one place it did not happen: a slow page showed
+   * nothing until it was finished, and `_uf.loading.js` looked broken.
+   * See ubugeeei-prod/uf#374.
+   *
+   * The hook only ever sees the head, which is what makes this safe. Vite's
+   * injections are string-based against `<head>`, and its dev hook handles a
+   * document that ends mid-`<body>` without complaint — checked against Vite
+   * 8.2.2 before this existed, because "the parse step is the risk" was the
+   * open question on that issue.
+   *
+   * Absent everywhere else. `uf start`, `uf preview` and every deploy adapter
+   * have no such hook and stream already.
+   */
+  readonly transformHead?: (html: string) => Promise<string>,
 |};
 
 /**
@@ -601,7 +631,9 @@ export function renderDocument(node: React.Node, options: RenderOptions): Promis
       const { pipe, abort } = ReactDOMServer.renderToPipeableStream(node, {
         onShellReady() {
           pipe(queueDestination(queue));
-          resolve(bodyOf(assembled(queue.chunks(), options.shell), () => abort()));
+          resolve(
+            bodyOf(assembled(queue.chunks(), options.shell, options.transformHead), () => abort()),
+          );
         },
         onShellError(error: mixed) {
           reject(error);
@@ -661,7 +693,7 @@ export function renderWithReadableStream(
   const controller = new AbortController();
   return render(node, { onError: options.onError, signal: controller.signal }).then(
     (stream: ByteSource) =>
-      bodyOf(assembled(decoded(stream), options.shell), () => {
+      bodyOf(assembled(decoded(stream), options.shell, options.transformHead), () => {
         controller.abort();
       }),
   );
@@ -712,7 +744,9 @@ export async function prerenderDocument(node: React.Node, options: RenderOptions
     typeof ReactDOMStatic.prerenderToNodeStream === "function"
       ? await ReactDOMStatic.prerenderToNodeStream(node, settings)
       : await ReactDOMStatic.prerender(node, settings);
-  return bodyOf(assembled(preludeChunks(result.prelude), options.shell)).text();
+  return bodyOf(
+    assembled(preludeChunks(result.prelude), options.shell, options.transformHead),
+  ).text();
 }
 
 /**

--- a/packages/router/server.js
+++ b/packages/router/server.js
@@ -112,6 +112,21 @@ export type RenderOptions = {|
    * bytes. `uf dev` reports them in the terminal; a production host logs them.
    */
   readonly onError?: (error: mixed) => void,
+  /**
+   * Rewrite the opening chunk — everything up to and including the head —
+   * before it goes out.
+   *
+   * For `uf dev` and nothing else. Vite's `transformIndexHtml` injects
+   * `/@vite/client` and the refresh preamble and rewrites asset URLs, and it
+   * is a *whole document* hook, so the development server used to collect the
+   * page and transform it at the end. That made the one place a developer
+   * would notice streaming the one place it did not happen: a slow page showed
+   * nothing until it was finished, and `_uf.loading.js` looked broken.
+   * See ubugeeei-prod/uf#374.
+   *
+   * A production host passes nothing here and streams as it always did.
+   */
+  readonly transformHead?: (html: string) => Promise<string>,
 |};
 
 /** The two ids the server writes and the client reads. */
@@ -285,6 +300,7 @@ export function createRenderer(options: {|
       body = await renderDocument(<App url={url} initial={resolved} />, {
         shell: shellFor(assets),
         onError,
+        transformHead: settings?.transformHead,
       });
       streaming = true;
       // Recovered before the shell was ready: a `<Suspense>` boundary whose
@@ -315,6 +331,7 @@ export function createRenderer(options: {|
       body = await renderDocument(<App url={url} initial={resolved} />, {
         shell: shellFor(assets),
         onError,
+        transformHead: settings?.transformHead,
       });
     }
 

--- a/packages/router/server.js
+++ b/packages/router/server.js
@@ -125,6 +125,32 @@ export type RenderOptions = {|
    * See ubugeeei-prod/uf#374.
    *
    * A production host passes nothing here and streams as it always did.
+   *
+   * # What a plugin that injects into the body gets
+   *
+   * `transformIndexHtml` is a whole-document hook and this hands it one chunk,
+   * so `injectTo` is answered against a document that stops inside `<body>`.
+   * Measured against Vite 8.2.2, injecting all four positions into a whole
+   * document and into a head-only one:
+   *
+   * | `injectTo`     | whole document      | streamed |
+   * | -------------- | ------------------- | -------- |
+   * | `head-prepend` | after `<head>`      | same     |
+   * | `head`         | before `</head>`    | same     |
+   * | `body-prepend` | after `<body>`      | same     |
+   * | `body`         | before `</body>`    | **after `<body>`** |
+   *
+   * Nothing is dropped — every tag still reaches the document — but a `body`
+   * tag lands at the *top* of the body rather than after the content, because
+   * the content has not been rendered yet when the hook runs. For a `<script>`
+   * that expects a complete DOM that is a real difference, and it is the price
+   * of streaming: a hook that wants the whole document and a server that sends
+   * the head first cannot both be satisfied.
+   *
+   * uf's own injections are `head` and `head-prepend`, and Vite's client is
+   * head-injected, so this is about a third-party plugin. `dev-head-transform`
+   * in `tests/library` pins the table above, so the day it changes is a failing
+   * test rather than a surprise.
    */
   readonly transformHead?: (html: string) => Promise<string>,
 |};

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -696,15 +696,25 @@ function flowPlugin({ routerRoot, appEntry, strictMode, command, accessibility }
                   // result by then — so the terminal hears about it here or not
                   // at all.
                   onError: (error) => reportRenderError(devServer, url, error),
+                  // Vite sees the head and only the head. That is what lets the
+                  // development server stream like every other host — see below.
+                  transformHead: (head) => devServer.transformIndexHtml(url, head),
                 },
               );
               if (result.error != null) reportRenderError(devServer, url, result.error);
-              // Collected rather than piped: `transformIndexHtml` is a
-              // whole-document hook, so there is no first byte to send until it
-              // has run. `uf start` and `uf preview` stream — see
-              // `internal/serve.js` — and that is a property of the development
-              // server rather than of the renderer. ubugeeei-prod/uf#374.
-              const html = await devServer.transformIndexHtml(url, await result.text());
+              // Piped, like every other host. This used to collect the whole
+              // document and transform it at the end, because
+              // `transformIndexHtml` is a *whole document* hook — which made the
+              // one place a developer would notice streaming the one place it
+              // did not happen: a slow page showed nothing until it was finished
+              // and `_uf.loading.js` looked broken.
+              //
+              // `transformHead` above is the seam. `internal/stream.js` already
+              // held the opening chunk back until the head was complete and
+              // forwarded everything after it untouched, so the hook only ever
+              // sees the head — and Vite's dev hook handles a document that ends
+              // mid-`<body>` without complaint, which was the open question on
+              // ubugeeei-prod/uf#374.
               response.statusCode = result.status ?? 200;
               // The render's own headers, then the content type over the top:
               // exactly the order `@uniflowed/server`'s `fetch.js` writes them
@@ -714,7 +724,7 @@ function flowPlugin({ routerRoot, appEntry, strictMode, command, accessibility }
                 response.setHeader(name, value);
               }
               response.setHeader("content-type", "text/html; charset=utf-8");
-              response.end(html);
+              await result.pipe(response);
               return true;
             });
 

--- a/tests/library/dev-head-transform.test.js
+++ b/tests/library/dev-head-transform.test.js
@@ -1,0 +1,99 @@
+// @flow
+//
+// What Vite's `transformIndexHtml` does with the one chunk `uf dev` gives it.
+//
+// `uf dev` streams (ubugeeei-prod/uf#374): `internal/stream.js` holds the
+// opening chunk back until the head is complete, hands *that* to
+// `transformIndexHtml`, and forwards the rest untouched. Vite's hook is a
+// whole-document hook, so this file is the answer to what a document that
+// stops inside `<body>` does to it — the question #374 called "the parse step
+// is the risk", and the limitation the streaming trade buys.
+//
+// Driven against a real Vite server rather than a stub, because the whole
+// point is what *Vite* does. A stub would assert what this file already
+// believes.
+
+import { describe, expect, it } from "@uniflowed/test";
+
+/** A document, and the same document cut where a first chunk would end. */
+const WHOLE =
+  "<!doctype html><html><head><title>t</title></head><body><main>x</main></body></html>";
+const STREAMED = "<!doctype html><html><head><title>t</title></head><body>";
+
+/** A plugin that asks for every position, so each can be found by name. */
+const injector = {
+  name: "test:inject",
+  transformIndexHtml() {
+    return ["head-prepend", "head", "body-prepend", "body"].map((at) => ({
+      tag: "script",
+      attrs: { "data-at": at },
+      injectTo: at,
+    }));
+  },
+};
+
+async function transformed(html: string): Promise<string> {
+  const { createServer } = await import("vite");
+  const server = await createServer({
+    root: process.cwd(),
+    logLevel: "silent",
+    server: { middlewareMode: true },
+    plugins: [injector],
+  });
+  try {
+    return await server.transformIndexHtml("/", html);
+  } finally {
+    await server.close();
+  }
+}
+
+/** Where each injection landed, as an order rather than an offset. */
+function order(html: string): Array<string> {
+  return ["head-prepend", "head", "body-prepend", "body"]
+    .map((at) => [at, html.indexOf(`data-at="${at}"`)])
+    .filter(([, at]) => at !== -1)
+    .sort(([, a], [, b]) => Number(a) - Number(b))
+    .map(([name]) => String(name));
+}
+
+describe("the head chunk `uf dev` hands to Vite", () => {
+  it("keeps the transform working on a document that stops inside the body", async () => {
+    // The question #374 was blocked on. If Vite refused a partial document, or
+    // dropped its injections, `uf dev` could not stream at all and the fix
+    // would have had to be a Vite-side one.
+    const out = await transformed(STREAMED);
+
+    expect(out).toContain("/@vite/client");
+    expect(order(out)).toEqual(["head-prepend", "head", "body-prepend", "body"]);
+    // The chunk itself survives: this is a rewrite, not a re-render.
+    expect(out).toContain("<title>t</title>");
+  }, 60_000);
+
+  it("moves an `injectTo: body` tag to the top of the body, and nothing else", async () => {
+    // The cost of streaming, measured rather than assumed, and the reason it is
+    // written down on `RenderOptions.transformHead`.
+    //
+    // Three of the four positions are decided by markup the head chunk already
+    // holds — `<head>`, `</head>`, `<body>` — so they land where they always
+    // did. `body` means *before `</body>`*, and there is no `</body>` yet, so
+    // it goes to the end of what there is: the top of the body.
+    //
+    // Nothing is dropped either way. A `<script>` that expects a complete DOM
+    // is the case this costs, and no uf injection is one — uf uses `head` and
+    // `head-prepend`, and Vite's client is head-injected.
+    const whole = await transformed(WHOLE);
+    const streamed = await transformed(STREAMED);
+
+    // In a whole document the body tag comes after the content.
+    expect(whole.indexOf('data-at="body"')).toBeGreaterThan(whole.indexOf("<main>"));
+
+    // In the streamed chunk it is last only because the content is not there.
+    expect(order(streamed)).toEqual(["head-prepend", "head", "body-prepend", "body"]);
+    expect(streamed).not.toContain("<main>");
+    // And it sits immediately after `body-prepend`, which is what "the top of
+    // the body" means when nothing has been rendered into it yet.
+    const prepend = streamed.indexOf('data-at="body-prepend"');
+    const body = streamed.indexOf('data-at="body"');
+    expect(streamed.slice(prepend, body)).not.toContain("<main>");
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #374.

`uf dev` was the one server that did not stream. `uf start`, `uf preview` and every deploy adapter answer with the shell as soon as it is ready; the development server collected the whole document and transformed it at the end, because `transformIndexHtml` is a **whole document** hook and there is no first byte to send until it has run.

So the one place a developer would notice streaming was the one place it did not happen. A slow page showed nothing until it was finished, and `_uf.loading.js` — the fallback that exists to be seen — looked like it did not work.

| `/slow/1` on the fixture | fallback | page |
| --- | ---: | ---: |
| before | 1360 ms in | 1360 ms in |
| after | **22 ms in** | 524 ms in |

Before, the first byte *is* the last byte.

## The seam

The hook only ever has to see the head. `internal/stream.js` already held the opening chunk back until the head was complete and forwarded everything after it untouched — which is exactly what this needed:

- `RenderOptions` gains `transformHead`
- `assembled` runs it on whichever of its opening chunks it reaches
- the dev server passes `transformIndexHtml` into it and pipes the result

A production host passes nothing and streams as it always did.

## The open question is answered

#374 said the risk was Vite's parse step: *"confirm what Vite's dev HTML hook does with a document that ends mid-`<body>` — the answer decides whether this is a small change or needs a Vite-side one."*

It handles it. Checked against Vite 8.2.2 **before** any of this was written:

```
--- head-only ---
  injected /@vite/client: true
  ends with: "></script>\n<title>t</title></head><body>"
```

So it is the small change. The served page still carries the client and the refresh preamble — verified by hand against the fixture as well as in the suite.

## One copy of the rule

`streamed` is the assertion `uf preview` and `uf start` were already held to, lifted out of `assert_served` so all three servers share it rather than letting a second copy drift. It fails on the collected version, and its message is where the numbers in the table come from:

```
`uf dev` sent the fallback and the page together: the fallback was 1360ms in
and the page 1360ms in, and the page waits 500ms — so nothing streamed
```

53 `vite` tests, 2,670 library tests. Rebased onto alpha.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791476239&installation_model_id=422833&pr_number=685&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F685&signature=15b3f819514c89690da0988392ab87411d3d1132ace8dd55ef55e61f140d8ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Development rendering now streams the page shell before the complete page, allowing visible content to appear sooner.
  - Vite HTML transformations are applied during streaming, preserving development-time integrations and supporting head and body injections.

- **Bug Fixes**
  - Improved consistency of HTML transformation across normal and error-rendering paths.
  - Streaming behavior is now checked consistently across development, preview, and production-start workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->