### PR TITLE
feat(config, router): a link the browser follows, and the key that says so

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -28,7 +28,7 @@ use uf_bundle::{
     BudgetMetric, BundleBudgets, BundleReport, ByteSize, ReportOptions, build_report,
     collect_assets, evaluate, write_report,
 };
-use uf_config::{DeployAdapter, LibraryPlan, Prerender, RenderingPlan, load_config};
+use uf_config::{DeployAdapter, LibraryPlan, Navigation, Prerender, RenderingPlan, load_config};
 use uf_router::{Route, discover_routes, discover_server_modules, write_router_manifest};
 use uf_rsc::{
     BuildId, ProjectScanOptions, RSC_MANIFEST_BUILD_DIR, RSC_MANIFEST_ENV, RscAnalysis,
@@ -381,6 +381,12 @@ pub(crate) fn build(
             "server": plan.emits_a_server(),
             "declaredBy": plan.source().key(),
             "perRequest": vite.per_request.clone().unwrap_or_default(),
+            // Beside the prerender because a deploy step asks the same
+            // question about it: whether what is in the output directory is
+            // answered by the browser or by the documents alone. `client`
+            // for every project that has not set it, so the field is a fact
+            // rather than a presence to test for.
+            "navigation": plan.navigation().as_str(),
         },
         "runtime": {
             "default": resolved.config.app.runtime.default,
@@ -517,6 +523,17 @@ pub(crate) fn build(
         Prerender::Everything => "every route prerendered",
         Prerender::Possible => "prerendered where it can be, the rest per request",
         Prerender::Nothing => "nothing prerendered; every route per request",
+    };
+    // And what it decided about the other axis. A row rather than a line only
+    // when it is not the default: `app.rendering.navigation` is `client` in
+    // every project that has not heard of it, and a summary row saying so on
+    // every build is a row nobody reads. A build that ships no client router
+    // has to say so — it is the difference between a link that resolves in the
+    // page and a link that fetches a document, and nothing in `dist/` shows
+    // which one happened.
+    let navigation = match plan.navigation() {
+        Navigation::Client => None,
+        Navigation::Document => Some("a document request; this build ships no client router"),
     };
     let per_request = vite.per_request.clone().unwrap_or_default();
     let per_request_count = per_request.len().to_string();
@@ -672,6 +689,9 @@ pub(crate) fn build(
             Tone::Number,
         ));
         summary_rows.push(KeyValue::new("rendering", rendering));
+        if let Some(navigation) = navigation {
+            summary_rows.push(KeyValue::new("navigation", navigation));
+        }
         renderer.key_values(out, 2, &summary_rows);
         renderer.blank(out);
 
@@ -905,6 +925,14 @@ fn refuse_an_application_artefact(
 /// a refusal in `uf` does. Without it the driver would have to reconstruct
 /// "which setting made this a static build" from a flag that no longer says,
 /// and the two halves of one rule would tell a reader to look in two places.
+///
+/// `app.rendering.navigation` is deliberately **not** a fourth. It is not a
+/// decision about this build — it is the same answer for `uf dev`, `uf build`
+/// and `uf preview`, and neither of the first two is handed a rendering plan
+/// at all — so a builder reads it out of `uf.config.js` the way it reads
+/// `app.react.strictMode`. Passing it here as well would make the client entry
+/// a function of two sources that agree until one of them is a flag somebody
+/// forgot to forward.
 fn build_arguments(out_dir: &str, plan: RenderingPlan) -> Vec<String> {
     let mut args = vec![
         String::from("--out-dir"),

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -848,14 +848,7 @@ fn build_stages(resolved: &ResolvedConfig) -> Vec<Stage> {
             // and it is the finer point of red line 7: uf names the providers
             // it orchestrates, and a provider's internals stay the provider's.
             provider: builder_provider(resolved),
-            detail: match RenderingPlan::resolve(&resolved.config).emits_a_server() {
-                true => "client bundle, then the server bundle".to_string(),
-                // Said, because the difference is the whole of what
-                // `build.staticBuild` does and none of it is visible from the
-                // output directory. The bundle is still built — the prerender
-                // renders through it — and then removed.
-                false => "client bundle, then a server bundle the build removes".to_string(),
-            },
+            detail: bundle_detail(RenderingPlan::resolve(&resolved.config)),
         },
         prerender_stage(resolved),
         adapter_stage(resolved),
@@ -913,6 +906,32 @@ fn library_build_stages(resolved: &ResolvedConfig, plan: &LibraryPlan) -> Vec<St
 
 /// What the build renders now, and what it leaves to a server.
 ///
+/// The two bundles, and what the client one is an entry for.
+///
+/// The server half is the one `build.staticBuild` changes, and it is said out
+/// loud because the difference is the whole of what that setting does and none
+/// of it is visible from the output directory: the bundle is still built — the
+/// prerender renders through it — and then removed.
+///
+/// The client half is the one `app.rendering.navigation` changes, and it is
+/// said for the same reason. Two `dist/` directories built from one project
+/// with the two settings hold the same documents and the same chunks; what
+/// differs is whether the entry that runs in them takes navigation over, and
+/// red line 7 is that a reader should not have to open a chunk to find out.
+fn bundle_detail(plan: RenderingPlan) -> String {
+    let server = match plan.emits_a_server() {
+        true => "client bundle, then the server bundle",
+        false => "client bundle, then a server bundle the build removes",
+    };
+    match plan.ships_a_client_router() {
+        true => server.to_string(),
+        false => format!(
+            "{server}; the client entry hydrates and installs no router, because \
+             `app.rendering.navigation` is `document`"
+        ),
+    }
+}
+
 /// The answer to a question `uf explain build` could not answer until
 /// ubugeeei-prod/uf#336: `app.rendering.modes` and `build.staticBuild` select
 /// between three behaviours, and a reader looking at `dist/` cannot tell which

--- a/crates/uf_config/src/app.rs
+++ b/crates/uf_config/src/app.rs
@@ -614,6 +614,11 @@ pub struct RenderingConfig {
     /// The default is all four, which is "decide per route and deploy a
     /// server" — the behaviour every uf project had before anything read this.
     pub modes: Vec<RenderingMode>,
+    /// What happens when a visitor follows a link.
+    ///
+    /// A second question from [`modes`](Self::modes), and deliberately not a
+    /// fifth value in that list; see [`Navigation`].
+    pub navigation: Navigation,
     pub cache: CacheConfig,
 }
 
@@ -626,7 +631,67 @@ impl Default for RenderingConfig {
                 RenderingMode::Ssg,
                 RenderingMode::Isr,
             ],
+            navigation: Navigation::default(),
             cache: CacheConfig::default(),
+        }
+    }
+}
+
+/// What happens when a visitor follows a link.
+///
+/// The other half of "what does this project deploy", and a **different
+/// question** from [`RenderingMode`] rather than a fifth value in it. That
+/// list says where a document comes from and is decided per route; this says
+/// what the browser does with the document once it has one, and is one answer
+/// for the whole application.
+///
+/// The two compose, which is the proof they are two axes and not one:
+///
+/// | | `client` | `document` |
+/// | --- | --- | --- |
+/// | `ssg` | a prerendered site the client router takes over | a static site of documents |
+/// | `ssr` | a server-rendered app the client router takes over | a server-rendered application in the older sense |
+///
+/// Every cell is a deployment somebody wants, and none of the four is a
+/// rendering strategy the build could pick *per route*: a route is prerendered
+/// or it is not, and the answer does not change because of what the browser
+/// does afterwards. Spelling this as `modes: ["mpa", …]` would have put a
+/// whole-application decision into a per-route allowlist, where
+/// `["mpa", "ssr"]` permits two things that are not alternatives — and an
+/// allowlist entry the build can never select is the defect
+/// `RenderingMode::Ppr` already is.
+///
+/// It is also deliberately not spelled the way the neighbours spell it.
+/// Next.js says `output: "export"` and Astro says `output: "static"`, and each
+/// conflates "no server" with "no client router" because each has one answer
+/// for both. uf already has a name for "no server" — `build.staticBuild` — so
+/// borrowing either spelling would give one question two names, which is
+/// `docs/red-lines.md`'s line 2 from the inside.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Navigation {
+    /// The client router takes the link over: the next route is resolved and
+    /// rendered in the page that is already open.
+    ///
+    /// The default, and what every uf application did before this key existed.
+    #[default]
+    Client,
+    /// The browser follows the link: a full document request, the way a link
+    /// works with no JavaScript at all.
+    ///
+    /// The application still hydrates — a `"use client"` component is still a
+    /// `"use client"` component — and what it does not do is take navigation
+    /// over. See the guide for what that costs and what it does not.
+    Document,
+}
+
+impl Navigation {
+    /// The spelling a `uf.config.js` uses.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Client => "client",
+            Self::Document => "document",
         }
     }
 }

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -21,7 +21,7 @@ pub use app::{
     AppConfig, BuiltinConfig, CacheConfig, CacheModeConfig, ComponentBoundary, DataEngine,
     EffectEngine, FetchConfig, FrameworkPreset, GraphQlConfig, HighlightConfig, HighlightThemes,
     LinkPrefetchMode, LoaderConfig, MarkdownConfig, MarkdownEngineConfig, MdxConfig,
-    MdxPipelinePluginConfig, MotionConfig, MotionEngineConfig, OrmConfig, PwaConfig,
+    MdxPipelinePluginConfig, MotionConfig, MotionEngineConfig, Navigation, OrmConfig, PwaConfig,
     ReactCompilerConfig, ReactCompilerImplementation, ReactCompilerMode, ReactConfig,
     RenderingConfig, RenderingMode, RouterConfig, RouterConvention, RuntimeTarget, StyleEngine,
     TemporalConfig, TuiConfig, TuiStandardConfig, WebConfig,

--- a/crates/uf_config/src/rendering.rs
+++ b/crates/uf_config/src/rendering.rs
@@ -17,6 +17,14 @@
 //! only two questions the rest of the toolchain asks: **what gets prerendered**
 //! and **is there a server**.
 //!
+//! A third setting rides along without interacting with either:
+//! `app.rendering.navigation`, which says what the browser does once it has a
+//! document. It is carried here rather than read separately for the reason the
+//! other two are resolved together — the plan is what every caller already
+//! asks for, and a second reader of the same file is a second place for it to
+//! be wrong — but it decides nothing about the prerender, and
+//! [`RenderingPlan::resolve`] says so where it is copied in.
+//!
 //! # Why a plan and not two booleans
 //!
 //! Because the interesting case is the contradiction. `staticBuild: true` with
@@ -29,7 +37,7 @@
 
 use camino::Utf8Path;
 
-use crate::{ConfigError, RenderingMode, UniflowedConfig};
+use crate::{ConfigError, Navigation, RenderingMode, UniflowedConfig};
 
 /// How much of the route table `uf build` prerenders.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,6 +112,7 @@ pub struct RenderingPlan {
     prerender: Prerender,
     server: bool,
     source: PlanSource,
+    navigation: Navigation,
 }
 
 impl RenderingPlan {
@@ -113,6 +122,13 @@ impl RenderingPlan {
         let modes = &config.app.rendering.modes;
         let per_request = modes.contains(&RenderingMode::Ssr);
         let prerendered = modes.contains(&RenderingMode::Ssg);
+        // Carried rather than resolved *with* the two settings above, because
+        // it does not interact with either: a document is prerendered or it is
+        // not, and what the browser does after it has one does not change the
+        // answer. It is in the plan because the plan is the one thing every
+        // caller already asks for, and a second `config.app.rendering.…` read
+        // at each of them is how two readers of one file come apart.
+        let navigation = config.app.rendering.navigation;
 
         // `staticBuild` first, because it is the stronger claim: it is about
         // the artefact rather than about the routes, and a project that has
@@ -126,6 +142,7 @@ impl RenderingPlan {
                 prerender: Prerender::Everything,
                 server: false,
                 source: PlanSource::StaticBuild,
+                navigation,
             };
         }
         match (prerendered, per_request) {
@@ -137,6 +154,7 @@ impl RenderingPlan {
                 // message quoting a key that changed no decision sends the
                 // reader to a line that is not the problem.
                 source: PlanSource::Default,
+                navigation,
             },
             (true, false) => Self {
                 prerender: Prerender::Everything,
@@ -147,11 +165,13 @@ impl RenderingPlan {
                 // `uf start`. Every document it serves is one the build wrote.
                 server: true,
                 source: PlanSource::Modes,
+                navigation,
             },
             (false, true) => Self {
                 prerender: Prerender::Nothing,
                 server: true,
                 source: PlanSource::Modes,
+                navigation,
             },
             // Refused by `check`, which runs before any of this. Kept total
             // rather than `unreachable!()`: the fallback that cannot happen is
@@ -160,6 +180,7 @@ impl RenderingPlan {
                 prerender: Prerender::Possible,
                 server: true,
                 source: PlanSource::Default,
+                navigation,
             },
         }
     }
@@ -190,6 +211,24 @@ impl RenderingPlan {
     #[must_use]
     pub const fn source(self) -> PlanSource {
         self.source
+    }
+
+    /// What the browser does when a visitor follows a link.
+    ///
+    /// Carried by the plan rather than read from the config at each call site,
+    /// for the reason the other two are: one file, one reader.
+    #[must_use]
+    pub const fn navigation(self) -> Navigation {
+        self.navigation
+    }
+
+    /// Whether the client router takes navigation over.
+    ///
+    /// The predicate every caller actually wants, so that "is this an MPA" is
+    /// asked once here rather than spelled as a comparison in four places.
+    #[must_use]
+    pub const fn ships_a_client_router(self) -> bool {
+        matches!(self.navigation, Navigation::Client)
     }
 
     /// The clause a refusal starts with: the setting, and what it asked for.

--- a/crates/uf_config/src/rendering/tests.rs
+++ b/crates/uf_config/src/rendering/tests.rs
@@ -1,7 +1,7 @@
 use camino::Utf8Path;
 
 use super::{PlanSource, Prerender, RenderingPlan, check};
-use crate::{ConfigError, RenderingMode, UniflowedConfig};
+use crate::{ConfigError, Navigation, RenderingMode, UniflowedConfig};
 
 /// A config whose `modes` is exactly `modes`, with everything else default.
 fn with_modes(modes: &[RenderingMode]) -> UniflowedConfig {
@@ -126,4 +126,61 @@ fn static_build_with_no_ssg_is_the_contradiction_that_is_refused() {
     let message = error.to_string();
     assert!(message.contains("staticBuild"), "{message}");
     assert!(message.contains("ssg"), "{message}");
+}
+
+#[test]
+fn navigation_is_the_client_router_unless_a_project_says_otherwise() {
+    let plan = RenderingPlan::resolve(&UniflowedConfig::default());
+    assert_eq!(plan.navigation(), Navigation::Client);
+    assert!(plan.ships_a_client_router());
+}
+
+#[test]
+fn document_navigation_changes_nothing_about_the_prerender() {
+    // The whole argument for `navigation` being a second key rather than a
+    // fifth `modes` value, as an assertion: it composes with each of the three
+    // prerender answers and moves none of them.
+    for modes in [
+        vec![RenderingMode::Ssg, RenderingMode::Ssr],
+        vec![RenderingMode::Ssg],
+        vec![RenderingMode::Ssr],
+    ] {
+        let mut config = with_modes(&modes);
+        let before = RenderingPlan::resolve(&config);
+        config.app.rendering.navigation = Navigation::Document;
+        let after = RenderingPlan::resolve(&config);
+        assert_eq!(before.prerender(), after.prerender(), "{modes:?}");
+        assert_eq!(before.emits_a_server(), after.emits_a_server(), "{modes:?}");
+        assert_eq!(before.source(), after.source(), "{modes:?}");
+        assert!(!after.ships_a_client_router(), "{modes:?}");
+    }
+}
+
+#[test]
+fn a_static_build_carries_its_navigation_too() {
+    // `staticBuild` returns early, before the match, so it is the one path
+    // that could have dropped the setting on the floor.
+    let mut config = UniflowedConfig::default();
+    config.build.static_build = true;
+    config.app.rendering.navigation = Navigation::Document;
+    let plan = RenderingPlan::resolve(&config);
+    assert_eq!(plan.prerender(), Prerender::Everything);
+    assert!(!plan.emits_a_server());
+    assert_eq!(plan.navigation(), Navigation::Document);
+}
+
+#[test]
+fn document_navigation_is_never_a_refusal_on_its_own() {
+    // There is no `modes` it contradicts: every cell of the table in
+    // `Navigation`'s documentation is a deployment somebody wants.
+    for modes in [
+        vec![RenderingMode::Ssg, RenderingMode::Ssr],
+        vec![RenderingMode::Ssg],
+        vec![RenderingMode::Ssr],
+        vec![RenderingMode::Ssg, RenderingMode::Isr],
+    ] {
+        let mut config = with_modes(&modes);
+        config.app.rendering.navigation = Navigation::Document;
+        check(Utf8Path::new("uf.config.js"), &config).unwrap();
+    }
 }

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -148,6 +148,11 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb: "Vite runs both; uf decides what it is handed.",
       },
       {
+        href: "/guide/rendering",
+        title: "Rendering modes",
+        blurb: "Where a document comes from, and what the browser does once it has one.",
+      },
+      {
         href: "/guide/cache",
         title: "Caching",
         blurb: "A route cache and a fetch cache, opt-in, in memory, and honest about it.",

--- a/docs/app/guide/rendering/_uf.page.mdx
+++ b/docs/app/guide/rendering/_uf.page.mdx
@@ -1,0 +1,128 @@
+---
+title: "Rendering modes · uf"
+description: "Where a document comes from, and what the browser does once it has one."
+---
+
+<p className="eyebrow">The tools</p>
+
+# Rendering modes
+
+<div className="lede">
+Two questions, not one. Where does the document come from, and what happens
+when a visitor clicks a link? uf answers them with two settings, because the
+answers compose.
+</div>
+
+## The two axes
+
+`app.rendering.modes` says where a document comes from, and `uf build` picks
+between the strategies it allows **per route**: a route with no parameters is
+prerendered, a route with parameters is prerendered when its page exports
+`generateStaticParams`, and anything left over is rendered per request. The
+[config reference](/reference/config) has the table.
+
+`app.rendering.navigation` says what happens next, and it is one answer for the
+whole application:
+
+| | `"client"` (the default) | `"document"` |
+| --- | --- | --- |
+| a link | the router resolves the next route in the page that is open | the browser fetches the next document |
+| `["ssg"]` | a prerendered site the client router takes over | a static site of documents |
+| `["ssr"]` | a server-rendered app the client router takes over | a server-rendered application in the older sense |
+
+Every cell is a deployment somebody wants, which is why this is a second key
+rather than a fifth value in the first one. A route is prerendered or it is
+not, and the answer does not change because of what the browser does with the
+result.
+
+## `navigation: "document"`
+
+```js
+// uf.config.js
+export default defineConfig({
+  app: {
+    rendering: {
+      modes: ["ssg"],
+      navigation: "document",
+    },
+  },
+  build: { staticBuild: true },
+});
+```
+
+What changes:
+
+- **A `Link` is an ordinary anchor.** No handler of uf's on it, nothing calling
+  `preventDefault`, no prefetch on hover or focus. The element the browser gets
+  is the one `<a href>` would have produced.
+- **`useRouter().push` and `.replace` hand the URL to the browser**, as
+  `location.assign` and `location.replace`. `refresh()` is a reload.
+- **No `popstate` listener is installed.** Nothing pushed a history entry, so
+  the back button asks the browser for the previous document — which is the one
+  it already has.
+
+What does not change:
+
+- **The page still hydrates.** A `"use client"` component is still a
+  `"use client"` component: a search box still filters, a theme toggle still
+  toggles. This mode is the client router minus the takeover, not the browser
+  minus JavaScript.
+- **Every route is still prerendered or rendered exactly as `modes` says.** The
+  documents in the output directory are the same documents.
+- **`uf dev` behaves the way the deployment does.** The mode is written into
+  the client entry with no `isProduction` beside it, because a development
+  server whose links resolve in the page and a deployment whose links fetch a
+  document are two applications, and the one on the screen is not the one being
+  shipped.
+
+`uf build` says so in its summary:
+
+```text
+  rendering    every route prerendered
+  navigation   a document request; this build ships no client router
+```
+
+and `uf explain build` names it on the bundle stage. `.uf/build/meta/uf-build-manifest.json`
+carries it as `rendering.navigation`, for a deploy step that needs to know
+whether the output directory is answered by the browser or by the documents
+alone.
+
+## What it does not buy you
+
+The honest limit, because it is the thing people expect and do not get.
+
+**It does not empty the bundle.** uf hydrates the whole document rather than
+per-island, so a route with a `"use client"` boundary anywhere in it still
+loads React and still loads that route's components. What document navigation
+removes is the navigation: the history listener, the prefetching, and resolving
+a route in the browser. A route that reaches **no** client boundary already
+ships no page at all — that is the server-component split, and it is on by
+default in both modes — so a content site written in server components was
+already close to zero JavaScript before this key existed, and this key is what
+stops the router taking its links over.
+
+**It is not a separate runtime.** `@uniflowed/router` is one package with one
+client entry, and the mode is a constant the entry passes to it. Making the
+navigation code *absent* from the bundle rather than unreachable would mean
+`RouterProvider` taking its navigator from the entry rather than from module
+state; that is a real change and it is not this one.
+
+**It is not faster on its own.** A document request is a round trip to the
+origin or the CDN. What it buys is a page that behaves the way the web does
+without uf being involved: the browser's scroll restoration, the browser's
+history, the browser's handling of a middle click, and one less thing that can
+be wrong.
+
+## When to choose it
+
+- The site is documents — a manual, a blog, a marketing site — and the client
+  router is buying an animation nobody asked for.
+- Something downstream needs a full document per URL: a caching layer that
+  keys on the URL, an analytics tag that runs on load, an embed that expects
+  a page load.
+- The application is being served behind something that rewrites documents.
+
+And when not to: an application with state that has to survive a navigation —
+a media player that keeps playing, a form half filled in, a list scrolled to
+where the visitor left it — is asking for the client router, which is why it is
+the default.

--- a/docs/app/reference/config/_uf.page.mdx
+++ b/docs/app/reference/config/_uf.page.mdx
@@ -77,6 +77,7 @@ which is the fastest way to answer "what is it actually using".
 | `builtins.reactCompiler` | on | The official React Compiler |
 | `builtins.style` | — | The style engine |
 | `rendering.modes` | `["ppr", "ssr", "ssg", "isr"]` | Which rendering strategies this project will deploy — see below |
+| `rendering.navigation` | `"client"` | What a link does: the client router takes it over, or the browser fetches a document — see below |
 | `rendering.cache.*` | all `false` | Which of uf's caches are on; `data` and `actions` are refused rather than ignored |
 | `targets` | — | Runtime targets the build must satisfy |
 
@@ -118,6 +119,33 @@ which is how a route with *no* parameters keeps out of the prerender —
 generate. `"auto"` is the default. Next.js's `"force-static"` and `"error"` are
 constraints uf does not check yet, and a page that names one is refused rather
 than quietly rendered as `"auto"`.
+
+### rendering.navigation
+
+A **different question** from `modes`, which is why it is a second key rather
+than a fifth value in that list: `modes` says where a document comes from and is
+decided per route, and this says what the browser does once it has one.
+
+| Value | What a link does |
+| --- | --- |
+| `"client"` (the default) | The router takes a plain left click over, resolves the next route and commits it into the page that is open |
+| `"document"` | Nothing of uf's: the browser follows the link, the way it follows one on a page with no JavaScript at all |
+
+Under `"document"` a `Link` renders the same anchor with no click handler and
+no prefetching, `useRouter().push` and `.replace` become `location.assign` and
+`location.replace`, `refresh()` is a reload, and no `popstate` listener is
+installed. The page still **hydrates**, so a `"use client"` component is still
+interactive — this is the client router minus the takeover, not the browser
+minus JavaScript. It composes with every value of `modes`: a static site of
+documents is `["ssg"]` with `"document"`, and a server-rendered application in
+the older sense is `["ssr"]` with it.
+
+The mode is written into the client entry as a constant with no `isProduction`
+beside it, so `uf dev` behaves the way the deployment does. `uf build` prints a
+`navigation` row when it is not the default, `uf explain build` names it on the
+bundle stage, and `.uf/build/meta/uf-build-manifest.json` carries it as
+`rendering.navigation`. The [guide](/guide/rendering) has what it buys and what
+it does not.
 
 ## dev
 

--- a/packages/config/internal/schema.js
+++ b/packages/config/internal/schema.js
@@ -360,6 +360,13 @@ export type UniflowedConfig = {
     },
     readonly rendering?: {
       readonly modes?: $ReadOnlyArray<"ppr" | "ssr" | "ssg" | "isr">,
+      // What the browser does when a visitor follows a link, which is a
+      // different question from `modes` rather than a fifth value in it:
+      // `modes` says where a document comes from, per route, and this says
+      // what happens once the browser has one. `"document"` is a full document
+      // request — the client router is not installed and `Link` renders an
+      // ordinary anchor. See docs/app/guide/routing/navigation.
+      readonly navigation?: "client" | "document",
       readonly cache?: {
         readonly actions?: boolean,
         readonly data?: boolean,

--- a/packages/router/client.js
+++ b/packages/router/client.js
@@ -49,6 +49,17 @@
 // `app.react.strictMode: false` in `uf.config.js` turns it off. See
 // ubugeeei-prod/uf#516.
 //
+// # And an application can decline to be navigated
+//
+// `app.rendering.navigation: "document"` is the whole application saying what
+// the paragraph below says about one route: the document the server wrote is
+// what a link produces, and the browser fetches the next one. It is *not* the
+// same as declining to hydrate — the page still hydrates, so a `"use client"`
+// component is still interactive — and what it removes is the takeover. The
+// flag reaches the runtime through `installNavigation` before the first render;
+// see `internal/runtime.js` for what `RouterProvider` and `Link` then do, and
+// `docs/app/guide/rendering` for when a project wants it.
+//
 // # A route can decline to be hydrated
 //
 // uf's server-component analysis decides which routes have a `"use client"`
@@ -65,8 +76,10 @@ import { hydrateRoot } from "react-dom/client";
 
 import {
   type AppProps,
+  type Navigation,
   type RouteTable,
   hasClientPage,
+  installNavigation,
   installRoutes,
   matchRoute,
   resolveMatch,
@@ -86,6 +99,7 @@ export async function hydrate(options: {|
   readonly notFound: RouteTable["notFound"],
   readonly errors: RouteTable["errors"],
   readonly strictMode?: boolean,
+  readonly navigation?: Navigation,
 |}): Promise<void> {
   const table: RouteTable = {
     routes: options.routes,
@@ -93,6 +107,11 @@ export async function hydrate(options: {|
     errors: options.errors,
   };
   installRoutes(table);
+  // Beside the table, and before anything renders. `"client"` when the entry
+  // says nothing, which is what `virtual:uf/client` generated before
+  // `app.rendering.navigation` existed and what a hand-written entry still
+  // means: the default is the behaviour, not the absence of one.
+  installNavigation(options.navigation ?? "client");
 
   // Before the loader data is read and before `resolveMatch` is called: both
   // would go looking for a page module that is not in this bundle.

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -1854,16 +1854,57 @@ export type RouteInfo = {|
   readonly pending: boolean,
 |};
 
+/**
+ * What this application does when a visitor follows a link.
+ *
+ * `app.rendering.navigation` in `uf.config.js`, and the same two words: the
+ * client router takes the link over, or the browser does.
+ */
+export type Navigation = "client" | "document";
+
 type RouterState = {|
   readonly resolved: ResolvedRoute,
   readonly router: Router,
   readonly pending: boolean,
+  readonly navigation: Navigation,
 |};
 
 const RouterContext: React.Context<?RouterState> = createContext(null);
 
 /** The route table the application was started with. */
 let installedTable: ?RouteTable = null;
+
+/**
+ * How the application navigates, installed by the entry that started it.
+ *
+ * Module state beside `installedTable`, and for the same reason: the entry is
+ * the only thing that knows, and every component that needs the answer is
+ * somewhere under a `RouterProvider` it did not construct. `routerView` builds
+ * that provider from two props the server handed it, and threading a third one
+ * from the entry through the application root would have made every
+ * hand-written `<App>` in a test a place the default lives.
+ *
+ * `"client"` until something says otherwise, which is what every uf
+ * application did before `app.rendering.navigation` existed and what a test
+ * that renders `routerView` directly still gets.
+ */
+let installedNavigation: Navigation = "client";
+
+/**
+ * Say how this application navigates. Called once, by the client entry.
+ *
+ * `@uniflowed/vite` generates the call into `virtual:uf/client` from
+ * `app.rendering.navigation`; nothing else should call it, and calling it after
+ * the first render is a change no rendered `Link` will notice.
+ */
+export function installNavigation(navigation: Navigation): void {
+  installedNavigation = navigation;
+}
+
+/** How this application navigates. */
+export function navigationMode(): Navigation {
+  return installedNavigation;
+}
 
 /** Register the generated route table. Called once by the client and server entries. */
 export function installRoutes(table: RouteTable): void {
@@ -1911,10 +1952,31 @@ function isBrowser(): boolean {
  * provider listens to history and to `Link` clicks; a navigation resolves the
  * next route (loading its chunks and running its loader) *before* committing,
  * inside a transition, so the previous page stays interactive meanwhile.
+ *
+ * # Unless the application asked the browser to do it
+ *
+ * Under `app.rendering.navigation: "document"` every one of those sentences
+ * stops being true, and the provider is still here: the tree below it still
+ * reads `useRoute`, still renders `<RouteView>`, and still hydrates whatever
+ * `"use client"` boundary made the document interactive. What it does not do is
+ * take the link over. `navigate` hands the URL to the browser, no `popstate`
+ * listener is installed, and `prefetch` — which exists to load the chunks of a
+ * route this page will render — has no page to load them for.
+ *
+ * That is one branch rather than a second provider because the two differ in
+ * what happens on a click and in nothing else. A second implementation would
+ * have had to keep `resolved`, `pending`, the context and every hook that
+ * reads it in step with this one, which is four things to keep in step for one
+ * that actually differs.
  */
 export component RouterProvider(url: string, initial: ResolvedRoute, children: React.Node) {
   const [resolved, setResolved] = useState<ResolvedRoute>(initial);
   const [pending, setPending] = useState<boolean>(false);
+  // Read once per render rather than per navigation: it is installed by the
+  // entry before the first render and never changes after it, and a `Link`
+  // that asked at click time would be asking a question whose answer decided
+  // what it rendered.
+  const navigation = navigationMode();
 
   const navigate = async (to: string, options?: NavigateOptions): Promise<void> => {
     if (!isBrowser()) {
@@ -1922,6 +1984,19 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
     }
     const target = new URL(to, window.location.href);
     const next = target.pathname + target.search;
+    // The browser's job in this application. `assign` and `replace` rather
+    // than the history API, because the point is a document request: the
+    // history entry, the scroll position, the `Referer` and the unload
+    // handlers are then the browser's, done the way they are done for a link
+    // in a page with no JavaScript on it at all.
+    if (navigation === "document") {
+      if (options?.replace === true) {
+        window.location.replace(target.href);
+      } else {
+        window.location.assign(target.href);
+      }
+      return;
+    }
     // The half of the split that is not about bytes. A route whose page is not
     // in this bundle is not a route this router can render, and pretending
     // otherwise is the silent break: the navigation would resolve to nothing
@@ -1971,6 +2046,15 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
     if (!isBrowser()) {
       return undefined;
     }
+    // Nothing pushed a history entry, so there is nothing to pop back into: a
+    // document-navigating application left this page when the link was
+    // followed, and the back button asks the browser for the previous document
+    // rather than asking this listener to rebuild it. Installing one anyway
+    // would put a `resolveMatch` on the back button of a page that is about to
+    // be replaced by the one the browser already has.
+    if (navigation === "document") {
+      return undefined;
+    }
     const onPopState = () => {
       const next = window.location.pathname + window.location.search;
       // Back into a route this bundle has no page for. The history entry is
@@ -2000,7 +2084,12 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
     push: (to, options) => navigate(to, options),
     replace: (to) => navigate(to, { replace: true }),
     prefetch: async (to) => {
-      if (!isBrowser()) {
+      // A prefetch loads the modules the *next render* will need, and under
+      // document navigation there is no next render in this page: the browser
+      // fetches a document and throws this one away. Loading the chunks would
+      // be bytes spent on a page that is leaving, so this declines rather than
+      // warming a cache nothing reads.
+      if (!isBrowser() || navigation === "document") {
         return;
       }
       const target = new URL(to, window.location.href);
@@ -2016,6 +2105,14 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
     },
     refresh: async () => {
       if (!isBrowser()) {
+        return;
+      }
+      // The same URL, rendered again — which under document navigation is what
+      // the browser calls a reload. Resolving it in the page instead would
+      // re-run the loader and commit a tree whose links this application has
+      // already said it does not drive.
+      if (navigation === "document") {
+        window.location.reload();
         return;
       }
       const nextResolved = await resolveMatch(
@@ -2042,7 +2139,7 @@ export component RouterProvider(url: string, initial: ResolvedRoute, children: R
     },
   };
 
-  const value: RouterState = { resolved, router, pending };
+  const value: RouterState = { resolved, router, pending, navigation };
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
 }
 
@@ -2682,6 +2779,22 @@ export type LinkPrefetch = "off" | "intent" | "render";
  * default) loads the destination's chunks on hover or focus, and
  * `transition={false}` makes this one navigation a cut — most navigations are
  * a link, so the opt-out in [`NavigateOptions`] has to be reachable from one.
+ *
+ * # Under `app.rendering.navigation: "document"` it is only the anchor
+ *
+ * No click handler of uf's, no `preventDefault`, no prefetch listeners: the
+ * element the browser gets is the one it would have got from `<a href>` in the
+ * source. That is the whole of what changing the mode does to a component,
+ * which is the point — a project moving between the two rewrites its
+ * `uf.config.js` and none of its pages, and a component library built on
+ * `Link` works in both without knowing which it is in.
+ *
+ * It matters that the handler is *absent* rather than a handler that calls
+ * `location.assign`. The two look the same for a left click and are not the
+ * same link: `preventDefault` and a scripted navigation lose `download`, lose
+ * a `target`, and change what the browser does with a middle click and with a
+ * gesture uf has not heard of. An ordinary link is not an approximation of an
+ * ordinary link.
  */
 export component Link(
   to: string,
@@ -2693,11 +2806,12 @@ export component Link(
   onClick?: (event: SyntheticMouseEvent<HTMLAnchorElement>) => mixed,
   ...rest: { readonly [string]: mixed }
 ) {
-  const router = useRouter();
+  const { router, navigation } = useRouterState();
   const prefetched = React.useRef(false);
+  const drives = navigation === "client";
 
   const doPrefetch = () => {
-    if (prefetch === "off" || prefetched.current || isExternal(to)) {
+    if (!drives || prefetch === "off" || prefetched.current || isExternal(to)) {
       return;
     }
     prefetched.current = true;
@@ -2733,14 +2847,18 @@ export component Link(
     });
   };
 
+  // The caller's own `onClick` still runs under document navigation — it is
+  // theirs, and an application that closes a menu when a link is clicked is
+  // not asking uf to take the navigation over — so it is passed through rather
+  // than dropped with the rest of the behaviour.
   return (
     <a
       {...rest}
       href={to}
       className={className}
-      onClick={handleClick}
-      onMouseEnter={prefetch === "intent" ? doPrefetch : undefined}
-      onFocus={prefetch === "intent" ? doPrefetch : undefined}
+      onClick={drives ? handleClick : onClick}
+      onMouseEnter={drives && prefetch === "intent" ? doPrefetch : undefined}
+      onFocus={drives && prefetch === "intent" ? doPrefetch : undefined}
     >
       {children}
     </a>

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -135,6 +135,13 @@ export default function uniflowed(options = {}) {
   // no `uf.config.js` will mention. It only ever reaches the *development*
   // client entry; see `flowPlugin`'s `load`. ubugeeei-prod/uf#516.
   const strictMode = app.react?.strictMode !== false;
+  // What the browser does with a link, read here for the reason Strict Mode is
+  // and honoured in every command rather than in the build alone: it is the
+  // one setting whose whole effect is what happens on a click, so a dev server
+  // that disagreed with the deployment would be the wrong application to look
+  // at. Anything but `"document"` is the client router, which is what every
+  // project that has not heard of the key has.
+  const navigation = app.rendering?.navigation === "document" ? "document" : "client";
 
   const accessibility = ufConfig.accessibility ?? {};
 
@@ -143,6 +150,7 @@ export default function uniflowed(options = {}) {
       routerRoot,
       appEntry,
       strictMode,
+      navigation,
       command: options.command,
       accessibility,
     }),
@@ -157,7 +165,7 @@ export default function uniflowed(options = {}) {
   ];
 }
 
-function flowPlugin({ routerRoot, appEntry, strictMode, command, accessibility }) {
+function flowPlugin({ routerRoot, appEntry, strictMode, navigation, command, accessibility }) {
   let root = process.cwd();
   let isProduction = false;
   /**
@@ -356,8 +364,16 @@ function flowPlugin({ routerRoot, appEntry, strictMode, command, accessibility }
       // Strict Mode belongs to the client entry and to development only: a
       // build passes `false`, so the generated module is the one that existed
       // before #516 and a visitor's browser renders once.
+      //
+      // `navigation` is in the same entry and has no `isProduction` beside it,
+      // deliberately: it is what a link does, and a dev server whose links
+      // behave differently from the deployment is the wrong thing to be
+      // looking at. See `clientModuleSource`.
       if (id === resolved(VIRTUAL.client)) {
-        return clientModuleSource(entryPath, { strictMode: strictMode && !isProduction });
+        return clientModuleSource(entryPath, {
+          strictMode: strictMode && !isProduction,
+          navigation,
+        });
       }
       if (id === resolved(VIRTUAL.server)) return serverModuleSource(entryPath);
       // Only `virtual:uf/server` imports this, so it is only ever asked for in

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -803,15 +803,31 @@ export default routes;
  * hydrates the way its deployment does, which is the whole of the escape
  * hatch.
  *
+ * # Navigation is a generated constant for a different reason
+ *
+ * `app.rendering.navigation` decides whether the client router takes a link
+ * over, and it is written in here for the reason Strict Mode is not: it must
+ * be the *same* in development and in the build. A `uf dev` whose links
+ * resolve in the page and a deployment whose links fetch a document are two
+ * applications, and the one a person is looking at is the one that is not
+ * deployed. So this is generated from the config with no `isProduction` beside
+ * it, and `uf dev`, `uf build` and `uf preview` all get what the project asked
+ * for.
+ *
+ * `"client"` is emitted as an absent argument rather than as
+ * `navigation: "client"`, so the module a default project gets is byte for
+ * byte the one it got before this option existed.
+ *
  * @param {string} appEntry the project's `app.js`, as an import specifier
- * @param {{ strictMode?: boolean }} [options]
+ * @param {{ strictMode?: boolean, navigation?: "client" | "document" }} [options]
  */
 export function clientModuleSource(appEntry, options = {}) {
   const strictMode = options.strictMode === true ? ", strictMode: true" : "";
+  const navigation = options.navigation === "document" ? ', navigation: "document"' : "";
   return `import { hydrate } from "@uniflowed/router/client";
 import { routes, notFound, errors } from ${JSON.stringify(VIRTUAL.routes)};
 import App from ${JSON.stringify(appEntry)};
-hydrate({ App, routes, notFound, errors${strictMode} });
+hydrate({ App, routes, notFound, errors${strictMode}${navigation} });
 `;
 }
 

--- a/tests/library/navigation.test.js
+++ b/tests/library/navigation.test.js
@@ -1,0 +1,460 @@
+// @flow
+//
+// `app.rendering.navigation`: what a link does.
+//
+// uf has always shipped one answer — the client router takes a plain left
+// click over, resolves the next route and commits it into the page that is
+// already open. `"document"` is the other one: the browser follows the link,
+// the way it follows a link on a page with no JavaScript on it at all.
+//
+// Two halves, and they fail in different places.
+//
+// **The generated entry.** `@uniflowed/vite` writes the mode into
+// `virtual:uf/client` as a constant, so a build has nothing to decide and a
+// project that never set the key gets the module it has always got. Getting
+// this wrong is a build that hydrates in a mode the config did not ask for,
+// and nothing in `dist/` shows which one happened.
+//
+// **The runtime.** A `Link` under document navigation has to be an *ordinary*
+// anchor — no handler of uf's on it, nothing calling `preventDefault` — rather
+// than a handler that performs the navigation itself. The two look identical
+// for a plain left click and are not the same link: a scripted navigation
+// loses `download`, loses a `target`, and decides for the browser what it
+// should do with a gesture uf has not heard of. So what is asserted below is
+// that the click event comes out of React *unprevented*, which is the only
+// observable difference between a link and an imitation of one.
+//
+// The runtime half needs a document, so the imports are split the way
+// `rsc-split.test.js` splits them: `@uniflowed/router/client` reads `document`
+// while it is being evaluated, so it is imported after `installDom` and not at
+// the top of the file.
+
+import * as React from "@uniflowed/react";
+import { useState } from "@uniflowed/react";
+import { act, cleanup, userEvent } from "@uniflowed/react-testing";
+import { afterEach, describe, expect, it } from "@uniflowed/test";
+
+import { installDom } from "../../packages/react-testing/internal/dom.js";
+// By path rather than through `@uniflowed/router`, and it is not a shortcut:
+// `installNavigation` is module state, so a test that reached it through the
+// package specifier and a runtime that reached it relatively would have to be
+// the same module instance for the reset below to reset anything. Taking both
+// from the one path is how that stops being a property of the resolver.
+import {
+  Link,
+  installNavigation,
+  routerView,
+  useRouter,
+} from "../../packages/router/internal/runtime.js";
+import { clientModuleSource } from "../../packages/vite/internal/routes.js";
+
+// ---------------------------------------------------------------------------
+// The generated entry
+// ---------------------------------------------------------------------------
+
+describe("the client entry @uniflowed/vite generates", () => {
+  it("says nothing about navigation when the project said nothing", () => {
+    // Byte for byte the module a project got before this option existed. A
+    // default that is spelled out is a default that shows up in every diff of
+    // every project the day it is added.
+    const source = clientModuleSource("/app.js");
+
+    expect(source).toContain("hydrate({ App, routes, notFound, errors });");
+    expect(source).not.toContain("navigation");
+  });
+
+  it("says nothing when the project asked for the client router", () => {
+    const source = clientModuleSource("/app.js", { navigation: "client" });
+
+    expect(source).toContain("hydrate({ App, routes, notFound, errors });");
+  });
+
+  it("writes the mode in when the project asked for document navigation", () => {
+    const source = clientModuleSource("/app.js", { navigation: "document" });
+
+    expect(source).toContain('hydrate({ App, routes, notFound, errors, navigation: "document" });');
+  });
+
+  it("carries Strict Mode alongside it", () => {
+    // The two are independent — one is a development-only double render, the
+    // other is what a link does in every environment — and the entry has to be
+    // able to say both.
+    const source = clientModuleSource("/app.js", { strictMode: true, navigation: "document" });
+
+    expect(source).toContain(
+      'hydrate({ App, routes, notFound, errors, strictMode: true, navigation: "document" });',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The runtime
+// ---------------------------------------------------------------------------
+
+async function clientModule() {
+  installDom();
+  return import("@uniflowed/router/client");
+}
+
+async function serverModule() {
+  installDom();
+  return import("@uniflowed/router/server");
+}
+
+/** How many times each route's module was asked for, by path. */
+const loaded: { [string]: number } = {};
+
+/** The route the prefetch tests aim at, and nothing else does. */
+const PREFETCHED = "/prefetched";
+
+/**
+ * The route table, built once.
+ *
+ * Memoised for the reason `rsc-split.test.js` memoises its own: `loadOnce`
+ * caches a module by the identity of the function that loads it, and the
+ * server render and the hydration have to be the same components for React's
+ * comparison to mean anything.
+ */
+let built: mixed = null;
+
+function tables() {
+  if (built != null) {
+    return built;
+  }
+
+  component Home() {
+    const router = useRouter();
+    const [clicked, setClicked] = useState<number>(0);
+    return (
+      <section>
+        <h1>home</h1>
+        <Link to="/other">other</Link>
+        <Link to="/other" data-testid="with-onclick" onClick={() => setClicked(clicked + 1)}>
+          other, with an onClick
+        </Link>
+        <output>{clicked}</output>
+        <button type="button" onClick={() => void router.push("/other")}>
+          push
+        </button>
+        <button type="button" onClick={() => void router.replace("/other")}>
+          replace
+        </button>
+        <button type="button" onClick={() => void router.prefetch(PREFETCHED)}>
+          prefetch
+        </button>
+      </section>
+    );
+  }
+
+  component Other() {
+    return <h1>other</h1>;
+  }
+
+  const home = {
+    path: "/",
+    params: [],
+    mdx: false,
+    file: "app/_uf.page.js",
+    page: () => {
+      loaded["/"] = (loaded["/"] ?? 0) + 1;
+      return Promise.resolve({ default: Home });
+    },
+    layouts: [],
+    loading: [],
+  };
+  const other = {
+    path: "/other",
+    params: [],
+    mdx: false,
+    file: "app/other/_uf.page.js",
+    page: () => {
+      loaded["/other"] = (loaded["/other"] ?? 0) + 1;
+      return Promise.resolve({ default: Other });
+    },
+    layouts: [],
+    loading: [],
+  };
+
+  built = { routes: [home, other], other };
+  return built;
+}
+
+/**
+ * The prefetch target, built fresh for each hydration.
+ *
+ * `loadOnce` in the runtime caches a module by the identity of the function
+ * that loads it, and that cache is a module-level one that outlives a test. A
+ * memoised loader would therefore be a cache hit for every test after the
+ * first, and "the client router prefetched it" would be indistinguishable
+ * from "something earlier in this file already had it". A new function per
+ * hydration is a new cache key, so each test asks the question from cold.
+ */
+function prefetchRoute() {
+  const { other } = tables();
+  return {
+    path: PREFETCHED,
+    params: [],
+    mdx: false,
+    file: "app/prefetched/_uf.page.js",
+    page: () => {
+      loaded[PREFETCHED] = (loaded[PREFETCHED] ?? 0) + 1;
+      return other.page();
+    },
+    layouts: [],
+    loading: [],
+  };
+}
+
+/** Put the document the server would have written into the live DOM. */
+async function serve(url: string): Promise<void> {
+  const { createRenderer, ROOT_ID } = await serverModule();
+  const { routes } = tables();
+  const renderer = createRenderer({
+    App: routerView("./app"),
+    routes,
+    notFound: [],
+    errors: [],
+  });
+  const { html } = await renderer.prerender(url, { scripts: [], styles: [], preloads: [] });
+
+  const parsed = new globalThis.DOMParser().parseFromString(html, "text/html");
+  const rendered = parsed.getElementById(ROOT_ID);
+  if (rendered == null) {
+    throw new Error(`the server wrote no #${ROOT_ID}:\n${html}`);
+  }
+  const root = globalThis.document.createElement("div");
+  root.id = ROOT_ID;
+  root.innerHTML = rendered.innerHTML;
+  globalThis.document.body.replaceChildren(root);
+  globalThis.window.history.pushState(null, "", url);
+}
+
+/** Hydrate the current document in one of the two modes. */
+async function hydrateHere(navigation: "client" | "document"): Promise<void> {
+  const { hydrate } = await clientModule();
+  const { routes } = tables();
+  await act(async () => {
+    await hydrate({
+      App: routerView("./app"),
+      routes: [...routes, prefetchRoute()],
+      notFound: [],
+      errors: [],
+      navigation,
+    });
+  });
+}
+
+function ufRoot(): Element | null {
+  return globalThis.document.getElementById("uf-root");
+}
+
+function linkTo(href: string): Element {
+  const link = ufRoot()?.querySelector(`a[href="${href}"]`);
+  if (link == null) {
+    throw new Error(`no link to ${href} in:\n${ufRoot()?.innerHTML ?? "(no root)"}`);
+  }
+  return link;
+}
+
+/** The second link home renders: the same destination, plus an `onClick`. */
+function linkWithOnClick(): Element {
+  const link = ufRoot()?.querySelector('a[data-testid="with-onclick"]');
+  if (link == null) {
+    throw new Error(`no link with an onClick in:\n${ufRoot()?.innerHTML ?? "(no root)"}`);
+  }
+  return link;
+}
+
+function buttonSaying(label: string): Element {
+  for (const button of ufRoot()?.querySelectorAll("button") ?? []) {
+    if (button.textContent === label) {
+      return button;
+    }
+  }
+  throw new Error(`no ${label} button in:\n${ufRoot()?.innerHTML ?? "(no root)"}`);
+}
+
+/**
+ * Click `element` and report whether anything called `preventDefault`.
+ *
+ * The listener is on the document, so it runs after React's own — React
+ * attaches at the root container — and it prevents the default itself once it
+ * has read the answer, because the default for an anchor is a navigation and
+ * this is a test, not a browser.
+ */
+async function clickAndReportPrevention(element: Element): Promise<boolean> {
+  let prevented = null;
+  const listener = (event: Event) => {
+    prevented = event.defaultPrevented;
+    event.preventDefault();
+  };
+  globalThis.document.addEventListener("click", listener);
+  try {
+    await act(async () => {
+      await userEvent.click(element);
+    });
+  } finally {
+    globalThis.document.removeEventListener("click", listener);
+  }
+  if (prevented == null) {
+    throw new Error("the click never reached the document");
+  }
+  return prevented;
+}
+
+/** Record what a navigation asked the browser to do, and put it back after. */
+async function watchingLocation(
+  run: () => Promise<void>,
+): Promise<{ assigned: Array<string>, replaced: Array<string> }> {
+  const assigned: Array<string> = [];
+  const replaced: Array<string> = [];
+  const location = globalThis.window.location;
+  const originalAssign = location.assign;
+  const originalReplace = location.replace;
+  const stub = (into: Array<string>) => (to: string) => {
+    into.push(String(to));
+  };
+  Object.defineProperty(location, "assign", {
+    configurable: true,
+    writable: true,
+    value: stub(assigned),
+  });
+  Object.defineProperty(location, "replace", {
+    configurable: true,
+    writable: true,
+    value: stub(replaced),
+  });
+  try {
+    await run();
+  } finally {
+    Object.defineProperty(location, "assign", {
+      configurable: true,
+      writable: true,
+      value: originalAssign,
+    });
+    Object.defineProperty(location, "replace", {
+      configurable: true,
+      writable: true,
+      value: originalReplace,
+    });
+  }
+  return { assigned, replaced };
+}
+
+afterEach(() => {
+  if (globalThis.document == null) {
+    return;
+  }
+  cleanup();
+  globalThis.document.body.replaceChildren();
+  // The mode is module state on the runtime, and a worker runs many files out
+  // of one module registry: a test that left `"document"` installed would be
+  // deciding what a `Link` does in whichever file the scheduler put next. See
+  // ubugeeei-prod/uf#445, which is the same hazard one question over.
+  installNavigation("client");
+  for (const key of Object.keys(loaded)) {
+    delete loaded[key];
+  }
+});
+
+describe("a link under document navigation", () => {
+  it("is left for the browser, unprevented", async () => {
+    await serve("/");
+    await hydrateHere("document");
+
+    const prevented = await clickAndReportPrevention(linkTo("/other"));
+
+    expect(prevented).toBe(false);
+    // And nothing was rendered over the top of it: the page a document
+    // navigation leaves behind is the page that was there.
+    expect(ufRoot()?.textContent).toContain("home");
+  });
+
+  it("is taken over under the default, which is what it has always done", async () => {
+    // The other half of the pair, and the one that must not regress: the same
+    // markup, the same click, and the router answers it.
+    await serve("/");
+    await hydrateHere("client");
+
+    const prevented = await clickAndReportPrevention(linkTo("/other"));
+
+    expect(prevented).toBe(true);
+  });
+
+  it("still runs the caller's own onClick", async () => {
+    // Dropping uf's behaviour is not dropping the application's. An
+    // application that closes a menu when a link is clicked has not asked uf
+    // to take the navigation over.
+    await serve("/");
+    await hydrateHere("document");
+
+    const prevented = await clickAndReportPrevention(linkWithOnClick());
+
+    expect(prevented).toBe(false);
+    expect(ufRoot()?.querySelector("output")?.textContent).toBe("1");
+  });
+});
+
+describe("prefetching under document navigation", () => {
+  it("loads nothing, because there is no next render in this page", async () => {
+    // `prefetch="intent"` is `Link`'s default, so under the client router the
+    // destination's chunks are loaded on hover. A document navigation throws
+    // this page away, so those bytes would be spent on a page that is leaving.
+    await serve("/");
+    await hydrateHere("document");
+
+    await act(async () => {
+      await userEvent.click(buttonSaying("prefetch"));
+    });
+
+    expect(loaded[PREFETCHED] ?? 0).toBe(0);
+  });
+
+  it("loads the destination under the client router", async () => {
+    // The pair, so that the assertion above is about the mode rather than
+    // about a prefetch that never worked.
+    await serve("/");
+    await hydrateHere("client");
+
+    await act(async () => {
+      await userEvent.click(buttonSaying("prefetch"));
+    });
+
+    expect(loaded[PREFETCHED] ?? 0).toBe(1);
+  });
+});
+
+describe("the router under document navigation", () => {
+  it("hands push to the browser", async () => {
+    await serve("/");
+    await hydrateHere("document");
+
+    const { assigned, replaced } = await watchingLocation(async () => {
+      await act(async () => {
+        await userEvent.click(buttonSaying("push"));
+      });
+    });
+
+    expect(assigned.length).toBe(1);
+    expect(assigned[0].endsWith("/other")).toBe(true);
+    expect(replaced.length).toBe(0);
+    // Not `history.pushState`: the browser owns the entry, and it will own it
+    // again when the document it is fetching arrives.
+    expect(globalThis.window.location.pathname).toBe("/");
+  });
+
+  it("hands replace to the browser as a replace", async () => {
+    await serve("/");
+    await hydrateHere("document");
+
+    const { assigned, replaced } = await watchingLocation(async () => {
+      await act(async () => {
+        await userEvent.click(buttonSaying("replace"));
+      });
+    });
+
+    expect(replaced.length).toBe(1);
+    expect(replaced[0].endsWith("/other")).toBe(true);
+    expect(assigned.length).toBe(0);
+  });
+});


### PR DESCRIPTION
`uf` prerenders every route under `build.staticBuild`, and then the client
router hydrates and takes the links over. This is that minus the takeover, and
the key that asks for it.

## The design decision, and why it is not a `RenderingMode`

`RenderingMode` is an **allowlist of where a document comes from**, decided
**per route**: a route with no parameters is prerendered, one with parameters
is prerendered when its page exports `generateStaticParams`, and the rest are
rendered per request. MPA is none of those things.

- **It is not per-route.** A document is prerendered or it is not, and the
  answer does not change because of what the browser does with the result.
  `modes: ["mpa", "ssr"]` would be an allowlist holding two entries that are
  not alternatives, and the build would have nothing to pick between.
- **It would be allowed and never selected.** That is exactly the defect
  `RenderingMode::Ppr` is, and this repository's own rule — from
  `packages/server/cache.js` — is that a key which accepts a value and changes
  nothing is worse than a key that is not there.
- **The two compose, which is the proof they are two axes.** Every cell of this
  table is a deployment somebody wants:

  | | `navigation: "client"` | `navigation: "document"` |
  | --- | --- | --- |
  | `modes: ["ssg"]` | a prerendered site the client router takes over | a static site of documents |
  | `modes: ["ssr"]` | a server-rendered app the client router takes over | a server-rendered application in the older sense |

  A single enum cannot express a product of two independent choices without
  becoming the cross product, which is four names for two decisions.

**And it is deliberately not spelled the neighbours' way.** Next.js says
`output: "export"` and Astro says `output: "static"`; each conflates "no
server" with "no client router" because each has one answer for both. uf
already has a name for "no server" — `build.staticBuild` — so borrowing either
spelling would give one question two names, which is `docs/red-lines.md` line 2
("never mirror the complete configuration schema of an upstream tool") from the
inside. The setting is named after what it decides, which is navigation.

So: **`app.rendering.navigation: "client" | "document"`**, defaulting to
`"client"`.

## What `"document"` does

- **`Link` is an ordinary anchor.** No handler of uf's, nothing calling
  `preventDefault`, no prefetch on hover or focus. Absent rather than a handler
  that calls `location.assign`: those look identical for a plain left click and
  are not the same link — a scripted navigation loses `download`, loses a
  `target`, and decides for the browser what to do with a gesture uf has not
  heard of. The caller's own `onClick` still runs, because an application that
  closes a menu on click has not asked uf to take the navigation over.
- **`useRouter().push`/`.replace` hand the URL to the browser**;
  `refresh()` is a reload; `prefetch` declines, because a document navigation
  throws this page away and the chunks would be bytes spent on a page that is
  leaving.
- **No `popstate` listener.** Nothing pushed a history entry, so the back
  button asks the browser for a document it already has.

`<Link>` keeps working in both modes with no change to any component, which was
the requirement: a project changes `uf.config.js` and none of its pages.

## Where the decision lives

The mode is written into `virtual:uf/client` as a constant — the same shape as
`app.react.strictMode`, and with one deliberate difference: **no `isProduction`
beside it.** Strict Mode is development-only on purpose; navigation must not
be, or `uf dev` is a different application from the deployment and the one on
the screen is the one that is not shipped.

It is read out of `uf.config.js` by the builder rather than passed as a driver
argument, because `dev`, `build` and `preview` must all agree and the first two
are handed no rendering plan at all — the builder contract in
`docs/architecture.md` is unchanged. `RenderingPlan` carries it on the Rust side
so `uf` has one reader of the file, and it decides nothing about the prerender;
a test asserts that adding it moves neither `prerender()` nor
`emits_a_server()` for any `modes`.

## The build says what it did

```text
  rendering    every route prerendered
  navigation   a document request; this build ships no client router
```

Only when it is not the default — a row saying "client" on every build is a row
nobody reads. `uf explain build` names it on the bundle stage (red line 7), and
`.uf/build/meta/uf-build-manifest.json` carries `rendering.navigation` for a
deploy step that needs to know whether the output directory is answered by the
browser or by the documents alone.

## The honest limit

**This does not empty the bundle**, and the guide says so under a heading of
its own rather than leaving it to be discovered. uf hydrates the whole document
rather than per-island, so a route with a `"use client"` boundary anywhere in
it still loads React and that route's components. What document navigation
removes is the navigation itself. A route that reaches *no* client boundary
already ships no page — that is the existing server-component split, on by
default in both modes — so a content site in server components was already near
zero JavaScript, and this key is what stops the router taking its links over.

Two shapes were considered and rejected:

- **Zero-JS MPA**: refuse a reachable `"use client"` boundary and generate a
  client entry that carries only stylesheets. It would make "no router in the
  output" literally true, and it would refuse uf's own manual, which has one
  `"use client"` module for the theme toggle. A mode that cannot build the
  repository's own site is not a mode.
- **Making the navigation code absent rather than unreachable**, by having
  `RouterProvider` take its navigator from the entry instead of module state.
  That is a real improvement and a separate change: it moves the default for
  every hand-mounted `routerView` — eight test suites in this repository alone —
  and mixing it into the change that introduces the setting would put two
  arguments in one diff.

## Tests

- `crates/uf_config/src/rendering/tests.rs`: the default is `client`; the
  setting composes with all three prerender answers and moves none of them;
  `staticBuild`'s early return carries it; it is a refusal on its own for no
  `modes`.
- `tests/library/navigation.test.js`: the generated entry says nothing when the
  project said nothing (byte for byte what it emitted before this key) and
  writes the mode in when it did; a click on a `Link` comes out of React
  **unprevented** under `"document"` and prevented under `"client"`; the
  caller's `onClick` still runs; `push` and `replace` reach `location`;
  `prefetch` loads nothing under `"document"` and loads the destination under
  `"client"`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p uf_config` — 99 passed, including the schema test that checks
  `packages/config/internal/schema.js` declares every key uf reads
- `uf run test:lib` — 2716 passed, 0 failed, 1 skipped (79 files)
- `uf fmt --check`, `uf lint` (0 errors), `docs:build` and the docs link check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791520390&installation_model_id=422833&pr_number=702&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F702&signature=83c2c0ab9b0f1434436a3dccc56c4036bca0b09243d94728f65009e750560343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->