### PR TITLE
feat(router): show which DOM subtree each boundary owns

### DIFF
--- a/docs/app/guide/dev/_uf.page.mdx
+++ b/docs/app/guide/dev/_uf.page.mdx
@@ -109,13 +109,66 @@ lead to your terminal:
   [Web vitals](/guide/vitals).
 - `/__uf/diagnostic` — where a diagnostic only the browser can produce is
   posted. A hydration mismatch is the loudest one — *When hydration fails* below
-  is what it says — and a page React DevTools cannot attach to is the other.
+  is what it says — a page React DevTools cannot attach to is the second, and
+  *Where each boundary begins and ends* below is the third.
 
 Both print with the severity, the page they came from and a code frame when
 there is a position to draw one around, which is the point of them: every other
 uf diagnostic arrives in the terminal you already have open, and one that lives
 only in a browser window has to be noticed by somebody who knows to look.
 Nothing on either path leaves the machine, and a built application has neither.
+
+### Where each boundary begins and ends
+
+A `_uf.loading.js` and a `_uf.error.js` are decisions about *part of the page*,
+and the part is the one thing you cannot see. A `<Suspense>` renders no element
+of its own and neither does an error boundary, so what one of them owns is a run
+of nodes among the layout's own — a `<nav>` before it, a `<footer>` after it —
+with nothing on the page to tell them apart. Reading the directory tells you a
+boundary exists; it does not tell you which rectangle goes away when it fires.
+
+So under `uf dev` the router marks what it renders. Every boundary's children
+sit between a pair of `<template data-uf-boundary>` elements, which are
+`display: none`, carry no content, and are ordinary siblings of the nodes
+between them:
+
+```html
+<div id="uf-root">
+  <nav class="masthead">…</nav>
+  <template data-uf-boundary="suspense:0" data-uf-boundary-edge="open"></template>
+  <article class="post">…</article>
+  <template data-uf-boundary="suspense:0" data-uf-boundary-edge="close"></template>
+  <footer class="colophon">…</footer>
+</div>
+```
+
+That is enough to answer the question in the inspector you already have —
+`document.querySelectorAll("[data-uf-boundary]")`, or one CSS rule of your own
+to outline them — and it is enough for uf to answer it in words. When the same
+route's boundaries *change*, which is the moment you added the file, your
+terminal says where it landed:
+
+```text
+› 3 boundaries render /docs/:slug
+    error (uf's own error page), outside every layout — owns div#uf-root
+    error (app/docs/_uf.error.js), inside 1 layout — owns article.doc, aside.toc
+    suspense, inside 2 layouts — showing its fallback
+```
+
+It is quiet otherwise: a boundary map printed on every reload is a banner
+nobody reads. For the page in front of you right now, `__ufBoundaries()` in the
+console prints the same report and returns it.
+
+The marks are added after the page has hydrated, never before, so the markup the
+server sent and the tree React checks it against contain none of them — this
+cannot cause a mismatch. And none of it is in a build: the whole thing is behind
+`import.meta.hot`, which is `undefined` in a bundle, so a visitor downloads no
+part of it.
+
+The third boundary — client versus server — is answered in the same terminal and
+from the other end: when a save moves a module across the client bundle, `uf
+dev` names the module and the chain of imports that put it there. That one comes
+out of the analysis rather than out of the page, so it needs no mark.
 
 To reach the dev server from another device, `--host` binds a routable address —
 but only if `dev.allowedHosts` in your config is non-empty. That is deliberate:

--- a/packages/router/internal/boundaries.js
+++ b/packages/router/internal/boundaries.js
@@ -1,0 +1,557 @@
+// @flow
+//
+// Internal to `@uniflowed/router`: which DOM subtree each boundary owns.
+//
+// An application has three boundaries a reader cannot see — Suspense, error,
+// and client/server — and all three are decisions the build already made.
+// ubugeeei-prod/uf#636 answered the third: `uf dev` says why a module is in the
+// client bundle, out loud, at the moment the answer changes. This is the other
+// two, and the gap it fills was named in that issue's triage: *the route table
+// already has the data*. `_uf.loading.js` nests and carries the number of
+// layouts outside it, `_uf.error.js` binds to the nearest ancestor, and
+// `RouteView` threads both into one stack. What did not exist is a way to point
+// at the **DOM subtree** each of them owns.
+//
+// That cannot be read off the table, and it cannot be read off the page either.
+// A `<Suspense>` renders no element of its own; nor does a class boundary. What
+// is on the page is a run of nodes, in a parent that also holds whatever the
+// layout above put beside them — a `<nav>` before, a `<footer>` after — and
+// nothing distinguishes the run from its neighbours. So the render has to say
+// so, which is what this module is.
+//
+// # The mechanism: a pair of inert marks, and why a pair
+//
+// Each boundary `RouteView` renders wraps its children between two
+// `<template data-uf-boundary>` elements. A `<template>` is `display: none` in
+// every browser's UA stylesheet and its content is inert, so it lays nothing
+// out and runs nothing; the pair are siblings of the nodes between them,
+// because React fragments create no element, so "what this boundary owns" is
+// `open.nextElementSibling` up to `close`.
+//
+// One mark would have been cheaper and would have been wrong. A boundary's run
+// ends where the enclosing layout's own trailing nodes begin, and from the
+// opening mark alone those are indistinguishable — the walk would hand a
+// boundary the footer underneath it. Two marks are the smallest thing that
+// closes.
+//
+// A wrapper element was the other candidate: one node instead of two, and
+// `wrapper.children` with no walk at all. It loses on the thing that matters
+// here — a wrapper has to exist from the first render, because introducing one
+// later moves the subtree into a new parent and React answers that by
+// unmounting and rebuilding everything under it. Marks are siblings, so they
+// can arrive after the page has settled, which is what the section below is
+// about.
+//
+// # They arrive after hydration, which is what makes them free of it
+//
+// Every edge renders `null` until it has mounted. So the tree React hydrates
+// against the server's markup contains no mark, the server's markup contains no
+// mark, and the two agree whatever either side believed about being in
+// development — the gate is allowed to answer differently in the two processes
+// because by the time it has any effect, hydration is over. `reportDevtools`
+// asks its question on the line after hydration for the same reason: a
+// development affordance that can turn a working page into a mismatch is worse
+// than no affordance.
+//
+// `marksAreLive` is what keeps that from costing a second commit forever. It is
+// latched by the first edge to mount, and every edge mounted afterwards — a
+// navigation, or a `_uf.loading.js` that HMR has just added — starts live and
+// is in the DOM in the same commit that created it. That matters for the report
+// below, which reads the DOM in the commit where the boundaries changed.
+//
+// # Where the report goes
+//
+// The terminal, on `./diagnostics.js`, which is the channel #583 established
+// and #636 argued for again: a diagnostic that exists only in a browser window
+// has to be noticed by somebody who does not know to look. And it is quiet
+// unless the answer *changed* — the first sighting of a route says nothing, the
+// same boundaries on the same route say nothing, and adding an `_uf.error.js`
+// says where it landed and what it took over. A boundary map printed on every
+// reload is the banner nobody reads.
+//
+// The marks themselves are the other half of "see it", and the cheaper half:
+// they are in the document, so the element inspector already shows where each
+// boundary opens and closes with no panel to open, and
+// `document.querySelectorAll("[data-uf-boundary]")` is the whole API. For the
+// page you are looking at right now there is `__ufBoundaries()`, which prints
+// the same report on demand.
+//
+// # None of it is in a build
+//
+// Nothing here is reachable from a production bundle: `runtime.js` guards every
+// reference with `BOUNDARY_MARKS`, which is `import.meta.hot != null` — the
+// gate `client.js` already uses, replaced by `undefined` in a build — and this
+// package is `sideEffects: false`, so with the references folded away the
+// module is dropped rather than merely unused.
+
+import * as React from "react";
+import { useEffect, useState } from "react";
+
+import { reportDiagnostic } from "./diagnostics.js";
+
+/** The attribute a mark carries its boundary's id in. */
+export const BOUNDARY_ATTRIBUTE: string = "data-uf-boundary";
+
+/** The attribute telling the two marks of one boundary apart. */
+export const EDGE_ATTRIBUTE: string = "data-uf-boundary-edge";
+
+/** The attribute naming the file a boundary was declared in, when one is known. */
+export const SOURCE_ATTRIBUTE: string = "data-uf-boundary-source";
+
+/** The name `uf dev` installs the on-demand report under. */
+export const BOUNDARY_GLOBAL: string = "__ufBoundaries";
+
+/**
+ * What `file` says for the error boundary the build synthesises.
+ *
+ * `routesModuleSource` writes this string where a declared boundary has a path,
+ * because the record has no module to name — the framework's own error page
+ * renders in its place. Written out again rather than imported for the reason
+ * `./devtools.js` gives about `DEVTOOLS_HOOK`: `@uniflowed/vite` is plain
+ * JavaScript loaded by Vite before any Flow transform exists, so the import
+ * cannot go either way. `boundaries.test.js` holds the two spellings together.
+ */
+export const SYNTHESISED_SOURCE: string = "@uniflowed/router";
+
+/** Which kind of boundary a mark belongs to. */
+export type BoundaryKind = "suspense" | "error";
+
+/**
+ * One boundary of a resolved route, as the marks and the report name it.
+ *
+ * `id` pairs the two marks and is stable for a boundary across renders, so a
+ * navigation that keeps a boundary keeps its marks mounted. `above` is how many
+ * of the route's layouts are outside it — the same number, spelled the same
+ * way, that `ResolvedRoute["errorBoundary"].above` and every `loading` entry
+ * carry, because there is no second vocabulary for where a thing sits in the
+ * stack.
+ *
+ * `source` is the file it was declared in, and is `null` for every `<Suspense>`
+ * boundary. That asymmetry is the route table's rather than this module's: an
+ * error boundary is matched by path, so the table carries its `file`, while a
+ * `_uf.loading.js` is carried by depth alone. Adding a path to the loading
+ * records would put one in every visitor's bundle to serve a report only
+ * `uf dev` reads.
+ */
+export type RouteBoundary = {|
+  readonly id: string,
+  readonly kind: BoundaryKind,
+  readonly above: number,
+  readonly source: ?string,
+|};
+
+/** The id of the `<Suspense>` boundary at `index` of a route's `loading`. */
+export function suspenseId(index: number): string {
+  return `suspense:${index}`;
+}
+
+/** The id of the boundary a route's own `_uf.error.js` renders. */
+export const ROUTE_ERROR_ID: string = "error:route";
+
+/**
+ * The id of the boundary that stands outside every layout.
+ *
+ * It has no module and renders the framework's page; it is what is between a
+ * throw in a root layout, or in the error component itself, and an unmounted
+ * document. Marked like any other, because "which subtree does the last resort
+ * own" is exactly as unanswerable from the page as the rest.
+ */
+export const ROOT_ERROR_ID: string = "error:root";
+
+/** The part of a resolved route this module reads. */
+type BoundedRoute = {
+  readonly errorBoundary: { readonly above: number, ... },
+  readonly loading: $ReadOnlyArray<{ readonly above: number, ... }>,
+  readonly error: mixed,
+  ...
+};
+
+/**
+ * Every boundary a resolved route renders, in the order they nest.
+ *
+ * A `Map` rather than a list because it is read both ways: `RouteView` asks for
+ * one by id as it builds the stack, and the report walks the values. One
+ * function answering both is the point — an id `RouteView` marks and the report
+ * cannot find is a boundary that silently disappears from the map, and
+ * ubugeeei-prod/uf#636 made the same argument about an explanation that can
+ * disagree with the thing it explains.
+ *
+ * The route's own error boundary is absent when the route *is* its error page,
+ * which is exactly when `RouteView` does not render one: wrapping that page in
+ * the boundary whose component it is would answer a throw inside it with
+ * itself.
+ *
+ * @param resolved the route being rendered
+ * @param errorSource the `file` of the nearest `_uf.error.js`, when the table
+ *   has one; `null` leaves the boundary named by its depth alone
+ */
+export function routeBoundaries(
+  resolved: BoundedRoute,
+  errorSource: ?string,
+): Map<string, RouteBoundary> {
+  const found: Map<string, RouteBoundary> = new Map();
+  found.set(ROOT_ERROR_ID, {
+    id: ROOT_ERROR_ID,
+    kind: "error",
+    above: 0,
+    source: SYNTHESISED_SOURCE,
+  });
+  if (resolved.error == null) {
+    found.set(ROUTE_ERROR_ID, {
+      id: ROUTE_ERROR_ID,
+      kind: "error",
+      above: resolved.errorBoundary.above,
+      source: errorSource,
+    });
+  }
+  resolved.loading.forEach((boundary, index) => {
+    const id = suspenseId(index);
+    found.set(id, { id, kind: "suspense", above: boundary.above, source: null });
+  });
+  return found;
+}
+
+/**
+ * Whether an edge that mounts now should be in the DOM immediately.
+ *
+ * Latched by the first edge to mount and never cleared. Read through
+ * `useState`'s initialiser rather than during the render body, which is the
+ * difference between "this component's first state" and "a module variable a
+ * memoising compiler is entitled to hold on to".
+ */
+let marksAreLive = false;
+
+/**
+ * One end of one boundary.
+ *
+ * A `<template>` and not a comment node, because React renders elements;
+ * `display: none` in the UA stylesheet is what makes an element acceptable
+ * here, and inert content is what makes it free. It carries no children, so
+ * nothing is parsed into its document fragment either.
+ */
+component BoundaryEdge(boundary: RouteBoundary, edge: "open" | "close") {
+  const [live, setLive] = useState<boolean>(() => marksAreLive);
+  useEffect(() => {
+    marksAreLive = true;
+    setLive(true);
+  }, []);
+  if (!live) {
+    return null;
+  }
+  if (edge === "close") {
+    return <template data-uf-boundary={boundary.id} data-uf-boundary-edge="close" />;
+  }
+  return (
+    <template
+      data-uf-boundary={boundary.id}
+      data-uf-boundary-edge="open"
+      data-uf-boundary-source={boundary.source ?? undefined}
+    />
+  );
+}
+
+/**
+ * `children`, between the two marks of `boundary`.
+ *
+ * `children` unchanged when there is no boundary to mark, so a caller never has
+ * to ask twice. The marks are the first and last children of a fragment rather
+ * than a wrapper's, so the nodes between them are siblings of them, and every
+ * position in the fragment is fixed — an edge going from `null` to a
+ * `<template>` after mount is an insertion beside `children` and not around it,
+ * which is why it costs no remount.
+ */
+export function insideBoundary(boundary: ?RouteBoundary, children: React.Node): React.Node {
+  if (boundary == null) {
+    return children;
+  }
+  return (
+    <>
+      <BoundaryEdge boundary={boundary} edge="open" />
+      {children}
+      <BoundaryEdge boundary={boundary} edge="close" />
+    </>
+  );
+}
+
+/**
+ * How far a walk between two marks will go before giving up.
+ *
+ * A closing mark is a sibling of its opening one and the run between them is a
+ * route's rendered output, so this is never reached by a page that is behaving.
+ * It is here because `docs/security.md` asks that a report have no unbounded
+ * anything in it, and because a DOM somebody else's script has been editing is
+ * exactly where an unbounded walk would be found.
+ */
+const WALK_LIMIT = 512;
+
+/** How many owned elements one line of the report names before it counts them. */
+const NAMED_LIMIT = 3;
+
+/** One boundary, as the page has it. */
+export type BoundaryFinding = {|
+  readonly boundary: RouteBoundary,
+  /** The top-level elements between its marks, as short selectors. */
+  readonly owns: $ReadOnlyArray<string>,
+  /** How many more there were than [`NAMED_LIMIT`]. */
+  readonly more: number,
+  /** False when the boundary rendered no marks — it is showing its fallback. */
+  readonly rendered: boolean,
+|};
+
+/**
+ * What each boundary owns on the page right now.
+ *
+ * Takes the document rather than reaching for a global, so a test can build one
+ * and ask — the same shape `hydrationReport` has, and for the same reason: the
+ * analysis worth checking is the one that runs in a browser, so the test has to
+ * be able to call exactly it.
+ *
+ * A boundary with no marks in the document is not missing, it is *suspended*:
+ * React removes a boundary's content while its fallback is up, and its marks
+ * are part of that content. Saying so is more useful than leaving it out.
+ */
+export function boundaryFindings(
+  boundaries: Map<string, RouteBoundary>,
+  document: Document,
+): $ReadOnlyArray<BoundaryFinding> {
+  const findings: Array<BoundaryFinding> = [];
+  for (const boundary of boundaries.values()) {
+    const open = document.querySelector(
+      `[${BOUNDARY_ATTRIBUTE}="${boundary.id}"][${EDGE_ATTRIBUTE}="open"]`,
+    );
+    if (open == null) {
+      findings.push({ boundary, owns: [], more: 0, rendered: false });
+      continue;
+    }
+    const owned: Array<string> = [];
+    let steps = 0;
+    let node = open.nextElementSibling;
+    while (node != null && steps < WALK_LIMIT && !closes(node, boundary.id)) {
+      if (node.getAttribute(BOUNDARY_ATTRIBUTE) == null) {
+        owned.push(describeElement(node));
+      }
+      node = node.nextElementSibling;
+      steps += 1;
+    }
+    findings.push({
+      boundary,
+      owns: owned.slice(0, NAMED_LIMIT),
+      more: Math.max(0, owned.length - NAMED_LIMIT),
+      rendered: true,
+    });
+  }
+  return findings;
+}
+
+/** Whether `element` is the closing mark of `id`. */
+function closes(element: Element, id: string): boolean {
+  return (
+    element.getAttribute(BOUNDARY_ATTRIBUTE) === id &&
+    element.getAttribute(EDGE_ATTRIBUTE) === "close"
+  );
+}
+
+/**
+ * One element, short enough to sit in a line of a report.
+ *
+ * A CSS selector rather than a tag name, because a page has eleven `<div>`s and
+ * the one being named has to be findable: the id if it has one, and otherwise
+ * the first class, which is what a person would type into the inspector's
+ * search box. Nothing more — the report says which subtree, and the page says
+ * what is in it.
+ */
+export function describeElement(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  const id = element.getAttribute("id");
+  if (id != null && id !== "") {
+    return `${tag}#${id}`;
+  }
+  const className = element.getAttribute("class");
+  const first = className == null ? "" : className.trim().split(/\s+/)[0];
+  return first === "" ? tag : `${tag}.${first}`;
+}
+
+/**
+ * The report, as the terminal will print it.
+ *
+ * Separated from the sending so that a test can pin the wording, which is the
+ * part worth pinning: somebody reading this in a terminal has to be able to act
+ * on it without opening this file.
+ */
+export function formatBoundaries(
+  path: string,
+  findings: $ReadOnlyArray<BoundaryFinding>,
+): {| readonly message: string, readonly detail: $ReadOnlyArray<string> |} {
+  const count = findings.length;
+  return {
+    message: `${count} ${count === 1 ? "boundary renders" : "boundaries render"} ${path}`,
+    detail: findings.map(describeFinding),
+  };
+}
+
+/** One boundary as one line: what it is, where it sits, and what it owns. */
+function describeFinding(finding: BoundaryFinding): string {
+  const { boundary } = finding;
+  const kind = boundary.kind === "error" ? "error" : "suspense";
+  const source =
+    boundary.source == null
+      ? ""
+      : boundary.source === SYNTHESISED_SOURCE
+        ? " (uf's own error page)"
+        : ` (${boundary.source})`;
+  const where =
+    boundary.above === 0
+      ? "outside every layout"
+      : `inside ${boundary.above} ${boundary.above === 1 ? "layout" : "layouts"}`;
+  if (!finding.rendered) {
+    return `${kind}${source}, ${where} — showing its fallback`;
+  }
+  if (finding.owns.length === 0) {
+    return `${kind}${source}, ${where} — owns no element of its own`;
+  }
+  const named = finding.owns.join(", ");
+  const more = finding.more === 0 ? "" : ` and ${finding.more} more`;
+  return `${kind}${source}, ${where} — owns ${named}${more}`;
+}
+
+/**
+ * How many routes the "has this changed" memory keeps.
+ *
+ * A route table is finite and this is larger than any project's hot set, so the
+ * ceiling is `docs/security.md`'s rule rather than a policy about routes: a map
+ * a page can grow by navigating is a map with a bound.
+ */
+const MEMORY_LIMIT = 64;
+
+/** The last boundary set seen for each route path. */
+const seen: Map<string, string> = new Map();
+
+/** What the on-demand report reads; the reporter keeps it current. */
+let current: {| readonly path: string, readonly boundaries: Map<string, RouteBoundary> |} | null =
+  null;
+
+/**
+ * The boundary set as one comparable string.
+ *
+ * Kind, depth and source — everything a reader would notice — and not what the
+ * page currently owns: a boundary whose subtree changed because the route's
+ * data changed has not changed, and reporting it would make this fire on every
+ * keystroke behind a search box.
+ */
+function signature(boundaries: Map<string, RouteBoundary>): string {
+  return [...boundaries.values()].map((it) => `${it.id}@${it.above}:${it.source ?? ""}`).join("|");
+}
+
+/**
+ * Send the report for whatever is on the page now.
+ *
+ * Exported for [`BOUNDARY_GLOBAL`] and used by the reporter, so the on-demand
+ * answer and the automatic one are the same sentence about the same page.
+ */
+export function reportBoundaries(
+  path: string,
+  boundaries: Map<string, RouteBoundary>,
+  document: Document,
+): $ReadOnlyArray<BoundaryFinding> {
+  const findings = boundaryFindings(boundaries, document);
+  const { message, detail } = formatBoundaries(path, findings);
+  reportDiagnostic({ severity: "info", message, detail });
+  return findings;
+}
+
+/**
+ * Watches the boundary set and says when it changed.
+ *
+ * Renders nothing, and its effect has no dependency list on purpose: the
+ * question is asked after every commit, and the answer is a string comparison
+ * over a handful of entries before anything touches the DOM. The document is
+ * read only in the commit that is about to be reported, which is also the
+ * commit the marks are in — every edge mounted after the first one starts live,
+ * so a boundary that has just appeared is in the page by the time this runs.
+ *
+ * Quiet on the first sighting of a route, for the reason ubugeeei-prod/uf#636
+ * is quiet on the first scan: a listing of everything, at the moment somebody
+ * loaded a page, is not a thing anybody asked.
+ */
+export component BoundaryReporter(path: string, boundaries: Map<string, RouteBoundary>) {
+  useEffect(() => {
+    current = { path, boundaries };
+    installOnDemand();
+    const next = signature(boundaries);
+    const previous = seen.get(path);
+    if (seen.size >= MEMORY_LIMIT && previous === undefined) {
+      const oldest = seen.keys().next();
+      if (!oldest.done) {
+        seen.delete(oldest.value);
+      }
+    }
+    seen.set(path, next);
+    if (previous === undefined || previous === next) {
+      return;
+    }
+    const document = globalThis.document;
+    if (document == null) {
+      return;
+    }
+    reportBoundaries(path, boundaries, document);
+  });
+  return null;
+}
+
+/**
+ * The global object, under the one description this module has of it.
+ *
+ * A read-only indexer, which is what makes the annotation assignable at all:
+ * `globalThis` is a namespace to the checker, and every one of its members is
+ * read-only, so a writable indexer disagrees with all of them at once. The same
+ * shape `@uniflowed/react-testing`'s `internal/dom.js` reads globals through,
+ * and for the same reason — a name in, and no claim about what comes out.
+ */
+type Globals = { readonly [string]: mixed };
+
+/** The global object, for reading. */
+const globals: Globals = globalThis;
+
+/**
+ * Install `__ufBoundaries()`, once.
+ *
+ * The answer to "and how do I see the page I am looking at *now*", which the
+ * change-driven report deliberately does not give. A function on the global
+ * rather than a key binding or a panel: there is nothing to discover by
+ * accident, nothing to intercept a page's own keystrokes, and the console is
+ * already open in the window this is about. It returns the findings as well as
+ * printing them, so the browser shows the tree and the terminal keeps the line.
+ *
+ * Defined rather than assigned, for the reason `internal/dom.js` gives about
+ * `navigator`: a name the host declared as an accessor cannot be assigned to,
+ * and a development affordance must not be able to throw on a page.
+ */
+function installOnDemand(): void {
+  if (globals[BOUNDARY_GLOBAL] != null) {
+    return;
+  }
+  Object.defineProperty(globalThis, BOUNDARY_GLOBAL, {
+    value: () => {
+      const live = current;
+      const document = globalThis.document;
+      if (live == null || document == null) {
+        return [];
+      }
+      return reportBoundaries(live.path, live.boundaries, document);
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * Forget every route this module has seen.
+ *
+ * For tests, which share one module registry across files and would otherwise
+ * inherit a route's history from whichever file rendered it first.
+ */
+export function forgetBoundaries(): void {
+  seen.clear();
+  current = null;
+  marksAreLive = false;
+}

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -40,6 +40,21 @@ import { RenderProvider } from "@uniflowed/hooks/render";
 // — so the module that renders it is this one rather than `../server.js`.
 import { DATA_ID } from "./document.js";
 
+// The development-only half of [`RouteView`]: the marks that say which DOM
+// subtree each boundary owns, and the report that reads them. Every reference
+// to it is inside a `BOUNDARY_MARKS` branch, which is why a static import is
+// safe here where `../client.js` needs a dynamic one — a component cannot be
+// awaited in the middle of a render, and `false` folds the references away
+// before the bundler is asked to keep the module. See [`BOUNDARY_MARKS`].
+import {
+  BoundaryReporter,
+  ROOT_ERROR_ID,
+  ROUTE_ERROR_ID,
+  insideBoundary,
+  routeBoundaries,
+  suspenseId,
+} from "./boundaries.js";
+
 /** One parameter a route path captures. */
 export type RouteParamSpec = {| readonly name: string, readonly catchAll: boolean |};
 
@@ -2120,6 +2135,25 @@ export hook useLoaderData(): mixed {
 }
 
 /**
+ * Whether this bundle marks the boundaries it renders.
+ *
+ * `import.meta.hot` is the same gate `../client.js` uses for the hydration
+ * report and the DevTools check, chosen there for the reason it is chosen here:
+ * Vite defines it while serving and replaces it with `undefined` in a build, so
+ * every branch below is statically dead in a production bundle and the module
+ * behind it — `@uniflowed/router` is `sideEffects: false` — is dropped rather
+ * than shipped unused. Node leaves it undefined, so a host that imports this
+ * file without a bundler gets the production path, and so does the test suite.
+ *
+ * It is a module constant rather than a per-render question because the branch
+ * has to be foldable, and it may answer differently in the browser and on the
+ * server without costing anything: a mark renders nothing until it has mounted,
+ * so neither the server's markup nor the tree React hydrates against it can
+ * contain one. See `./boundaries.js`, which has the argument.
+ */
+const BOUNDARY_MARKS: boolean = import.meta.hot != null;
+
+/**
  * Renders the matched page inside its layouts, innermost last, with the
  * document metadata as hoistable head elements.
  *
@@ -2168,11 +2202,33 @@ export hook useLoaderData(): mixed {
  * with opposite answers to one question, so they are one line apart here, and
  * the whole of the difference is the `key` — see [`insideTemplates`], which is
  * that line's other half.
+ *
+ * # Where the boundary marks go
+ *
+ * Inside each boundary and around nothing else, under `uf dev` only. A
+ * `<Suspense>` and a class boundary each render no element of their own, so the
+ * run of nodes one owns is indistinguishable on the page from the layout's own
+ * nodes beside it — the marks are what distinguish it, and this loop is the
+ * only place that knows which boundary is which. `./boundaries.js` has the
+ * mechanism and the argument; every reference to it here is inside a
+ * [`BOUNDARY_MARKS`] branch, so a build has none of it. See
+ * ubugeeei-prod/uf#520.
  */
 export component RouteView() {
   const { resolved } = useRouterState();
   const { module, above } = resolved.errorBoundary;
   const loader = resolved.deferred;
+  // The route's boundaries, named once and read by both the marks below and the
+  // report that watches them. `installedTable` rather than [`routeTable`],
+  // which throws: a test may render this view without an entry having installed
+  // a table, and an error boundary named by its depth alone is worth less than
+  // one named by its file rather than wrong.
+  const marks = BOUNDARY_MARKS
+    ? routeBoundaries(
+        resolved,
+        nearestBoundary(installedTable?.errors ?? [], resolved.pathname)?.file,
+      )
+    : null;
   // The innermost element, so the `use` inside `AwaitedPage` suspends below
   // every boundary the loop below adds — which is what makes the layouts and
   // the fallback the shell rather than something waiting behind the loader.
@@ -2190,7 +2246,11 @@ export component RouteView() {
         continue;
       }
       const Fallback = loadingComponent(boundary.module);
-      element = <Suspense fallback={<Fallback />}>{element}</Suspense>;
+      element = (
+        <Suspense fallback={<Fallback />}>
+          {BOUNDARY_MARKS ? insideBoundary(marks?.get(suspenseId(index)), element) : element}
+        </Suspense>
+      );
     }
     // Placed on `above` alone, and not on there being a module: a `null` one is
     // the framework's own error page, and where it renders is exactly the
@@ -2207,7 +2267,7 @@ export component RouteView() {
     if (depth === above && resolved.error == null) {
       element = (
         <RouteErrorBoundary module={module} resetKey={resolved.pathname}>
-          {element}
+          {BOUNDARY_MARKS ? insideBoundary(marks?.get(ROUTE_ERROR_ID), element) : element}
         </RouteErrorBoundary>
       );
     }
@@ -2221,8 +2281,13 @@ export component RouteView() {
     <>
       <Head metadata={resolved.metadata} />
       <RouteErrorBoundary module={null} resetKey={resolved.pathname}>
-        {element}
+        {BOUNDARY_MARKS ? insideBoundary(marks?.get(ROOT_ERROR_ID), element) : element}
       </RouteErrorBoundary>
+      {/* After the tree rather than before it, so its effect runs once every
+          mark below has had its own — which is the commit the marks are in. */}
+      {BOUNDARY_MARKS && marks != null ? (
+        <BoundaryReporter path={resolved.path} boundaries={marks} />
+      ) : null}
     </>
   );
 }

--- a/tests/library/boundaries.test.js
+++ b/tests/library/boundaries.test.js
@@ -1,0 +1,613 @@
+// @flow
+//
+// Which DOM subtree each boundary owns.
+//
+// An application has three boundaries a reader cannot see, and
+// ubugeeei-prod/uf#636 answered one of them: `uf dev` says why a module is in
+// the client bundle. The other two are Suspense and error, and the thing that
+// was missing about them is not the *data* — the route table nests
+// `_uf.loading.js` and binds `_uf.error.js` to the nearest ancestor, and
+// `error-boundary.test.js` and `streaming.test.js` already hold both — but the
+// *page*. A `<Suspense>` renders no element and neither does a class boundary,
+// so what a boundary owns is a run of nodes in a parent that also holds the
+// layout's own, and nothing on the page tells the two apart.
+//
+// So the render says so, and there is a section for each half of that. The
+// marks delimit the run, which is the only claim worth testing hard: the test
+// that matters is a boundary between a `<nav>` and a `<footer>` — a single
+// opening mark would hand it the footer. The report is what a reader is told,
+// and it is quiet until the answer changes, which is the other half.
+//
+// The module is internal to `@uniflowed/router` and is reached by path, the way
+// `hydration.test.js` reaches `internal/hydration.js`: `internal/` is the half
+// of the router that only exists under `uf dev`, and nothing outside the
+// package has business rendering a mark.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as React from "@uniflowed/react";
+import { render } from "@uniflowed/react-testing";
+import { RouteView, RouterProvider, resolveMatch, routerView } from "@uniflowed/router";
+import { createRenderer } from "@uniflowed/router/server";
+// The renderer with no document behind it, which is the point of the one test
+// that uses it. `react-dom/server` reads nothing while it is imported, unlike
+// `react-dom/client` — see `hydration.test.js`, which has to require that one.
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterAll, beforeEach, describe, expect, it } from "@uniflowed/test";
+
+import { elementIn, elementsIn } from "./dom.js";
+import { routesModuleSource, scanRoutes } from "../../packages/vite/internal/routes.js";
+import { DIAGNOSTIC_ENDPOINT } from "../../packages/router/internal/diagnostics.js";
+import {
+  type BoundaryFinding,
+  type RouteBoundary,
+  BOUNDARY_ATTRIBUTE,
+  BOUNDARY_GLOBAL,
+  BoundaryReporter,
+  EDGE_ATTRIBUTE,
+  ROOT_ERROR_ID,
+  ROUTE_ERROR_ID,
+  SOURCE_ATTRIBUTE,
+  SYNTHESISED_SOURCE,
+  boundaryFindings,
+  describeElement,
+  forgetBoundaries,
+  formatBoundaries,
+  insideBoundary,
+  routeBoundaries,
+  suspenseId,
+} from "../../packages/router/internal/boundaries.js";
+
+const roots: Array<string> = [];
+
+afterAll(() => {
+  for (const root of roots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Everything this file has put in the document, so it can take it out again.
+ *
+ * The document belongs to the process rather than to the file — `uf test` runs
+ * several files in one worker — and a `<template data-uf-boundary>` left behind
+ * is a mark the next test in this file would find by `querySelector` and
+ * attribute to its own render. See the same paragraph in `hydration.test.js`.
+ */
+const mountedContainers: Array<Element> = [];
+
+beforeEach(() => {
+  while (mountedContainers.length > 0) {
+    mountedContainers.pop()?.remove();
+  }
+  // The module's own memory: which routes it has seen, and whether a mark that
+  // mounts now should be in the DOM immediately. Both are latched per process,
+  // and a test that inherited either from the test above it would be asserting
+  // the order the file happens to be written in.
+  forgetBoundaries();
+});
+
+/** Render `tree`, remembering the container so the next test starts clean. */
+function mount(tree: React.Node): Element {
+  const { container } = render(tree);
+  mountedContainers.push(container);
+  return container;
+}
+
+// --- The boundaries a route renders ----------------------------------------
+
+/** A router root holding each named file. */
+function appRoot(prefix: string, files: $ReadOnlyArray<string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  roots.push(root);
+  for (const relative of files) {
+    const file = path.join(root, relative);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "// @flow\nexport default function Part() {}\n");
+  }
+  return root;
+}
+
+/** A page module that renders one paragraph. */
+const pageOf = (text: string) => () => Promise.resolve({ default: () => <p>{text}</p> });
+
+/** A layout with something of its own on either side of the route. */
+component Frame(children: React.Node) {
+  return (
+    <div id="shell">
+      <nav className="masthead">the masthead</nav>
+      {children}
+      <footer className="colophon">the colophon</footer>
+    </div>
+  );
+}
+
+const loadFrame = () => Promise.resolve({ default: Frame });
+const loadFallback = () => Promise.resolve({ default: () => <p>loading</p> });
+
+describe("the boundaries a route renders", () => {
+  it("finds the two error boundaries a route with no fallback has", async () => {
+    // Two, and they are not the same thing twice: the outer one has no module
+    // and renders the framework's page, and the route's own is placed at the
+    // depth its file sits at. `RouteView`'s own comment makes the argument;
+    // this is the map agreeing with it.
+    const table = {
+      routes: [
+        {
+          path: "/first",
+          params: [],
+          mdx: false,
+          file: "app/first/_uf.page.js",
+          page: pageOf("the first page"),
+          layouts: [loadFrame],
+          loading: [],
+          templates: [],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    };
+    const resolved = await resolveMatch(table, "/first");
+
+    const found = routeBoundaries(resolved, "app/_uf.error.js");
+
+    expect([...found.keys()]).toEqual([ROOT_ERROR_ID, ROUTE_ERROR_ID]);
+    expect(found.get(ROOT_ERROR_ID)).toEqual({
+      id: ROOT_ERROR_ID,
+      kind: "error",
+      above: 0,
+      source: SYNTHESISED_SOURCE,
+    });
+    expect(found.get(ROUTE_ERROR_ID)?.source).toBe("app/_uf.error.js");
+  });
+
+  it("gives every `_uf.loading.js` its own boundary at the depth it sits at", async () => {
+    // `above` is how many of the route's layouts are outside the fallback, and
+    // it is the table's number rather than a second one computed here: one
+    // vocabulary for where a thing sits in the stack, which is the rule
+    // `LoadingRecord` and `errorBoundary.above` already follow.
+    const table = {
+      routes: [
+        {
+          path: "/deep",
+          params: [],
+          mdx: false,
+          file: "app/deep/_uf.page.js",
+          page: pageOf("the deep page"),
+          layouts: [loadFrame, loadFrame],
+          loading: [
+            { above: 0, module: loadFallback },
+            { above: 2, module: loadFallback },
+          ],
+          templates: [],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    };
+    const resolved = await resolveMatch(table, "/deep");
+
+    const found = routeBoundaries(resolved, null);
+
+    expect([...found.values()].map((it) => [it.id, it.kind, it.above])).toEqual([
+      [ROOT_ERROR_ID, "error", 0],
+      [ROUTE_ERROR_ID, "error", 0],
+      [suspenseId(0), "suspense", 0],
+      [suspenseId(1), "suspense", 2],
+    ]);
+    // No file, and that is the route table's asymmetry rather than this
+    // module's: an error boundary is matched by path so the table carries one,
+    // and putting a path on every loading record would ship it to every
+    // visitor for a report only `uf dev` reads.
+    expect(found.get(suspenseId(0))?.source).toBe(null);
+  });
+
+  it("leaves out the route's own boundary when the route is its error page", () => {
+    // `RouteView` does not render one there — the page *is* the boundary's
+    // component, and wrapping it in the same boundary would answer a throw
+    // inside it with itself — so a map that named one would be pointing at a
+    // subtree nothing owns.
+    const resolved = {
+      errorBoundary: { above: 1 },
+      loading: [],
+      error: { kind: "thrown", error: new Error("boom") },
+    };
+
+    const found = routeBoundaries(resolved, "app/_uf.error.js");
+
+    expect([...found.keys()]).toEqual([ROOT_ERROR_ID]);
+  });
+
+  it("spells the synthesised boundary's file the way the generated table does", () => {
+    // Two spellings of one string, in a package that cannot import the other:
+    // `@uniflowed/vite` is plain JavaScript loaded before any Flow transform
+    // exists. A duplicated constant with a test on it is honest; one without is
+    // how a report ends up naming a file nothing wrote. Same argument as
+    // `devtools.test.js` makes about `__REACT_DEVTOOLS_GLOBAL_HOOK__`.
+    const root = appRoot("uf-boundaries-source-", ["_uf.layout.js", "_uf.page.js"]);
+
+    const source = routesModuleSource(scanRoutes(root));
+
+    expect(source).toContain(`file: ${JSON.stringify(SYNTHESISED_SOURCE)}`);
+  });
+});
+
+// --- The marks, and what they delimit --------------------------------------
+
+const suspense = (id: string, above: number): RouteBoundary => ({
+  id,
+  kind: "suspense",
+  above,
+  source: null,
+});
+
+describe("the marks a boundary renders", () => {
+  it("owns the run between them and not the layout's own nodes beside it", () => {
+    // The test the pair exists for. A single opening mark cannot say where the
+    // run ends, so the walk from it would reach the colophon — a boundary
+    // credited with a subtree that stays on the page when it fails.
+    const boundary = suspense(suspenseId(0), 1);
+
+    const container = mount(
+      <Frame>{insideBoundary(boundary, <article className="post">the post</article>)}</Frame>,
+    );
+
+    const [finding] = boundaryFindings(new Map([[boundary.id, boundary]]), globalThis.document);
+    expect(finding.rendered).toBe(true);
+    expect(finding.owns).toEqual(["article.post"]);
+    // And the marks really are siblings of what they delimit, which is what
+    // makes the walk `nextElementSibling` rather than a tree search.
+    expect(elementsIn(container, "#shell > *").map((it) => it.tagName.toLowerCase())).toEqual([
+      "nav",
+      "template",
+      "article",
+      "template",
+      "footer",
+    ]);
+  });
+
+  it("nests, and neither boundary counts the other's marks as its own", () => {
+    // Two boundaries in one parent, which is what a `_uf.loading.js` inside
+    // another one produces. The outer owns all three paragraphs and none of the
+    // four `<template>`s; the inner owns exactly its own.
+    const outer = suspense(suspenseId(0), 0);
+    const inner = suspense(suspenseId(1), 0);
+
+    mount(
+      <Frame>
+        {insideBoundary(
+          outer,
+          <>
+            <p className="before">before</p>
+            {insideBoundary(inner, <p className="middle">middle</p>)}
+            <p className="after">after</p>
+          </>,
+        )}
+      </Frame>,
+    );
+
+    const findings = boundaryFindings(
+      new Map([
+        [outer.id, outer],
+        [inner.id, inner],
+      ]),
+      globalThis.document,
+    );
+    expect(findings[0].owns).toEqual(["p.before", "p.middle", "p.after"]);
+    expect(findings[1].owns).toEqual(["p.middle"]);
+  });
+
+  it("counts what it does not name", () => {
+    // A report with no ceiling on it is a report a page decides the size of,
+    // which `docs/security.md` asks that nothing here be.
+    const boundary = suspense(suspenseId(0), 0);
+
+    mount(
+      <Frame>
+        {insideBoundary(
+          boundary,
+          <>
+            <p id="one" />
+            <p id="two" />
+            <p id="three" />
+            <p id="four" />
+            <p id="five" />
+          </>,
+        )}
+      </Frame>,
+    );
+
+    const [finding] = boundaryFindings(new Map([[boundary.id, boundary]]), globalThis.document);
+    expect(finding.owns).toEqual(["p#one", "p#two", "p#three"]);
+    expect(finding.more).toBe(2);
+  });
+
+  it("says a boundary with no marks on the page is showing its fallback", () => {
+    // React removes a boundary's content while its fallback is up, and the
+    // marks are part of that content. "Not in the document" is therefore an
+    // answer rather than a gap, and it is the answer a reader wants.
+    const boundary = suspense(suspenseId(0), 0);
+
+    mount(<Frame>{null}</Frame>);
+
+    const [finding] = boundaryFindings(new Map([[boundary.id, boundary]]), globalThis.document);
+    expect(finding.rendered).toBe(false);
+    expect(finding.owns).toEqual([]);
+  });
+
+  it("puts no mark in the markup a server renders", () => {
+    // The whole of why a mark is a sibling that arrives after mount rather than
+    // a wrapper that is there from the start: the tree React hydrates against
+    // the server's markup has no mark in it, so the gate is free to answer
+    // differently in the two processes. An effect is what makes a mark appear,
+    // and a server render runs none.
+    const boundary = suspense(suspenseId(0), 0);
+
+    const html = renderToStaticMarkup(
+      <Frame>{insideBoundary(boundary, <article className="post">the post</article>)}</Frame>,
+    );
+
+    expect(html).not.toContain(BOUNDARY_ATTRIBUTE);
+    expect(html).toContain("the post");
+  });
+
+  it("returns the children untouched when there is no boundary to mark", () => {
+    const container = mount(<Frame>{insideBoundary(null, <article>the post</article>)}</Frame>);
+
+    expect(elementsIn(container, `[${BOUNDARY_ATTRIBUTE}]`)).toEqual([]);
+  });
+
+  it("names the file on the opening mark, where a reader will be looking", () => {
+    // The inspector is the other half of "see it" and the cheaper half, so the
+    // mark has to answer on its own: an id says which boundary and this says
+    // which file wrote it. Only on the opening one — the closing mark is a
+    // position, and a second copy of the answer is a second thing to keep true.
+    const boundary: RouteBoundary = {
+      id: ROUTE_ERROR_ID,
+      kind: "error",
+      above: 1,
+      source: "app/docs/_uf.error.js",
+    };
+
+    const container = mount(<Frame>{insideBoundary(boundary, <article>the post</article>)}</Frame>);
+
+    expect(elementsIn(container, `[${SOURCE_ATTRIBUTE}="app/docs/_uf.error.js"]`).length).toBe(1);
+    expect(elementIn(container, `[${SOURCE_ATTRIBUTE}]`).getAttribute(EDGE_ATTRIBUTE)).toBe("open");
+  });
+});
+
+// --- What a reader is told -------------------------------------------------
+
+describe("the report", () => {
+  it("names each boundary, where it sits and what it took over", () => {
+    const findings: $ReadOnlyArray<BoundaryFinding> = [
+      {
+        boundary: { id: ROOT_ERROR_ID, kind: "error", above: 0, source: SYNTHESISED_SOURCE },
+        owns: ["div#shell"],
+        more: 0,
+        rendered: true,
+      },
+      {
+        boundary: { id: ROUTE_ERROR_ID, kind: "error", above: 1, source: "app/docs/_uf.error.js" },
+        owns: ["article.doc", "aside.toc"],
+        more: 3,
+        rendered: true,
+      },
+      {
+        boundary: { id: suspenseId(0), kind: "suspense", above: 2, source: null },
+        owns: [],
+        more: 0,
+        rendered: false,
+      },
+    ];
+
+    const report = formatBoundaries("/docs/:slug", findings);
+
+    expect(report.message).toBe("3 boundaries render /docs/:slug");
+    expect(report.detail).toEqual([
+      "error (uf's own error page), outside every layout — owns div#shell",
+      "error (app/docs/_uf.error.js), inside 1 layout — owns article.doc, aside.toc and 3 more",
+      "suspense, inside 2 layouts — showing its fallback",
+    ]);
+  });
+
+  it("says nothing about a route it is seeing for the first time, or seeing again", async () => {
+    // Quiet on the first sighting, for the reason ubugeeei-prod/uf#636 is quiet
+    // on the first scan: a listing of everything, at the moment somebody loaded
+    // a page, is the banner nobody reads.
+    const boundaries: Map<string, RouteBoundary> = new Map([
+      [suspenseId(0), suspense(suspenseId(0), 0)],
+    ]);
+
+    const posted = withPoster(() => {
+      mount(<BoundaryReporter path="/docs/:slug" boundaries={boundaries} />);
+      mount(<BoundaryReporter path="/docs/:slug" boundaries={boundaries} />);
+    });
+
+    expect(posted).toEqual([]);
+  });
+
+  it("reports the moment the same route's boundaries change", async () => {
+    // Which is the moment somebody added an `_uf.error.js` and HMR handed the
+    // page a new table — the one time a boundary map is what the reader wants.
+    const before: Map<string, RouteBoundary> = new Map([
+      [suspenseId(0), suspense(suspenseId(0), 0)],
+    ]);
+    const routeError: RouteBoundary = {
+      id: ROUTE_ERROR_ID,
+      kind: "error",
+      above: 1,
+      source: "app/_uf.error.js",
+    };
+    const after: Map<string, RouteBoundary> = new Map([
+      [ROUTE_ERROR_ID, routeError],
+      [suspenseId(0), suspense(suspenseId(0), 0)],
+    ]);
+
+    const posted = withPoster(() => {
+      mount(<BoundaryReporter path="/docs/:slug" boundaries={before} />);
+      mount(<BoundaryReporter path="/docs/:slug" boundaries={after} />);
+    });
+
+    expect(posted.length).toBe(1);
+    expect(posted[0].target).toBe(DIAGNOSTIC_ENDPOINT);
+    const body = JSON.parse(String(posted[0].body));
+    // `info`, not `warn`: nothing is wrong. It is a measurement of a decision
+    // the build made, and a warning nobody can act on teaches a reader to
+    // ignore the warnings.
+    expect(body.severity).toBe("info");
+    expect(body.message).toBe("2 boundaries render /docs/:slug");
+    expect(body.detail).toEqual([
+      "error (app/_uf.error.js), inside 1 layout — showing its fallback",
+      "suspense, outside every layout — showing its fallback",
+    ]);
+  });
+});
+
+describe("the on-demand report", () => {
+  it("prints the page in front of you when the console asks for it", () => {
+    // The change-driven report deliberately says nothing about a route it is
+    // seeing for the first time, so this is the answer to "and what about the
+    // page I am on". It returns the findings as well as printing them: the
+    // browser shows the tree, the terminal keeps the line.
+    const boundary = suspense(suspenseId(0), 1);
+    const boundaries: Map<string, RouteBoundary> = new Map([[boundary.id, boundary]]);
+
+    const posted = withPoster(() => {
+      mount(
+        <Frame>
+          {insideBoundary(boundary, <article className="post">the post</article>)}
+          <BoundaryReporter path="/docs/:slug" boundaries={boundaries} />
+        </Frame>,
+      );
+      // Through a named object rather than `globalThis[…]`, which the checker
+      // reads as a computed property on a namespace: the same narrowing
+      // `@uniflowed/react-testing`'s `internal/dom.js` uses to read a global.
+      const globals: { readonly [string]: mixed } = globalThis;
+      const ask: $FlowFixMe = globals[BOUNDARY_GLOBAL];
+      expect(typeof ask).toBe("function");
+      expect(ask().map((it) => it.owns)).toEqual([["article.post"]]);
+    });
+
+    expect(posted.length).toBe(1);
+    expect(JSON.parse(String(posted[0].body)).detail).toEqual([
+      "suspense, inside 1 layout — owns article.post",
+    ]);
+  });
+});
+
+describe("naming an element", () => {
+  it("prefers the id, then the first class, then the tag", () => {
+    const document = globalThis.document ?? render(<div />).container.ownerDocument;
+    const withId = document.createElement("section");
+    withId.setAttribute("id", "shell");
+    withId.setAttribute("class", "wide dark");
+    const withClass = document.createElement("article");
+    withClass.setAttribute("class", "post featured");
+    const bare = document.createElement("p");
+
+    expect(describeElement(withId)).toBe("section#shell");
+    expect(describeElement(withClass)).toBe("article.post");
+    expect(describeElement(bare)).toBe("p");
+  });
+});
+
+// --- None of it is in a build ----------------------------------------------
+
+describe("a bundle without `import.meta.hot`", () => {
+  it("renders no mark at all", async () => {
+    // The gate is `import.meta.hot != null`, which Vite replaces with
+    // `undefined` in a build and Node never defines — so a host that imports
+    // the router without a bundler gets the production path, and so does this
+    // process. What is asserted here is that path: the same `RouteView` that
+    // marks under `uf dev` renders the tree it rendered before any of this
+    // existed.
+    const table = {
+      routes: [
+        {
+          path: "/plain",
+          params: [],
+          mdx: false,
+          file: "app/plain/_uf.page.js",
+          page: pageOf("the plain page"),
+          layouts: [loadFrame],
+          loading: [{ above: 1, module: loadFallback }],
+          templates: [],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    };
+    const resolved = await resolveMatch(table, "/plain");
+
+    const container = mount(
+      <RouterProvider url="/plain" initial={resolved}>
+        <RouteView />
+      </RouterProvider>,
+    );
+
+    expect(elementsIn(container, `[${BOUNDARY_ATTRIBUTE}]`)).toEqual([]);
+    expect(elementsIn(container, `[${EDGE_ATTRIBUTE}]`)).toEqual([]);
+  });
+
+  it("prerenders a document with none either", async () => {
+    const table = {
+      routes: [
+        {
+          path: "/plain",
+          params: [],
+          mdx: false,
+          file: "app/plain/_uf.page.js",
+          page: pageOf("the plain page"),
+          layouts: [loadFrame],
+          loading: [],
+          templates: [],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    };
+    const { prerender } = createRenderer({ App: routerView("./app"), ...table });
+
+    const result = await prerender("/plain", { scripts: [], styles: [], preloads: [] });
+
+    expect(result.html).not.toContain(BOUNDARY_ATTRIBUTE);
+  });
+});
+
+/** One post the reporter made, as the stub saw it. */
+type Posted = {| readonly target: string, readonly body: mixed |};
+
+/**
+ * Run `body` with the page's `fetch` replaced, and return what was posted.
+ *
+ * The diagnostic channel is a `fetch` to a path on the page's own origin, and
+ * this test process has a happy-dom window whose `fetch` would try to make the
+ * request. Swapping it is also the assertion: a reporter that posted somewhere
+ * else would show up here as nothing posted at all.
+ */
+function withPoster(body: () => void): $ReadOnlyArray<Posted> {
+  const posted: Array<Posted> = [];
+  const win: $FlowFixMe = globalThis.window;
+  const previous = Object.getOwnPropertyDescriptor(win, "fetch");
+  Object.defineProperty(win, "fetch", {
+    value: (target: string, init: { readonly body: mixed, ... }) => {
+      posted.push({ target, body: init.body });
+      return Promise.resolve(null);
+    },
+    configurable: true,
+    writable: true,
+  });
+  try {
+    body();
+  } finally {
+    if (previous == null) {
+      delete win.fetch;
+    } else {
+      Object.defineProperty(win, "fetch", previous);
+    }
+  }
+  return posted;
+}


### PR DESCRIPTION
**This is the boundary-visualizer half of ubugeeei-prod/uf#520 only.** The
Flight inspector — what arrived, in what order, and which part of the tree each
chunk built — stays open behind #519, and nothing here goes near it: an
inspector for what arrived needs something to arrive, and #519's own comment
sizes that as a second module graph rather than a second import. The
client/server third landed in #636. So #520 stays open with one third left.

## What was missing

Per that issue's triage, the *data* is already there: `_uf.loading.js` nests and
each record carries how many layouts are outside it, `_uf.error.js` binds to the
nearest ancestor, and `RouteView` threads both into one descending stack. What
did not exist is a way to point at **the DOM subtree each boundary owns**.

That cannot be read off the table, and it cannot be read off the page either. A
`<Suspense>` renders no element of its own and neither does a class boundary, so
what one owns is a *run* of nodes in a parent that also holds whatever the
enclosing layout put beside them — a `<nav>` before, a `<footer>` after — and
nothing distinguishes the run from its neighbours. Reading the directory tells
you a boundary exists; it does not tell you which rectangle goes away when it
fires.

## The mechanism: a pair of inert marks

`RouteView` now wraps each boundary's children between two
`<template data-uf-boundary>` elements. A `<template>` is `display: none` in
every UA stylesheet and its content is inert, so it lays nothing out and runs
nothing; both are ordinary siblings of the nodes between them, because a React
fragment creates no element — so "what this boundary owns" is
`open.nextElementSibling` up to `close`:

```html
<div id="uf-root">
  <nav class="masthead">…</nav>
  <template data-uf-boundary="suspense:0" data-uf-boundary-edge="open"></template>
  <article class="post">…</article>
  <template data-uf-boundary="suspense:0" data-uf-boundary-edge="close"></template>
  <footer class="colophon">…</footer>
</div>
```

Two decisions worth arguing, because both had a cheaper-looking alternative:

**A pair, not one mark.** A boundary's run ends where the enclosing layout's own
trailing nodes begin, and from the opening mark alone those are
indistinguishable — the walk would credit the boundary with the colophon
underneath it. That is the first test in the new file.

**Marks, not a wrapper.** One `<div style="display:contents">` per boundary
would have been one node and no walk. It loses on the thing that decides this:
a wrapper has to exist from the first render, because introducing one later
moves the subtree into a new parent and React answers that by unmounting and
rebuilding everything under it. Marks are siblings, so they can arrive after the
page has settled — which is the next section, and the reason none of this can
break a hydration.

**They arrive after hydration, which is what makes them free of it.** Every edge
renders `null` until it has mounted. So the markup the server wrote contains no
mark, the tree React hydrates against it contains no mark, and the two agree
*whatever either process believed about being in development* — the gate is
allowed to answer differently on the two sides because by the time it has any
effect, hydration is over. `reportDevtools` asks its question on the line after
hydration for the same reason. A module-level latch keeps that from costing a
second commit forever: every edge mounted after the first one starts live, so a
boundary HMR has just added is in the DOM in the commit that created it, which
is the commit the report reads.

`packages/router/internal/hydration.js` and `packages/router/client.js` are
untouched.

## Where the report goes: the terminal, and only when it changed

Following #636 and the #557 → #583 reasoning it cites, rather than an overlay: a
diagnostic that exists only in a browser window has to be noticed by somebody
who does not know to look. It goes out on `internal/diagnostics.js`, the same
`/__uf/diagnostic` channel the hydration report and the DevTools check use, at
`info` — nothing here is wrong, and a warning nobody can act on teaches a reader
to ignore the warnings.

And it is quiet unless the answer *changed*. The first sighting of a route says
nothing, the same boundaries on the same route say nothing, and a route whose
set moved — which is the moment you added the file and HMR handed the page a new
table — says where it landed and what it took over:

```text
› 3 boundaries render /docs/:slug
    error (uf's own error page), outside every layout — owns div#uf-root
    error (app/docs/_uf.error.js), inside 1 layout — owns article.doc, aside.toc
    suspense, inside 2 layouts — showing its fallback
```

That is #636's shape transposed: quiet on the first scan, loud at the moment the
answer moves. A boundary map printed on every reload is the banner nobody reads.

**The marks are the other half of "see it", and the cheaper half.** They are in
the document, so the element inspector already shows where each boundary opens
and closes with no panel to open and nothing to discover;
`document.querySelectorAll("[data-uf-boundary]")` is the whole API, and one CSS
rule outlines them. For the page in front of you right now — which the
change-driven report deliberately does not describe — `__ufBoundaries()` prints
the same report to the terminal and returns the findings to the console.

An error boundary's mark names its file and a `<Suspense>`'s does not, and that
asymmetry is the route table's rather than this module's: an error boundary is
matched by path so the table carries its `file`, while a loading record is
carried by depth alone. Putting a path on every loading record would ship one to
every visitor to serve a report only `uf dev` reads.

## The gate, and what a build contains

`const BOUNDARY_MARKS: boolean = import.meta.hot != null;` in
`internal/runtime.js` — the gate `client.js` already uses for the hydration
report and the DevTools check. Vite defines it while serving and replaces it
with `undefined` in a build, so every reference to `internal/boundaries.js` is
inside a statically dead branch; `@uniflowed/router` is `sideEffects: false`, so
the module is dropped rather than shipped unused. Node leaves it undefined, so a
host that imports the router without a bundler gets the production path — and so
does the test suite, which is what `a bundle without \`import.meta.hot\`` asserts.

Measured on this repository's own docs site, built with one `uf` binary against
both trees so the only variable is the source:

| `docs/dist/docs/assets` | before | after | change |
| --- | ---: | ---: | ---: |
| the client runtime (`client-*.js`) | 223,263 | 223,495 | **+232** |
| the same, gzipped | 68,838 | 68,944 | +106 |
| every other `*.js` chunk | — | — | 0, apart from the page that documents this |

**No chunk of the built site contains `data-uf-boundary`, `__ufBoundaries`, or
any string from `internal/boundaries.js`** — except the compiled MDX of the
guide page added here, which quotes them. Nothing renders, nothing reports, and
none of the module ships.

The +232 bytes are worth naming rather than rounding away, because they are
real: they are entirely the React Compiler's memo cache for `RouteView`
widening, `useMemoCache(16)` → `useMemoCache(27)`, because the compiler runs on
the source before Rollup folds the dead branch away. The alternative was to
hoist `RouteView`'s composition loop out of the component so the compiler sees
one call — a change to the hot render path of every production page, made for a
development affordance, which is the wrong trade. The cost at runtime is a wider
comparison in a component that renders once per navigation.

## Tests

`tests/library/boundaries.test.js`, 18 tests, in the style of
`hydration.test.js` — the analysis is reachable without a browser, so a test
builds the DOM and asks the same function the page asks:

- **the boundaries a route renders** — the two error boundaries a plain route
  has and where each sits; one `<Suspense>` per `_uf.loading.js` at the `above`
  the table gave it; the route's own boundary left out when the route *is* its
  error page, which is exactly when `RouteView` renders none; and that
  `SYNTHESISED_SOURCE` is spelled the way `routesModuleSource` spells it — a
  duplicated constant with a test on it, the way `devtools.test.js` holds the
  DevTools hook name.
- **the marks** — a boundary between a `<nav>` and a `<footer>` owns neither
  (the test the pair exists for), that the marks really are siblings of what
  they delimit, that two boundaries in one parent nest without counting each
  other's marks, that the named list is capped and the rest counted, that a
  boundary with no marks reads as *showing its fallback*, that a server render
  emits no mark at all, and that the opening mark names the file.
- **the report** — the exact three lines above; silence on a first sighting and
  on an unchanged one; one `info` diagnostic posted to `DIAGNOSTIC_ENDPOINT` the
  moment the same route's set changes; and `__ufBoundaries()` printing and
  returning the findings.
- **a bundle without `import.meta.hot`** — `RouteView` renders no mark and
  `prerender` writes a document with none, which is the production path this
  process is on.

## Checks

Run in the worktree with the prebuilt `uf`, on node 24:

- `uf fmt --check` — clean
- `uf lint` — 0 errors, the same 14 warnings as `main`
- `uf check` — 2,190 errors, byte-for-byte the count on `main`; both new files
  report none
- `uf test#library` — **2,723 passed, 0 failed, 1 skipped**, 79 files
- `uf build#docs` — builds, and is where the bundle numbers above come from

No `cargo` command was run: this change is JavaScript only, and nothing in
`crates/` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791521174&installation_model_id=422833&pr_number=703&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F703&signature=0e685913f32caf4dc310fbd8e9815519dd240bafe01dd6074055b31221874967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->