### PR TITLE
chore(release): uf@0.0.0-alpha.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,11 @@ binaries behind it. Two of the three doors Bun shut on module mocking have
 opened on 1.3.13, so what is left there is writing an implementation rather
 than waiting for Bun — the opposite of what that file said. And three release
 notes named a command uf does not have, one of them in the release before this:
-`uf profile`, `uf rm` and `uf approve-builds` are `uf_profiler`,
+what they called uf profile, uf rm and uf approve-builds are `uf_profiler`,
 `uf self-update` and `uf pm approve-builds`. A test asks clap now, and walks a
-nested path to its end, so there will not be a fourth.
+nested path to its end, so there will not be a fourth — and the three wrong
+names are unquoted right there because that test reads this file, and a
+backticked `uf <name>` in it is a thing a reader will type.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## uf@0.0.0-alpha.18
+
+_2026-09-08_
+
+Nine changes, and the thread running through most of them is a gap between
+what uf said and what uf did.
+
+`uf dev` streams a page now instead of collecting it. That was the one place a
+developer would notice streaming and the one place it did not happen, so a slow
+page showed nothing until it was finished and `_uf.loading.js` looked broken.
+`uf mcp` serves the read-only commands over a protocol an agent speaks, instead
+of leaving one to shell out and parse `--json`. And `uf build --adapter bun`
+writes a directory `bun server.js` runs — the second host, and it exists
+because somebody ran the benchmark the seam had been waiting on rather than
+assuming its result. Bun answers a dynamic route 32% faster and a small static
+asset 54% faster, and the whole of the static win is `Bun.file` rather than the
+handler around it, which is why the traversal and cookie policy stayed shared
+and only one line differs per host.
+
+The RSC check decides 57 hooks it used to ask about. `@uniflowed/hooks` has
+carried `server_component_safe` for every hook it exports since before
+`uf_rsc` existed, and nothing read it: a Server Component calling
+`useMediaQuery` got a warning saying uf could not say, from a binary that
+could. It is an error now, and it names the package. The hooks uf still cannot
+decide — `useRoute`, and anything a project wrote — say so exactly as before.
+
+The rest is the release pipeline and the notes about it. The Intel macOS target
+is built on Apple silicon and verified natively, which is the answer to the job
+that cost four times every other target and shipped alpha.9 to npm with no
+binaries behind it. Two of the three doors Bun shut on module mocking have
+opened on 1.3.13, so what is left there is writing an implementation rather
+than waiting for Bun — the opposite of what that file said. And three release
+notes named a command uf does not have, one of them in the release before this:
+`uf profile`, `uf rm` and `uf approve-builds` are `uf_profiler`,
+`uf self-update` and `uf pm approve-builds`. A test asks clap now, and walks a
+nested path to its end, so there will not be a fourth.
+
+### Added
+
+- **rsc, lib**: the hooks the registry already knew about are decided, not asked about (#690)
+- **server, vite, cli**: the bun deploy adapter, and the one line that makes it one (#689)
+- **cli, ui**: the commands an agent can call over MCP, and the stdout a protocol needs (#688)
+- **vite, router**: `uf dev` streams a page instead of collecting it (#685)
+
+### Documentation
+
+- **cli**: three release notes named a command uf does not have (#692)
+- **host**: two of Bun's three shut doors are open on 1.3.13 (#693)
+- **roadmap, config**: say that uf runs its own tasks, because it does (#687)
+
+### Internal
+
+- **deps**: Bump the fuzz group in /tools/fuzz with 2 updates (#691)
+- **release**: build the Intel macOS target on Apple silicon, verify it natively (#686)
+
 ## uf@0.0.0-alpha.17
 
 _2026-09-08_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,7 +3514,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_assets"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "ab_glyph",
  "base64",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "base64",
  "brotli",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "serde",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "serde",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "uf_i18n"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "serde",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "criterion",
  "phf",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "base64",
  "camino",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3813,14 +3813,14 @@ dependencies = [
 
 [[package]]
 name = "uf_profiler"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "compact_str",
  "serde",
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "serde",
  "smallvec",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "uf_task"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "base64",
  "camino",
@@ -3951,14 +3951,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "camino",
  "compact_str",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.17"
+version = "0.0.0-alpha.18"
 
 [workspace.dependencies]
 # Glyph outlines and coverage rasterisation, for `uf_assets::og`. Pure Rust

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.17",
-    "@uniflowed/config": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17",
-    "@uniflowed/router": "0.0.0-alpha.17",
-    "@uniflowed/vite": "0.0.0-alpha.17",
-    "@uniflowed/web": "0.0.0-alpha.17",
+    "@uniflowed/brand": "0.0.0-alpha.18",
+    "@uniflowed/config": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18",
+    "@uniflowed/router": "0.0.0-alpha.18",
+    "@uniflowed/vite": "0.0.0-alpha.18",
+    "@uniflowed/web": "0.0.0-alpha.18",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.17",
-        "@uniflowed/config": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17",
-        "@uniflowed/router": "0.0.0-alpha.17",
-        "@uniflowed/vite": "0.0.0-alpha.17",
-        "@uniflowed/web": "0.0.0-alpha.17",
+        "@uniflowed/brand": "0.0.0-alpha.18",
+        "@uniflowed/config": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18",
+        "@uniflowed/router": "0.0.0-alpha.18",
+        "@uniflowed/vite": "0.0.0-alpha.18",
+        "@uniflowed/web": "0.0.0-alpha.18",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       }
@@ -4392,65 +4392,65 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.17",
-        "@uniflowed/test": "0.0.0-alpha.17"
+        "@uniflowed/config": "0.0.0-alpha.18",
+        "@uniflowed/test": "0.0.0-alpha.18"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.17",
-        "@uniflowed/ui": "0.0.0-alpha.17",
-        "@uniflowed/validator": "0.0.0-alpha.17"
+        "@uniflowed/react": "0.0.0-alpha.18",
+        "@uniflowed/ui": "0.0.0-alpha.18",
+        "@uniflowed/validator": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4458,10 +4458,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.17"
+        "@uniflowed/fetch": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4469,19 +4469,19 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4489,120 +4489,120 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/i18n": {
       "name": "@uniflowed/i18n",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.17",
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/fetch": "0.0.0-alpha.17"
+        "@uniflowed/cell": "0.0.0-alpha.18",
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/fetch": "0.0.0-alpha.18"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.17",
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/config": "0.0.0-alpha.18",
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/hooks": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4610,7 +4610,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4618,28 +4618,28 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       }
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17",
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4649,7 +4649,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4658,20 +4658,20 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.17",
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/config": "0.0.0-alpha.18",
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.17",
-        "@uniflowed/server": "0.0.0-alpha.17"
+        "@uniflowed/hooks": "0.0.0-alpha.18",
+        "@uniflowed/server": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4680,46 +4680,46 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/cell": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17",
-        "@uniflowed/react-testing": "0.0.0-alpha.17",
-        "@uniflowed/test": "0.0.0-alpha.17"
+        "@uniflowed/mock": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18",
+        "@uniflowed/react-testing": "0.0.0-alpha.18",
+        "@uniflowed/test": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4727,26 +4727,26 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.17"
+        "@uniflowed/host": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "axe-core": ">=4"
@@ -4759,30 +4759,30 @@
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.17",
-        "@uniflowed/test": "0.0.0-alpha.17"
+        "@uniflowed/react-testing": "0.0.0-alpha.18",
+        "@uniflowed/test": "0.0.0-alpha.18"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.17",
+        "@uniflowed/react": "0.0.0-alpha.18",
         "react-reconciler": "^0.33.0"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/hooks": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/hooks": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4790,18 +4790,18 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.17",
-        "@uniflowed/server": "0.0.0-alpha.17",
+        "@uniflowed/host": "0.0.0-alpha.18",
+        "@uniflowed/server": "0.0.0-alpha.18",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4822,21 +4822,21 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.17",
-        "@uniflowed/core": "0.0.0-alpha.17"
+        "@uniflowed/browser": "0.0.0-alpha.18",
+        "@uniflowed/core": "0.0.0-alpha.18"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.17",
+      "version": "0.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.17",
-        "@uniflowed/hooks": "0.0.0-alpha.17",
-        "@uniflowed/react": "0.0.0-alpha.17"
+        "@uniflowed/core": "0.0.0-alpha.18",
+        "@uniflowed/hooks": "0.0.0-alpha.18",
+        "@uniflowed/react": "0.0.0-alpha.18"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Fine-grained reactivity: state, derived values, effects and resources, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "temporal.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.17",
-    "@uniflowed/test": "0.0.0-alpha.17"
+    "@uniflowed/config": "0.0.0-alpha.18",
+    "@uniflowed/test": "0.0.0-alpha.18"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "stream.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -26,9 +26,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.17",
-    "@uniflowed/ui": "0.0.0-alpha.17",
-    "@uniflowed/validator": "0.0.0-alpha.17"
+    "@uniflowed/react": "0.0.0-alpha.18",
+    "@uniflowed/ui": "0.0.0-alpha.18",
+    "@uniflowed/validator": "0.0.0-alpha.18"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.17"
+    "@uniflowed/fetch": "0.0.0-alpha.18"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,8 +27,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/i18n",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Type-safe internationalisation on MessageFormat 2: a message's arguments are checked at the call, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/cell": "0.0.0-alpha.17",
-    "@uniflowed/fetch": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/cell": "0.0.0-alpha.18",
+    "@uniflowed/fetch": "0.0.0-alpha.18"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.17",
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/config": "0.0.0-alpha.18",
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/hooks": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   }
 }

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17",
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.17",
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/config": "0.0.0-alpha.18",
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.17",
-    "@uniflowed/server": "0.0.0-alpha.17"
+    "@uniflowed/hooks": "0.0.0-alpha.18",
+    "@uniflowed/server": "0.0.0-alpha.18"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -44,6 +44,6 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/cell": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,10 +22,10 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17",
-    "@uniflowed/react-testing": "0.0.0-alpha.17",
-    "@uniflowed/test": "0.0.0-alpha.17"
+    "@uniflowed/mock": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18",
+    "@uniflowed/react-testing": "0.0.0-alpha.18",
+    "@uniflowed/test": "0.0.0-alpha.18"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,6 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -23,7 +23,7 @@
     "worker.js"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.17"
+    "@uniflowed/host": "0.0.0-alpha.18"
   },
   "peerDependencies": {
     "axe-core": ">=4"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.17",
-    "@uniflowed/test": "0.0.0-alpha.17"
+    "@uniflowed/react-testing": "0.0.0-alpha.18",
+    "@uniflowed/test": "0.0.0-alpha.18"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "A React renderer whose host is a terminal, following OpenTUI, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "internal/*.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.17",
+    "@uniflowed/react": "0.0.0-alpha.18",
     "react-reconciler": "^0.33.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -52,9 +52,9 @@
     "internal"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/hooks": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/hooks": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -33,8 +33,8 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.17",
-    "@uniflowed/server": "0.0.0-alpha.17",
+    "@uniflowed/host": "0.0.0-alpha.18",
+    "@uniflowed/server": "0.0.0-alpha.18",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.17",
-    "@uniflowed/core": "0.0.0-alpha.17"
+    "@uniflowed/browser": "0.0.0-alpha.18",
+    "@uniflowed/core": "0.0.0-alpha.18"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.17",
+  "version": "0.0.0-alpha.18",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,8 +23,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.17",
-    "@uniflowed/hooks": "0.0.0-alpha.17",
-    "@uniflowed/react": "0.0.0-alpha.17"
+    "@uniflowed/core": "0.0.0-alpha.18",
+    "@uniflowed/hooks": "0.0.0-alpha.18",
+    "@uniflowed/react": "0.0.0-alpha.18"
   }
 }


### PR DESCRIPTION
## Summary

`uf@0.0.0-alpha.18`. Nine changes since alpha.17, all merged today.

**Added**
- **#685** `uf dev` streams a page instead of collecting it — the one place a
  developer would notice streaming and the one place it did not happen.
- **#688** `uf mcp`, the read-only commands over a protocol an agent speaks.
- **#689** `uf build --adapter bun`, the second host, on a benchmark rather than
  an assumption.
- **#690** the RSC check decides 57 hooks it used to ask about.

**Documentation**
- **#692** three release notes named a command uf does not have.
- **#693** two of Bun's three shut doors on module mocking are open on 1.3.13.
- **#687** say that uf runs its own tasks.

**Internal**
- **#686** the Intel macOS target is built on Apple silicon and verified
  natively — the job that cost four times every other target.
- **#691** dependabot, the fuzz group.

Written by `uf release alpha` and `tools/release/bump-version.sh 0.0.0-alpha.18`,
in that order. The opening paragraphs are the only hand-written part.

## Verification

Locally, on this branch:

- [x] `tools/ci/changelog-covers-the-release.sh` — every commit in 6 released
      versions named
- [x] `tools/release/verify-npm.sh --closure-only`
- [x] `tools/release/test-bump-version.sh`
- [x] `tools/ci/publishable.sh` — 27 implemented, 15 published, 12 waiting on
      npm trust
- [x] `Cargo.toml`, every `packages/*/package.json`, `docs/package.json` and
      both lockfiles at `0.0.0-alpha.18`

After merge: the `uf@0.0.0-alpha.18` tag.

**Still true after this release, and only you can fix it:** `latest` is behind
on all 17 published names — `@uniflowed/core` is `latest=0.0.0-alpha.11` — so
`npm install @uniflowed/core` will give alpha.11 rather than this. The publish
workflow's OIDC token can publish and nothing else. `npm login` then
`tools/release/promote-latest.sh`, which is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791495721&installation_model_id=422833&pr_number=695&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F695&signature=3a75d492d742b412d5c19878b43a3b4f7df442ac5f4a42b835a4509d21ff61f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `uf dev` now streams pages.
  * `uf mcp` serves read-only commands through a protocol.
  * `uf build --adapter bun` produces a directory that Bun can run.

* **Bug Fixes**
  * RSC checks now automatically decide 57 previously interactive hooks.
  * Intel macOS builds are produced on Apple silicon.
  * Bun module mocking works with version 1.3.13.

* **Documentation**
  * Corrected release notes to reference the proper command names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->