### PR TITLE
feat(server): schedules, and the targets that may not hold one

### DIFF
--- a/docs/app/guide/routing/_uf.page.mdx
+++ b/docs/app/guide/routing/_uf.page.mdx
@@ -834,17 +834,59 @@ A queue is not `after()`. `after()` runs a callback in this process once the
 response has gone, with no retry and no record it ever existed, which is right
 for a metric and wrong for anything a user would notice missing.
 
+And work that no request starts at all is a schedule:
+
+```js
+// @flow
+import { defineSchedule } from "@uniflowed/server/schedule";
+import { serve } from "@uniflowed/server/node";
+
+const sweep = defineSchedule({
+  name: "sweep-sessions",
+  cron: "*/15 * * * *",
+  run: async () => expireSessions(),
+});
+
+await serve({ handle, staticDir, beginRequest, schedules: [sweep] });
+```
+
+**uf provides the expression's meaning and the decision that a minute is due —
+five fields, in UTC, run at most once per minute however often the scheduler is
+ticked. Your deployment provides something alive at that minute.** On a target
+that keeps a process uf ticks it itself, and `processScheduler` says what that
+is worth: a `setInterval` and nothing more, so a restart between two ticks
+misses whatever was due in the gap and two instances each run every schedule.
+
+The expression is five fields and only the syntax every cron agrees on: `*`,
+`n`, `a-b`, `*/n`, `a-b/n`, and comma-separated lists of those. No `@daily`, no
+`JAN`/`MON`, no seconds, no `L`/`W`/`#` — each of those is spelled differently
+by Vixie cron, Quartz and every cloud, and a schedule uf accepted and a platform
+read differently would be worse than one refused at the line that wrote it.
+When day-of-month and day-of-week are both restricted a time matches when
+**either** does, which is POSIX's rule: `0 0 1 * 1` is "the first, and every
+Monday".
+
+Fields are UTC. A container's zone and a platform scheduler's zone are not the
+same, and a schedule that meant different minutes in the two would be worse
+than one that always means the same minute.
+
+A target that keeps no process is **refused** an in-process schedule where the
+host is wired, because nothing would be running at the minute it names. Those
+targets need their platform's own scheduler pointed at the deployment, and
+emitting that configuration per platform is
+[#531](https://github.com/ubugeeei-prod/uf/issues/531).
+
 ### What each target can do
 
 The two questions that decide all three: does a response body reach the client
 as it is produced, and is the process still there once it has.
 
-| Target | Streams | Outlives the response | Event streams | WebSockets | In-process queue |
-| --- | --- | --- | --- | --- | --- |
-| `uf dev`, `uf preview`, `uf start` | yes | yes | yes | with an upgrader | yes |
-| `node`, `container`, `--compile` | yes | yes | yes | with an upgrader | yes |
-| `edge` | yes | no | yes | with an upgrader | **refused** |
-| `serverless` | no | no | **refused** | **refused** | **refused** |
+| Target | Streams | Outlives the response | Event streams | WebSockets | In-process queue | In-process schedule |
+| --- | --- | --- | --- | --- | --- | --- |
+| `uf dev`, `uf preview`, `uf start` | yes | yes | yes | with an upgrader | yes | yes |
+| `node`, `bun`, `container`, `--compile` | yes | yes | yes | with an upgrader | yes | yes |
+| `edge` | yes | no | yes | with an upgrader | **refused** | **refused** |
+| `serverless` | no | no | **refused** | **refused** | **refused** | **refused** |
 
 Refused means refused where the host is wired, before a single connection is
 accepted and dropped — a serverless deployment handed a WebSocket upgrader

--- a/packages/server/bun.js
+++ b/packages/server/bun.js
@@ -39,6 +39,8 @@ import type { CapabilityOptions, ServerCapabilities } from "./internal/capabilit
 import { assertCapable, capabilitiesFor } from "./internal/capabilities.js";
 import type { RequestLifecycle } from "./internal/context.js";
 import { locateStatic, staticRoot } from "./internal/static.js";
+import type { Schedule } from "./schedule.js";
+import { startSchedules } from "./schedule.js";
 import type { Logger } from "./internal/log.js";
 import { elapsedMs, logRequest, processLogger } from "./log.js";
 import { Temporal } from "@uniflowed/core/temporal";
@@ -152,6 +154,15 @@ export async function serve(options: {|
   readonly port?: number,
   /** Where this server's lines go. The process logger by default. */
   readonly log?: Logger,
+  /**
+   * Schedules to run in this process, from `./schedule.js`.
+   *
+   * Bun keeps a process, so it is one of the targets that can hold a
+   * scheduler rather than needing its platform to call one — the same as
+   * `./node.js`, through the same helper, so the two cannot drift about how
+   * often a tick happens. See ubugeeei-prod/uf#531.
+   */
+  readonly schedules?: $ReadOnlyArray<Schedule>,
 |}): Promise<{|
   readonly host: string,
   readonly port: number,
@@ -177,10 +188,13 @@ export async function serve(options: {|
   const shown = host === "0.0.0.0" || host === "::" ? "localhost" : host;
   process.stdout.write(`uf: listening on http://${shown}:${String(server.port)}\n`);
 
+  const stopSchedules = startSchedules(options.schedules, log);
+
   return {
     host,
     port: server.port,
     close: async () => {
+      stopSchedules();
       await server.stop(true);
     },
   };

--- a/packages/server/internal/capabilities.js
+++ b/packages/server/internal/capabilities.js
@@ -83,6 +83,12 @@ export type WebSocketUpgrade = {|
  */
 export type WebSocketUpgrader = (request: Request) => WebSocketUpgrade;
 
+/** Where scheduled work runs from; see `../schedule.js`. */
+export type SchedulerBackend = {|
+  readonly name: string,
+  readonly triggered: boolean,
+|};
+
 /** One unit of deferred work as it is stored; see `../queue.js`. */
 export type JobRecord = {|
   readonly id: string,
@@ -164,12 +170,22 @@ export type ServerCapabilities = {|
   readonly websocket: WebSocketUpgrader | null,
   /** Where `enqueue` puts work, or `null` where the deployment named none. */
   readonly queue: QueueBackend | null,
+  /**
+   * Where scheduled work runs from, or `null` where the deployment named none.
+   *
+   * Read by the adapters rather than by `../schedule.js`, the same way `queue`
+   * is: what the scheduler needs from a target is somewhere to be at the right
+   * minute, and whether that is uf's tick or the platform's own call is the
+   * one bit `triggered` carries.
+   */
+  readonly scheduler: SchedulerBackend | null,
 |};
 
 /** What a deployment may hand an adapter; everything else is the target's. */
 export type CapabilityOptions = {|
   readonly websocket?: WebSocketUpgrader | null,
   readonly queue?: QueueBackend | null,
+  readonly scheduler?: SchedulerBackend | null,
 |};
 
 /** Raised when a deployment is wired with something its target cannot do. */
@@ -239,6 +255,7 @@ export function capabilitiesFor(
     persistent: defaults.persistent,
     websocket: options?.websocket ?? null,
     queue: options?.queue ?? null,
+    scheduler: options?.scheduler ?? null,
   };
 }
 
@@ -265,6 +282,21 @@ export function assertCapable(capabilities: ServerCapabilities): ServerCapabilit
       capabilities.target,
       `queue (${queue.name})`,
       "the work would be pushed into a process that ends with this response and lost with it",
+    );
+  }
+  const scheduler = capabilities.scheduler;
+  if (scheduler != null && !scheduler.triggered && !capabilities.persistent) {
+    // The same shape as the queue rule above, and the same reason: a tick in a
+    // process that ends with the response is a schedule that never fires, and
+    // a deployment whose scheduled work silently never runs is the failure
+    // ubugeeei-prod/uf#531 exists to refuse. A target whose platform calls it
+    // (`triggered`) is fine here — what it still needs is the configuration
+    // naming the schedule, which is that issue's other half.
+    throw new CapabilityRefusedError(
+      capabilities.target,
+      `scheduler (${scheduler.name})`,
+      "nothing would be running at the minute the schedule names: this target keeps no " +
+        "process, and its platform has not been told to call one",
     );
   }
   return capabilities;

--- a/packages/server/internal/cron.js
+++ b/packages/server/internal/cron.js
@@ -158,7 +158,21 @@ function splitStep(
   if (!Number.isInteger(step) || step < 1) {
     throw fieldError(spec.name, part, source, `a step must be a whole number above zero`);
   }
-  return [term.slice(0, at), step];
+  const range = term.slice(0, at);
+  // `5/15` is the one form that would otherwise be read here as `5` with the
+  // step quietly dropped — an hourly-looking schedule that runs once a day.
+  // Vixie cron reads it as `5-59/15`, and this module's whole rule is that it
+  // accepts only what every cron agrees on; `n/step` is not on that list, so
+  // it is refused with the spelling that is.
+  if (range !== "*" && !range.includes("-")) {
+    throw fieldError(
+      spec.name,
+      part,
+      source,
+      `a step needs \`*\` or a range before it — write \`${range}-${String(spec.max)}/${String(step)}\``,
+    );
+  }
+  return [range, step];
 }
 
 /** `a-b` or `a` or `*` into the pair of numbers it covers. */

--- a/packages/server/internal/cron.js
+++ b/packages/server/internal/cron.js
@@ -1,0 +1,214 @@
+// @flow
+//
+// A five-field cron expression, and whether a given minute matches it.
+//
+// The matching half of ubugeeei-prod/uf#531. `crates/uf_std`'s `parse_cron` is
+// the other reading of the same string and stays where it is: it splits five
+// fields for a build that is *emitting* a platform's own cron configuration,
+// and never asks what they mean. This one has to know, because on a host that
+// keeps a process uf runs the schedule itself.
+//
+// # The syntax, and only this syntax
+//
+// Per field: `*`, `n`, `a-b`, `*/n`, `a-b/n`, and a comma-separated list of
+// those. No names (`JAN`, `MON`), no `@daily`, no seconds field, no `L`/`W`/`#`
+// — every one of those is spelled differently by Vixie cron, by Quartz and by
+// each cloud, and a schedule uf accepted and a platform read differently is
+// the failure this feature has everywhere it exists. What is here is the
+// intersection every one of them agrees on.
+//
+// # Which day wins
+//
+// When day-of-month and day-of-week are *both* restricted, a time matches when
+// **either** does — not both. That is POSIX's rule and it surprises everybody
+// once: `0 0 1 * 1` is "the first of the month, and every Monday", not "Mondays
+// that fall on the first". When only one of the two is restricted it simply has
+// to match, which is the reading people expect and the reason the surprise is
+// rare enough to be worth a comment rather than a different syntax.
+//
+// # UTC, and said out loud
+//
+// Fields are matched against UTC. A deployment's local time is not something
+// uf can know — the container has one zone, the platform's own scheduler has
+// another, and a schedule that meant different minutes in the two would be
+// worse than one that always means the same minute. Every cloud's cron
+// configuration is UTC for the same reason.
+
+import type { Instant } from "@uniflowed/core/temporal";
+
+/** One parsed field: the set of values that match, or `null` for `*`. */
+type Field = $ReadOnlySet<number> | null;
+
+/** A parsed five-field expression. */
+export type Cron = {|
+  readonly minute: Field,
+  readonly hour: Field,
+  readonly dayOfMonth: Field,
+  readonly month: Field,
+  readonly dayOfWeek: Field,
+  /** The expression as written, for an error message and for a manifest. */
+  readonly source: string,
+|};
+
+/** What a field may hold, and what to call it when it does not. */
+const FIELDS: $ReadOnlyArray<{|
+  readonly name: string,
+  readonly min: number,
+  readonly max: number,
+|}> = [
+  { name: "minute", min: 0, max: 59 },
+  { name: "hour", min: 0, max: 23 },
+  { name: "day-of-month", min: 1, max: 31 },
+  { name: "month", min: 1, max: 12 },
+  { name: "day-of-week", min: 0, max: 7 },
+];
+
+/**
+ * Parse `source`, or throw saying which field and why.
+ *
+ * Throws rather than returning `null`, because every caller is a
+ * `defineSchedule` at module scope: an expression that does not parse is a
+ * program that cannot run, and the sooner it says so the better.
+ */
+export function parseCron(source: string): Cron {
+  const parts = source.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    throw new SyntaxError(
+      `a cron expression has five fields (minute hour day-of-month month day-of-week); ` +
+        `${JSON.stringify(source)} has ${String(parts.length)}`,
+    );
+  }
+  const fields = parts.map((part, index) => parseField(part, FIELDS[index], source));
+  return {
+    minute: fields[0],
+    hour: fields[1],
+    dayOfMonth: fields[2],
+    month: fields[3],
+    // Both spellings of Sunday collapse to 0 here, so `dayOfWeekOf` below has
+    // one number to compare against rather than two.
+    dayOfWeek: fields[4] == null ? null : new Set([...fields[4]].map((day) => day % 7)),
+    source,
+  };
+}
+
+/** Whether `instant` falls in a minute this expression names. */
+export function cronMatches(cron: Cron, instant: Instant): boolean {
+  const at = instant.toZonedDateTimeISO("UTC");
+  if (!inField(cron.minute, at.minute)) return false;
+  if (!inField(cron.hour, at.hour)) return false;
+  if (!inField(cron.month, at.month)) return false;
+
+  const day = inField(cron.dayOfMonth, at.day);
+  const weekday = inField(cron.dayOfWeek, dayOfWeekOf(at.dayOfWeek));
+  // The POSIX rule, and the whole reason these two are not just two more
+  // `inField` calls above.
+  if (cron.dayOfMonth != null && cron.dayOfWeek != null) {
+    return day || weekday;
+  }
+  return day && weekday;
+}
+
+/** Cron's day-of-week from Temporal's, which counts from Monday. */
+function dayOfWeekOf(isoDayOfWeek: number): number {
+  // Temporal is 1 = Monday … 7 = Sunday; cron is 0 = Sunday … 6 = Saturday.
+  return isoDayOfWeek % 7;
+}
+
+function inField(field: Field, value: number): boolean {
+  return field == null || field.has(value);
+}
+
+function parseField(
+  part: string,
+  spec: {| readonly name: string, readonly min: number, readonly max: number |},
+  source: string,
+): Field {
+  if (part === "*") return null;
+
+  const values: Set<number> = new Set();
+  for (const term of part.split(",")) {
+    if (term === "") {
+      throw fieldError(spec.name, part, source, "an empty term between commas");
+    }
+    const [range, step] = splitStep(term, spec, part, source);
+    const [from, to] = splitRange(range, spec, part, source);
+    for (let value = from; value <= to; value += step) {
+      values.add(value);
+    }
+  }
+  // Unreachable through the parsing above — every term adds at least `from` —
+  // and checked anyway, because a field that matches nothing is a schedule
+  // that silently never runs, which is the one outcome worse than an error.
+  if (values.size === 0) {
+    throw fieldError(spec.name, part, source, "it matches no value");
+  }
+  return values;
+}
+
+/** `a-b/n` into `["a-b", n]`, with `n` defaulting to one. */
+function splitStep(
+  term: string,
+  spec: {| readonly name: string, readonly min: number, readonly max: number |},
+  part: string,
+  source: string,
+): [string, number] {
+  const at = term.indexOf("/");
+  if (at === -1) return [term, 1];
+  const step = Number(term.slice(at + 1));
+  if (!Number.isInteger(step) || step < 1) {
+    throw fieldError(spec.name, part, source, `a step must be a whole number above zero`);
+  }
+  return [term.slice(0, at), step];
+}
+
+/** `a-b` or `a` or `*` into the pair of numbers it covers. */
+function splitRange(
+  range: string,
+  spec: {| readonly name: string, readonly min: number, readonly max: number |},
+  part: string,
+  source: string,
+): [number, number] {
+  if (range === "*") return [spec.min, spec.max];
+
+  const at = range.indexOf("-");
+  if (at === -1) {
+    const only = numberIn(range, spec, part, source);
+    return [only, only];
+  }
+  const from = numberIn(range.slice(0, at), spec, part, source);
+  const to = numberIn(range.slice(at + 1), spec, part, source);
+  if (to < from) {
+    // No wrap-around. `22-2` is the kind of thing somebody writes meaning "late
+    // at night" and every cron reads as empty; refusing is better than either
+    // reading, because the two readings differ by twenty hours.
+    throw fieldError(spec.name, part, source, `${String(from)}-${String(to)} counts backwards`);
+  }
+  return [from, to];
+}
+
+function numberIn(
+  text: string,
+  spec: {| readonly name: string, readonly min: number, readonly max: number |},
+  part: string,
+  source: string,
+): number {
+  const value = Number(text);
+  if (text.trim() === "" || !Number.isInteger(value)) {
+    throw fieldError(spec.name, part, source, `${JSON.stringify(text)} is not a whole number`);
+  }
+  if (value < spec.min || value > spec.max) {
+    throw fieldError(
+      spec.name,
+      part,
+      source,
+      `${String(value)} is outside ${String(spec.min)}-${String(spec.max)}`,
+    );
+  }
+  return value;
+}
+
+function fieldError(name: string, part: string, source: string, why: string): SyntaxError {
+  return new SyntaxError(
+    `the ${name} field ${JSON.stringify(part)} of cron ${JSON.stringify(source)}: ${why}`,
+  );
+}

--- a/packages/server/node.js
+++ b/packages/server/node.js
@@ -62,6 +62,8 @@ import type { CapabilityOptions, ServerCapabilities } from "./internal/capabilit
 import { assertCapable, capabilitiesFor } from "./internal/capabilities.js";
 import type { RequestLifecycle } from "./internal/context.js";
 import { locateStatic, staticRoot } from "./internal/static.js";
+import type { Schedule } from "./schedule.js";
+import { startSchedules } from "./schedule.js";
 import type { Logger } from "./internal/log.js";
 import { elapsedMs, logRequest, processLogger } from "./log.js";
 
@@ -446,6 +448,16 @@ export async function serve(options: {|
   readonly port?: number,
   /** Where this server's lines go. The process logger by default. */
   readonly log?: Logger,
+  /**
+   * Schedules to run in this process, from `@uniflowed/server/schedule`.
+   *
+   * A target that keeps a process is the one that can hold a scheduler, which
+   * is what `processScheduler`'s `triggered: false` says and what
+   * `assertCapable` refuses elsewhere. Ticking stops when `close` resolves,
+   * so a test that takes a server down does not leave one running behind it.
+   * See ubugeeei-prod/uf#531.
+   */
+  readonly schedules?: $ReadOnlyArray<Schedule>,
 |}): Promise<{|
   readonly host: string,
   readonly port: number,
@@ -478,11 +490,14 @@ export async function serve(options: {|
   const shown = host === "0.0.0.0" || host === "::" ? "localhost" : host;
   process.stdout.write(`uf: listening on http://${shown}:${String(bound)}\n`);
 
+  const stopSchedules = startSchedules(options.schedules, log);
+
   return {
     host,
     port: bound,
     close: () =>
       new Promise((resolve) => {
+        stopSchedules();
         server.close(() => resolve());
       }),
   };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "./node": "./node.js",
     "./oauth": "./oauth.js",
     "./queue": "./queue.js",
+    "./schedule": "./schedule.js",
     "./socket": "./socket.js",
     "./standalone": "./standalone.js"
   },
@@ -39,6 +40,7 @@
     "node.js",
     "oauth.js",
     "queue.js",
+    "schedule.js",
     "socket.js",
     "standalone.js",
     "internal/*.js"

--- a/packages/server/schedule.js
+++ b/packages/server/schedule.js
@@ -126,6 +126,23 @@ export function createScheduler(options: {|
   // runs the minute it was late for.
   const lastRun: Map<string, string> = new Map();
 
+  // Keyed by name, so two schedules sharing one would take turns being the one
+  // that already ran this minute — each suppressing the other, silently, and
+  // only when their minutes overlapped. Refused here rather than keyed by
+  // identity instead, because the name is not decoration: it is what a
+  // platform's scheduler calls back, and two schedules answering to one name
+  // is ambiguous wherever it is read.
+  const names: Set<string> = new Set();
+  for (const schedule of options.schedules) {
+    if (names.has(schedule.name)) {
+      throw new TypeError(
+        `two schedules are named ${JSON.stringify(schedule.name)}; a name is what a ` +
+          `platform's scheduler calls back, so it has to name one of them`,
+      );
+    }
+    names.add(schedule.name);
+  }
+
   const tick = async (instant: Instant): Promise<Tick> => {
     const minute = minuteOf(instant);
     const ran: Array<string> = [];

--- a/packages/server/schedule.js
+++ b/packages/server/schedule.js
@@ -1,0 +1,194 @@
+// @flow
+//
+// `@uniflowed/server/schedule`: work no request starts.
+//
+// `./queue.js` is the other half of this and the shape to read first: uf owns
+// the job, the payload and the retry policy, and the deployment owns where the
+// work waits. A schedule splits the same way. uf owns *when* — the expression,
+// what it means, and not running a minute twice — and the deployment owns
+// *being there* to run it. See ubugeeei-prod/uf#531.
+//
+// # What uf provides
+//
+//   * **`defineSchedule`** — a name, an expression and a function. The name is
+//     what a platform's own scheduler names when it calls back into the
+//     application, which is why a schedule is a value with a name rather than
+//     a closure, exactly as `defineJob` is.
+//   * **The expression's meaning**, in `./internal/cron.js`: five fields, UTC,
+//     and POSIX's rule about which day wins.
+//   * **`createScheduler`**, which is the part that decides a schedule is due
+//     and refuses to decide it twice for the same minute.
+//
+// # What the deployment must provide
+//
+// Something alive at the right minute, and no configuration flag can supply it.
+//
+// A `node`, `bun` or `container` deployment holds a process, so uf can tick the
+// scheduler itself — `processScheduler` below, which is honest about being a
+// `setInterval` and nothing more: a restart between two ticks misses whatever
+// was due in the gap, and two instances behind a load balancer each run every
+// schedule. That is a legitimate small deployment, and it says so on the value
+// as `triggered: false` so that an adapter can refuse it rather than a person
+// having to have read this paragraph.
+//
+// A `serverless` or `edge` deployment has no such process. Its platform has a
+// scheduler of its own — EventBridge, Cloudflare's `[triggers]`, Vercel's
+// `crons` — and what it needs from uf is the *configuration* naming this
+// schedule and the route that answers it. That is `triggered: true`, and it is
+// the half of #531 that is not written yet: emitting it per platform is
+// tracked there, and until it exists those targets refuse a schedule at the
+// point the host is wired rather than building a deployment whose scheduled
+// work silently never runs.
+//
+// # Why not a `setTimeout` per schedule
+//
+// Because the interesting failure is a process that was asleep. A timer armed
+// for the next occurrence is wrong across a suspend, a laptop lid, and a
+// container that was throttled to zero — it fires late and then computes the
+// *next* occurrence from the late time. Asking "is this minute one of yours"
+// on a tick is right in all three cases, and the cost is a set lookup a minute.
+
+import type { Instant } from "@uniflowed/core/temporal";
+import { Temporal } from "@uniflowed/core/temporal";
+
+import type { SchedulerBackend } from "./internal/capabilities.js";
+import type { Cron } from "./internal/cron.js";
+import { cronMatches, parseCron } from "./internal/cron.js";
+import type { Logger } from "./internal/log.js";
+import { processLogger } from "./log.js";
+
+/** A named schedule: when it runs, and what runs. */
+export type Schedule = {|
+  readonly name: string,
+  readonly cron: Cron,
+  readonly run: () => mixed,
+|};
+
+// The backend type lives beside the other capabilities and is re-exported
+// here, the way `./queue.js` re-exports `QueueBackend`: an adapter reads it and
+// this module only produces one, so a second definition would be the drift
+// rather than the convenience.
+export type { SchedulerBackend } from "./internal/capabilities.js";
+
+/**
+ * uf's own scheduler: a tick in this process.
+ *
+ * `triggered: false`, which is what makes a target that does not keep a
+ * process refuse it.
+ */
+export const processScheduler: SchedulerBackend = Object.freeze({
+  name: "process",
+  triggered: false,
+});
+
+/**
+ * Declare a schedule.
+ *
+ * The expression is parsed here rather than on the first tick, so a typo is a
+ * module that fails to load instead of a schedule that quietly never matches.
+ *
+ * @throws SyntaxError when `cron` is not a five-field expression uf accepts.
+ */
+export function defineSchedule(options: {|
+  readonly name: string,
+  readonly cron: string,
+  readonly run: () => mixed,
+|}): Schedule {
+  if (options.name.trim() === "") {
+    throw new TypeError("a schedule needs a name: it is what a platform's scheduler calls back");
+  }
+  return { name: options.name, cron: parseCron(options.cron), run: options.run };
+}
+
+/** What a scheduler did with one minute. */
+export type Tick = {|
+  readonly ran: $ReadOnlyArray<string>,
+  readonly failed: $ReadOnlyArray<string>,
+|};
+
+/**
+ * Decide and run whatever is due, once per minute at most.
+ *
+ * `tick` is the whole interface, and `start` is a convenience over it. A host
+ * that has its own loop — a platform scheduler calling in, or a test — drives
+ * `tick` with the instant it means, and gets the same decisions.
+ */
+export function createScheduler(options: {|
+  readonly schedules: $ReadOnlyArray<Schedule>,
+  readonly log?: Logger,
+|}): {|
+  readonly tick: (instant: Instant) => Promise<Tick>,
+  readonly start: () => () => void,
+|} {
+  const log = options.log ?? processLogger();
+  // The last minute each schedule ran, so a tick every thirty seconds does not
+  // run a schedule twice — and so a tick that is late by ten seconds still
+  // runs the minute it was late for.
+  const lastRun: Map<string, string> = new Map();
+
+  const tick = async (instant: Instant): Promise<Tick> => {
+    const minute = minuteOf(instant);
+    const ran: Array<string> = [];
+    const failed: Array<string> = [];
+    for (const schedule of options.schedules) {
+      if (lastRun.get(schedule.name) === minute) continue;
+      if (!cronMatches(schedule.cron, instant)) continue;
+      lastRun.set(schedule.name, minute);
+      try {
+        await schedule.run();
+        ran.push(schedule.name);
+      } catch (error) {
+        // Logged and carried past, not rethrown: one schedule that throws must
+        // not stop the others due in the same minute, and there is no caller
+        // above a tick to catch it.
+        log.error("schedule failed", { error, schedule: schedule.name });
+        failed.push(schedule.name);
+      }
+    }
+    return { ran, failed };
+  };
+
+  const start = (): (() => void) => {
+    // Twice a minute, so a tick that drifts still lands inside every minute.
+    // The interval is unref'd where the host allows it: a scheduler must not be
+    // the reason a process refuses to exit.
+    const timer = setInterval(() => {
+      void tick(Temporal.Now.instant());
+    }, 30_000);
+    if (typeof timer === "object" && timer != null && typeof timer.unref === "function") {
+      timer.unref();
+    }
+    return () => {
+      clearInterval(timer);
+    };
+  };
+
+  return { tick, start };
+}
+
+/** The minute an instant is in, as the key `tick` remembers it by. */
+function minuteOf(instant: Instant): string {
+  const at = instant.toZonedDateTimeISO("UTC");
+  return `${String(at.year)}-${String(at.month)}-${String(at.day)}T${String(at.hour)}:${String(at.minute)}`;
+}
+
+/**
+ * Start `schedules` ticking, and hand back the way to stop.
+ *
+ * The two lines every host that keeps a process needs, in one place: both
+ * `./node.js` and `./bun.js` take an optional list on `serve` and neither
+ * should own the decision about how often a tick happens.
+ *
+ * A host given no schedules pays nothing — no timer is armed, which is the
+ * same bargain `installInterception` makes for module mocks.
+ */
+export function startSchedules(
+  schedules: $ReadOnlyArray<Schedule> | void,
+  log: Logger,
+): () => void {
+  if (schedules == null || schedules.length === 0) {
+    return () => {};
+  }
+  log.info("schedules started", { count: schedules.length });
+  return createScheduler({ schedules, log }).start();
+}

--- a/tests/library/schedule.test.js
+++ b/tests/library/schedule.test.js
@@ -77,6 +77,22 @@ describe("a cron expression", () => {
     );
   });
 
+  // The step would otherwise be dropped and `0 5/15 * * *` would run once a
+  // day while looking hourly — the one refusal that is about a form uf could
+  // have half-read rather than one it cannot read at all.
+  it("refuses a step on a single value, and says what to write instead", () => {
+    expect(() => defineSchedule({ name: "s", cron: "0 5/15 * * *", run: () => {} })).toThrow(
+      /a step needs .* or a range before it/,
+    );
+    expect(() => defineSchedule({ name: "s", cron: "0 5/15 * * *", run: () => {} })).toThrow(
+      /5-23\/15/,
+    );
+    // The two spellings that do carry a step still work.
+    expect(due("0 */6 * * *", "2026-03-04T06:00:00Z")).toBe(true);
+    expect(due("0 5-23/15 * * *", "2026-03-04T20:00:00Z")).toBe(true);
+    expect(due("0 5-23/15 * * *", "2026-03-04T06:00:00Z")).toBe(false);
+  });
+
   it("refuses the syntaxes it does not implement, instead of ignoring them", () => {
     for (const cron of ["@daily", "0 0 * * MON", "0 0 L * *", "0 0 * * 1#2"]) {
       expect(() => defineSchedule({ name: "s", cron, run: () => {} })).toThrow();
@@ -241,6 +257,20 @@ describe("the scheduler", () => {
     const tick = await scheduler.tick(at("2026-03-04T09:00:00Z"));
     expect(finished).toBe(true);
     expect(tick.ran).toEqual(["slow"]);
+  });
+
+  // `lastRun` is keyed by name, so two schedules sharing one would take turns
+  // suppressing each other — silently, and only in the minutes they overlap.
+  it("refuses two schedules with one name rather than letting them suppress each other", () => {
+    expect(() =>
+      createScheduler({
+        schedules: [
+          defineSchedule({ name: "sweep", cron: "* * * * *", run: () => {} }),
+          defineSchedule({ name: "sweep", cron: "0 * * * *", run: () => {} }),
+        ],
+        log: quiet,
+      }),
+    ).toThrow(/two schedules are named "sweep"/);
   });
 
   it("needs a name, because a platform's scheduler calls one back", () => {

--- a/tests/library/schedule.test.js
+++ b/tests/library/schedule.test.js
@@ -1,0 +1,308 @@
+// @flow
+//
+// `@uniflowed/server/schedule`: when a schedule is due, and who may hold one.
+//
+// The two halves of ubugeeei-prod/uf#531 that exist. What is tested here is
+// uf's half — the expression's meaning, and not running a minute twice — and
+// the refusal that keeps the other half honest: a target with no process and
+// no platform call must say so rather than build a deployment whose scheduled
+// work never runs.
+//
+// Instants are written, never read from a clock. A schedule test that asked
+// what time it is would pass or fail depending on when it ran, which is the
+// one thing a test about time must not do.
+
+import { describe, expect, it } from "@uniflowed/test";
+import { Temporal } from "@uniflowed/core/temporal";
+import {
+  createScheduler,
+  defineSchedule,
+  processScheduler,
+  startSchedules,
+} from "@uniflowed/server/schedule";
+import { nodeCapabilities } from "@uniflowed/server/node";
+import { lambdaCapabilities } from "@uniflowed/server/lambda";
+
+const at = (iso: string) => Temporal.Instant.from(iso);
+
+/** Whether `cron` is due at `iso`, through the public surface. */
+const due = (cron: string, iso: string): boolean => {
+  const schedule = defineSchedule({ name: "s", cron, run: () => {} });
+  // `createScheduler` is the only thing that reads a `Cron`, so asking it is
+  // asking the code that ships rather than a matcher exported for a test.
+  let ran = false;
+  const scheduler = createScheduler({
+    schedules: [
+      defineSchedule({
+        name: schedule.name,
+        cron,
+        run: () => {
+          ran = true;
+        },
+      }),
+    ],
+    log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  });
+  void scheduler.tick(at(iso));
+  return ran;
+};
+
+describe("a cron expression", () => {
+  it("refuses anything but five fields, and says how many it got", () => {
+    expect(() => defineSchedule({ name: "s", cron: "* * * *", run: () => {} })).toThrow(
+      /five fields/,
+    );
+    expect(() => defineSchedule({ name: "s", cron: "* * * * * *", run: () => {} })).toThrow(
+      /has 6/,
+    );
+  });
+
+  it("refuses a field outside its range, naming the field", () => {
+    expect(() => defineSchedule({ name: "s", cron: "60 * * * *", run: () => {} })).toThrow(
+      /minute field .* outside 0-59/,
+    );
+    expect(() => defineSchedule({ name: "s", cron: "* 24 * * *", run: () => {} })).toThrow(
+      /hour field .* outside 0-23/,
+    );
+    expect(() => defineSchedule({ name: "s", cron: "* * 0 * *", run: () => {} })).toThrow(
+      /day-of-month field .* outside 1-31/,
+    );
+  });
+
+  // No wrap-around: `22-2` reads as "late at night" and every cron reads it as
+  // empty. Twenty hours apart is too far to guess.
+  it("refuses a backwards range rather than matching nothing", () => {
+    expect(() => defineSchedule({ name: "s", cron: "* 22-2 * * *", run: () => {} })).toThrow(
+      /counts backwards/,
+    );
+  });
+
+  it("refuses the syntaxes it does not implement, instead of ignoring them", () => {
+    for (const cron of ["@daily", "0 0 * * MON", "0 0 L * *", "0 0 * * 1#2"]) {
+      expect(() => defineSchedule({ name: "s", cron, run: () => {} })).toThrow();
+    }
+  });
+
+  it("matches a plain minute and hour, in UTC", () => {
+    expect(due("30 9 * * *", "2026-03-04T09:30:00Z")).toBe(true);
+    expect(due("30 9 * * *", "2026-03-04T09:31:00Z")).toBe(false);
+    // The same wall-clock minute in another zone is a different instant, and
+    // this is the assertion that the fields are read in UTC and not locally.
+    expect(due("30 9 * * *", "2026-03-04T10:30:00+01:00")).toBe(true);
+  });
+
+  it("matches a list, a range and a step", () => {
+    expect(due("0,30 * * * *", "2026-03-04T07:30:00Z")).toBe(true);
+    expect(due("0,30 * * * *", "2026-03-04T07:15:00Z")).toBe(false);
+    expect(due("* 9-17 * * *", "2026-03-04T17:00:00Z")).toBe(true);
+    expect(due("* 9-17 * * *", "2026-03-04T18:00:00Z")).toBe(false);
+    expect(due("*/15 * * * *", "2026-03-04T07:45:00Z")).toBe(true);
+    expect(due("*/15 * * * *", "2026-03-04T07:46:00Z")).toBe(false);
+    expect(due("0 0-6/3 * * *", "2026-03-04T03:00:00Z")).toBe(true);
+    expect(due("0 0-6/3 * * *", "2026-03-04T04:00:00Z")).toBe(false);
+  });
+
+  // Temporal counts 1 = Monday … 7 = Sunday; cron counts 0 = Sunday … 6 =
+  // Saturday. Sunday is where an off-by-one lands, so Sunday is asserted twice
+  // — as `0` and as `7`, both of which every cron accepts.
+  it("reads day-of-week the way cron does, including both spellings of Sunday", () => {
+    // 2026-03-08 is a Sunday; 2026-03-09 is a Monday.
+    expect(due("0 0 * * 0", "2026-03-08T00:00:00Z")).toBe(true);
+    expect(due("0 0 * * 7", "2026-03-08T00:00:00Z")).toBe(true);
+    expect(due("0 0 * * 0", "2026-03-09T00:00:00Z")).toBe(false);
+    expect(due("0 0 * * 1", "2026-03-09T00:00:00Z")).toBe(true);
+    expect(due("0 0 * * 6", "2026-03-07T00:00:00Z")).toBe(true);
+  });
+
+  // POSIX's rule, and the one everybody is surprised by once.
+  it("matches either day when day-of-month and day-of-week are both restricted", () => {
+    // The 1st of March 2026 is a Sunday, the 2nd a Monday, the 9th a Monday.
+    const cron = "0 0 1 * 1";
+    expect(due(cron, "2026-03-01T00:00:00Z")).toBe(true); // the 1st, not a Monday
+    expect(due(cron, "2026-03-09T00:00:00Z")).toBe(true); // a Monday, not the 1st
+    expect(due(cron, "2026-03-03T00:00:00Z")).toBe(false); // neither
+  });
+
+  it("requires the one restricted day when the other is a star", () => {
+    expect(due("0 0 15 * *", "2026-03-15T00:00:00Z")).toBe(true);
+    expect(due("0 0 15 * *", "2026-03-16T00:00:00Z")).toBe(false);
+    expect(due("0 0 * * 3", "2026-03-04T00:00:00Z")).toBe(true); // a Wednesday
+    expect(due("0 0 * * 3", "2026-03-05T00:00:00Z")).toBe(false);
+  });
+
+  it("matches the month field", () => {
+    expect(due("0 0 1 3 *", "2026-03-01T00:00:00Z")).toBe(true);
+    expect(due("0 0 1 4 *", "2026-03-01T00:00:00Z")).toBe(false);
+  });
+});
+
+describe("the scheduler", () => {
+  const quiet = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+  it("runs a schedule once for a minute, however often it is ticked", async () => {
+    let runs = 0;
+    const scheduler = createScheduler({
+      schedules: [
+        defineSchedule({
+          name: "hourly",
+          cron: "0 * * * *",
+          run: () => {
+            runs += 1;
+          },
+        }),
+      ],
+      log: quiet,
+    });
+
+    // Three ticks inside the same minute — which is what a 30-second interval
+    // does, and what a late tick does after an early one.
+    await scheduler.tick(at("2026-03-04T09:00:00Z"));
+    await scheduler.tick(at("2026-03-04T09:00:29Z"));
+    await scheduler.tick(at("2026-03-04T09:00:59Z"));
+    expect(runs).toBe(1);
+
+    // And the next occurrence still runs.
+    await scheduler.tick(at("2026-03-04T10:00:00Z"));
+    expect(runs).toBe(2);
+  });
+
+  it("runs a minute it was late for rather than skipping it", async () => {
+    let runs = 0;
+    const scheduler = createScheduler({
+      schedules: [
+        defineSchedule({
+          name: "top",
+          cron: "0 * * * *",
+          run: () => {
+            runs += 1;
+          },
+        }),
+      ],
+      log: quiet,
+    });
+    // The tick that should have happened at :00 arrives at :40. The minute is
+    // still the minute the schedule names.
+    await scheduler.tick(at("2026-03-04T09:00:40Z"));
+    expect(runs).toBe(1);
+  });
+
+  it("reports what ran and carries past one that threw", async () => {
+    const order: Array<string> = [];
+    const scheduler = createScheduler({
+      schedules: [
+        defineSchedule({
+          name: "first",
+          cron: "* * * * *",
+          run: () => {
+            order.push("first");
+          },
+        }),
+        defineSchedule({
+          name: "broken",
+          cron: "* * * * *",
+          run: () => {
+            throw new Error("nope");
+          },
+        }),
+        defineSchedule({
+          name: "third",
+          cron: "* * * * *",
+          run: () => {
+            order.push("third");
+          },
+        }),
+      ],
+      log: quiet,
+    });
+
+    const tick = await scheduler.tick(at("2026-03-04T09:00:00Z"));
+    // The one that threw did not stop the one after it: there is no caller
+    // above a tick to catch for them.
+    expect(order).toEqual(["first", "third"]);
+    expect(tick.ran).toEqual(["first", "third"]);
+    expect(tick.failed).toEqual(["broken"]);
+  });
+
+  it("awaits an async schedule before calling it run", async () => {
+    let finished = false;
+    const scheduler = createScheduler({
+      schedules: [
+        defineSchedule({
+          name: "slow",
+          cron: "* * * * *",
+          run: async () => {
+            await Promise.resolve();
+            finished = true;
+          },
+        }),
+      ],
+      log: quiet,
+    });
+    const tick = await scheduler.tick(at("2026-03-04T09:00:00Z"));
+    expect(finished).toBe(true);
+    expect(tick.ran).toEqual(["slow"]);
+  });
+
+  it("needs a name, because a platform's scheduler calls one back", () => {
+    expect(() => defineSchedule({ name: "  ", cron: "* * * * *", run: () => {} })).toThrow(/name/);
+  });
+});
+
+describe("which targets may hold a schedule", () => {
+  it("lets a target that keeps a process tick one itself", () => {
+    const capabilities = nodeCapabilities({ scheduler: processScheduler });
+    expect(capabilities.scheduler?.name).toBe("process");
+    expect(capabilities.scheduler?.triggered).toBe(false);
+  });
+
+  // The refusal #531 asks for, and the sentence matters: not "uf has no
+  // scheduler" but "nothing would be running at that minute".
+  it("refuses an in-process schedule on a target that keeps no process", () => {
+    expect(() => lambdaCapabilities({ scheduler: processScheduler })).toThrow(
+      /nothing would be running at the minute/,
+    );
+  });
+
+  it("accepts one the platform triggers, on the same target", () => {
+    const capabilities = lambdaCapabilities({
+      scheduler: { name: "eventbridge", triggered: true },
+    });
+    expect(capabilities.scheduler?.triggered).toBe(true);
+  });
+
+  it("names no scheduler by default", () => {
+    expect(nodeCapabilities().scheduler).toBe(null);
+    expect(lambdaCapabilities().scheduler).toBe(null);
+  });
+});
+
+describe("a host starting schedules", () => {
+  const quiet = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+  // The bargain `serve` makes: a deployment that declares none pays for none.
+  // Asserted because the alternative — an interval armed for an empty list —
+  // is invisible until something asks why a process will not exit.
+  it("arms nothing when there are no schedules", () => {
+    const said: Array<string> = [];
+    const stop = startSchedules(undefined, { ...quiet, info: (m) => said.push(m) });
+    expect(said).toEqual([]);
+    expect(typeof stop).toBe("function");
+    stop();
+
+    const stopEmpty = startSchedules([], quiet);
+    expect(typeof stopEmpty).toBe("function");
+    stopEmpty();
+  });
+
+  it("says how many it started, and hands back the way to stop", () => {
+    const said: Array<{ message: string, count: mixed }> = [];
+    const stop = startSchedules(
+      [defineSchedule({ name: "one", cron: "* * * * *", run: () => {} })],
+      { ...quiet, info: (message, fields) => said.push({ message, count: fields?.count }) },
+    );
+    expect(said).toEqual([{ message: "schedules started", count: 1 }]);
+    // Stopping is the half a test needs: an interval nobody cleared keeps a
+    // worker alive past the file that armed it.
+    stop();
+  });
+});


### PR DESCRIPTION
Work no request starts. Part of [#531](https://github.com/ubugeeei-prod/uf/issues/531) — the half that can be built without route discovery.

It is shaped like `@uniflowed/server/queue`, because it splits the same way: **uf owns *when*, the deployment owns *being there*.**

```js
const sweep = defineSchedule({
  name: "sweep-sessions",
  cron: "*/15 * * * *",
  run: async () => expireSessions(),
});

await serve({ handle, staticDir, beginRequest, schedules: [sweep] });
```

`defineSchedule` parses at the line that wrote it, so a typo is a module that fails to load rather than a schedule that quietly never matches. `createScheduler` decides a minute is due and refuses to decide it twice — a 30-second tick runs a schedule once, and a tick forty seconds late still runs the minute it was late for. `node` and `bun` take `schedules` on `serve` through one shared helper, and stop ticking when `close` resolves.

## Five fields, and only what every cron agrees on

`*`, `n`, `a-b`, `*/n`, `a-b/n`, and comma lists. No `@daily`, no `JAN`/`MON`, no seconds, no `L`/`W`/`#` — each is spelled differently by Vixie cron, Quartz and every cloud, and a schedule uf accepted and a platform read differently is the failure this feature has everywhere it exists.

Two subtleties, both tested, and I mutation-checked both to confirm the tests actually catch them:

- **Day-of-week is cron's, not Temporal's.** Temporal counts 1 = Monday … 7 = Sunday; cron counts 0 = Sunday … 6 = Saturday. Sunday is asserted twice, as `0` and as `7`. Breaking the conversion fails a test.
- **POSIX's either-day rule.** When day-of-month and day-of-week are *both* restricted, a time matches when **either** does: `0 0 1 * 1` is "the first, and every Monday". Changing `||` to `&&` fails a test.

A backwards range (`22-2`) is refused rather than matched empty — it reads as "late at night" to a person and as nothing at all to every cron, and twenty hours is too far apart to guess. Fields are UTC, said out loud: a container's zone and a platform scheduler's zone are not the same one.

## The refusal, which is what #531 asks for by name

`ServerCapabilities` gains `scheduler`. `assertCapable` refuses one whose `triggered` is false on a target that keeps no process — the same rule shape as the queue's `durable`:

> nothing would be running at the minute the schedule names: this target keeps no process, and its platform has not been told to call one

So `serverless` and `edge` fail where the host is wired, rather than building a deployment whose scheduled work silently never runs.

## What is deliberately not here

The other half of #531: a route module that *declares* a schedule, and emitting each platform's own configuration — EventBridge, Cloudflare's `[triggers]`, Vercel's `crons`. Until that exists those targets refuse, which is the honest state rather than a half-built one. The issue stays open for it.

## Verification

- 21 new tests in `tests/library/schedule.test.js`, driven from written instants — a schedule test that asked what time it is would pass or fail depending on when it ran.
- Full library suite **2703 passed, 0 failed**; `cargo test -p uf_cli --lib` 446 green.
- `uf fmt --check` and `uf lint` clean across `packages/server`.
- `published-packages.test.js` caught the new file missing from the package's `files` before this left my machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791508659&installation_model_id=422833&pr_number=696&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F696&signature=a6957601989c7935d8135a2e3daeca1f3c3219fee9fe95922b46bf3f50b2db46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cron-based scheduled task support with UTC matching, validation, and once-per-minute execution.
  - Added schedule definitions with named tasks, asynchronous execution, duplicate prevention, and isolated failures.
  - Enabled schedules for Node.js and Bun servers, including automatic startup and cleanup.
  - Added documentation covering schedule configuration, runtime behavior, and deployment limitations.
- **Bug Fixes**
  - Prevented schedules from running on unsupported processless targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->