### PR TITLE
feat(cli, ui): the commands an agent can call over MCP, and the stdout a protocol needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ reference, with every flag and exit code.
 | `uf info`, `uf inspect`, `uf explain` | What uf found, what your config resolved to, and which provider does each stage of a command |
 | `uf prepare` | The code generation and checks a commit should not go without; `--fix` makes the checks write |
 | `uf lsp` | The language server, over stdio |
+| `uf mcp` | The same commands as MCP tools, over stdio, for an agent |
 | `uf env`, `uf use`, `uf self-update` | The JavaScript hosts a project pins, the shared store they live in, and the uf that runs it |
 
 ## One config file

--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -428,6 +428,11 @@ pub(crate) enum Commands {
     },
     /// Serve the language server over stdin/stdout, for an editor.
     Lsp,
+    /// Serve the Model Context Protocol over stdin/stdout, for an agent.
+    ///
+    /// The read-only commands become tools of the same name; the two that
+    /// write are separate and say so: `uf_fmt_write`, `uf_lint_fix`.
+    Mcp,
     /// Run the checks and code generation a commit should not go without.
     Prepare {
         /// Apply `uf lint`'s safe fixes to the staged files and format them,
@@ -803,6 +808,7 @@ impl Commands {
             Self::Complete { .. }
             | Self::Completion { .. }
             | Self::Lsp
+            | Self::Mcp
             | Self::Transform
             | Self::Assets => true,
             Self::Run { script, .. } => script.is_some(),

--- a/crates/uf_cli/src/commands.rs
+++ b/crates/uf_cli/src/commands.rs
@@ -21,6 +21,7 @@ pub(crate) mod i18n;
 pub(crate) mod info;
 pub(crate) mod inspect;
 pub(crate) mod lint;
+pub(crate) mod mcp;
 pub(crate) mod pm;
 pub(crate) mod prepare;
 pub(crate) mod release;

--- a/crates/uf_cli/src/commands/completion.rs
+++ b/crates/uf_cli/src/commands/completion.rs
@@ -56,6 +56,7 @@ const COMMANDS: &[&str] = &[
     "lint",
     "ls",
     "lsp",
+    "mcp",
     "prepare",
     "preview",
     "publish",

--- a/crates/uf_cli/src/commands/completion/tests.rs
+++ b/crates/uf_cli/src/commands/completion/tests.rs
@@ -81,6 +81,7 @@ fn explain_completes_everything_it_can_explain() {
         "exec",
         "env",
         "lsp",
+        "mcp",
         "self-update",
         "use",
         "ls",

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -79,6 +79,7 @@ pub(crate) const KNOWN: &[&str] = &[
     "publish",
     "release",
     "lsp",
+    "mcp",
 ];
 
 pub(crate) fn explain(cwd: &Utf8Path, ui: &mut Ui, command: &str, as_json: bool) -> Result<()> {
@@ -221,6 +222,7 @@ fn stages_for(command: &str, resolved: &ResolvedConfig) -> Option<Vec<Stage>> {
         "publish" => publish_stages(resolved),
         "release" => release_stages(resolved),
         "lsp" => lsp_stages(resolved),
+        "mcp" => mcp_stages(),
         _ => return None,
     })
 }
@@ -603,6 +605,38 @@ fn lsp_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
             detail: format!(
                 "the same printer `uf fmt` uses, at {} columns",
                 resolved.config.fmt.line_width
+            ),
+        },
+    ]
+}
+
+/// `uf mcp`, whose two facts are the framing and the fact that it runs the
+/// commands rather than reimplementing them.
+fn mcp_stages() -> Vec<Stage> {
+    let tools = crate::commands::mcp::tools();
+    let writes = tools
+        .iter()
+        .filter(|tool| {
+            tool["description"]
+                .as_str()
+                .is_some_and(|text| text.contains("WRITES"))
+        })
+        .count();
+    vec![
+        Stage {
+            name: "transport",
+            provider: "uf".to_string(),
+            // Not `uf lsp`'s framing, and the difference is the whole reason
+            // this line is here: MCP's stdio transport is one JSON message per
+            // line, with no `Content-Length` header.
+            detail: "JSON-RPC over stdio, newline-delimited".to_string(),
+        },
+        Stage {
+            name: "tools",
+            provider: "uf".to_string(),
+            detail: format!(
+                "{} tools over the same commands this CLI runs; {writes} of them write",
+                tools.len()
             ),
         },
     ]

--- a/crates/uf_cli/src/commands/mcp.rs
+++ b/crates/uf_cli/src/commands/mcp.rs
@@ -123,6 +123,19 @@ fn serve(input: &mut impl BufRead, output: &mut impl Write, cwd: &Utf8Path) -> R
             respond_error(output, Value::Null, PARSE_ERROR, "the line was not JSON")?;
             continue;
         };
+        // A line that parsed but is not an object: an array (JSON-RPC batching,
+        // which MCP's stdio transport does not use), or a bare scalar. There is
+        // no `id` to answer with, so it is answered with a null one — silence
+        // would leave a client waiting for a reply that is never coming.
+        if !message.is_object() {
+            respond_error(
+                output,
+                Value::Null,
+                INVALID_REQUEST,
+                "a message must be a JSON object; this server does not accept batches",
+            )?;
+            continue;
+        }
         let id = message.get("id").cloned();
         let Some(method) = message.get("method").and_then(Value::as_str) else {
             // A notification with no method is nothing; a request with none is

--- a/crates/uf_cli/src/commands/mcp.rs
+++ b/crates/uf_cli/src/commands/mcp.rs
@@ -1,0 +1,507 @@
+//! `uf mcp`: the toolchain over the Model Context Protocol, on stdio.
+//!
+//! An agent that wants `uf check`'s diagnostics today spawns `uf check --json`
+//! and parses what comes back. This is the same answers over a protocol built
+//! for asking: a tool per command, JSON Schema for the arguments, and a result
+//! the caller does not have to know a shell to obtain. See
+//! ubugeeei-prod/uf#507.
+//!
+//! # It runs the commands rather than reimplementing them
+//!
+//! Every tool below calls the same function `crates/uf_cli/src/lib.rs`
+//! dispatches to — `check`, `lint`, `info`, `routes`, `explain`, `test`, `fmt`
+//! — with a `Ui` that captures stdout instead of writing it. That is the whole
+//! reason [`Ui::capturing`] exists: a tool that formatted its own JSON would be
+//! a second surface, and the two would drift the first time a diagnostic gained
+//! a field.
+//!
+//! [`SPECS`] is the one table both `tools/list` and `tools/call` read, so an
+//! advertised tool and a dispatched one cannot come apart either.
+//!
+//! It is also a correctness requirement rather than a preference. **stdout is
+//! the protocol here.** A command that wrote its own output to the real stdout
+//! would interleave with the JSON-RPC frames and corrupt the stream, which is
+//! why capturing had to come first.
+//!
+//! # Framing
+//!
+//! Newline-delimited JSON, which is MCP's stdio transport — one message per
+//! line, no `Content-Length`. That is *not* what `uf lsp` beside it uses:
+//! LSP frames with headers, and the two are different protocols that happen to
+//! share JSON-RPC. Mixing them up produces a server that looks right and that
+//! no client can talk to.
+//!
+//! # What is exposed, and what is marked
+//!
+//! The read-only commands are tools of the same name. The two that write —
+//! `uf fmt --write` and `uf lint --fix` — are separate tools whose names say so
+//! (`uf_fmt_write`, `uf_lint_fix`), because an agent choosing a tool from a
+//! list should not have to read a description to learn that one edits the
+//! checkout.
+//!
+//! `uf_test` is the third case and is neither: it writes nothing, but it
+//! executes the project's own code, which is not what "reads only" promises.
+//! [`Effect`] is the three-way distinction, and every description ends with
+//! the sentence for its own — a tool that says "Reads only" means it.
+//!
+//! # What a real client found
+//!
+//! Two bugs here were invisible to unit tests and immediate the first time the
+//! official MCP SDK's client was pointed at the server, which is why
+//! `tests/library/mcp.test.js` drives the real binary:
+//!
+//! - `uf_info` returned an empty string, because [`Ui::render`] writes nothing
+//!   in JSON mode and `uf info` only renders. [`Speaks`] is the fix: the mode
+//!   is a property of the command, not a constant.
+//! - A failing `uf_check` returned its JSON report with the failure sentence
+//!   appended, so the report no longer parsed. A command's output and the
+//!   reason it failed are now two content blocks.
+
+use anyhow::{Context, Result};
+use camino::Utf8Path;
+use serde_json::{Value, json};
+use std::io::{BufRead, IsTerminal, Write};
+
+use crate::commands;
+use crate::fix::files::FixMode;
+use crate::ui::{OutputMode, Ui};
+
+/// The protocol version this server speaks.
+///
+/// `initialize` answers with this one whatever the client asked for, which is
+/// what the specification calls for: a server that does not support the
+/// requested version responds with one it does, and lets the client decide
+/// whether it can proceed. Echoing an unknown version back instead would
+/// claim support this server has not got.
+const PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// JSON-RPC's own codes, the three this server can raise.
+const PARSE_ERROR: i64 = -32700;
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+
+/// Serve the Model Context Protocol on stdio until the input ends.
+///
+/// # Errors
+///
+/// When stdin cannot be read or stdout cannot be written. A malformed message
+/// is answered with a JSON-RPC error and is not one of these.
+pub(crate) fn mcp(cwd: &Utf8Path) -> Result<()> {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout().lock();
+
+    // The same courtesy `uf lsp` extends: a person who typed this at a prompt
+    // gets a sentence rather than a server that appears to hang.
+    if stdin.is_terminal() {
+        writeln!(stdout, "uf mcp: Model Context Protocol stdio server ready")
+            .with_context(|| "failed to write the mcp banner")?;
+        return Ok(());
+    }
+
+    serve(&mut std::io::BufReader::new(stdin.lock()), &mut stdout, cwd)
+}
+
+/// The message loop, over any pair of streams.
+///
+/// Separated from [`mcp`] so that the protocol can be tested without a
+/// subprocess: everything above this line is stdio, everything below it is MCP.
+fn serve(input: &mut impl BufRead, output: &mut impl Write, cwd: &Utf8Path) -> Result<()> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = input
+            .read_line(&mut line)
+            .with_context(|| "failed to read from stdin")?;
+        if read == 0 {
+            return Ok(());
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let Ok(message) = serde_json::from_str::<Value>(&line) else {
+            respond_error(output, Value::Null, PARSE_ERROR, "the line was not JSON")?;
+            continue;
+        };
+        let id = message.get("id").cloned();
+        let Some(method) = message.get("method").and_then(Value::as_str) else {
+            // A notification with no method is nothing; a request with none is
+            // a request nobody can answer.
+            if let Some(id) = id {
+                respond_error(
+                    output,
+                    id,
+                    INVALID_REQUEST,
+                    "the message carried no `method`",
+                )?;
+            }
+            continue;
+        };
+
+        match method {
+            "initialize" => {
+                respond(
+                    output,
+                    id,
+                    json!({
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": { "tools": {} },
+                        "serverInfo": {
+                            "name": "uf",
+                            "version": env!("CARGO_PKG_VERSION"),
+                        },
+                    }),
+                )?;
+            }
+            // Notifications are not answered, by the specification and by
+            // JSON-RPC: a reply to one has no `id` to carry.
+            "notifications/initialized" | "notifications/cancelled" => {}
+            "ping" => respond(output, id, json!({}))?,
+            "tools/list" => respond(output, id, json!({ "tools": tools() }))?,
+            "tools/call" => {
+                let params = message.get("params").cloned().unwrap_or(Value::Null);
+                let name = params.get("name").and_then(Value::as_str).unwrap_or("");
+                let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
+                let outcome = call(cwd, name, &arguments);
+                respond(output, id, outcome)?;
+            }
+            other => {
+                if let Some(id) = id {
+                    respond_error(
+                        output,
+                        id,
+                        METHOD_NOT_FOUND,
+                        &format!("this server has no method {other:?}"),
+                    )?;
+                }
+            }
+        }
+    }
+}
+
+/// What a tool does to the project, which is the first thing a caller
+/// choosing one from a list needs to know.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Effect {
+    /// Reads the project and reports. Nothing on disk changes and no project
+    /// code runs.
+    Reads,
+    /// Rewrites files in the checkout.
+    Writes,
+    /// Executes the project's own code.
+    Runs,
+}
+
+impl Effect {
+    /// The sentence every description ends with, so that the warning is in
+    /// the prose as well as in the name.
+    fn note(self) -> &'static str {
+        match self {
+            Self::Reads => "Reads only.",
+            Self::Writes => "WRITES to files in the checkout.",
+            Self::Runs => "RUNS the project's own code.",
+        }
+    }
+}
+
+/// Which output a command produces, and so which [`OutputMode`] it must be
+/// given.
+///
+/// **Not decoration.** [`Ui::render`] writes nothing at all in JSON mode, so a
+/// command that only renders — `uf info`, `uf routes list` — returns an empty
+/// string when asked for JSON. Getting this wrong is silent: the tool call
+/// succeeds and hands back nothing, which is what the first client to try it
+/// found.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Speaks {
+    /// The command has a `--json` shape, and that is what the tool returns.
+    Json,
+    /// The command renders a report for a reader; the tool returns that text,
+    /// unstyled.
+    Prose,
+}
+
+impl Speaks {
+    fn mode(self) -> OutputMode {
+        match self {
+            Self::Json => OutputMode::Json,
+            Self::Prose => OutputMode::Human,
+        }
+    }
+}
+
+/// One tool: everything both [`tools`] and [`call`] need to agree about.
+///
+/// A single table rather than a list and a `match` that happen to line up,
+/// because the drift between an advertised tool and a dispatched one is
+/// exactly what #507 asks this server not to have.
+struct Spec {
+    name: &'static str,
+    effect: Effect,
+    speaks: Speaks,
+    description: &'static str,
+    schema: fn() -> Value,
+}
+
+/// A schema with no arguments at all.
+fn no_arguments() -> Value {
+    json!({ "type": "object", "properties": {}, "additionalProperties": false })
+}
+
+/// A schema whose only argument is the usual optional list of paths.
+fn paths_only() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "paths": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Files or directories to act on. Defaults to the whole project.",
+            },
+        },
+        "additionalProperties": false,
+    })
+}
+
+fn explain_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "The command to explain, such as `build` or `test`.",
+            },
+        },
+        "required": ["command"],
+        "additionalProperties": false,
+    })
+}
+
+fn test_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "filter": {
+                "type": "string",
+                "description": "Keep only tests whose fully qualified name contains this.",
+            },
+            "paths": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Only run files whose path contains one of these. Defaults to \
+                                the whole suite.",
+            },
+        },
+        "additionalProperties": false,
+    })
+}
+
+/// Every tool this server exposes.
+///
+/// Named for the command each one runs, so that a caller who knows uf knows
+/// this list, and the two that write say so in the name.
+const SPECS: &[Spec] = &[
+    Spec {
+        name: "uf_check",
+        effect: Effect::Reads,
+        speaks: Speaks::Json,
+        description: "Type-check the project with Flow and report diagnostics as JSON.",
+        schema: paths_only,
+    },
+    Spec {
+        name: "uf_lint",
+        effect: Effect::Reads,
+        speaks: Speaks::Json,
+        description: "Lint the project and report diagnostics as JSON.",
+        schema: paths_only,
+    },
+    Spec {
+        name: "uf_info",
+        effect: Effect::Reads,
+        speaks: Speaks::Prose,
+        description: "What uf resolved about this project: versions, hosts, and the \
+                      configuration in effect.",
+        schema: no_arguments,
+    },
+    Spec {
+        name: "uf_routes",
+        effect: Effect::Reads,
+        speaks: Speaks::Prose,
+        description: "The route table, as `uf build` counts it: which file serves which URL path.",
+        schema: no_arguments,
+    },
+    Spec {
+        name: "uf_explain",
+        effect: Effect::Reads,
+        speaks: Speaks::Json,
+        description: "Explain how uf will run one command \u{2014} the provider, the stages, and \
+                      what decided each.",
+        schema: explain_schema,
+    },
+    Spec {
+        name: "uf_test",
+        effect: Effect::Runs,
+        speaks: Speaks::Json,
+        description: "Run the project's tests and report the results as JSON.",
+        schema: test_schema,
+    },
+    Spec {
+        name: "uf_fmt_write",
+        effect: Effect::Writes,
+        speaks: Speaks::Prose,
+        description: "Format the project and write the result to disk.",
+        schema: paths_only,
+    },
+    Spec {
+        name: "uf_lint_fix",
+        effect: Effect::Writes,
+        speaks: Speaks::Json,
+        description: "Lint the project and write every safe fix to disk.",
+        schema: paths_only,
+    },
+];
+
+/// The `tools/list` payload.
+pub(crate) fn tools() -> Vec<Value> {
+    SPECS
+        .iter()
+        .map(|spec| {
+            json!({
+                "name": spec.name,
+                "description": format!("{} {}", spec.description, spec.effect.note()),
+                "inputSchema": (spec.schema)(),
+            })
+        })
+        .collect()
+}
+
+/// Run one tool and shape the result the way `tools/call` answers.
+///
+/// A command that fails is a tool result with `isError`, not a JSON-RPC error:
+/// the call succeeded and the answer is that the project does not check. A
+/// protocol error would tell the caller its *request* was wrong, which is a
+/// different thing and the distinction the specification draws.
+fn call(cwd: &Utf8Path, name: &str, arguments: &Value) -> Value {
+    let Some(spec) = SPECS.iter().find(|spec| spec.name == name) else {
+        return json!({
+            "content": [{ "type": "text", "text": format!("no tool named {name:?}") }],
+            "isError": true,
+        });
+    };
+
+    let paths: Vec<String> = arguments
+        .get("paths")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    let json = spec.speaks == Speaks::Json;
+
+    let mut ui = Ui::capturing(spec.speaks.mode());
+    let outcome = match spec.name {
+        "uf_check" => commands::check::check(cwd, &mut ui, json, FixMode::Report, &paths),
+        "uf_lint" => commands::lint::lint_command(
+            cwd,
+            &mut ui,
+            commands::lint::LintCommand::Lint,
+            json,
+            FixMode::Report,
+            &paths,
+        ),
+        "uf_info" => commands::info::info(cwd, &mut ui),
+        "uf_routes" => commands::routes::routes(cwd, &mut ui, crate::cli::RoutesCommand::List),
+        "uf_explain" => {
+            let command = arguments
+                .get("command")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            commands::explain::explain(cwd, &mut ui, command, json)
+        }
+        "uf_test" => commands::test::test(
+            cwd,
+            &mut ui,
+            commands::test::TestArgs {
+                json,
+                filter: arguments
+                    .get("filter")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
+                paths,
+                ..Default::default()
+            },
+        ),
+        "uf_fmt_write" => commands::fmt::fmt(cwd, &mut ui, false, &paths),
+        "uf_lint_fix" => commands::lint::lint_command(
+            cwd,
+            &mut ui,
+            commands::lint::LintCommand::Lint,
+            json,
+            FixMode::Safe,
+            &paths,
+        ),
+        // Unreachable while the contract test passes: `SPECS` is what was
+        // searched above, so a name that resolved to a spec and has no arm
+        // here is a tool added to the table and nowhere else.
+        other => {
+            return json!({
+                "content": [{ "type": "text", "text": format!("no tool named {other:?}") }],
+                "isError": true,
+            });
+        }
+    };
+
+    // What the command wrote is one block, whole. A command that failed adds
+    // the reason as a *second* block rather than appending it: the output is
+    // usually JSON and usually the interesting half, and a sentence glued to
+    // the end of it is a document that no longer parses.
+    let written = ui.take_captured();
+    let mut content = Vec::new();
+    if !written.is_empty() {
+        content.push(json!({ "type": "text", "text": written }));
+    }
+    let failed = match outcome {
+        Ok(()) => false,
+        Err(error) => {
+            content.push(json!({ "type": "text", "text": format!("{error:#}") }));
+            true
+        }
+    };
+    // A command that succeeded in silence still owes the caller a block, since
+    // an empty `content` is a result with nothing in it to read.
+    if content.is_empty() {
+        content.push(json!({ "type": "text", "text": "" }));
+    }
+    json!({ "content": content, "isError": failed })
+}
+
+/// Write one JSON-RPC result, or nothing when the message was a notification.
+fn respond(stdout: &mut impl Write, id: Option<Value>, result: Value) -> Result<()> {
+    let Some(id) = id else { return Ok(()) };
+    write_message(
+        stdout,
+        &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+    )
+}
+
+/// Write one JSON-RPC error.
+fn respond_error(stdout: &mut impl Write, id: Value, code: i64, message: &str) -> Result<()> {
+    write_message(
+        stdout,
+        &json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } }),
+    )
+}
+
+/// One message, one line, flushed — a client is waiting on it.
+fn write_message(stdout: &mut impl Write, message: &Value) -> Result<()> {
+    let line = serde_json::to_string(message).with_context(|| "failed to serialise a reply")?;
+    writeln!(stdout, "{line}").with_context(|| "failed to write to stdout")?;
+    stdout.flush().with_context(|| "failed to flush stdout")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_cli/src/commands/mcp/tests.rs
+++ b/crates/uf_cli/src/commands/mcp/tests.rs
@@ -1,0 +1,389 @@
+use camino::Utf8PathBuf;
+use serde_json::{Value, json};
+
+use super::*;
+
+/// Drive the server with a script of messages and read back what it wrote.
+///
+/// One line per message, which is the transport: a test that passed a slice of
+/// `Value`s would be testing a function this server does not have.
+fn exchange(cwd: &Utf8Path, messages: &[Value]) -> Vec<Value> {
+    let script = messages
+        .iter()
+        .map(|message| serde_json::to_string(message).expect("a message serialises"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    replies(cwd, &script)
+}
+
+/// The same, for input a well-formed client would never send.
+fn replies(cwd: &Utf8Path, script: &str) -> Vec<Value> {
+    let mut input = std::io::Cursor::new(script.as_bytes().to_vec());
+    let mut output = Vec::new();
+    serve(&mut input, &mut output, cwd).expect("the server reads to the end");
+    let text = String::from_utf8(output).expect("replies are UTF-8");
+    text.lines()
+        .map(|line| serde_json::from_str(line).expect("every reply is one JSON line"))
+        .collect()
+}
+
+fn scratch() -> tempfile::TempDir {
+    tempfile::tempdir().expect("a temporary directory")
+}
+
+fn path_of(dir: &tempfile::TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("a UTF-8 temporary path")
+}
+
+fn request(id: u32, method: &str, params: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params })
+}
+
+#[test]
+fn initialize_answers_with_the_version_this_server_speaks() {
+    let dir = scratch();
+    let out = exchange(
+        &path_of(&dir),
+        &[request(
+            1,
+            "initialize",
+            json!({ "protocolVersion": PROTOCOL_VERSION }),
+        )],
+    );
+
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0]["id"], 1);
+    assert_eq!(out[0]["jsonrpc"], "2.0");
+    assert_eq!(out[0]["result"]["protocolVersion"], PROTOCOL_VERSION);
+    assert_eq!(out[0]["result"]["serverInfo"]["name"], "uf");
+    // Tools are the whole capability set: no resources, no prompts, and
+    // saying so is how a client knows not to ask.
+    assert!(out[0]["result"]["capabilities"]["tools"].is_object());
+    assert!(out[0]["result"]["capabilities"].get("resources").is_none());
+}
+
+/// A client asking for a version this server does not speak is told which one
+/// it does, rather than having its own echoed back at it.
+#[test]
+fn initialize_does_not_claim_a_version_it_was_merely_asked_for() {
+    let dir = scratch();
+    let out = exchange(
+        &path_of(&dir),
+        &[request(
+            1,
+            "initialize",
+            json!({ "protocolVersion": "3000-01-01" }),
+        )],
+    );
+
+    assert_eq!(out[0]["result"]["protocolVersion"], PROTOCOL_VERSION);
+}
+
+#[test]
+fn a_notification_is_not_answered() {
+    let dir = scratch();
+    let out = exchange(
+        &path_of(&dir),
+        &[
+            json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+            request(7, "ping", json!({})),
+        ],
+    );
+
+    // Only the ping. A reply to the notification would have no `id` to carry
+    // and would desynchronise a client counting responses.
+    assert_eq!(out.len(), 1, "{out:?}");
+    assert_eq!(out[0]["id"], 7);
+}
+
+#[test]
+fn an_unknown_method_is_a_protocol_error() {
+    let dir = scratch();
+    let out = exchange(&path_of(&dir), &[request(2, "resources/list", json!({}))]);
+
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0]["error"]["code"], METHOD_NOT_FOUND);
+    assert!(out[0].get("result").is_none());
+}
+
+/// A bad line is answered and the session continues. The alternative — closing
+/// the stream — loses every request behind it over one client's bad frame.
+#[test]
+fn a_line_that_is_not_json_does_not_end_the_session() {
+    let dir = scratch();
+    let out = replies(
+        &path_of(&dir),
+        "{ not json\n\n{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"ping\"}\n",
+    );
+
+    assert_eq!(out.len(), 2, "{out:?}");
+    assert_eq!(out[0]["error"]["code"], PARSE_ERROR);
+    assert_eq!(out[0]["id"], Value::Null);
+    // And the blank line between them was skipped rather than answered.
+    assert_eq!(out[1]["id"], 9);
+}
+
+#[test]
+fn tools_list_names_the_commands_and_says_which_ones_write() {
+    let dir = scratch();
+    let out = exchange(&path_of(&dir), &[request(3, "tools/list", json!({}))]);
+
+    let listed = out[0]["result"]["tools"]
+        .as_array()
+        .expect("a list of tools")
+        .iter()
+        .map(|tool| tool["name"].as_str().expect("a name").to_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        listed,
+        [
+            "uf_check",
+            "uf_lint",
+            "uf_info",
+            "uf_routes",
+            "uf_explain",
+            "uf_test",
+            "uf_fmt_write",
+            "uf_lint_fix",
+        ]
+    );
+}
+
+/// The names carry the warning as well as the prose: an agent picking from a
+/// list should not have to read a description to learn that a tool edits the
+/// checkout.
+#[test]
+fn the_tools_that_write_are_named_for_it() {
+    for tool in tools() {
+        let name = tool["name"].as_str().expect("a name");
+        let description = tool["description"].as_str().expect("a description");
+        let named_as_writing = name.ends_with("_write") || name.ends_with("_fix");
+        assert_eq!(
+            named_as_writing,
+            description.contains(Effect::Writes.note()),
+            "{name} and its description disagree about writing"
+        );
+    }
+}
+
+/// Every description ends with exactly one of the three sentences, so that a
+/// tool claiming "Reads only" is one that does.
+#[test]
+fn every_description_states_one_effect() {
+    let notes = [Effect::Reads, Effect::Writes, Effect::Runs].map(Effect::note);
+    for tool in tools() {
+        let name = tool["name"].as_str().expect("a name");
+        let description = tool["description"].as_str().expect("a description");
+        let stated = notes
+            .iter()
+            .filter(|note| description.contains(*note))
+            .count();
+        assert_eq!(stated, 1, "{name}: {description}");
+        assert!(description.ends_with('.'), "{name}");
+    }
+}
+
+/// The one tool that runs project code says so rather than passing for a
+/// reader.
+#[test]
+fn running_the_suite_is_not_described_as_reading() {
+    let test_tool = tools()
+        .into_iter()
+        .find(|tool| tool["name"] == "uf_test")
+        .expect("uf_test is exposed");
+    let description = test_tool["description"].as_str().expect("a description");
+
+    assert!(description.contains(Effect::Runs.note()), "{description}");
+    assert!(!description.contains(Effect::Reads.note()), "{description}");
+}
+
+#[test]
+fn every_tool_declares_an_object_schema() {
+    for tool in tools() {
+        let name = tool["name"].as_str().expect("a name").to_owned();
+        let schema = &tool["inputSchema"];
+        assert_eq!(schema["type"], "object", "{name}");
+        assert!(schema["properties"].is_object(), "{name}");
+        // Closed, so that a client sending a misspelled argument is told
+        // rather than silently ignored.
+        assert_eq!(schema["additionalProperties"], false, "{name}");
+    }
+}
+
+/// The contract that keeps [`tools`] and [`call`] from drifting apart: a tool
+/// this server advertises is a tool it dispatches. Nothing but a test can hold
+/// this — the list is data and the dispatch is a `match`, and they are only
+/// the same by hand.
+#[test]
+fn every_advertised_tool_is_one_the_server_dispatches() {
+    let dir = scratch();
+    let cwd = path_of(&dir);
+
+    for tool in tools() {
+        let name = tool["name"].as_str().expect("a name").to_owned();
+        let result = call(&cwd, &name, &json!({ "command": "build" }));
+        let text = result["content"][0]["text"]
+            .as_str()
+            .expect("a text block")
+            .to_owned();
+        assert!(
+            !text.contains("no tool named"),
+            "{name} is listed but not dispatched"
+        );
+    }
+}
+
+#[test]
+fn an_unknown_tool_is_a_tool_error_not_a_protocol_error() {
+    let dir = scratch();
+    let out = exchange(
+        &path_of(&dir),
+        &[request(
+            4,
+            "tools/call",
+            json!({ "name": "uf_rm_rf", "arguments": {} }),
+        )],
+    );
+
+    // The request was well-formed and this server answered it. What it says is
+    // that there is no such tool — which is a result, not a JSON-RPC failure.
+    assert!(out[0].get("error").is_none(), "{:?}", out[0]);
+    assert_eq!(out[0]["result"]["isError"], true);
+    assert!(
+        out[0]["result"]["content"][0]["text"]
+            .as_str()
+            .expect("a text block")
+            .contains("uf_rm_rf")
+    );
+}
+
+/// The point of the whole exercise: what comes back is the command's own
+/// output, not something this module formatted.
+#[test]
+fn a_tool_returns_what_the_command_itself_printed() {
+    let dir = scratch();
+    let out = exchange(
+        &path_of(&dir),
+        &[request(
+            5,
+            "tools/call",
+            json!({ "name": "uf_check", "arguments": {} }),
+        )],
+    );
+
+    assert_eq!(out[0]["result"]["isError"], false, "{:?}", out[0]);
+    let text = out[0]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("a text block");
+    let report: Value = serde_json::from_str(text).expect("uf check's own JSON, unaltered");
+    assert_eq!(report["command"], "uf check");
+    assert_eq!(report["filesChecked"], 0);
+}
+
+/// A command that fails is still a tool call that succeeded, and the reason
+/// comes back as text rather than as a protocol failure.
+#[test]
+fn a_command_that_fails_is_a_tool_error_carrying_its_reason() {
+    let dir = scratch();
+    let out = exchange(
+        &path_of(&dir),
+        &[request(
+            6,
+            "tools/call",
+            json!({ "name": "uf_explain", "arguments": { "command": "not-a-command" } }),
+        )],
+    );
+
+    assert!(out[0].get("error").is_none(), "{:?}", out[0]);
+    assert_eq!(out[0]["result"]["isError"], true);
+    // `uf explain` bails before printing anything, so the reason is the only
+    // block — an empty one ahead of it would be noise.
+    let blocks = out[0]["result"]["content"]
+        .as_array()
+        .expect("content blocks");
+    assert_eq!(blocks.len(), 1, "{blocks:?}");
+    assert!(
+        blocks[0]["text"]
+            .as_str()
+            .expect("a text block")
+            .contains("not-a-command")
+    );
+}
+
+/// A project whose sources do not parse: `uf lint` reports and exits non-zero.
+fn broken_project() -> tempfile::TempDir {
+    let dir = scratch();
+    let root = dir.path();
+    std::fs::write(root.join("uf.config.js"), "export default {};\n").expect("a config");
+    std::fs::write(
+        root.join("package.json"),
+        "{\"name\":\"broken\",\"private\":true}\n",
+    )
+    .expect("a manifest");
+    std::fs::create_dir_all(root.join("src")).expect("a source directory");
+    std::fs::write(root.join("src/bad.js"), "// @flow\nexport function f( {\n")
+        .expect("a source file");
+    dir
+}
+
+/// The regression the first real client found: a failing command's report and
+/// the reason it failed are two blocks, so the report is still the JSON
+/// document it was. One block carrying both parses as neither.
+#[test]
+fn a_failing_commands_report_is_still_parseable() {
+    let dir = broken_project();
+    let out = exchange(
+        &path_of(&dir),
+        &[request(
+            8,
+            "tools/call",
+            json!({ "name": "uf_lint", "arguments": {} }),
+        )],
+    );
+
+    assert_eq!(out[0]["result"]["isError"], true, "{:?}", out[0]);
+    let blocks = out[0]["result"]["content"]
+        .as_array()
+        .expect("content blocks");
+    assert_eq!(blocks.len(), 2, "{blocks:?}");
+
+    let report: Value = serde_json::from_str(blocks[0]["text"].as_str().expect("a report"))
+        .expect("the report is JSON on its own");
+    assert_eq!(report["command"], "uf lint");
+    assert!(
+        report["errors"].as_u64().expect("a count") > 0,
+        "{report:?}"
+    );
+    // And the reason is prose, in its own block, where it cannot corrupt it.
+    assert!(serde_json::from_str::<Value>(blocks[1]["text"].as_str().expect("a reason")).is_err());
+}
+
+/// The bug the same client found first: a command that renders for a reader
+/// must not be run in JSON mode, where `Ui::render` writes nothing at all.
+#[test]
+fn a_command_that_renders_for_a_reader_returns_its_text() {
+    let dir = broken_project();
+    let out = exchange(
+        &path_of(&dir),
+        &[request(
+            9,
+            "tools/call",
+            json!({ "name": "uf_info", "arguments": {} }),
+        )],
+    );
+
+    let text = out[0]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("a text block");
+    assert!(!text.is_empty(), "uf_info returned nothing");
+    assert!(text.contains("uf"), "{text}");
+}
+
+/// `serve` returns when the input does, rather than treating a closed stdin as
+/// an error: a client that exits is a session that ended.
+#[test]
+fn the_session_ends_when_the_input_does() {
+    let dir = scratch();
+    assert!(replies(&path_of(&dir), "").is_empty());
+}

--- a/crates/uf_cli/src/commands/mcp/tests.rs
+++ b/crates/uf_cli/src/commands/mcp/tests.rs
@@ -380,6 +380,27 @@ fn a_command_that_renders_for_a_reader_returns_its_text() {
     assert!(text.contains("uf"), "{text}");
 }
 
+/// A JSON value that is not an object — an array, which is how JSON-RPC spells
+/// a batch, or a bare scalar. Neither is a message this server can act on, and
+/// both must be *answered*: a client waiting on a reply that never comes is a
+/// worse failure than one told its request was invalid.
+#[test]
+fn a_message_that_is_not_an_object_is_refused_rather_than_ignored() {
+    let dir = scratch();
+    let out = replies(
+        &path_of(&dir),
+        "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}]\n42\n{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"ping\"}\n",
+    );
+
+    assert_eq!(out.len(), 3, "{out:?}");
+    for refused in &out[..2] {
+        assert_eq!(refused["error"]["code"], INVALID_REQUEST);
+        assert_eq!(refused["id"], Value::Null);
+    }
+    // And the well-formed request behind them was still answered.
+    assert_eq!(out[2]["id"], 3);
+}
+
 /// `serve` returns when the input does, rather than treating a closed stdin as
 /// an error: a client that exits is a session that ended.
 #[test]

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -328,6 +328,7 @@ fn run(cli: Cli, target: Option<&str>, ui: &mut Ui) -> Result<()> {
         ),
         Commands::Clean { deps, dry_run } => commands::clean::clean(&cwd, ui, deps, dry_run),
         Commands::Lsp => commands::dev::lsp(&cwd),
+        Commands::Mcp => commands::mcp::mcp(&cwd),
         Commands::Preview { host, port, mode } => {
             commands::serve::preview(&cwd, ui, commands::serve::ServeArgs { host, port, mode })
         }

--- a/crates/uf_cli/src/ui.rs
+++ b/crates/uf_cli/src/ui.rs
@@ -30,6 +30,17 @@ pub(crate) struct Ui {
     stderr: Renderer,
     mode: OutputMode,
     buffer: String,
+    /// Where stdout goes, when it is not going to stdout.
+    ///
+    /// `None` for every command a person runs. `Some` for a caller that has to
+    /// *read* what a command wrote rather than let it reach the terminal —
+    /// which is `uf mcp`, where stdout carries the JSON-RPC frames and a
+    /// command's own output written there would corrupt the protocol.
+    ///
+    /// stderr is deliberately not captured. It is where a server logs, no
+    /// machine output goes there, and a command's warnings reaching the
+    /// operator is correct in both cases.
+    captured: Option<String>,
 }
 
 impl Ui {
@@ -41,6 +52,43 @@ impl Ui {
             stderr: Renderer::new(Capabilities::for_stderr(choice, &env)),
             mode,
             buffer: String::with_capacity(8 * 1024),
+            captured: None,
+        }
+    }
+
+    /// A [`Ui`] whose stdout is a string the caller can read back.
+    ///
+    /// The command runs unchanged — same code, same `--json`, same everything
+    /// a terminal would have got — and what it wrote is taken with
+    /// [`Ui::take_captured`]. Capabilities are resolved as if stdout were not
+    /// a terminal, because it is not: a captured stream has no width and no
+    /// colour, and a caller reading it back wants the plain form.
+    pub(crate) fn capturing(mode: OutputMode) -> Self {
+        Self {
+            stdout: Renderer::new(Capabilities::plain()),
+            stderr: Renderer::new(Capabilities::plain()),
+            mode,
+            buffer: String::with_capacity(8 * 1024),
+            captured: Some(String::new()),
+        }
+    }
+
+    /// Everything written to stdout since the last take, leaving it empty.
+    ///
+    /// Empty for a [`Ui`] that is not capturing, which is the honest answer:
+    /// what it wrote went to the terminal and is not uf's to hand back.
+    pub(crate) fn take_captured(&mut self) -> String {
+        self.captured
+            .as_mut()
+            .map(std::mem::take)
+            .unwrap_or_default()
+    }
+
+    /// Write to stdout, or to the capture buffer when there is one.
+    fn write_out(&mut self, text: &str) {
+        match &mut self.captured {
+            Some(sink) => sink.push_str(text),
+            None => write_all(&mut io::stdout().lock(), text),
         }
     }
 
@@ -56,7 +104,11 @@ impl Ui {
         }
         self.buffer.clear();
         body(&self.stdout, &mut self.buffer);
-        write_all(&mut io::stdout().lock(), &self.buffer);
+        // Lent out and put back, so the reusable allocation survives a write
+        // that needs `&mut self` while the text it writes lives in `self`.
+        let rendered = std::mem::take(&mut self.buffer);
+        self.write_out(&rendered);
+        self.buffer = rendered;
     }
 
     /// Render a block to stderr. Always rendered, including in JSON mode,
@@ -77,7 +129,7 @@ impl Ui {
     /// the silence [`Ui::render`] would give it, since both commands are in
     /// JSON mode precisely because they own stdout.
     pub(crate) fn plain(&mut self, text: &str) {
-        write_all(&mut io::stdout().lock(), text);
+        self.write_out(text);
     }
 
     /// Write text to stderr exactly as given, with no styling and no framing.
@@ -96,7 +148,7 @@ impl Ui {
     pub(crate) fn json(&mut self, value: &serde_json::Value) -> serde_json::Result<()> {
         let mut rendered = serde_json::to_string_pretty(value)?;
         rendered.push('\n');
-        write_all(&mut io::stdout().lock(), &rendered);
+        self.write_out(&rendered);
         Ok(())
     }
 
@@ -175,6 +227,46 @@ pub(crate) fn widest<'a>(values: impl IntoIterator<Item = &'a str>) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A capturing `Ui` hands back what a command wrote instead of printing it.
+    ///
+    /// The property `uf mcp` needs: stdout carries the JSON-RPC frames there,
+    /// so a command that wrote its own output to the real stdout would corrupt
+    /// the protocol. See ubugeeei-prod/uf#507.
+    #[test]
+    fn a_capturing_ui_keeps_stdout_instead_of_printing_it() {
+        let mut ui = Ui::capturing(OutputMode::Json);
+        ui.json(&serde_json::json!({ "ok": true }))
+            .expect("serialises");
+        ui.plain("tail\n");
+
+        let written = ui.take_captured();
+        assert!(written.contains("\"ok\": true"), "{written:?}");
+        assert!(written.ends_with("tail\n"), "{written:?}");
+        // Taken, not copied: a second call sees only what came after.
+        assert_eq!(ui.take_captured(), "");
+    }
+
+    /// Human rendering is captured too, not only the machine output.
+    ///
+    /// `--json` is not the only thing an in-process caller might want back, and
+    /// a capture that silently dropped the rendered form would be a second
+    /// surface — which is the thing #507 exists to avoid.
+    #[test]
+    fn a_capturing_ui_keeps_rendered_output_as_well() {
+        let mut ui = Ui::capturing(OutputMode::Human);
+        ui.render(|_, out| out.push_str("rendered\n"));
+        ui.render(|_, out| out.push_str("twice\n"));
+
+        assert_eq!(ui.take_captured(), "rendered\ntwice\n");
+    }
+
+    /// And a `Ui` that is not capturing says so rather than inventing output.
+    #[test]
+    fn an_ordinary_ui_captures_nothing() {
+        let mut ui = Ui::new(ColorChoice::Never, OutputMode::Json);
+        assert_eq!(ui.take_captured(), "");
+    }
 
     #[test]
     fn json_mode_suppresses_human_rendering() {

--- a/crates/uf_cli/tests/every_command.rs
+++ b/crates/uf_cli/tests/every_command.rs
@@ -76,6 +76,10 @@ const COVERAGE: &[(&str, &str)] = &[
     ("lint", "here, and output.rs for the report"),
     ("lsp", "cli.rs: speaks a protocol over stdio"),
     (
+        "mcp",
+        "tests/library/mcp.test.js: speaks MCP over stdio, against this binary",
+    ),
+    (
         "prepare",
         "here, and prepare.rs for the staged set and the steps",
     ),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1173,6 +1173,36 @@ it, reading `.` instead of the directory it resolved. That is a bug in the
 server rather than in the clients; until it is fixed, `cwd` is the only thing
 that works, and every README under `editors/` says so.
 
+`uf mcp` is the same idea for an agent rather than an editor, and shares no code
+with `uf lsp` beyond the observation that both are JSON-RPC. The transports are
+different: LSP frames each message with a `Content-Length` header, and MCP's
+stdio transport is one JSON message per line. `tests/library/mcp.test.js`
+asserts the framing against the real binary for exactly that reason — a server
+that confused the two would pass every unit test and talk to no client.
+
+What it exposes is the commands themselves. Each tool calls the function
+`crates/uf_cli/src/lib.rs` already dispatches to, with a `Ui` that captures
+stdout instead of writing it (`Ui::capturing`), and returns what the command
+printed. That is not a preference: in a stdio server stdout *is* the protocol,
+so a command writing its own output would corrupt the stream. It also means
+there is no second surface to drift — a diagnostic that gains a field gains it
+here on the same commit.
+
+One table, `SPECS`, is what `tools/list` advertises and what `tools/call`
+dispatches, and it carries two things per tool. `Effect` is the three-way
+distinction a caller needs before choosing: reads, writes, or runs the
+project's code — stated in the name for the two that write (`uf_fmt_write`,
+`uf_lint_fix`) and in the last sentence of every description. `Speaks` is which
+`OutputMode` the command needs, and it is load-bearing rather than
+housekeeping: `Ui::render` writes nothing at all in JSON mode, so `uf info` and
+`uf routes list` return an empty string if they are asked for JSON. Both of
+those were found by pointing the official MCP SDK's client at the server, which
+is the check a unit test cannot make.
+
+Unlike `uf lsp`, `uf mcp` takes the resolved working directory as an argument,
+so `uf --cwd <project> mcp` works and an agent can name the project on the
+command line.
+
 Native package output follows a napi-rs-style target model. The generated
 TypeScript declaration files are converted into Flow declaration files so the
 repository and published library surface remain Flow-first.

--- a/tests/library/mcp.test.js
+++ b/tests/library/mcp.test.js
@@ -1,0 +1,270 @@
+// @flow
+//
+// `uf mcp`, driven the way an agent drives it.
+//
+// The sibling of `lsp.test.js`, and deliberately so: both are JSON-RPC over
+// stdio and they are *not* the same wire. LSP frames with `Content-Length`
+// headers; MCP's stdio transport is one JSON message per line. A server that
+// confused the two would look right in every unit test and would not talk to
+// any client, so the framing is asserted here, against the real binary, rather
+// than assumed.
+//
+// The binary is the one running this suite: `uf test` puts its own path in
+// `UF_BINARY`, which is what makes this a test about this checkout rather than
+// about whatever `uf` is on PATH.
+//
+// What is checked here and not in `crates/uf_cli/src/commands/mcp/tests.rs` is
+// everything that only a subprocess can show: the framing, the fact that
+// nothing else writes to stdout, and that a tool's answer survives the trip.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "@uniflowed/test";
+
+const UF: string = (() => {
+  const binary = process.env.UF_BINARY;
+  if (binary == null || binary === "") {
+    throw new Error(
+      "UF_BINARY is not set: this test drives `uf mcp`, and `uf test` is what names the binary",
+    );
+  }
+  return binary;
+})();
+
+type Message = { [string]: mixed };
+
+type Content = { type: string, text: string };
+type Tool = { name: string, description: string, inputSchema: { type: string, ... } };
+type Result = {
+  protocolVersion?: string,
+  capabilities?: { tools?: { ... } },
+  serverInfo?: { name: string, version: string },
+  tools?: Array<Tool>,
+  content?: Array<Content>,
+  isError?: boolean,
+};
+type Wire = {
+  jsonrpc: string,
+  id?: number,
+  result?: Result,
+  error?: { code: number, message: string },
+};
+
+/**
+ * Run one conversation against `uf mcp` and parse everything it said.
+ *
+ * One message per line going in, one reply per line coming back — and the
+ * parse below is the assertion that it *is* one per line: a stray banner, a
+ * log line, or a `Content-Length` header would make `JSON.parse` throw.
+ */
+const session = (messages: Array<Message>, cwd: string): Array<Wire> => {
+  const run = spawnSync(UF, ["mcp"], {
+    input: messages.map((message) => `${JSON.stringify(message)}\n`).join(""),
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (run.status !== 0) {
+    throw new Error(`uf mcp exited with ${String(run.status)}: ${String(run.stderr)}`);
+  }
+  return run.stdout
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line));
+};
+
+const request = (id: number, method: string, params?: Message): Message => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  ...(params == null ? {} : { params }),
+});
+
+const INITIALIZE: Message = request(1, "initialize", {
+  protocolVersion: "2024-11-05",
+  capabilities: {},
+  clientInfo: { name: "uf-test", version: "0" },
+});
+
+const answered = (messages: Array<Wire>, id: number): Result => {
+  const found = messages.find((message) => message.id === id);
+  if (found == null) {
+    throw new Error(`no answer for id ${id} in ${JSON.stringify(messages)}`);
+  }
+  if (found.result == null) {
+    throw new Error(`id ${id} answered with an error: ${JSON.stringify(found.error)}`);
+  }
+  return found.result;
+};
+
+/** The text blocks of a `tools/call` answer. */
+const blocks = (messages: Array<Wire>, id: number): Array<Content> => {
+  const content = answered(messages, id).content;
+  if (content == null) {
+    throw new Error(`id ${id} was not a tool result`);
+  }
+  return content;
+};
+
+const callTool = (id: number, name: string, args: Message = {}): Message =>
+  request(id, "tools/call", { name, arguments: args });
+
+/** A project uf can load, whose one source file does not parse. */
+const brokenProject = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "uf-mcp-"));
+  fs.writeFileSync(path.join(root, "uf.config.js"), "export default {};\n");
+  fs.writeFileSync(path.join(root, "package.json"), '{"name":"broken","private":true}\n');
+  fs.mkdirSync(path.join(root, "src"));
+  fs.writeFileSync(path.join(root, "src", "bad.js"), "// @flow\nexport function f( {\n");
+  return root;
+};
+
+describe("uf mcp", () => {
+  it("speaks newline-delimited JSON, not LSP's framing", () => {
+    const root = brokenProject();
+    const run = spawnSync(UF, ["mcp"], {
+      input: `${JSON.stringify(INITIALIZE)}\n`,
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(run.status).toBe(0);
+    // The whole of stdout is one line of JSON: no header, no banner, nothing
+    // a client would have to skip past.
+    expect(run.stdout).not.toContain("Content-Length");
+    expect(run.stdout.trimEnd().split("\n")).toHaveLength(1);
+    expect(JSON.parse(run.stdout).result.serverInfo.name).toBe("uf");
+  });
+
+  it("answers initialize with the version it speaks and the tools capability", () => {
+    const out = session([INITIALIZE], brokenProject());
+    const result = answered(out, 1);
+
+    expect(result.protocolVersion).toBe("2024-11-05");
+    expect(result.capabilities?.tools).toBeDefined();
+    expect(result.serverInfo?.name).toBe("uf");
+  });
+
+  it("does not answer a notification", () => {
+    const out = session(
+      [INITIALIZE, { jsonrpc: "2.0", method: "notifications/initialized" }, request(2, "ping")],
+      brokenProject(),
+    );
+
+    // Two requests, two replies. A third would desynchronise a client that
+    // counts them.
+    expect(out).toHaveLength(2);
+    expect(out.map((message) => message.id)).toEqual([1, 2]);
+  });
+
+  it("lists the commands as tools, and names the ones that write", () => {
+    const out = session([INITIALIZE, request(2, "tools/list")], brokenProject());
+    const tools = answered(out, 2).tools ?? [];
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "uf_check",
+      "uf_lint",
+      "uf_info",
+      "uf_routes",
+      "uf_explain",
+      "uf_test",
+      "uf_fmt_write",
+      "uf_lint_fix",
+    ]);
+    for (const tool of tools) {
+      expect(tool.inputSchema.type).toBe("object");
+      const writes = tool.name.endsWith("_write") || tool.name.endsWith("_fix");
+      expect(tool.description.includes("WRITES")).toBe(writes);
+    }
+  });
+
+  // The two halves of the bug the first real MCP client found: a command that
+  // renders for a reader returned nothing when it was run in JSON mode, and a
+  // command that failed had the reason appended to its JSON report.
+  it("returns the text of a command that renders for a reader", () => {
+    const out = session([INITIALIZE, callTool(2, "uf_info")], brokenProject());
+    const content = blocks(out, 2);
+
+    expect(answered(out, 2).isError).toBe(false);
+    expect(content).toHaveLength(1);
+    expect(content[0].text.length).toBeGreaterThan(0);
+  });
+
+  it("keeps a failing command's report parseable, in its own block", () => {
+    const out = session([INITIALIZE, callTool(2, "uf_lint")], brokenProject());
+    const content = blocks(out, 2);
+
+    expect(answered(out, 2).isError).toBe(true);
+    expect(content).toHaveLength(2);
+
+    // The report, whole, exactly as `uf lint --json` writes it.
+    const report = JSON.parse(content[0].text);
+    expect(report.command).toBe("uf lint");
+    expect(report.errors).toBeGreaterThan(0);
+    // And the reason beside it, where it cannot corrupt the report.
+    expect(content[1].text).toContain("uf lint");
+  });
+
+  it("answers an unknown tool as a tool error, not a protocol error", () => {
+    const out = session([INITIALIZE, callTool(2, "uf_rm_rf")], brokenProject());
+
+    expect(out.find((message) => message.id === 2)?.error).toBeUndefined();
+    expect(answered(out, 2).isError).toBe(true);
+    expect(blocks(out, 2)[0].text).toContain("uf_rm_rf");
+  });
+
+  it("answers an unknown method as a protocol error", () => {
+    const out = session([INITIALIZE, request(2, "resources/list")], brokenProject());
+    const found = out.find((message) => message.id === 2);
+
+    expect(found?.error?.code).toBe(-32601);
+    expect(found?.result).toBeUndefined();
+  });
+
+  // `uf lsp` reads `load_config(".")` and so ignores the `--cwd` it was given,
+  // which is why every editor README under `editors/` has to talk about the
+  // working directory. `uf mcp` takes the resolved directory as an argument,
+  // and this is the test that keeps it that way: an agent naming the project
+  // on the command line is the ordinary case, not the exception.
+  it("honours --cwd, unlike uf lsp", () => {
+    const root = brokenProject();
+    const elsewhere = fs.mkdtempSync(path.join(os.tmpdir(), "uf-mcp-elsewhere-"));
+    const run = spawnSync(UF, ["--cwd", root, "mcp"], {
+      input: `${JSON.stringify(INITIALIZE)}\n${JSON.stringify(callTool(2, "uf_lint"))}\n`,
+      cwd: elsewhere,
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const out = run.stdout
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => JSON.parse(line));
+
+    // The broken file is in `root`, and `elsewhere` is empty: a server that
+    // read its own working directory would have found nothing to report.
+    const report = JSON.parse(blocks(out, 2)[0].text);
+    expect(report.errors).toBeGreaterThan(0);
+    expect(report.diagnostics[0].path).toBe("src/bad.js");
+  });
+
+  it("survives a line that is not JSON", () => {
+    const root = brokenProject();
+    const run = spawnSync(UF, ["mcp"], {
+      input: `{ not json\n${JSON.stringify(request(2, "ping"))}\n`,
+      cwd: root,
+      encoding: "utf8",
+    });
+    const out = run.stdout
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => JSON.parse(line));
+
+    expect(out).toHaveLength(2);
+    expect(out[0].error?.code).toBe(-32700);
+    // And the request behind the bad line was still answered, which is the
+    // point: one client's bad frame must not lose everything after it.
+    expect(out[1].id).toBe(2);
+  });
+});


### PR DESCRIPTION
`uf mcp` speaks the Model Context Protocol on stdio. Closes #507.

```
$ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | uf mcp
```

| tool | effect |
| --- | --- |
| `uf_check`, `uf_lint`, `uf_info`, `uf_routes`, `uf_explain` | reads only |
| `uf_test` | runs the project's code |
| `uf_fmt_write`, `uf_lint_fix` | writes to the checkout |

The two that write are named for it, so a caller picking from a list need not
read prose to learn that one edits the checkout. `uf_test` is the third case
and is neither — it writes nothing but runs the project's own code — so
`Effect` is a three-way distinction and every description ends with the
sentence for its own.

## It runs the commands, rather than reimplementing them

Each tool calls the same function `crates/uf_cli/src/lib.rs` already dispatches
to. One `SPECS` table is both what `tools/list` advertises and what
`tools/call` dispatches, so an advertised tool and a dispatched one cannot come
apart; a test walks the list and calls each name.

## The sink

In a stdio server stdout *is* the protocol, so a command writing its own output
would corrupt the stream. `Ui::capturing` runs a command unchanged — same code,
same `--json` — and hands back what it wrote. `render`, `plain` and `json` now
route through one `write_out`; every existing caller is unaffected, and
`Ui::new` still writes to stdout exactly as before.

It could not land on its own: clippy's `-D warnings` rejects a constructor with
no consumer, which is the honest signal that the sink and its first caller are
one change.

## What a real client found

Two bugs were invisible to unit tests and immediate the first time the official
MCP SDK's client was pointed at the server:

- **`uf_info` returned an empty string.** `Ui::render` writes nothing in JSON
  mode and `uf info` only renders, so it returned nothing at all — silently,
  with `isError: false`. The output mode had to become a property of the
  command (`Speaks`) rather than a constant.
- **A failing `uf_check` returned unparseable JSON.** The failure sentence was
  appended to the report. Output and reason are now two content blocks, so the
  report stays the document it was.

`tests/library/mcp.test.js` drives the real binary for exactly that reason.

## Framing

MCP's stdio transport is one JSON message per line — *not* the `Content-Length`
frames `uf lsp` uses beside it. Two protocols that share JSON-RPC and nothing
else; confusing them yields a server that passes every unit test and talks to
no client, so the framing is asserted against the real binary.

Unlike `uf lsp`, which reads `load_config(".")` and ignores the `--cwd` it was
given, `uf mcp` takes the resolved directory as an argument. `uf --cwd
<project> mcp` works, and a test holds it.

## Verification

- 18 unit tests in `crates/uf_cli/src/commands/mcp/tests.rs`, 3 in `ui.rs`
- 10 end-to-end tests driving the real binary in `tests/library/mcp.test.js`
- `cargo test -p uf_cli` green (exit code read from cargo, not from a pipe); `cargo clippy --all-targets -- -D warnings` and
  `cargo fmt --check` clean
- connected with `@modelcontextprotocol/sdk`'s own `Client` over
  `StdioClientTransport`: negotiates, lists 8 tools, calls them, closes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791485321&installation_model_id=422833&pr_number=688&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F688&signature=dd69618ce7970c5d7422924614d21cdf8d81ab1b6cb882b86d6ab7c6fc564ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `uf mcp` command, providing Model Context Protocol access over newline-delimited JSON via standard input and output.
  - Exposes eight tools for checking, linting, formatting, testing, inspecting, and explaining projects.
  - Supports tool discovery, execution, structured results, error reporting, and working-directory selection.

- **Documentation**
  - Added `uf mcp` to command references, completion, explanations, and architecture documentation.

- **Tests**
  - Added comprehensive coverage for MCP protocol behavior, tool execution, errors, output formats, and command integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->