### PR TITLE
docs(cli, mcp): `uf check --json`'s `errors` counts findings `diagnostics` does not hold

### DIFF
--- a/crates/uf_cli/src/commands/mcp.rs
+++ b/crates/uf_cli/src/commands/mcp.rs
@@ -318,7 +318,10 @@ const SPECS: &[Spec] = &[
         name: "uf_check",
         effect: Effect::Reads,
         speaks: Speaks::Json,
-        description: "Type-check the project with Flow and report diagnostics as JSON.",
+        description: "Type-check the project with Flow and report diagnostics as JSON. \
+                      The report holds two lists: `diagnostics` is lint findings and \
+                      `typeCheck.diagnostics` is type errors, and `errors` is the sum \
+                      of both \u{2014} so a project can fail with `diagnostics` empty.",
         schema: paths_only,
     },
     Spec {

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -716,6 +716,26 @@ Type-checks the project with Flow. `--json` for the machine-readable report.
 apply the *lint* fixes. Type inference has no fix catalogue — a type error is
 not something uf knows how to rewrite.
 
+#### The `--json` report has two lists of diagnostics
+
+`uf check` is `uf lint` plus inference, and the report keeps the two kinds of
+finding apart — so **`errors` is a total, and `diagnostics` is not where the
+type errors are**:
+
+| Field | What is in it |
+| --- | --- |
+| `errors`, `warnings` | The **sum** across both lists |
+| `diagnostics` | Lint findings only — the same array `uf lint --json` writes |
+| `typeCheck.diagnostics` | Type errors, from the inference backend |
+| `typeCheck.status` | `checked`, or why inference did not run |
+| `typeCheck.backend`, `.filesChecked`, `.filesFromCache`, `.elapsedMs` | What inference did and how long it took |
+| `unavailableRules` | Lint rules that need inference uf does not implement yet, and did not run |
+
+A reader who counts `diagnostics` and reports that gets zero for a project with
+twenty type errors, because a project can fail `uf check` on inference alone
+and have nothing to say about its lints. Read `errors` for the verdict and both
+arrays for the detail.
+
 ### uf lint
 
 Runs uf's rules and Flow's built-in lints. `--json` for the report.


### PR DESCRIPTION
Documentation only. No behaviour change.

`uf check` is `uf lint` plus inference, and its `--json` report keeps the two kinds of finding apart. Nothing said so:

```
errors: 22   diagnostics: 0   typeCheck.diagnostics: 22
```

`errors` is the **sum**. `diagnostics` is the lint array — the same one `uf lint --json` writes. The type errors are under `typeCheck.diagnostics`. So a consumer that counts `diagnostics` and reports that finds zero problems in a project with twenty type errors, and that is not a corner case: it is the ordinary shape of a project whose lints are clean and whose types are not.

I hit this reading a real report while checking three files in `packages/server`, and had to go into `crates/uf_cli/src/commands/check.rs` to find out where the twenty-two had gone. `typeCheck` appears nowhere in the docs.

## What this adds

- A short table in the CLI reference beside `uf check`, saying what each field holds and that `errors` is a total.
- The same sentence in `uf mcp`'s `uf_check` tool description.

That second one is why this was worth finding rather than just noting. An agent picks a tool from a list by its description and then reads the JSON it gets back; `diagnostics: []` next to `errors: 22` is exactly the shape that gets misread by something with no way to ask a follow-up question. The tool now says where to look:

> Type-check the project with Flow and report diagnostics as JSON. The report holds two lists: `diagnostics` is lint findings and `typeCheck.diagnostics` is type errors, and `errors` is the sum of both — so a project can fail with `diagnostics` empty. Reads only.

The report's shape itself is deliberate and consumers depend on it, so nothing about it changes here.

Verified: 444 lib tests, `clippy --all-targets -- -D warnings` and `cargo fmt --check` clean, the 10 `mcp.test.js` end-to-end tests, and `docs-tables` / `docs-nav` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791495307&installation_model_id=422833&pr_number=694&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F694&signature=153a4945823375ebb39fd06a4bb9c0e0eb3f06b34f8c4317f75a0a3dfe6a485b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->