### PR TITLE
perf(lint, transform): put the profiler in the hot path it was written for

### DIFF
--- a/crates/uf_lint/Cargo.toml
+++ b/crates/uf_lint/Cargo.toml
@@ -12,6 +12,13 @@ authors.workspace = true
 uf_config = { path = "../uf_config" }
 uf_flow = { path = "../uf_flow" }
 uf_infra = { path = "../uf_infra" }
+# `profile_span!` in the hot path, and the counting allocator behind the
+# figures in ubugeeei-prod/uf#668. A dependency rather than a dev-dependency
+# because the spans are compiled into the library itself: with the gate shut
+# each one is a relaxed atomic load and a `bool`, which is the price of a
+# profiler that is already there when the question arrives rather than one
+# that has to be added first. See `uf_profiler`'s own header.
+uf_profiler = { path = "../uf_profiler" }
 uf_react_compiler = { path = "../uf_react_compiler" }
 uf_router = { path = "../uf_router" }
 uf_transform = { path = "../uf_transform" }
@@ -22,10 +29,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-# For `examples/alloc_report.rs`: the counting allocator behind the figures in
-# ubugeeei-prod/uf#668, so the next person to touch the linter's hot path can
-# take them again rather than trust them.
-uf_profiler = { path = "../uf_profiler" }
 
 [[bench]]
 name = "lint"

--- a/crates/uf_lint/examples/alloc_report.rs
+++ b/crates/uf_lint/examples/alloc_report.rs
@@ -4,18 +4,46 @@
 //! that one measures the Babel tree, this one measures the linter that asks for
 //! it. Run it as
 //! `cargo run --release --example alloc_report -p uf_lint -- <file>`.
+//!
+//! # The per-phase table
+//!
+//! The headline says how much; `--phases` says where. It turns
+//! [`uf_profiler::scope`] on and prints one row per `profile_span!` in the
+//! linter and in the transform pipeline underneath it, which is the table
+//! ubugeeei-prod/uf#668 was reduced to taking by editing the source and
+//! recompiling. The spans are compiled in unconditionally and cost a relaxed
+//! atomic load each when the gate is shut, so the headline is measured with
+//! them present either way and the two numbers are comparable.
+//!
+//! **The rows do not sum to the total, and the parent rows are inclusive.**
+//! `run_react_tree_rules` parses on a thread of its own — `uf_flow` says why —
+//! and a worker's spans reach the report through
+//! [`uf_profiler::scope::flush_thread_spans`], which folds them in as roots
+//! rather than as children of the span that spawned the thread. So
+//! `estree::parse` and `lower::lower` appear both in their own rows and inside
+//! `run_react_tree_rules`'s, and that row's `self` column is really its
+//! inclusive time. Read a parent against the headline, and the children
+//! against the parent.
 
 use uf_config::UniflowedConfig;
 use uf_lint::SourceFile;
-use uf_profiler::{AllocSnapshot, CountingAllocator, Window};
+use uf_profiler::{
+    AllocSnapshot, CountingAllocator, Recorder, ReportConfig, SortBy, Window, scope,
+};
 
 #[global_allocator]
 static GLOBAL: CountingAllocator = CountingAllocator::new();
 
 fn main() {
-    let path = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| String::from("packages/router/internal/runtime.js"));
+    let mut path = None;
+    let mut phases = false;
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--phases" => phases = true,
+            other => path = Some(other.to_owned()),
+        }
+    }
+    let path = path.unwrap_or_else(|| String::from("packages/router/internal/runtime.js"));
     let source = std::fs::read_to_string(&path).expect("read the module");
     let file = SourceFile {
         path: path.clone(),
@@ -27,17 +55,16 @@ fn main() {
     // Warm up: the first run pays for whatever is initialised once.
     let _ = uf_lint::lint_source(&file, &config).expect("lints");
 
+    let runs = 5;
     CountingAllocator::enable();
     let window = Window::open();
     let before = AllocSnapshot::capture();
-    let runs = 5;
     for _ in 0..runs {
         let report = uf_lint::lint_source(&file, &config).expect("lints");
         std::hint::black_box(&report);
     }
     let after = AllocSnapshot::capture();
     drop(window);
-    CountingAllocator::disable();
 
     let delta = after.delta_from(&before);
     println!("allocs / run   {}", delta.allocations / runs);
@@ -49,4 +76,26 @@ fn main() {
         "peak           {:.2} MiB",
         delta.peak_above_baseline as f64 / (1024.0 * 1024.0)
     );
+
+    if phases {
+        // Measured in a second pass rather than the one above: the spans read
+        // the allocator's counters as they open and close, and that is work
+        // the headline should not be made to carry.
+        scope::enable();
+        let mut recorder = Recorder::new("lint_source").with_config(ReportConfig {
+            sort_by: SortBy::Allocations,
+            ..ReportConfig::default()
+        });
+        for _ in 0..runs {
+            recorder.record(|| {
+                let report = uf_lint::lint_source(&file, &config).expect("lints");
+                std::hint::black_box(report)
+            });
+        }
+        let report = recorder.finish();
+        scope::disable();
+        println!();
+        println!("{}", report.render_table());
+    }
+    CountingAllocator::disable();
 }

--- a/crates/uf_lint/src/runner/flow_syntax.rs
+++ b/crates/uf_lint/src/runner/flow_syntax.rs
@@ -3,6 +3,7 @@
 
 use uf_config::UniflowedConfig;
 use uf_flow::FlowParser;
+use uf_profiler::profile_span;
 
 use crate::scan::FileScan;
 use crate::{Diagnostic, LintError, push, severity};
@@ -12,6 +13,7 @@ pub(crate) fn run_flow_syntax(
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<(), LintError> {
+    profile_span!("run_flow_syntax");
     let Some(severity) = severity(config, "flow/syntax") else {
         return Ok(());
     };

--- a/crates/uf_lint/src/runner/flow_type.rs
+++ b/crates/uf_lint/src/runner/flow_type.rs
@@ -3,6 +3,7 @@
 //! whose exactness the author never said out loud.
 
 use uf_config::UniflowedConfig;
+use uf_profiler::profile_span;
 
 use crate::flow_builtin::FlowBuiltinLint;
 use crate::scan::{
@@ -26,6 +27,7 @@ pub(crate) fn run_flow_unclear_type(
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    profile_span!("run_flow_unclear_type");
     let rule = FlowBuiltinLint::UnclearType.as_rule_id();
     let Some(severity) = severity(config, rule) else {
         return;

--- a/crates/uf_lint/src/runner/react_compiler.rs
+++ b/crates/uf_lint/src/runner/react_compiler.rs
@@ -8,6 +8,7 @@
 //! for `uf lint` and `uf build` to disagree about a component.
 
 use uf_config::UniflowedConfig;
+use uf_profiler::profile_span;
 use uf_react_compiler::ReactCompilerRule;
 
 use crate::scan::FileScan;
@@ -23,6 +24,7 @@ pub(crate) fn run_react_compiler_rules(
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    profile_span!("run_react_compiler_rules");
     if ReactCompilerRule::ALL
         .iter()
         .all(|rule| severity(config, rule.id()).is_none())

--- a/crates/uf_lint/src/runner/react_tree.rs
+++ b/crates/uf_lint/src/runner/react_tree.rs
@@ -36,6 +36,7 @@
 use serde_json::Value;
 use uf_config::UniflowedConfig;
 use uf_infra::{FxHashMap, FxHashSet};
+use uf_profiler::profile_span;
 use uf_transform::{ReactCompilerMode, TransformOptions};
 
 use crate::scan::FileScan;
@@ -81,6 +82,7 @@ pub(crate) fn run_react_tree_rules(
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    profile_span!("run_react_tree_rules");
     let derived = severity(config, DERIVED_STATE);
     // A project that has turned the compiler off gets no report: without it,
     // a hand-written `useMemo` is the only memoization there is.
@@ -244,7 +246,13 @@ fn analyse(
     std::thread::scope(|scope| {
         std::thread::Builder::new()
             .stack_size(uf_flow::PARSE_STACK_BYTES)
-            .spawn_scoped(scope, work)
+            .spawn_scoped(scope, || {
+                let found = work();
+                // Spans opened here are thread-local and die with the thread;
+                // this is the hand-over `scope::flush_thread_spans` documents.
+                uf_profiler::scope::flush_thread_spans();
+                found
+            })
             .ok()?
             .join()
             .ok()?

--- a/crates/uf_lint/src/runner/tree.rs
+++ b/crates/uf_lint/src/runner/tree.rs
@@ -87,6 +87,7 @@ use uf_config::UniflowedConfig;
 use uf_flow::ast::jsx;
 use uf_flow::ast_visitor::{self, AstVisitor};
 use uf_flow::{Loc, ast};
+use uf_profiler::profile_span;
 
 use crate::scan::FileScan;
 use crate::{Diagnostic, Severity, push_at, severity};
@@ -118,6 +119,7 @@ pub(crate) fn run_tree_rules(
     config: &UniflowedConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    profile_span!("run_tree_rules");
     let levels = Levels::for_config(config);
     if levels.all_off() {
         return;

--- a/crates/uf_lint/src/scan.rs
+++ b/crates/uf_lint/src/scan.rs
@@ -14,6 +14,7 @@ mod search;
 mod tests;
 
 use uf_infra::LineIndex;
+use uf_profiler::profile_span;
 
 use crate::SourceFile;
 use line::{Carry, scan_line};
@@ -126,6 +127,7 @@ impl<'a> FileScan<'a> {
     /// Masking preserves every byte offset, so a diagnostic measured against it
     /// lands in the same place in the real file.
     pub fn new(file: &'a SourceFile, source: &'a str) -> Self {
+        profile_span!("FileScan::new");
         let index = LineIndex::new(source);
 
         let mut lines = Vec::with_capacity(index.line_count());

--- a/crates/uf_transform/Cargo.toml
+++ b/crates/uf_transform/Cargo.toml
@@ -26,6 +26,13 @@ serde_json.workspace = true
 thiserror.workspace = true
 uf_flow = { path = "../uf_flow" }
 uf_infra = { path = "../uf_infra" }
+# `profile_span!` in the hot path, and the counting allocator behind the
+# figures in ubugeeei-prod/uf#668. A dependency rather than a dev-dependency
+# because the spans are compiled into the library itself: with the gate shut
+# each one is a relaxed atomic load and a `bool`, which is the price of a
+# profiler that is already there when the question arrives rather than one
+# that has to be added first. See `uf_profiler`'s own header.
+uf_profiler = { path = "../uf_profiler" }
 
 [dev-dependencies]
 criterion.workspace = true
@@ -36,11 +43,6 @@ similar-asserts.workspace = true
 # ask it what it read. This crate is where that test lives because it is the
 # only one that can see every entry point.
 uf_check = { path = "../uf_check" }
-
-# For `examples/alloc_report.rs`: the counting allocator that produced the
-# figures in ubugeeei-prod/uf#668, so the next person to touch this pipeline can
-# reproduce them rather than take them on trust.
-uf_profiler = { path = "../uf_profiler" }
 
 [[bench]]
 name = "transform"

--- a/crates/uf_transform/src/babel.rs
+++ b/crates/uf_transform/src/babel.rs
@@ -15,6 +15,7 @@
 //! which it uses for positional queries.
 
 use serde_json::{Map, Value, json};
+use uf_profiler::profile_span;
 
 use crate::TransformError;
 use crate::lower::{Edit, bool_field, node_type, str_field, take, transform_post};
@@ -26,6 +27,7 @@ use crate::lower::{Edit, bool_field, node_type, str_field, take, transform_post}
 /// [`TransformError::Internal`] when a node is not the shape the parser
 /// produces — a `Property` whose method value is not a function, say.
 pub fn to_babel(mut program: Value, source: &str) -> Result<Value, TransformError> {
+    profile_span!("babel::to_babel");
     transform_post(&mut program, &mut |node| convert(node))?;
     let mut file = wrap_file(program);
     let lines = LineTable::new(source);

--- a/crates/uf_transform/src/estree.rs
+++ b/crates/uf_transform/src/estree.rs
@@ -16,6 +16,7 @@ use flow_parser::loc::Loc;
 use flow_parser::offset_utils::{OffsetKind, OffsetTable};
 use flow_parser::parse_error::ParseError;
 use serde_json::Value;
+use uf_profiler::profile_span;
 
 use crate::TransformError;
 
@@ -36,6 +37,7 @@ pub const MAX_SOURCE_BYTES: usize = 8 * 1024 * 1024;
 /// [`TransformError::SourceTooLarge`] over the ceiling, and
 /// [`TransformError::Syntax`] with the first error the parser reported.
 pub fn parse(source: &str) -> Result<Value, TransformError> {
+    profile_span!("estree::parse");
     if source.len() > MAX_SOURCE_BYTES {
         return Err(TransformError::SourceTooLarge {
             bytes: source.len(),

--- a/crates/uf_transform/src/lower/mod.rs
+++ b/crates/uf_transform/src/lower/mod.rs
@@ -25,6 +25,7 @@ pub mod matches;
 pub mod strip;
 
 use serde_json::Value;
+use uf_profiler::profile_span;
 
 use crate::TransformError;
 
@@ -52,6 +53,7 @@ pub struct Lowered {
 /// [`TransformError::Internal`] when the tree is not the shape the parser
 /// promised.
 pub fn lower(program: &mut Value, source: &str) -> Result<Lowered, TransformError> {
+    profile_span!("lower::lower");
     let may_compile = components::lower(program)?;
     matches::lower(program)?;
     enums::lower(program, source)?;


### PR DESCRIPTION
## Why

`uf_profiler` landed in #660 and **nothing has ever used it**. `profile_span!` appears zero times in `crates/` outside the crate that defines it, so the per-phase tables in ubugeeei-prod/uf#668 and ubugeeei-prod/uf#678 could only be taken by editing the source, recompiling, and reverting.

That is not a hypothetical cost. #668's last comment records exactly this:

> One thing I could not re-take: the per-phase table. It came from `profile_span!` inside the three steps of `babel_ast`, and there is no `profile_span!` in `uf_lint` on `main` […] So whether `run_react_tree_rules` is still 94% of the total is unmeasured; only the total is.

This makes it measurable from a command.

## What

Eight spans, at the phase boundaries the two issues already name — three in the pipeline (`estree::parse`, `lower::lower`, `babel::to_babel`) and six in the linter (`FileScan::new`, `run_flow_syntax`, `run_flow_unclear_type`, `run_tree_rules`, `run_react_tree_rules`, `run_react_compiler_rules`).

`uf_profiler` becomes a **dependency** rather than a dev-dependency of `uf_lint` and `uf_transform`. That is the arrangement its own header argues for:

> a profiler you have to add before you can use it is one that is never there when the question arrives.

With the gate shut a span is one relaxed atomic load and a `bool`.

`run_react_tree_rules` parses on a thread with a larger stack, and a worker's spans die with it, so it now calls `scope::flush_thread_spans`.

## The table, taken from a command

```
$ cargo run --release --example alloc_report -p uf_lint -- packages/router/internal/runtime.js --phases

packages/router/internal/runtime.js: 113734 bytes
allocs / run   441986
bytes / run    45.22 MiB
peak           19.36 MiB

lint_source — 5 iteration(s)
  span                         hits        self       total       bytes     allocs
  run_react_tree_rules            5   190.96 ms   190.96 ms   190.4 MiB    1955540
  estree::parse                   5    62.28 ms    62.28 ms   139.2 MiB    1272410
  lower::lower                    5    86.35 ms    86.35 ms    50.9 MiB     681225
  run_tree_rules                  5    17.29 ms    17.29 ms    16.3 MiB     122355
  run_flow_syntax                 5    15.97 ms    15.97 ms    16.3 MiB     122300
  run_flow_unclear_type           5     1.15 ms     1.15 ms    34.3 KiB       9595
  run_react_compiler_rules        5     2.38 ms     2.38 ms     2.4 MiB         95
  FileScan::new                   5     1.81 ms     1.81 ms   775.3 KiB         11
```

Per run, that is `run_react_tree_rules` at **391,108 of 441,986 allocations — 88.5%**, and inside it `estree::parse` at **254,482 (57.6% of the whole linter)** and `lower::lower` at 136,245 (30.8%).

**The check that the instrumentation measures what it claims:** those two numbers were already filed in #668 by the edit-and-recompile route — 254,481 and 136,245. They agree to one allocation.

So #668's "94% is one rule" is now **88.5%**, and the rule's cost is no longer a Babel AST: `babel::to_babel` does not appear at all under the default config, because #676 moved `react/derived-state` to the lowered tree. The largest phase is now the parser rendering its typed AST as `serde_json::Value`.

## One caveat, documented in the example

The rows do not sum, and parent rows are inclusive. A worker's spans are folded in as roots rather than as children of the span that spawned the thread, so `estree::parse` and `lower::lower` appear both in their own rows and inside `run_react_tree_rules`'s — and that row's `self` column is really its inclusive time.

## Verification

- `cargo clippy -p uf_lint -p uf_transform -p uf_profiler --all-targets -- -D warnings` — clean
- `cargo test -p uf_lint -p uf_transform -p uf_profiler` — 444 passed, 0 failed
- The headline (441,986 / 45.22 MiB) is unchanged from `main`, which is the point: the spans cost nothing while the gate is shut.

This does not itself make anything faster. It makes the next change measurable, and it is the prerequisite for option 3 in #668 (share one Babel AST per file across commands), which is the largest idea left there.

Refs ubugeeei-prod/uf#668, ubugeeei-prod/uf#678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791518619&installation_model_id=422833&pr_number=697&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F697&signature=5bf3e36102729b9b0577c15cd8232f3151471ff2934a00a63d210be396c1eb82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed performance profiling across linting, parsing, transformation, and file-scanning operations.
  * Enhanced allocation reporting with an optional per-phase allocation table and inclusive parent measurements.
  * Improved profiling support for work performed across parsing threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->