### PR TITLE
docs(host): two of Bun's three shut doors are open on 1.3.13

### DIFF
--- a/packages/host/module-mocks.js
+++ b/packages/host/module-mocks.js
@@ -55,7 +55,7 @@
 // *mocked* package still gets a URL of its own, from its revision — being
 // stood in for is exactly the case where identity has to be given up.
 //
-// # Bun, and the three doors that are shut
+// # Bun, and the doors that were shut
 //
 // Bun is a declared host, and a suite that can replace a module on one host and
 // not the other is a suite a person cannot move between them
@@ -64,6 +64,22 @@
 // section is what a run of Bun 1.1.27 said when each way of using it was tried,
 // written down because "it did not work" is the kind of thing that gets tried
 // twice — and because each of the three looks obviously right until it is run.
+//
+// **Two of the three have since opened.** Re-run on **Bun 1.3.13**, the third
+// door below — a stand-in written after the process started — loads, and an
+// `onResolve` answering with its path redirects an `import` *declaration* and
+// not merely a dynamic `import()`. That is a whole mechanism: with the hook
+// installed once and a mutable registry consulted per resolution, a mock
+// registers and clears the way it does on Node. So the reason this file still
+// raises `UnsupportedError` on Bun is that nobody has written it, not that
+// Bun cannot — which is the opposite of what the three paragraphs below said
+// when they were written, and the reason they are kept with a date on them
+// rather than deleted.
+//
+// The first door is half open and it is not the useful half: the `ENOENT` is
+// gone, so a query-carrying path resolves and loads, but `onLoad` still never
+// sees the query and so cannot serve the stand-in's contents. The second is
+// still shut. The re-entrancy warning at the end of this section still holds.
 //
 // The whole design turns on giving the stand-in an identity of its own, so all
 // three questions are "where does *somewhere else* go":
@@ -87,6 +103,8 @@
 //     `ENOENT reading "file:/…"` even though `Bun.resolveSync` finds it and
 //     `import()` of the same absolute path loads it, so a mock registered
 //     while the suite runs cannot be written down anywhere Bun will read.
+//     **This is the one that opened**: on Bun 1.3.13 the file created after
+//     start-up loads, and this is the door to build on.
 //
 // Bun's own `mock.module` does all of this and is available outside `bun test`.
 // It is not the answer here, and the reason is above: it maintains live
@@ -104,7 +122,13 @@
 //
 // So `uft.mock` raises `UnsupportedError` on Bun, naming the host and what it
 // would take, and `crates/uf_cli/tests/bun_host.rs` starts a real Bun and holds
-// it to that. Until one of the three doors opens, that message is the feature.
+// it to that.
+//
+// That message is still the right one to give today, and it is worth being
+// exact about why now that a door has opened: it says this *implementation*
+// needs `registerHooks` and Bun has none, which stays true. What is no longer
+// true is the conclusion a reader would draw from it. The work is writing a
+// second implementation against the plugin API, not waiting for Bun.
 
 import * as nodeModule from "node:module";
 


### PR DESCRIPTION
Comment-only. No behaviour changes.

`packages/host/module-mocks.js` carries a section titled "Bun, and the three doors that are shut" — what each way of mocking a module did when it was tried, *"written down because 'it did not work' is the kind of thing that gets tried twice"*. #419 repeats it and strikes out its own earlier supposition on the same evidence.

That evidence is from **Bun 1.1.27**. Eight minor versions later, on **1.3.13**, two of the three answers have changed — so the note that exists to stop a wasted attempt is now steering people away from the door that opened.

## Re-run, all three

**The third door is open, and it is a whole mechanism.** A stand-in written *after* the process started loads — it was `ENOENT` — and an `onResolve` answering with its path redirects an `import` **declaration**, not merely a dynamic `import()`, which is the case the feature exists for. With the hook installed once and a registry consulted per resolution, the lifecycle works:

```
  before any mock : real
  with a mock     : STAND-IN
  after clearing  : real
```

**The first is half open and not the useful half.** The `ENOENT` on a query-carrying path is gone, and `import("./x.js?n=1")` returns a distinct instance instead of never returning. But `onLoad` still never sees the query — filtered on the query it does not fire, filtered on the bare name it does not fire for a redirected path — so the identity can be minted and the contents cannot be served through it.

**The second is still shut.** A plugin namespace for an `import` declaration: `Cannot find package 'uf-mock:client-stand-in'`. Different message from the recorded `InvalidURL`, same door.

The re-entrancy warning at the end of that section still holds — every probe needed the guard it describes.

## What does not change

`uft.mock` still raises `UnsupportedError` on Bun, `crates/uf_cli/tests/bun_host.rs` still holds it to that, and the message is still the right one: it says *this implementation* needs `registerHooks` and Bun has none, which stays true.

What changed is the conclusion a reader draws. The work is writing a second implementation against the plugin API — not waiting for Bun. The reproductions are on [#419](https://github.com/ubugeeei-prod/uf/issues/419); implementing it is that issue's own work and not this PR.

Verified: `uf fmt --check` and `uf lint` clean, and the 78 tests in `module-mock.test.js` and `mock.test.js` pass — a comment change should not move them, and it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791491710&installation_model_id=422833&pr_number=693&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F693&signature=f5eac777d22157ee191470d48bdad31f5fbd6350eaf454f8987593e15fd00481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->