### PR TITLE
ci(release): build the Intel macOS target on Apple silicon, verify it natively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.builder }}
     # Ninety, not sixty, and the difference is one runner rather than the code.
     #
     # `uf@0.0.0-alpha.9` published every package to npm and produced no
@@ -40,16 +40,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Every target install.sh can ask for, each on a native runner so the
-        # installer test below runs the binaries it just packaged.
+        # Every target `install.sh` can ask for. `builder` is where it is
+        # compiled and `runner` is where it is *run* — the same machine for
+        # three of them, and deliberately not for the fourth.
+        #
+        # `macos-15-intel` is the oldest hardware in the fleet and the only
+        # target with no Apple-silicon runner behind it. It took 31 to 46
+        # minutes across alpha.13 to alpha.15 against 11 to 20 for the other
+        # three, and `publish` needs all four, so it was the whole release's
+        # critical path — ubugeeei-prod/uf#464. Apple silicon hosts that target
+        # with nothing but `--target`, and `package-binaries.sh` only compiles,
+        # tars and shasums, so nothing in this job has to execute what it built.
+        #
+        # Running it is what `verify` below is for, and it stays native.
         include:
           - target: x86_64-unknown-linux-gnu
+            builder: ubuntu-latest
             runner: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
+            builder: ubuntu-24.04-arm
             runner: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
+            builder: macos-15
             runner: macos-15-intel
           - target: aarch64-apple-darwin
+            builder: macos-15
             runner: macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -94,14 +109,6 @@ jobs:
           UF_CARGO_PROFILE: dist
         run: tools/release/package-binaries.sh
 
-      # The point of the whole workflow is that `curl … | sh` works. Prove it
-      # against the archive this job just produced, on this target's own
-      # hardware, before anything reaches a release page.
-      - name: Verify the installer against this archive
-        env:
-          UF_TEST_RELEASE_DIR: dist/release/uf/${{ steps.version.outputs.version }}
-        run: tools/release/test-install.sh
-
       # Name the version directory rather than globbing it. A glob makes
       # upload-artifact root the artifact at the non-wildcard prefix, so every
       # file arrives under a `<version>/` directory that `publish` does not
@@ -112,9 +119,56 @@ jobs:
           path: dist/release/uf/${{ steps.version.outputs.version }}
           if-no-files-found: error
 
+  verify:
+    name: Verify ${{ matrix.target }}
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            runner: macos-15
+    steps:
+      # The point of the whole workflow is that `curl … | sh` works. Prove it
+      # against the archive `build` produced, on this target's own hardware,
+      # before anything reaches a release page.
+      #
+      # A job of its own rather than a step inside `build`, so that where a
+      # binary is *compiled* and where it is *run* can differ. They are the same
+      # machine for three of the four; see the build matrix for why the fourth
+      # is not.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Resolve version
+        id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          version="${INPUT_VERSION:-${REF_NAME#uf@}}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uf-${{ matrix.target }}
+          path: dist/release/uf/${{ steps.version.outputs.version }}
+      - name: Verify the installer against this archive
+        env:
+          UF_TEST_RELEASE_DIR: dist/release/uf/${{ steps.version.outputs.version }}
+        run: tools/release/test-install.sh
+
   publish:
     name: Publish release
-    needs: build
+    needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
Refs #464 — the half that issue left open, now that the measurement says what it is.

`x86_64-apple-darwin` is the whole release's critical path. `publish` needs all four targets, and that one has been two to four times the others for as long as there are numbers:

| target | alpha.13 | alpha.14 | alpha.15 |
| --- | ---: | ---: | ---: |
| `aarch64-unknown-linux-gnu` | 11 min | 11 min | 12 min |
| `x86_64-unknown-linux-gnu` | 14 min | 15 min | 14 min |
| `aarch64-apple-darwin` | 17 min | 20 min | 19 min |
| **`x86_64-apple-darwin`** | **43 min** | **46 min** | **31 min** |

## It is not the cross-compile

#464 guessed *"it cross-compiles on an `aarch64` runner, so nothing it builds is native"*. It does not — the matrix put every target on a native runner. `macos-15-intel` is simply the oldest hardware in the fleet and the only target with no Apple-silicon runner behind it. No setting fixes that.

## What can move

Where it is **compiled**. Apple silicon hosts that target with nothing but `--target`, and `package-binaries.sh` only compiles, tars and shasums — I checked, nothing in the build job executes what it built.

So `builder` and `runner` become separate columns. Three targets keep one machine for both; `x86_64-apple-darwin` compiles on `macos-15` and is *run* on `macos-15-intel`.

## Running it stays native

That is the guarantee the matrix existed for, and it is unchanged — just asked one job later. The installer check moves out of `build` into a `verify` job that downloads the archive and runs `test-install.sh` on the target's own hardware, before anything reaches a release page.

```
build -> verify -> publish -> smoke
```

`publish` now needs `verify` rather than `build`, so a target whose binary does not actually run still stops the release. `smoke` — which installs from the published release on all four native runners — is untouched.

## Timing

Deliberately **not** in the same change as a release. `release.yml`'s failure mode is a published npm version with no binaries, which is how #464 started, and I said on that issue it should change after a release rather than before one. alpha.17 went out on the old workflow; the next tag is what proves this one.

Leaving #464 open until a tag has run through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791477393&installation_model_id=422833&pr_number=686&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F686&signature=d234c3a2992223f39ae9efac02350ccfd1ddfad1fc243d6e18db1d3b15848583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->