### PR TITLE
docs(roadmap, config): say that uf runs its own tasks, because it does

### DIFF
--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -1552,6 +1552,19 @@ impl Default for TaskRunnerConfig {
 #[non_exhaustive]
 pub enum TaskRunnerEngine {
     /// Vite+'s Rust task runner, invoked through the public `vp run` interface.
+    ///
+    /// Which is *not* how most tasks run, and the name is the last thing that
+    /// still says otherwise. A task that names a command is run by uf —
+    /// `uf_task` builds the dependency graph, runs independent nodes up to a
+    /// concurrency limit, and answers from `.uf/cache/task` when the files a
+    /// task declares it reads have not changed. This engine is reached only by
+    /// a task with *no* command of its own, which is Vite+'s to define; see
+    /// `uf run`'s `execute_task`, where handing `ci` to `vp run ci` once asked
+    /// Vite+ for a script it had never heard of.
+    ///
+    /// It stays the default because it is the only variant, and because the
+    /// hand-over it names is still real for the command-less case. See
+    /// ubugeeei-prod/uf#272.
     #[default]
     ViteTask,
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,7 +91,9 @@ in `uf`.
   rather than by name, so `@uniflowed/vite` is one implementation of a written
   contract rather than a dependency four commands reach for (done).
 - Keep `uf.config.js` as the single config and task surface; generated projects
-  do not use npm scripts, and task execution goes through Vite Task.
+  do not use npm scripts, and uf runs the tasks it defines. Vite Task runs a
+  task that names no command of its own, and nothing else: `uf.config.js` is
+  where a task's meaning is written down and `vp run` cannot read it.
 - Keep app execution runtime-agnostic through Capability JS Hosts: Node.js,
   Deno, and Bun.
 - Add LSP JSON-RPC loop over config, parser diagnostics, formatter, and lints.


### PR DESCRIPTION
Refs #272 — the part that issue says comes first: *"The decision comes first and the code follows it, because 'delegate to Vite Task' and 'do it natively' are both defensible and the config currently claims the first while doing neither."*

**The code has since answered: natively.** `uf_task` builds the dependency graph, runs independent nodes up to a concurrency limit, and answers from `.uf/cache/task` keyed on the files each task declares it reads. `uf run` has `--concurrency`, `--force` and `--why`, `TaskCommand` has `inputs`/`outputs`/`cache`, and `uf explain` reports `run`'s provider — which was the honesty half of #272.

Two claims did not move with it, and **the roadmap now contradicts itself**:

- **Line 16** already says tasks run natively, and that "Vite Task still runs a task that names no command of its own".
- **Line 94** still said flatly that "task execution goes through Vite Task" — true of exactly the command-less case and of nothing anybody writes.

`TaskRunnerEngine`'s own documentation said the same: *"Vite+'s Rust task runner, invoked through the public `vp run` interface"*, describing what the variant did before `execute_task` narrowed it. The comment there records why it was narrowed — handing `ci` to `vp run ci` asked Vite+ for a script it had never heard of, so every task defined in `uf.config.js` failed both on a machine that had `vp` and on one that did not.

**No behaviour changes.** This is the sentence catching up with the code.

## What #272 still wants

Not closing it. Of its three "either way" items:

1. `TaskCommand` gains `inputs`, `outputs`, `cache` — **done**
2. independent `depends_on` run concurrently, with a limit — **done** (`Concurrency`, `DEFAULT_CONCURRENCY`, `--concurrency`)
3. `--filter` addresses workspace packages — **not done**, and it is what is left

`uf run` has no `--filter` and cannot address a workspace package, over the discovery `uf_pm::install_workspace` already has. That is the remaining work on that issue, and it is a feature rather than a correction, so it is not in this change.

`uf run docs:verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791479042&installation_model_id=422833&pr_number=687&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F687&signature=dd77e0170fa04981ff2e96ea2bfabb0b4ab2468405eabc532ca6a27a41eb92df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->