### PR TITLE
docs(rsc): the server action and the boundary it crosses

### DIFF
--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -96,6 +96,18 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb: "Files become routes; layouts nest; loaders run before the page.",
       },
       {
+        href: "/guide/server-components",
+        title: "Server Components",
+        blurb:
+          "The boundary a directive draws, the graph that resolves it, and a split at the route, not the module.",
+      },
+      {
+        href: "/guide/server-actions",
+        title: "Server actions",
+        blurb:
+          "A function the browser calls by id: what may cross, what is refused, and why it authorizes itself.",
+      },
+      {
         href: "/guide/styling",
         title: "Styling and content",
         blurb: "CSS, StyleX, tokens, dark mode, Markdown and MDX.",

--- a/docs/app/guide/server-actions/_uf.page.mdx
+++ b/docs/app/guide/server-actions/_uf.page.mdx
@@ -1,0 +1,414 @@
+---
+title: "Server actions · uf"
+description: "A function the browser calls by id: what may cross, what is refused, and why it authorizes itself."
+---
+
+<p className="eyebrow">Writing code</p>
+
+# Server actions
+
+<div className="lede">
+A `"use server"` export is a function the browser can invoke over the network,
+and it is a public HTTP endpoint from the moment the build contains it. So this
+page is as much about what uf refuses as about what you write: the grammar the
+arguments have to fit, the three independent things standing between the
+endpoint and a cross-site call, and the one guarantee uf cannot give you —
+that whoever made the call was allowed to.
+</div>
+
+## Writing one
+
+A module whose first statement is `"use server";`. Every export is an action,
+and every export has to be an async function.
+
+```js
+"use server";
+// @flow
+// app/counter/_actions/tally.js
+import { cookies } from "@uniflowed/server";
+
+import { tallyFor } from "./ledger.js";
+
+/** Record a count and answer with what the server made of it. */
+export async function recordCount(count: number): Promise<{|
+  readonly total: number,
+  readonly visitor: string,
+|}> {
+  return {
+    total: tallyFor(count),
+    visitor: cookies().get("visitor") ?? "anonymous",
+  };
+}
+```
+
+Two things in that file are the point of it. `cookies()` comes from
+`@uniflowed/server`, which imports `node:async_hooks`; `./ledger.js` is an
+ordinary module with no directive of its own, standing in for the database
+handle a real action reaches for. **Neither reaches the browser.**
+`@uniflowed/vite` answers the client build with a generated module *in place of*
+this file — one reference per callable export — so the body, its imports, and
+everything only they reached stay where they were written. The graph agrees with
+the bundler about it: an import from the client graph into a `"use server"`
+module is coloured server, so a database handle reached only through an action
+is not in the client graph at all.
+
+## Calling one
+
+An ordinary import and an ordinary call.
+
+```js
+"use client";
+// @flow
+// app/counter/_components/Counter.js
+import * as React from "@uniflowed/react";
+import { useState } from "@uniflowed/react";
+
+import { recordCount } from "../_actions/tally.js";
+
+export default component Counter() {
+  const [count, setCount] = useState<number>(0);
+  const [recorded, setRecorded] = useState<string>("");
+  return (
+    <div>
+      <button type="button" onClick={() => setCount(count + 1)}>
+        add one
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void recordCount(count).then((answer) => {
+            setRecorded(`${String(answer.total)} ${answer.visitor}`);
+          });
+        }}
+      >
+        record
+      </button>
+      <output>{recorded}</output>
+    </div>
+  );
+}
+```
+
+On the server that import *is* the function. In the browser it is a reference:
+`createServerReference(id, "app/counter/_actions/tally.js#recordCount")`, which
+is an id and a `fetch`. You never write one — `@uniflowed/vite` emits one per
+callable export, in the client graph only.
+
+**Flow reads the module, not the reference.** The bundler's substitution is not
+something the checker sees, so `recordCount("nine")` against
+`recordCount(count: number)` is a `uf check` error rather than a `400` with
+nothing in it. That half needs nothing from the runtime, and
+`tests/type-tests/server-actions.js` exists so that a change which breaks it is
+caught by a test rather than by a user.
+
+## Forms
+
+A reference is an ordinary async function, which is all React 19's form APIs
+ask for.
+
+```js
+"use server";
+// @flow
+// app/counter/_actions/notes.js
+import { maxLength, minLength, object, pipe, safeParse, string, trim } from "@uniflowed/validator";
+import { put } from "@uniflowed/validator/plain-object";
+
+const Note = object({ note: pipe(string(), trim(), minLength(1), maxLength(80)) });
+
+/** What `useActionState` holds between submits. */
+export type NoteState = {| readonly saved: string | null, readonly problem: string | null |};
+
+export async function submitNote(previous: NoteState, form: FormData): Promise<NoteState> {
+  const fields: { [string]: string } = {};
+  for (const [name, value] of form.entries()) {
+    if (typeof value === "string") {
+      put(fields, name, value);
+    }
+  }
+
+  const parsed = safeParse(Note, fields);
+  if (!parsed.ok) {
+    // The previous `saved` survives a rejected submit, which is why
+    // `useActionState` hands an action the previous state at all.
+    return { saved: previous.saved, problem: "a note is 1 to 80 characters" };
+  }
+  return { saved: parsed.value.note, problem: null };
+}
+```
+
+```js
+"use client";
+// @flow
+// app/counter/_components/NoteForm.js
+import * as React from "@uniflowed/react";
+import { useActionState } from "@uniflowed/react";
+import { useFormStatus } from "react-dom";
+
+import { type NoteState, submitNote } from "../_actions/notes.js";
+
+const NO_NOTE: NoteState = { saved: null, problem: null };
+
+component SaveNote() {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending}>
+      save note
+    </button>
+  );
+}
+
+export default component NoteForm() {
+  const [note, saveNote] = useActionState<NoteState, FormData>(submitNote, NO_NOTE);
+  return (
+    <form action={saveNote}>
+      <input name="note" maxLength={80} defaultValue="" />
+      <SaveNote />
+      <output>{note.saved ?? note.problem ?? ""}</output>
+    </form>
+  );
+}
+```
+
+`<form action={fn}>` hands the action a `FormData`; `useActionState` hands it
+the previous state and then the `FormData`. `useFormStatus` has to be read from
+a component *inside* the form, which is React's rule rather than uf's — a button
+that knows whether its own submit is in flight cannot be the component rendering
+the `<form>`.
+
+The schema is on the server because that is the only place it is a check.
+`<input required maxlength="80">` is a convenience for the person typing, and
+the request that reaches the function was not necessarily made by that document.
+
+A rejected submit is a value on the state rather than an exception: the endpoint
+answers a thrown action with a `500` and nothing in it, and "your note is too
+long" is not an internal error.
+
+**A form submitted before its page has hydrated does not work.** That is the one
+piece of React's form story uf does not have, and it is a deliberate trade; the
+last section says what it buys.
+
+## What may cross
+
+**A server action's arguments are plain JSON data, plus at most one form.** One
+object, `{"args": [...]}`, of valid UTF-8. Each value is `null`, a boolean, a
+finite number, a string, an array of those, or a plain object whose keys are
+ordinary strings. The result comes back under the same grammar, plus `undefined`
+for an action that returns nothing — and never a form, because a form is
+something a browser submits and not something a server answers with.
+
+| Bound | Value |
+| --- | --- |
+| Request body | 1 MiB |
+| Positional arguments | 16 |
+| Nesting depth | 24 |
+| Values in one payload | 10,000 |
+| Fields in one submitted form | 256 |
+| Length of one form field name | 128 |
+
+And what is refused, each for a reason:
+
+- **Functions, symbols, bigints, `undefined` as an argument.** JSON has no
+  spelling for them, and an action declared to take one would be taking
+  something the caller cannot send.
+- **`NaN` and the infinities.** `JSON.stringify` writes `null` for each, so
+  accepting one would mean the action was called with a different number from
+  the one the caller passed.
+- **Class instances, `Map`, `Set`, `Date`, `RegExp`, typed arrays, React
+  elements.** Each would need a tag in the payload naming a constructor to call,
+  and a tag naming a constructor is what every deserialisation CVE is made of.
+  An action that wants a date takes an ISO string and parses it, where the parse
+  is yours and is checked.
+- **`__proto__`, `constructor` and `prototype` as keys.** `JSON.parse` gives
+  `__proto__` an *own* property rather than changing the prototype, so a payload
+  carrying one is not itself pollution — it becomes pollution in the first line
+  of application code that spreads or merges it. Refused in one place rather
+  than left for every action to remember.
+- **A value that refers to itself, or twice to the same object.** The
+  alternative is a marker meaning "this is the object you saw earlier", which is
+  a reference format by another name.
+- **A file in a form.** Bytes here would be base64 in a JSON string with no
+  ceiling of their own, and an upload wants a content type, a streaming read and
+  a size limit that are not this module's.
+- **A second form in one call.** The envelope names the form's position once.
+- **Symbol keys.** `JSON.stringify` drops them silently, so the payload would
+  arrive missing a property nobody could see was missing.
+
+The same grammar runs on both sides, so the browser refuses to *send* what the
+server would refuse to receive. A bad argument is
+`argument 2.createdAt is a class instance …` thrown at the call site with a
+stack that reaches your component, rather than a `400` with nothing in it.
+
+A submitted form does not widen any of that. It travels *beside* the values —
+`{"args": [null, null], "form": {"at": 1, "entries": [["note", "hi"]]}}` — never
+inside one. A tag in the value tree would be a payload saying which constructor
+to call; outside the tree, `at` names a position and not a type, the slot it
+names must hold `null`, and the decoder's only constructor is `FormData`, fixed
+in the code and never named by the payload.
+
+## The call, and the endpoint
+
+A `POST` to **the page's own URL**, with `uf-action: <id>`,
+`content-type: application/json`, `credentials: same-origin` and `cache: no-store`.
+
+The URL is the page rather than a path uf reserves so that the middleware
+guarding that path runs above the call exactly as it does above the page — no
+new route to collide with a project's own, and no second spelling of "which
+guard applies here". Every host runs the action dispatcher in the same place:
+below the middleware, above the route handlers. A guard that answers is the
+whole request; a request naming no action is declined outright, so a
+`_uf.route.js` at the same path still gets it.
+
+Every answer is one of these, and every refusal carries the same fixed body —
+the status says what a caller may usefully do differently, and nothing says what
+went wrong:
+
+| Status | When |
+| --- | --- |
+| `200` | The action ran and its result crossed |
+| `400` | The payload is not this grammar |
+| `403` | `Origin` is absent, unparseable, or not equal to `Host` |
+| `404` | No row has that id — malformed, well-formed but unknown, or not callable |
+| `405` | Not a `POST`. Carries `Allow: POST` |
+| `413` | The body is larger than an action accepts |
+| `415` | The content type is not exactly `application/json` |
+| `500` | The action threw, or its result cannot cross |
+
+**Cross-site calls cannot happen by accident, three times over.** `uf-action` is
+not a header a simple request may set, so a cross-origin caller needs a
+preflight and nothing answers one. `application/json` is not a content type a
+`<form>` can produce. And `Origin` must be present and must equal `Host`. Any
+one of the three would do; all three are there because the cost is three `if`s
+and the failure is somebody's account.
+
+`Origin` is compared against `Host` and against nothing else, because `Host` is
+what the browser was talking to and `X-Forwarded-Host` is a string the caller
+wrote. **A proxy in front of a uf application has to preserve `Host`**, and one
+that rewrites it turns every action call into a `403` rather than into a hole.
+The port is part of the comparison, so `:5173` and `:5174` on one machine are
+two origins — which is what a cookie already thinks.
+
+## An action authorizes itself
+
+The middleware running above the call is a convenience and **it is not a
+boundary**, because the URL is the caller's to choose: a client that wants to
+skip the guard on `/dashboard` posts the same id to `/`.
+
+**A server action is the unit of authorization, the way a route handler is.** A
+`"use server"` function that relies on a path guard having run is a function
+with a hole in it. Read the session inside the action, decide inside the action,
+and treat every argument as something a stranger sent — because one may have.
+
+## The id, and what is dialable at all
+
+An action id is `HMAC-SHA256(build id, module ‖ export ‖ kind)`, rendered as 64
+lowercase hexadecimal characters. Four properties follow, and each answers a
+failure that has produced a real CVE in another React framework.
+
+- **Ids are not guessable.** The whole repository plus a published sourcemap is
+  not enough to derive the id of a function the interface does not offer,
+  because the build id is the key and is never published — the manifest carries
+  only a fingerprint of it.
+- **Ids do not survive a rebuild.** A new build id changes every action id, so
+  an id captured from an older, more permissive deployment cannot be replayed.
+- **Only actions a client boundary can reach have a row.** An action nothing can
+  hand across a boundary is recorded in the registry and never written to the
+  manifest, so it has no endpoint. There is no path from a request to a module
+  specifier, a file name or an export name: the id selects a row, and the row
+  was decided at build time.
+- **Every failed lookup answers identically.** A malformed id, a well-formed id
+  nobody has, and an id naming something not callable are all `404` with the
+  same body — and the table is scanned in full with a constant-time comparison,
+  so the time taken does not answer either. A malformed *payload* is decided
+  before the id is even looked up, so a bad body cannot be used to test a guess.
+
+Set `UF_BUILD_ID` when a build has to be reproducible. It is an HMAC key, so it
+has to be at least 8 bytes and at most 256; a value outside that is ignored and
+one is generated from operating-system entropy instead, which is also what
+happens when the variable is unset.
+
+## Nothing about a failure comes back
+
+An action that throws is a `500` with a fixed body. The exception goes to the
+host's error reporting with the module and export named; a message, a name or a
+stack in the *response* is your application's internals published to whoever
+asked for them. This is true in development too, because `uf dev` and `uf build`
+have to agree about what the endpoint answers, and the terminal is where you
+read the exception anyway.
+
+On the browser side a failed call is a `ServerActionError` carrying the status
+and the action's build-time `module#export` name, and nothing else — because
+nothing else came back.
+
+## Draft mode
+
+A server action is one of the two places `draftMode().enable()` is allowed, the
+other being a route handler. Both own a response, and a cookie is part of one.
+That is what makes a CMS whose "preview" is a button rather than a link work.
+
+The refusals stay outside that scope: a `403` for a cross-origin call carries no
+cookie, and nothing in that path ran that could have asked for one. See
+[Routing](/guide/routing) for the rest of draft mode.
+
+## The types the wire needs
+
+Flow reading a declaration tells you `createUser(36)` is wrong. It cannot tell
+you whether `string` is a thing that can cross a network — and
+`createUser(when: Date)` type-checks perfectly at every call site and then
+arrives on the server as `{}`.
+
+<div className="command"><code>uf prepare</code></div>
+
+`uf prepare` writes `server-actions.js`: every callable action of the project
+keyed by `module#export`, with its real type read off the declaring module
+through `import typeof`, plus two lines that hold every action's arguments and
+result against the wire grammar over the whole project at once. An action taking
+a callback, or returning a `Map`, is a `uf check` error naming the offending
+type.
+
+The file is types only — every import in it is erased — so importing it adds
+nothing to a bundle. It is for code holding an action's *name* rather than the
+action: a dispatch table, a test harness, an RPC client. A client component that
+imports the action already has its type.
+
+## What is not here
+
+- **Progressive enhancement.** A form that submits before its JavaScript has
+  arrived does not work. React's mechanism for that is a `$$FORM_ACTION`
+  property that turns the submit into a *native* form post, and a native form
+  post is `multipart/form-data` — the content type this endpoint refuses on
+  purpose. So a reference carries no such property, React writes
+  `action="javascript:throw …"` as it does for any client action, and a submit
+  before hydration throws in the page rather than posting anywhere. Nothing
+  reaches a server that was not meant to; what is missing is the submit working
+  at all. [#252](https://github.com/ubugeeei-prod/uf/issues/252).
+- **Uploads.** A `File` entry is refused by name at the call site. Multipart
+  parsing is its own attack surface and is deliberately absent; use a route
+  handler.
+- **Inline `"use server"` closures.** A closure whose body opens with the
+  directive is recognised, keyed and written into the manifest, but it has no
+  export name to import — so it gets no reference in the client bundle and no
+  row in the server's table, and nothing can call it. Reaching one needs the
+  payload [#252](https://github.com/ubugeeei-prod/uf/issues/252) is about. Write
+  a module export.
+- **A reference format.** Nothing in a payload can name a function, a module, a
+  class, a prototype, a React element or a reference, and this grammar is not
+  where one grows quietly. That is the same absence
+  [#519](https://github.com/ubugeeei-prod/uf/issues/519) describes from the
+  other side.
+- **A type error for two forms in one signature.** The wire refuses a second
+  form at run time; the types accept the signature, because saying it needs a
+  walk over the parameter tuple that
+  [#300](https://github.com/ubugeeei-prod/uf/issues/300) makes answer *wrongly*
+  rather than fail. A constraint built on it would report every signature as
+  fine, which is worse than none.
+- **An action cache.** `rendering.cache.actions` is refused by name when the
+  config loads rather than accepted and ignored. See [Caching](/guide/cache).
+- **A static deployment.** `build.staticBuild` and `uf build --adapter static`
+  refuse a project whose build the browser can call an action in: the client
+  bundle carries the reference either way, so the button would be wired with
+  nothing to answer it. `--adapter node` and the other four server targets run
+  the same application file.
+
+The whole of the split this sits inside — what a `"use client"` boundary is,
+and what is still route-shaped — is in
+[Server Components](/guide/server-components).

--- a/docs/app/guide/server-components/_uf.page.mdx
+++ b/docs/app/guide/server-components/_uf.page.mdx
@@ -1,0 +1,271 @@
+---
+title: "Server Components · uf"
+description: "The boundary a directive draws, the graph that resolves it, and a split at the route, not the module."
+---
+
+<p className="eyebrow">Writing code</p>
+
+# Server Components
+
+<div className="lede">
+Every module in a uf application belongs to the server until it says otherwise,
+and `"use client"` is how it says otherwise. What that directive is worth is
+decided by a graph rather than by a convention: uf resolves the whole import
+tree, finds every place the server hands off to the browser, and reports every
+way an application can break the contract. What it does not do yet is split
+anything smaller than a route, and that is written down here rather than left
+for you to discover by measuring `dist/`.
+</div>
+
+## Three kinds of module
+
+A module's environment is decided by its first statement and by nothing else.
+
+| First statement | Environment | What it means |
+| --- | --- | --- |
+| nothing | Server | A Server Component, or ordinary server code. The default. |
+| `"use client";` | Client | A client bundle root. Its code is the browser's, and everything it imports comes with it. |
+| `"use server";` | Server actions | Every export is a function the browser may call by id. See [Server actions](/guide/server-actions). |
+
+A directive is honoured under the ECMAScript *directive prologue* rules, which
+is what React and the bundlers implement:
+
+- a UTF-8 BOM, a `#!` line, comments and blank lines may come before it;
+- it must be a plain single- or double-quoted string literal, so a template
+  literal or a concatenation is not one;
+- it must end at `;`, at a line break, at the `}` that closes its block, or at
+  the end of the file;
+- the text between the quotes is compared byte for byte, so `"use  client"`
+  with two spaces is an ordinary string statement — exactly as `"use strict"`
+  behaves in the language.
+
+**A directive uf cannot honour is reported rather than ignored.** A `"use
+client"` further down the file, one built by concatenation, a module declaring
+both directives, a `"use client"` inside a function body: each is a named
+diagnostic. Silently dropping one is how a module its author believed was a
+Client Component ends up rendered only on the server, which is the bug this
+pass exists to prevent.
+
+A `"use server"` at the top of a *function body* is a different and supported
+construct — it marks that one closure as an action rather than changing the
+module. Those are collected separately, and the limit on them is in
+[Server actions](/guide/server-actions).
+
+## The boundary is an import
+
+```js
+// @flow
+// app/counter/_uf.page.js
+import * as React from "@uniflowed/react";
+
+import Counter from "./_components/Counter.js";
+
+export default component CounterPage() {
+  return (
+    <section>
+      <h1>rsc-split-app counter</h1>
+      <Counter />
+    </section>
+  );
+}
+```
+
+```js
+"use client";
+// @flow
+// app/counter/_components/Counter.js
+import * as React from "@uniflowed/react";
+import { useState } from "@uniflowed/react";
+
+export default component Counter() {
+  const [count, setCount] = useState<number>(0);
+  return (
+    <button type="button" onClick={() => setCount(count + 1)}>
+      {count}
+    </button>
+  );
+}
+```
+
+That import is the boundary: a server module importing a `"use client"` module.
+The `"use client"` module becomes a client bundle root, and the analysis records
+the edge. Both files are trimmed from
+`crates/uf_cli/tests/fixtures/rsc-split-app`, which is the project uf's own build
+tests read the answer out of rather than asserting it.
+
+## What the graph decides
+
+For every module in the project, the analysis answers four questions.
+
+| Question | Answers |
+| --- | --- |
+| Which environment does it run in? | `server`, `client`, `server-actions` |
+| Which halves reach it? | `unreachable`, `server-only`, `client-only`, `server-and-client` |
+| Can a closure it defines cross into the browser? | `isolated`, `reaches-boundary` |
+| Does the browser have to evaluate it? | yes when it declares `"use client"`, and yes when it reaches a boundary |
+
+The last one is the split, and it is two facts joined by an `or`. A
+`"use client"` module is a bundle root by definition. A module *above* a
+boundary is in the browser too, and that second half is uf's client renderer
+talking rather than React's: `packages/router/client.js` hydrates by
+re-rendering the matched tree from the same modules the server rendered it
+from, so a Server Component above a boundary is a module React needs in order
+to reach the boundary at all.
+
+Which leaves the module that reaches **no** boundary. Nothing under it is ever
+rendered in the browser, so nothing under it has to be shipped — and that is
+the whole of the split uf performs today.
+
+## The split is at the route
+
+`uf build` drops a route's page from the *client* route table when no client
+boundary is reachable from that route's page, its layouts, its `_uf.loading.js`
+and `_uf.template.js` modules, or the not-found and error boundaries that cover
+it. Nothing in the browser imports the page, so nothing only the page reached is
+emitted.
+
+Three properties of that are worth knowing before you rely on it.
+
+**A dropped route is not hydrated, and a `Link` into one is a document
+navigation.** There is no page for the client router to render, so the browser
+fetches the document — which is what the anchor would have done on its own. See
+[Routing](/guide/routing).
+
+**A dropped page is still imported for its side effects.** A uf build links the
+stylesheets it finds in the client module graph, and those are the whole graph's
+— so a route removed from it outright would take its rules off every page of the
+site. The import stays, nothing is read from it, and the code is tree-shaken
+rather than never resolved.
+
+**Unknown means ship it.** The analysis scans `.js`. A page written as `.mdx`, a
+`.jsx` module, a file past the scanner's size limit: none of them is in the
+manifest, and the honest reading of a module the analysis never saw is that it
+might reach a boundary. Every unknown answers "keep it", so the split can only
+remove a route uf has positively decided needs no browser — and a manifest that
+is missing, unreadable, or written by an older uf removes nothing at all. A
+project driving Vite itself, without `uf build` or `uf dev`, gets no split.
+
+## Seeing what moved
+
+<div className="command"><code>uf dev</code></div>
+
+The analysis is rerun on every save, and what moved across the client bundle
+since the last scan is reported under a `client bundle` heading. A module that
+entered it is named with the shortest chain of imports that put it there —
+`app/counter/_uf.page.js imports app/counter/_components/Counter.js, which
+declares "use client"` — and a module that left is named with no chain, because
+there is none to give. So a page arriving in the browser's bundle is a line in
+the terminal on the save that did it, rather than a number in a bundle report a
+week later.
+
+The whole project is rescanned rather than one module patched, because whether a
+module is client-only depends on which entries reach it — there is no per-module
+answer that is also a complete one.
+
+<div className="command"><code>uf build</code></div>
+
+The build's summary counts what the analysis found:
+
+```
+  modules            11
+  client components  3
+  server actions     0
+  rsc diagnostics    0
+```
+
+and adds a `pages in the client bundle  2 of 5` row **only** when the split
+removed something. The absence of that row means what it meant before the split
+existed: every page went to the browser.
+
+`.uf/build/meta/uf-rsc-manifest.json` carries the decision per module as
+`proximity`, along with every boundary, every bundle root, and every callable
+action. It does not carry the build id, only a fingerprint of it —
+[Server actions](/guide/server-actions) says why that matters.
+
+## What it reports
+
+Every one of these is an error, and `uf build` prints them before it runs the
+bundler and then fails: a module that breaks the contract is not going to be
+fixed by bundling it. The one exception is the last row.
+
+| Rule | What it means |
+| --- | --- |
+| `rsc/server-only-import-in-client` | A module the client graph reaches imports `@uniflowed/db`, `@uniflowed/server`, `server-only`, a subpath of one of those, or a `*.server.js` file |
+| `rsc/client-only-api-in-server` | A Server Component calls `useState`, `useEffect`, `createContext` and the rest, or reads `window`, `document`, `localStorage`, `sessionStorage`, `navigator` or `alert` |
+| `rsc/client-only-hook-in-server` | A Server Component calls a hook `@uniflowed/hooks` declares as browser-only |
+| `rsc/server-action-not-async` | A `"use server"` export React cannot call, because it is not an async function |
+| `rsc/server-action-not-a-function` | A `"use server"` module exporting something that is not a function at all |
+| `rsc/import-escapes-project-root` | An import that resolves outside the project |
+| `rsc/module-outside-project-root` | A module whose own path is not inside the project |
+| `rsc/directive-not-in-prologue` | A directive that is not the module's first statement |
+| `rsc/directive-not-a-string-literal` | A directive built from a template literal or a concatenation |
+| `rsc/conflicting-directives` | One module declaring both `"use client"` and `"use server"` |
+| `rsc/client-directive-in-function` | `"use client"` inside a function body, which React does not support |
+| `rsc/unclassified-hook-in-server` | **A warning.** The check matched names and this hook is not one of them |
+
+That last row is the only thing in the analysis that is not a verdict, and it is
+a warning because it is a statement that the analysis *stopped*. The client-only
+check matches identifiers against two name lists, so `useState` in a Server
+Component is caught and `useRoute` — which is built on `useContext` — is not,
+and neither is any hook you wrote yourself. Deciding it properly means binding
+an export to the APIs its body reaches; that is
+[#388](https://github.com/ubugeeei-prod/uf/issues/388). Until then the honest
+output is the question rather than silence, because silence reads as "checked
+and fine", which is the one thing it is not.
+
+`uf dev` prints the same list and changes no exit code. A dev server that
+refused to serve a module over a contract violation would be a dev server you
+could not use to fix one.
+
+## Where `uf lint` fits
+
+Four of uf's lint rules are about this boundary. They read one file at a time,
+by text, with no graph — which is why they can run on a git hook over the staged
+files, and why they are not a substitute for the analysis above.
+
+| Rule | What it matches |
+| --- | --- |
+| `server/no-server-only-import-in-client` | A `"use client"` module importing `@uniflowed/server` or a `*.server.js` file |
+| `server/no-client-secret` | A line in a `"use client"` module mentioning `SECRET` or `PRIVATE_` |
+| `server/use-client-directive-position` | A boundary directive that is not the module's first statement |
+| `server/use-server-actions` | A module under `server/` or named `*.server.js` that mentions `serverAction` and does not open with `"use server";` |
+
+All four are errors by default. The first and third answer a narrower version of
+an `rsc/` question sooner — one file, no imports resolved, no graph. The second
+has no counterpart in the graph, because a secret read from a client module is a
+string and not an edge. The fourth is about where a project keeps its action
+modules rather than about the boundary at all.
+
+## What is not here
+
+**The Flight payload, and everything downstream of it.** uf has no
+client-re-renderable payload describing the tree the server rendered, so:
+
+- **the split cannot be at the module.** A Server Component above a boundary
+  ships whole, because the client re-renders the matched tree from the same
+  modules the server used. The analysis, the bundler and the roadmap all carry
+  that same sentence, and it is why the unit is a route.
+- **a `"use client"` module is not a reference in the server render.** It is a
+  module the browser also gets, which is ordinary SSR with full hydration for
+  every route that keeps its page.
+- **`rsc/server-only-import-in-client` does not cover a page above a
+  boundary.** It asks about modules the client graph *reaches*, and a module
+  above a boundary is not one of them — it is server-reachable code that the
+  route-level split ships anyway. Until the payload lands, keep a `cookies()`
+  call out of a page that renders a client component, or move it behind an
+  action.
+
+Streaming is *not* the missing half: `renderToPipeableStream` and
+`renderToReadableStream` are what uf renders documents with, and Suspense
+boundaries already resolve independently in the HTML stream. What is missing is
+the payload a **client** re-renders a tree from, and it is a second module graph
+rather than a second dependency — React's server renderer only loads under the
+`react-server` export condition, which resolves `react` to a build with no
+`useState` in it, and `react-dom/server` needs the ordinary one. Two builds of
+React cannot share one module registry, so this needs a Vite environment uf does
+not have yet, a client-reference manifest keyed to Rollup's chunk ids, and a
+rewrite of the client's hydration.
+
+[#252](https://github.com/ubugeeei-prod/uf/issues/252) and
+[#519](https://github.com/ubugeeei-prod/uf/issues/519) carry that argument in
+full. [What uf does not do](/guide/scope) lists this beside every other gap.


### PR DESCRIPTION
`crates/uf_rsc` is 2,372 lines of directive scanning, graph analysis and a keyed
action registry; `packages/router/action.js` and `internal/action-endpoint.js`
are a working endpoint with 54 tests behind them; `packages/vite/internal/rsc.js`
splits the client route table and substitutes references for `"use server"`
modules. The manual said nothing about any of it — thirty pages under
`docs/app/guide/` and not one for either half.

Two pages, and both are as much about the limits as about the API.

### `/guide/server-components`

The three module environments and the directive-prologue rules that decide them
(byte-exact text, first statement only, and a directive uf cannot honour is a
named diagnostic rather than silence). What the graph answers per module —
environment, reachability, `proximity`, and whether the browser has to evaluate
it. The route-level split and its three properties: a dropped route is not
hydrated, a dropped page is still imported for its stylesheet, and unknown means
ship it. How to see it (`uf dev`'s per-save `client bundle` report with the
shortest import chain; `uf build`'s summary rows; `proximity` in
`uf-rsc-manifest.json`). The twelve `rsc/` rules, with
`rsc/unclassified-hook-in-server` called out as the only warning and why silence
would be the wrong output. Where the four `server/*` lint rules fit, and why they
are not a substitute for the graph.

### `/guide/server-actions`

Writing a `"use server"` module and what stays off the browser because of it;
calling one from a `"use client"` component, and that Flow reads the declaration
rather than the substituted reference; `<form action={fn}>` with `useActionState`
and `useFormStatus`; the wire grammar with every bound (1 MiB, 16 arguments,
depth 24, 10,000 values, 256 form fields, 128-character names) and every refusal
and its reason; the envelope that carries a form *beside* the values rather than
inside one; the call (`POST` to the page's own URL, `uf-action`,
`application/json`) and why the page URL rather than a reserved path; the eight
answers the endpoint gives and the three independent things standing between it
and a cross-site call; the keyed id and the four properties that follow from it;
draft mode; and the generated `server-actions.js`.

It states plainly, in its own section, the point
`internal/action-endpoint.js` makes and that must not be lost in a doc: **a
server action authorizes itself.** The middleware above the call is a convenience
and not a boundary, because the URL is the caller's to choose.

### Named as not implemented

- The client-re-renderable Flight payload, so the split is at the route and a
  Server Component above a boundary still ships whole — ubugeeei-prod/uf#519,
  ubugeeei-prod/uf#252. Streaming is explicitly *not* the missing half.
- A `"use client"` module is not a reference in the server render; a route that
  keeps its page is ordinary SSR with full hydration.
- `rsc/server-only-import-in-client` does not cover a page above a boundary — the
  check asks about modules the client graph *reaches*, and a module above a
  boundary is server-reachable code the route-level split ships anyway.
- Progressive enhancement: a form submitted before hydration throws in the page,
  because `$$FORM_ACTION` would mean accepting `multipart/form-data`
  (ubugeeei-prod/uf#252).
- Uploads; inline `"use server"` closures, which are keyed and written to the
  manifest and callable by nothing; a type error for two forms in one signature
  (ubugeeei-prod/uf#300); `rendering.cache.actions`; and the `staticBuild` /
  `--adapter static` refusal.

Every code sample is trimmed from `crates/uf_cli/tests/fixtures/rsc-split-app`,
which is the project `crates/uf_cli/tests/vite.rs` reads the split out of, so
each one is code that builds today.

Both pages are in `docs/app/_design/nav.js` under **Writing code**, after
Routing.

### Verification

| Check | Result |
| --- | --- |
| `docs:build` | ok — 40 documents, both new routes prerendered and in `sitemap.xml` |
| `docs:links` | ok — 2,286 links, 2,004 internal, 73 anchors |
| `test:lib` | 2,705 passed, 0 failed, 1 skipped, 78 files |
| `uf fmt --check` | already formatted |
| `uf lint` | 0 errors, 0 warnings |

Refs ubugeeei-prod/uf#252, ubugeeei-prod/uf#519.

### One thing found and not fixed here

`/guide/scope`, `/guide/compare` and `/guide/migrate` still say "no server action
is callable", "`renderToString`, so no", "route handlers dispatched only under
`uf dev`" and "middleware … never called". Those are stale well beyond RSC and
contradict `/guide/routing` and `/guide/dev` as much as they do these two pages;
a sweep over them is its own change rather than a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791519748&installation_model_id=422833&pr_number=701&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F701&signature=af530a6199d9d8bd7ea29265b30d87c11f2b13c40b66f2a9545e5057e55d41ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->