### PR TITLE
feat(server): a durable route cache, so a restart does not empty it

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -397,6 +397,12 @@ pub(crate) fn build(
             "fetch": resolved.config.app.rendering.cache.fetch,
             "data": resolved.config.app.rendering.cache.data,
             "actions": resolved.config.app.rendering.cache.actions,
+            // Where the entries go, for a deploy step that has to provision it:
+            // `"filesystem"` needs a writable directory that outlives the
+            // process, and a module specifier needs whatever that module
+            // connects to. Absent means memory, which needs nothing.
+            "store": resolved.config.app.rendering.cache.store.as_deref(),
+            "storeDir": resolved.config.app.rendering.cache.store_dir.as_deref(),
         },
     });
     timer.measure("manifest", || write_json_file(&build_manifest, &payload))?;

--- a/crates/uf_config/src/app.rs
+++ b/crates/uf_config/src/app.rs
@@ -744,7 +744,7 @@ impl RenderingMode {
     }
 }
 
-/// Which of uf's caches a project has turned on.
+/// Which of uf's caches a project has turned on, and where they keep things.
 ///
 /// Four switches, and for a long time all four of them were read once, copied
 /// into `dist/uf-build-manifest.json` and read by nothing — so setting any of
@@ -769,6 +769,29 @@ impl RenderingMode {
 /// All four still default to `false`. `docs/roadmap.md` says "opt-in-only cache
 /// controls" and that has not changed; what has changed is that opting in now
 /// does something.
+///
+/// # And a fifth key, which is a name rather than a switch
+///
+/// [`CacheConfig::store`] says *where* entries live, and it is what turns the
+/// route cache into incremental static regeneration. Absent — the default —
+/// means the memory of one process, which is what the cache has always been:
+/// four servers behind a load balancer hold four of them, a restart empties
+/// one, and an invalidation in one does not reach the other three. A store that
+/// outlives the process fixes all three at once, and the time-based
+/// revalidation and on-demand invalidation that make it ISR were already there.
+///
+/// It is a *name* and not an enumeration on purpose. `docs/red-lines.md`'s
+/// third line says every built-in provider must be replaceable and that "a
+/// provider a project can replace has to be a name it can write, and an enum
+/// with one variant cannot become one without a release of uf" — so
+/// `"filesystem"` is uf's built-in and anything else is a module specifier
+/// exporting `createCacheProvider`, exactly as `builder.module` names a builder.
+/// A project with a Redis or a KV namespace puts it behind the seam without a
+/// release of uf and without uf naming either.
+///
+/// Persistence is a second opt-in on top of the first and never a way around
+/// it: a route with no stated lifetime is still not cached, wherever the cache
+/// keeps things.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
@@ -781,4 +804,18 @@ pub struct CacheConfig {
     pub fetch: bool,
     /// A rendered document, through `@uniflowed/server/fetch`.
     pub route: bool,
+    /// Where entries live: `"memory"`, `"filesystem"`, or a module specifier.
+    ///
+    /// `None` is `"memory"` and is the default. Not resolved or validated here:
+    /// a module specifier is resolved from the project by the host that
+    /// constructs the store, which is the only place it can be — this crate has
+    /// no module resolver and inventing one to reject a name early would be a
+    /// second, worse copy of Node's.
+    pub store: Option<CompactString>,
+    /// Where `"filesystem"` keeps entries. Defaults to `.uf/cache/route`.
+    ///
+    /// A path a *deployment* has to be able to write, which is why it is a
+    /// setting rather than a constant: a container has one mounted volume, a
+    /// Lambda has `/tmp`, and a checkout has the project directory.
+    pub store_dir: Option<CompactString>,
 }

--- a/crates/uf_config/src/tests.rs
+++ b/crates/uf_config/src/tests.rs
@@ -500,6 +500,75 @@ fn reads_the_two_cache_switches_that_are_implemented() {
     assert!(config.app.rendering.cache.fetch);
     assert!(!config.app.rendering.cache.data);
     assert!(!config.app.rendering.cache.actions);
+    // Nothing persists unasked. A project that turned the route cache on and
+    // said nothing else has the store it has always had: memory, one process.
+    assert_eq!(config.app.rendering.cache.store, None);
+    assert_eq!(config.app.rendering.cache.store_dir, None);
+}
+
+/// Where entries live is a name, and it survives the parse as one.
+///
+/// `store` is deliberately not an enumeration — `docs/red-lines.md`'s third
+/// line says a provider a project can replace has to be a name it can write —
+/// so this crate reads whatever string is there and validates none of it. The
+/// resolution is the host's, at the point it constructs the store, because that
+/// is the only place a module specifier means anything.
+#[test]
+fn reads_where_a_project_wants_its_cache_kept() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = Utf8PathBuf::from_path_buf(dir.path().join("uf.config.js")).unwrap();
+    fs::write(
+        &path,
+        r#"
+            export default defineConfig({
+              app: {
+                rendering: {
+                  cache: { route: true, store: "filesystem", storeDir: "/var/cache/uf" },
+                },
+              },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let config = load_config_file(&path).unwrap();
+
+    assert_eq!(
+        config.app.rendering.cache.store.as_deref(),
+        Some("filesystem")
+    );
+    assert_eq!(
+        config.app.rendering.cache.store_dir.as_deref(),
+        Some("/var/cache/uf")
+    );
+}
+
+/// A provider uf has never heard of is carried through, not refused.
+///
+/// The whole point of the key being a name: `"./cache/redis.js"` is a module
+/// this project wrote, and a config loader that only accepted words uf shipped
+/// would make every new provider need a release of uf — which is the failure
+/// `docs/red-lines.md` is about.
+#[test]
+fn carries_a_cache_provider_uf_does_not_ship() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = Utf8PathBuf::from_path_buf(dir.path().join("uf.config.js")).unwrap();
+    fs::write(
+        &path,
+        r#"
+            export default defineConfig({
+              app: { rendering: { cache: { route: true, store: "./cache/redis.js" } } },
+            });
+        "#,
+    )
+    .unwrap();
+
+    let config = load_config_file(&path).unwrap();
+
+    assert_eq!(
+        config.app.rendering.cache.store.as_deref(),
+        Some("./cache/redis.js")
+    );
 }
 
 /// A cache uf does not have is refused where it is asked for.

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -155,7 +155,8 @@ export const sections: $ReadOnlyArray<Section> = [
       {
         href: "/guide/cache",
         title: "Caching",
-        blurb: "A route cache and a fetch cache, opt-in, in memory, and honest about it.",
+        blurb:
+          "A route cache and a fetch cache, opt-in, in memory by default, durable when you say so.",
       },
       {
         href: "/guide/auth",

--- a/docs/app/guide/cache/_uf.page.mdx
+++ b/docs/app/guide/cache/_uf.page.mdx
@@ -305,6 +305,11 @@ The last column is the half a median cannot show. Ten simultaneous requests for 
 page nobody has asked for yet are one render, because a request that arrives
 while an entry is being filled joins the fill rather than starting a second one.
 
+Those numbers are the memory store. A durable one adds a read of the provider on
+a key this process has not seen — and a read is what it replaces a *render* with,
+which is the trade the whole feature is: 0.16 ms becomes a file read or a network
+hop instead of 52 ms, on every process rather than on the one that rendered it.
+
 ## What is not here
 
 - **The data cache and the action cache.** `rendering.cache.data` and

--- a/docs/app/guide/cache/_uf.page.mdx
+++ b/docs/app/guide/cache/_uf.page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Caching · uf"
-description: "A route cache and a fetch cache, opt-in, in memory, and honest about it."
+description: "A route cache and a fetch cache, opt-in, in memory by default, durable when you say so."
 ---
 
 <p className="eyebrow">The tools</p>
@@ -8,11 +8,13 @@ description: "A route cache and a fetch cache, opt-in, in memory, and honest abo
 # Caching
 
 <div className="lede">
-A route cache and a fetch cache, both off by default, both opt-in per route and
-per request, and both in the memory of one process. Time-based revalidation with
-an optional stale-while-revalidate window, and on-demand invalidation by tag or
-by path. What uf does not have is named here too, because a cache you cannot
-describe is a cache you cannot trust.
+A route cache and a fetch cache, both off by default and both opt-in per route
+and per request. Time-based revalidation with an optional stale-while-revalidate
+window, and on-demand invalidation by tag or by path. In the memory of one
+process unless you name somewhere else to keep it — and naming somewhere else is
+what turns all of the above into incremental static regeneration. What uf does
+not have is named here too, because a cache you cannot describe is a cache you
+cannot trust.
 </div>
 
 ## Turning it on
@@ -53,9 +55,8 @@ export default async function Posts() {
 ```
 
 A page that says nothing is rendered for every request, exactly as it is with
-the cache off. There is no default lifetime and there will not be one: an
-in-memory entry with no stated end is an answer served until the process
-restarts.
+the cache off. There is no default lifetime and there will not be one: an entry
+with no stated end is an answer served until somebody notices.
 
 ## What the two numbers mean
 
@@ -153,20 +154,136 @@ under the other's name.
 
 ## Where it lives
 
-**In memory, in one process.** Four server processes behind a load balancer hold
-four caches and they disagree; a restart empties one; `revalidateTag` in one of
-them does not reach the other three. There is no configuration that changes
-this.
+**In memory, in one process, until you say otherwise.** That is still the
+default and it is still a real limit: four server processes behind a load
+balancer hold four caches and they disagree, a restart empties one, and
+`revalidateTag` in one of them does not reach the other three.
 
-That is a real limit, and it is stated rather than implied because the shape of
-the alternative is already decided: the store is one method, `resolve`, and
-anything that can answer it can be the store. A durable one is an adapter's to
-provide, and per uf's deployment rules a target that cannot provide one has to
-say so rather than degrade quietly.
+Naming a store is what fixes it:
 
-Cache entries are bounded by count — the least recently used entry goes when the
-store is full — and nothing sweeps in the background, because a cache with a
-timer in it is a process that will not exit.
+<div className="command"><code>uf.config.js</code></div>
+
+```js
+// @flow
+export default {
+  app: {
+    rendering: {
+      cache: {
+        route: true,
+        store: "filesystem",
+        // Optional. Defaults to `.uf/cache/route` under the project.
+        storeDir: "/var/cache/uf",
+      },
+    },
+  },
+};
+```
+
+Then a restart finds the entries where it left them, every process of one
+deployment reads one store, and `revalidateTag` takes an entry out of the store
+all of them fill from. With `revalidate`/`expire` and on-demand invalidation
+already in place, that is **incremental static regeneration**: a URL is rendered
+once, served from the store until it goes stale, refreshed behind a reader
+inside the window, and dropped the moment a mutation says it is wrong.
+
+Persistence is a second opt-in on top of the first, and nothing about the first
+changes. A route still has to state a lifetime; a render that read the request
+is still never stored; `data` and `actions` are still refused.
+
+### Entries are keyed by the build
+
+A durable entry outlives the build that produced it, which an in-memory one
+cannot, so **the identity of the build is the first part of every durable key**.
+A deploy therefore reads a cold cache rather than answering the new build's URLs
+with the previous build's documents — a class of bug that has no symptom except
+a page that is subtly wrong.
+
+`uf build` mints that identity and writes it beside the server bundle. Set
+`UF_BUILD_ID` when two artefacts have to *be* one build — a blue/green pair, or
+a rebuild of a tagged commit — which is the same variable, read for the same
+reason, as the one server action ids are derived from.
+
+A store asked to persist with no build identity to key it by **refuses to
+start**, and says so. It does not fall back to memory: a project that asked for
+a cache surviving restarts and got one that does not would see nothing but a
+`MISS` on every cold request, which is what a cold cache looks like anyway.
+
+### Somewhere else than a disk
+
+`"filesystem"` is uf's built-in and it is a convenience, not an architecture.
+Behind the store's one method — `resolve` — anything that can answer six calls
+can hold the entries, so a Redis, a KV namespace or an S3 bucket is a module you
+write and name:
+
+<div className="command"><code>cache/redis.js</code></div>
+
+```js
+// @flow
+import type { CacheProvider, DurableCacheEntry } from "@uniflowed/server/cache";
+
+export function createCacheProvider(): CacheProvider {
+  return {
+    name: "redis",
+    async read(key) {
+      const found = await client.get(key);
+      return found == null ? null : JSON.parse(found);
+    },
+    async write(key, entry: DurableCacheEntry) {
+      await client.set(key, JSON.stringify(entry));
+      for (const tag of entry.tags) await client.sAdd(`tag:${tag}`, key);
+    },
+    async remove(key) {
+      await client.del(key);
+    },
+    async invalidateTag(tag) {
+      const keys = await client.sMembers(`tag:${tag}`);
+      await client.del([...keys, `tag:${tag}`]);
+      return keys.length;
+    },
+    async invalidatePath(path) {
+      return dropAll(await client.sMembers(`path:${path}`));
+    },
+    async clear() {
+      await client.flushDb();
+    },
+  };
+}
+```
+
+```js
+cache: { route: true, store: "./cache/redis.js" }
+```
+
+A provider stores entries and nothing else. It does not decide what is stale, it
+does not run a fill, and it never sees a value uf has not already encoded — so
+the five answers above hold identically whichever store is behind them, and a
+provider cannot get them subtly different. The value is encoded by uf because a
+rendered document is a `Uint8Array` and plain JSON turns one into an object of
+six thousand numeric keys with no error anywhere.
+
+A deployment adapter can hand a store its provider directly rather than through
+the config, which is what a target with a binding rather than a package does:
+
+```js
+createCacheStore({ provider: myProvider, build: BUILD_ID });
+```
+
+`--adapter edge` **refuses** `"filesystem"` at the build rather than linking
+`node:fs` into a Worker that would fail on its first request. A Worker's durable
+store is a module you name, and that is the one target where naming one is not
+optional.
+
+### What a shared store does not reach
+
+An entry another process is **already holding in memory** when you invalidate a
+tag. It is gone from the shared store, so nothing fills from it again and no
+process without a copy can serve it; a process that has a copy serves it until
+its own `revalidate` — the number the page itself named as how stale it may be.
+
+Entries are bounded by count on both sides: the least recently used goes from
+memory when the store is full, and the filesystem provider sweeps its directory
+coldest-first, expired entries first. Nothing sweeps in the background, because
+a cache with a timer in it is a process that will not exit.
 
 ## What it is worth
 
@@ -192,11 +309,12 @@ while an entry is being filled joins the fill rather than starting a second one.
 
 - **The data cache and the action cache.** `rendering.cache.data` and
   `rendering.cache.actions` are refused rather than ignored.
-- **A durable store.** See "Where it lives".
+- **Prerendering into the store.** `uf build` prerenders routes into `dist/` and
+  that is a cache of a kind; seeding the durable store from it would make the
+  *first* request to a cold URL a read rather than a render. Today the first
+  request to each URL renders, and every request after it is the cache. That is
+  the remaining half of ISR and it is not written.
 - **Build-time enforcement** of the request-state rule, above.
-- **ISR.** `uf build` prerenders routes and that is a cache of a kind; joining it
-  to this one is what incremental static regeneration is, and the join is not
-  written.
 - **`uf build --compile`.** A compiled binary answers from bytes it carries
   rather than from a directory, so it has its own copy of the resolution order
   and not its own copy of the cache. `uf preview`, `uf start` and every

--- a/docs/app/reference/config/_uf.page.mdx
+++ b/docs/app/reference/config/_uf.page.mdx
@@ -78,7 +78,9 @@ which is the fastest way to answer "what is it actually using".
 | `builtins.style` | — | The style engine |
 | `rendering.modes` | `["ppr", "ssr", "ssg", "isr"]` | Which rendering strategies this project will deploy — see below |
 | `rendering.navigation` | `"client"` | What a link does: the client router takes it over, or the browser fetches a document — see below |
-| `rendering.cache.*` | all `false` | Which of uf's caches are on; `data` and `actions` are refused rather than ignored |
+| `rendering.cache.route`, `.fetch` | `false` | Which of uf's caches are on; `data` and `actions` are refused rather than ignored |
+| `rendering.cache.store` | `"memory"` | Where entries live: one process, `"filesystem"`, or a module exporting `createCacheProvider` |
+| `rendering.cache.storeDir` | `.uf/cache/route` | Where `"filesystem"` keeps them |
 | `targets` | — | Runtime targets the build must satisfy |
 
 ### rendering.modes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -597,12 +597,28 @@ an entry *stale* and a tag makes it *expired*, which are deliberately different;
 eviction is least-recently-used, bounded by count, with no background sweep; and
 a request that arrives during a fill joins it rather than starting a second one.
 
-The key departs from both of the disk caches described above, and the departure
-is the reason the store is in memory. `.uf/cache/check` and `.uf/cache/transform`
-each put the identity of the `uf` that produced the entry into the key, because
-both outlive the process that wrote them. This one cannot, so that identity is a
-constant rather than an input — and the day a durable store exists behind
-`resolve`, the key gains a build id before anything is written to it.
+The key has two forms, and the difference is the whole of what makes a durable
+store safe. `.uf/cache/check` and `.uf/cache/transform` each put the identity of
+the `uf` that produced the entry into the key, because both outlive the process
+that wrote them. An in-memory cache entry cannot, so in memory that identity is
+a constant rather than an input. A **durable** entry can, so `hashDurableCacheKey`
+puts the build id in front of the key before anything is written to a provider,
+and a deploy reads a cold cache instead of answering the new build's URLs with
+the previous build's documents. A store handed a provider and no build identity
+is refused where it is constructed rather than allowed to guess.
+
+`rendering.cache.store` selects the store: `"memory"` (the default),
+`"filesystem"` for uf's built-in provider, or a module specifier exporting
+`createCacheProvider` — the same shape `builder.module` has, so a Redis or a KV
+namespace goes behind the seam without uf naming either. The seam itself is
+`packages/server/internal/cache-provider.js`: five methods over strings, no
+staleness, no eviction policy, no fill. Everything a cache decides stays in the
+store; a provider decides only where bytes go. A durable store is what turns
+time-based revalidation and on-demand invalidation into ISR — a URL rendered
+once, served from a store four processes share, refreshed behind a reader, and
+dropped the moment a mutation says it is wrong. What is not written is seeding
+that store from `uf build`'s prerender, so the *first* request to each URL still
+renders.
 
 Nothing is cached without a stated lifetime: a route says `cacheLife` and
 `cacheTag` from inside its own render, a request says `cache` at the call, and a
@@ -623,9 +639,12 @@ Node 24, twenty pairs, medians):
 
 The cold request is fractionally slower because a document has to be whole
 before it can be an entry, so a cached route buffers where an uncached one
-streams. It is in memory and in one process, which means four server processes
-hold four caches that disagree and a restart empties one. `docs/app/guide/cache`
-says all of that to a reader rather than to a maintainer.
+streams. Those numbers are the default store: in memory and in one process,
+which means four server processes hold four caches that disagree and a restart
+empties one. A project that names `rendering.cache.store` trades a read of the
+provider on a cold key for a cache the four of them share and a restart does not
+empty. `docs/app/guide/cache` says all of that to a reader rather than to a
+maintainer.
 
 That analysis is load-bearing at the route level, and only there. `uf_rsc`
 resolves the module graph and marks every module a `"use client"` boundary is

--- a/packages/config/internal/schema.js
+++ b/packages/config/internal/schema.js
@@ -372,6 +372,17 @@ export type UniflowedConfig = {
         readonly data?: boolean,
         readonly fetch?: boolean,
         readonly route?: boolean,
+        // Where cache entries live, and the only thing here that is a *name*
+        // rather than a switch: `"memory"` (the default) is one process,
+        // `"filesystem"` is uf's built-in durable provider, and anything else
+        // is a module specifier exporting `createCacheProvider` — the same
+        // shape `builder.module` has, and for the same red line. Turning this
+        // on caches nothing new: a route still has to state a lifetime.
+        readonly store?: string,
+        // Where `"filesystem"` keeps them. Defaults to `.uf/cache/route` under
+        // the project. A deployment that has one writable directory — `/tmp` on
+        // a Lambda, a mounted volume in a container — names it here.
+        readonly storeDir?: string,
       },
     },
   },

--- a/packages/server/cache-filesystem.js
+++ b/packages/server/cache-filesystem.js
@@ -1,0 +1,422 @@
+// @flow
+//
+// `@uniflowed/server/cache/filesystem`: one durable cache provider, on a disk.
+//
+// `./internal/cache-provider.js` is the seam and this is the implementation uf
+// ships with it — deliberately the least interesting one that is actually
+// correct, because `docs/red-lines.md` line 3 is about the seam being real and
+// not about uf shipping the replacement. What proves the seam is that this file
+// contains no cache logic at all: no staleness, no eviction policy beyond a
+// bound on the directory, no notion of a fill. It reads and writes files. Every
+// decision about *when* an entry may be used is in `./internal/cache-store.js`,
+// where the contract is written down, and a Redis provider written by an
+// adapter answers the same five methods with none of this.
+//
+// # A separate module, and separately exported
+//
+// `node:fs` is in here, so this cannot be `./cache.js`. `./fetch.js`'s header
+// makes the rule: the application half "touches no filesystem, holds no Node
+// types", which is what lets the same handler run in a worker. A worker's
+// bundle must not acquire `node:fs` because a project turned a cache on, so the
+// filesystem provider is a module a host imports on purpose — and a target
+// without a filesystem simply never names it.
+//
+// # The layout, and why an entry is two files
+//
+// Under the directory, per entry:
+//
+//     <hash>.json   the record: key, timestamps, tags, path
+//     <hash>.bin    the encoded value
+//
+// Two files rather than one, and the reason is `invalidateTag`. A tag
+// invalidation has to find every entry carrying a name, and with one file per
+// entry that means reading every entry — which for a route cache means reading
+// every cached *document*, hundreds of kilobytes each, to look at a list of
+// strings. Split, an invalidation reads only the small halves: a few hundred
+// bytes per entry instead of a few hundred kilobytes.
+//
+// The alternative was a tag index, and it was rejected for a reason worth
+// recording: an index is a second source of truth that several processes write
+// at once, so it can disagree with the entries, and an invalidation that misses
+// an entry because an index was stale is precisely the bug a cache must not
+// have. Reading the directory is O(entries) and always right. If that becomes
+// the bottleneck, the answer is a provider whose store has an index natively —
+// which is what the seam is for.
+//
+// Write order is body then record, and remove order is record then body, so a
+// reader that arrives mid-write sees an entry that does not exist yet rather
+// than a record pointing at a body that is not there. What that leaves behind
+// is an orphaned body, which costs disk and nothing else, and which the bound
+// below takes out.
+//
+// # What bounds it
+//
+// A count of entries, swept coldest-first, exactly as `crates/uf_check`'s cache
+// and the transform cache are bounded — and for the reason ubugeeei-prod/uf#218
+// gives: nothing in a content-addressed cache ever *removes* an entry, so a
+// directory only grows. Expired entries go first, because they cannot be served
+// and their disk is free to reclaim; after them, the least recently modified.
+//
+// No timer, for the reason `./internal/cache-store.js` gives about the same
+// question: a cache with a timer in it is a process that will not exit.
+
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import type { CacheProvider, DurableCacheEntry } from "./internal/cache-provider.js";
+
+export type { CacheProvider, DurableCacheEntry } from "./internal/cache-provider.js";
+
+/** How a filesystem provider is set up. */
+export type FilesystemCacheOptions = {|
+  /**
+   * Where entries go.
+   *
+   * Required, and named by the host rather than defaulted here, because the
+   * right answer is a fact about the deployment and nothing in this module
+   * knows it: a container wants a mounted volume that outlives the container, a
+   * Lambda has only `/tmp` and only for the life of one execution environment,
+   * and `uf start` on a box wants somewhere under the project. A default would
+   * be right for one of those and quietly wrong for the others.
+   */
+  readonly directory: string,
+  /**
+   * Most entries kept. Defaults to 1024, the same as the store's memory bound.
+   *
+   * The same number for a different resource, and they are not the same limit:
+   * this one is shared by every process reading the directory and survives all
+   * of them, where `maxEntries` bounds one process's heap.
+   */
+  readonly maxEntries?: number,
+|};
+
+/** One durable cache provider, keeping entries in a directory. */
+export type FilesystemCacheProvider = {
+  ...CacheProvider,
+  /** The directory entries are in, resolved. */
+  readonly directory: string,
+  ...
+};
+
+/**
+ * What a record file holds: an entry without its value.
+ *
+ * Spelled out rather than derived from `DurableCacheEntry` because it is
+ * deliberately *not* one — the value lives in the other file, and a type that
+ * carried an always-empty `value` would invite somebody to read it.
+ */
+type Record = {|
+  /** The durable key, for a person reading the directory. Never matched on. */
+  readonly key: string,
+  readonly storedAt: number,
+  readonly revalidateAt: number,
+  readonly expiresAt: number,
+  readonly tags: $ReadOnlyArray<string>,
+  readonly path: string | null,
+|};
+
+/**
+ * A provider that keeps entries in `directory`.
+ *
+ * The directory is created here, and a directory that cannot be created is a
+ * failure of *this call* rather than of the first request. That is the one
+ * place this module is strict, and it is the opposite of what
+ * `@uniflowed/host`'s transform cache does with the same failure — it writes
+ * tolerantly and a read-only checkout simply runs slower. The difference is who
+ * asked. A transform cache is uf's own idea and nobody opted into it; a durable
+ * route cache is something a project turned on and expects, so a deployment
+ * whose disk it cannot use should fail where it is wired instead of answering
+ * every request from an empty cache while `x-uf-cache` says `MISS` forever.
+ */
+export function createFilesystemCache(options: FilesystemCacheOptions): FilesystemCacheProvider {
+  const directory = path.resolve(options.directory);
+  const maxEntries = options.maxEntries ?? 1024;
+  if (!Number.isInteger(maxEntries) || maxEntries < 1) {
+    throw new RangeError(
+      `@uniflowed/server: maxEntries is ${String(maxEntries)}; a durable store that can hold ` +
+        "no entries is a directory that only costs.",
+    );
+  }
+  try {
+    mkdirSync(directory, { recursive: true });
+  } catch (error) {
+    throw new Error(
+      `@uniflowed/server: the durable cache directory ${directory} could not be created. ` +
+        "A project that asked for a cache that survives a restart should be told here " +
+        "rather than serve every request from an empty one.",
+      { cause: error },
+    );
+  }
+
+  // What this process believes is in the directory, so that an ordinary write
+  // is one write and not a `readdir`. Deliberately a belief and not a fact:
+  // other processes are writing the same directory, so it drifts, and every
+  // sweep replaces it with a count that was true a moment ago. Drift costs a
+  // sweep that happens slightly early or slightly late, which is the cheapest
+  // thing here to be wrong about.
+  let believed: number | null = null;
+
+  const recordFile = (key: string) => path.join(directory, `${digest(key)}.json`);
+  const bodyFile = (key: string) => path.join(directory, `${digest(key)}.bin`);
+
+  const provider: FilesystemCacheProvider = {
+    name: "filesystem",
+    directory,
+
+    async read(key: string): Promise<DurableCacheEntry | null> {
+      const record = readRecord(recordFile(key));
+      if (record == null) {
+        return null;
+      }
+      let value: string;
+      try {
+        value = readFileSync(bodyFile(key), "utf8");
+      } catch {
+        // A record whose body is gone: a half-finished remove, or a sweep that
+        // took the body of an entry written at the same moment. Not an error —
+        // the store reads it as a miss and renders, which is right.
+        return null;
+      }
+      return {
+        value,
+        storedAt: record.storedAt,
+        revalidateAt: record.revalidateAt,
+        expiresAt: record.expiresAt,
+        tags: record.tags,
+        path: record.path,
+      };
+    },
+
+    async write(key: string, entry: DurableCacheEntry): Promise<void> {
+      const record: Record = {
+        key,
+        storedAt: entry.storedAt,
+        revalidateAt: entry.revalidateAt,
+        expiresAt: entry.expiresAt,
+        tags: entry.tags,
+        path: entry.path,
+      };
+      // Body first: a reader that arrives between the two finds no record and
+      // renders, where the other order would find a record naming a body that
+      // is not there yet.
+      writeAtomically(bodyFile(key), entry.value);
+      writeAtomically(recordFile(key), JSON.stringify(record));
+      believed = (believed ?? countEntries(directory)) + 1;
+      if (believed > maxEntries) {
+        believed = sweep(directory, maxEntries, Date.now());
+      }
+    },
+
+    async remove(key: string): Promise<void> {
+      // Record first: the entry stops being reachable at the first unlink, so
+      // there is no moment where it is half-removed and still servable.
+      const existed = discard(recordFile(key));
+      discard(bodyFile(key));
+      if (existed && believed != null) {
+        believed -= 1;
+      }
+    },
+
+    async invalidateTag(tag: string): Promise<number> {
+      const dropped = expireWhere(directory, (record) => record.tags.includes(tag));
+      if (dropped > 0) believed = null;
+      return dropped;
+    },
+
+    async invalidatePath(target: string): Promise<number> {
+      const dropped = expireWhere(directory, (record) => record.path === target);
+      if (dropped > 0) believed = null;
+      return dropped;
+    },
+
+    async clear(): Promise<void> {
+      for (const name of list(directory)) {
+        discard(path.join(directory, name));
+      }
+      believed = 0;
+    },
+  };
+  return provider;
+}
+
+/**
+ * The filename a durable key gets.
+ *
+ * The key is already exact — `./internal/cache-key.js` builds it so that two
+ * keys cannot collide and one key cannot spell itself twice — but it is a JSON
+ * array containing slashes, quotes and anything a URL may contain, and that is
+ * not a filename on any filesystem. So it is hashed, and the key it came from
+ * is written *inside* the record: a person looking at a directory of hex names
+ * can still find out what each one is about, which is the whole reason the
+ * record carries a field nothing matches on.
+ */
+function digest(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+/** The record at `file`, or `null` for anything that is not one. */
+function readRecord(file: string): Record | null {
+  let parsed: mixed;
+  try {
+    parsed = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    // Absent, or half-written by a process that died between the rename and
+    // the flush. Both read as "there is no entry here", which is true.
+    return null;
+  }
+  if (parsed == null || typeof parsed !== "object") return null;
+  const record: $FlowFixMe = parsed;
+  if (typeof record.expiresAt !== "number" || typeof record.revalidateAt !== "number") return null;
+  if (!Array.isArray(record.tags)) return null;
+  return {
+    key: typeof record.key === "string" ? record.key : "",
+    storedAt: typeof record.storedAt === "number" ? record.storedAt : 0,
+    revalidateAt: record.revalidateAt,
+    expiresAt: record.expiresAt,
+    tags: record.tags.filter((tag: mixed) => typeof tag === "string"),
+    path: typeof record.path === "string" ? record.path : null,
+  };
+}
+
+/** Everything in `directory`, or nothing when it has gone. */
+function list(directory: string): Array<string> {
+  try {
+    return readdirSync(directory);
+  } catch {
+    return [];
+  }
+}
+
+/** How many entries the directory holds, by counting records. */
+function countEntries(directory: string): number {
+  return list(directory).filter((name) => name.endsWith(".json")).length;
+}
+
+/** Drop every entry `matches` describes, counting them. */
+function expireWhere(directory: string, matches: (record: Record) => boolean): number {
+  let dropped = 0;
+  for (const name of list(directory)) {
+    if (!name.endsWith(".json")) continue;
+    const record = readRecord(path.join(directory, name));
+    if (record == null || !matches(record)) continue;
+    discard(path.join(directory, name));
+    discard(path.join(directory, `${stemOf(name)}.bin`));
+    dropped += 1;
+  }
+  return dropped;
+}
+
+/**
+ * Bring the directory back under `maxEntries`, answering what is left.
+ *
+ * Expired entries first — they cannot be served, so removing them costs
+ * nothing — and then the least recently written, which is the same order the
+ * in-memory store evicts in and is picked for the same reason: what nothing has
+ * wanted for longest is the cheapest thing to make somebody render again.
+ *
+ * `mtime` rather than a recorded read time, because reading an entry here does
+ * not write anything and making it write would turn every cache hit into a
+ * disk write. The consequence is that this is least-recently-*written* rather
+ * than least-recently-used, which for entries that all have a stated lifetime
+ * is close enough to be the same list in a different order.
+ */
+function sweep(directory: string, maxEntries: number, at: number): number {
+  const records: Array<{| name: string, expiresAt: number, mtime: number |}> = [];
+  for (const name of list(directory)) {
+    if (!name.endsWith(".json")) continue;
+    const file = path.join(directory, name);
+    const record = readRecord(file);
+    let mtime = 0;
+    try {
+      mtime = statSync(file).mtimeMs;
+    } catch {
+      continue;
+    }
+    records.push({ name, expiresAt: record?.expiresAt ?? 0, mtime });
+  }
+
+  const doomed = records
+    .filter((entry) => entry.expiresAt <= at)
+    .concat(
+      records
+        .filter((entry) => entry.expiresAt > at)
+        .sort((left, right) => left.mtime - right.mtime),
+    );
+  const live = new Set(records.map((entry) => stemOf(entry.name)));
+  let kept = records.length;
+  for (const entry of doomed) {
+    if (kept <= maxEntries) break;
+    const stem = stemOf(entry.name);
+    discard(path.join(directory, entry.name));
+    live.delete(stem);
+    kept -= 1;
+  }
+
+  // Every body with no record above it: the ones this sweep just orphaned, and
+  // the ones left behind by a removal interrupted between its two unlinks.
+  // Cleaned here rather than never, because nothing will ever look at them
+  // again and nothing else walks this directory.
+  for (const name of list(directory)) {
+    if (!name.endsWith(".bin")) continue;
+    if (!live.has(name.slice(0, -".bin".length))) {
+      discard(path.join(directory, name));
+    }
+  }
+  return kept;
+}
+
+/** The hex name a `<hash>.json` is about. */
+function stemOf(name: string): string {
+  return name.slice(0, -".json".length);
+}
+
+/** Remove `file`. Answers whether there was one. */
+function discard(file: string): boolean {
+  try {
+    unlinkSync(file);
+    return true;
+  } catch {
+    try {
+      // A directory somebody put in the cache directory by hand. Removing it is
+      // not this module's business beyond not tripping over it.
+      rmSync(file, { recursive: false });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Write `contents` to `file` so a concurrent reader never sees half of it.
+ *
+ * The same technique and the same reasoning as
+ * `@uniflowed/host/write-atomically` — a truncate-then-write is observable in
+ * its middle, and ubugeeei-prod/uf#240 is what that costs — and a separate copy
+ * of it because `@uniflowed/server` may not depend on `@uniflowed/host`: the
+ * host package is the toolchain, and this one is what a deployment links.
+ *
+ * Not tolerant. A durable cache that cannot write is the thing a project asked
+ * for not happening, so the failure goes back to `./internal/cache-store.js`,
+ * which reports it through `onError` and answers the request from the render.
+ */
+function writeAtomically(file: string, contents: string): void {
+  const temporary = `${file}.${process.pid}.${Math.random().toString(36).slice(2)}`;
+  try {
+    writeFileSync(temporary, contents);
+    renameSync(temporary, file);
+  } catch (error) {
+    discard(temporary);
+    throw error;
+  }
+}

--- a/packages/server/cache.js
+++ b/packages/server/cache.js
@@ -42,11 +42,34 @@
 //
 // # Where it lives
 //
-// In memory, in one process. Four processes behind a load balancer hold four of
-// these and disagree; a restart empties it; `revalidateTag` in one of them does
-// not reach the other three. That is the whole truth about it today and there
-// is no configuration that changes it. What would is a durable store behind
-// `resolve`, which is an adapter's to provide.
+// In memory, in one process, unless a host gives the store somewhere else to
+// keep things. That was the whole truth once — four processes behind a load
+// balancer held four of these and disagreed, a restart emptied one, and
+// `revalidateTag` in one did not reach the other three — and the fix this
+// header named is now written: **a durable store behind `resolve`**.
+//
+// `./internal/cache-provider.js` is the seam, five methods over strings.
+// `./cache-filesystem.js` is one implementation of it, and a deployment adapter
+// with a Redis or a KV namespace writes another without uf naming either. A
+// store handed one keeps entries across a restart, shares them between
+// processes, and takes an invalidated tag out of the store all of them fill
+// from — which, with the `revalidate`/`expire` window and the on-demand
+// invalidation that were already here, is incremental static regeneration.
+//
+// Two things stay exactly as they were, and both are deliberate.
+//
+// **Nothing caches without a stated lifetime**, durable or not. Persistence is
+// a second opt-in on top of the first and never a way around it.
+//
+// **A durable store needs the identity of the build that filled it.**
+// `./internal/cache-key.js` argues why at length: a durable entry outlives the
+// build, so the build is the first member of every durable key, and a store
+// constructed with a provider and no `build` is refused rather than allowed to
+// serve the last deployment's documents.
+//
+// What is still not here is **prerendering into it** — `uf build` filling the
+// store so the first request to a cold URL is a read rather than a render. See
+// the guide.
 
 import type {
   CacheLifetime,
@@ -70,6 +93,20 @@ export type {
   CacheStoreOptions,
 } from "./internal/cache-store.js";
 export { CacheStore } from "./internal/cache-store.js";
+
+// The durable seam, re-exported from the package's front door for the cache so
+// that an adapter writing a provider imports one module and not two — and, more
+// to the point, so that "what a provider is" is part of the public surface
+// rather than something reached by path into `internal/`. `encodeCacheValue`
+// comes with them because a provider that wants to store something other than
+// a string — a Redis hash, a KV entry with metadata — still has to agree with
+// uf about what an entry *is*.
+export type { CacheProvider, DurableCacheEntry } from "./internal/cache-provider.js";
+export {
+  UnserialisableCacheValueError,
+  decodeCacheValue,
+  encodeCacheValue,
+} from "./internal/cache-provider.js";
 
 /**
  * Raised when something that only means anything inside a cached fill is called
@@ -116,7 +153,9 @@ export class OutsideCachedRequestError extends Error {
  *
  * A function rather than the constructor as the front door, so the store can
  * grow a second implementation — a durable one, from an adapter — without every
- * caller having named a class.
+ * caller having named a class. That second implementation turned out to be an
+ * option rather than a class: pass `provider` and `build` and the same store
+ * keeps its entries where the provider puts them.
  */
 export function createCacheStore(options?: CacheStoreOptions): CacheStore {
   return new CacheStore(options);
@@ -191,23 +230,65 @@ function require$Cache(binding: string): CacheOptions {
 }
 
 /**
- * Expire every entry filled under `tag`. Answers how many went.
+ * Expire every entry filled under `tag`. Answers how many went **here**.
  *
  * Expired, not marked stale: a tag is invalidated because somebody changed the
  * thing it names, so the entry is known wrong rather than possibly old. See
  * `./internal/cache-store.js`, which argues the difference.
  *
- * In this process. A deployment with four of them has four caches and this
- * empties one — which is why the count comes back rather than nothing, so a
- * caller can log what it actually did rather than what it meant to.
+ * The number is this process's, and with a durable store that is a smaller
+ * number than the invalidation. The store this process shares with the other
+ * three loses every entry carrying the tag; what this counts is the copies in
+ * *this* process's memory, because that is the only quantity available without
+ * making a mutation handler wait on a disk to find out an integer it is going
+ * to put in a log. Nothing is lost by that: the durable half is finished before
+ * the request is, which is what [`carryDurableWork`] arranges.
+ *
+ * With no durable store this is exactly what it always was — a count of what
+ * one process forgot, in a deployment where that is all there is to forget.
  */
 export function revalidateTag(tag: string): number {
-  return require$Cache("revalidateTag").store.revalidateTag(tag);
+  const store = require$Cache("revalidateTag").store;
+  const dropped = store.revalidateTag(tag);
+  carryDurableWork(store);
+  return dropped;
 }
 
-/** Expire every entry filled for `path`. Answers how many went. */
+/** Expire every entry filled for `path`. Answers how many went here. */
 export function revalidatePath(path: string): number {
-  return require$Cache("revalidatePath").store.revalidatePath(path);
+  const store = require$Cache("revalidatePath").store;
+  const dropped = store.revalidatePath(path);
+  carryDurableWork(store);
+  return dropped;
+}
+
+/**
+ * Make the request wait for the durable half of what just happened.
+ *
+ * A durable invalidation is started and not awaited — see the store — which is
+ * right for a long-lived server and is a dropped write on a host that stops the
+ * process the moment a response is written. Every serverless target is one of
+ * those, and it is the target where a shared cache matters most, so the work is
+ * handed to the request: `after()` runs at `settle()`, which is where a worker
+ * hands `ctx.waitUntil` its promise and where `./node.js` waits for the bytes.
+ *
+ * Registered here rather than inside the store because the store deliberately
+ * does not know what a request is — `./internal/cache-store.js`'s note on
+ * `refresh` gives that reason and this respects it. Outside a request there is
+ * nothing to register with and nothing to do: a caller holding a store directly
+ * has `store.settled()`.
+ *
+ * `./fetch.js` registers the same thing once per request, because a route fill
+ * writes durably without anybody calling this. Both registrations landing is
+ * not a problem worth code to avoid: `settled()` is idempotent and resolves
+ * without yielding when there is nothing outstanding.
+ */
+function carryDurableWork(store: CacheStore): void {
+  const context = currentContext();
+  if (context == null) {
+    return;
+  }
+  context.deferred.push(() => store.settled());
 }
 
 /** The cache answering this request, or `null` where the host installed none. */

--- a/packages/server/fetch.js
+++ b/packages/server/fetch.js
@@ -217,6 +217,15 @@ export function createFetchHandler(
     const context = currentContext();
     if (context != null && cache != null) {
       context.cache = cache;
+      // And, in the same breath, the durable half of whatever this request
+      // does to that cache. A store with a provider starts its writes and does
+      // not await them — a reader must not wait on a disk for a document it is
+      // already holding — so something has to, or a host that stops the process
+      // when the response is written drops them. That host is every serverless
+      // one, and a shared cache is worth most exactly there. `settled()`
+      // resolves immediately when nothing is outstanding, which is every
+      // request on a memory-only store.
+      context.deferred.push(() => cache.store.settled());
     }
     // And beside it, for the same reason and at the same moment: a handler
     // that upgrades a connection or queues work is inside `dispatch` too, and

--- a/packages/server/internal/cache-key.js
+++ b/packages/server/internal/cache-key.js
@@ -43,14 +43,29 @@
 // outlive the process that wrote them — the entry on disk is read by the next
 // build, which may be a different build.
 //
-// This one cannot outlive the process, so the identity of the code that
-// produced an entry is fixed for the whole life of the store and there is
+// An **in-memory** entry cannot outlive the process, so the identity of the
+// code that produced it is fixed for the whole life of the store and there is
 // nothing to put in the key. That is not a shortcut around their lesson; it is
-// the same lesson pointing the other way, and it is the reason the store is in
-// memory and stays there until something durable exists to hold it. The day an
-// adapter offers a store that survives a restart, this key gains a generation
-// — the build id — before that store is written to, because on that day the
-// entry outlives the build and every word of those two headers applies.
+// the same lesson pointing the other way.
+//
+// That day has arrived, and this is the other half of it. A durable store
+// exists — `./cache-provider.js` is the seam and `../cache-filesystem.js` is
+// one implementation — so an entry now outlives the build, every word of those
+// two headers applies, and the key gains a generation before that store is
+// written to: [`hashDurableCacheKey`]. Deploy a fix to a loader, and the URL it
+// renders is a *different key* under the new build rather than the same key
+// holding the old build's answer. Nothing sweeps the previous generation on the
+// way past — the provider's own bound does that — because an entry that cannot
+// be named cannot be served, and taking it out is housekeeping rather than
+// correctness.
+//
+// The rule the transform cache states about a process that cannot name its
+// compiler — "reads nothing and writes nothing… slower, never wrong" — applies
+// here as a refusal instead of a shrug, and `./cache-store.js` is where it is
+// enforced: a store handed a provider and no build identity throws where it is
+// constructed. A host wires a durable cache once, on purpose; discovering
+// halfway through a deployment that it has been serving the previous build's
+// documents is not a thing to leave to a runtime fallback.
 
 /** A cache key, as a caller writes it: `["route", "GET", "/posts"]`. */
 export type CacheKey = $ReadOnlyArray<string>;
@@ -76,4 +91,29 @@ export function hashCacheKey(key: CacheKey): string {
     }
   }
   return JSON.stringify(key);
+}
+
+/**
+ * The same key, under the build that produced the entry.
+ *
+ * The generation goes in as an ordinary first member rather than as a prefix
+ * joined on afterwards, which is the same argument [`hashCacheKey`] makes about
+ * separators one paragraph up: `JSON.stringify` over an array of strings is
+ * unambiguous, so `["b1", "route", "GET", "/a"]` and `["b1route", "GET", "/a"]`
+ * are two names and cannot become one. A build id concatenated with a `:` would
+ * make them one the first time a build id ended in a colon.
+ *
+ * `build` is checked like every other member, and emptiness is checked as well:
+ * `""` is a string, and a store that keyed every generation under it would be
+ * the un-generationed key wearing a generation's clothes.
+ */
+export function hashDurableCacheKey(build: string, key: CacheKey): string {
+  if (typeof build !== "string" || build === "") {
+    throw new TypeError(
+      "@uniflowed/server: a durable cache key needs the identity of the build that filled " +
+        `the entry, and it is ${JSON.stringify(build)}. Without one, a deploy serves the ` +
+        "previous build's documents under the new build's URLs.",
+    );
+  }
+  return hashCacheKey([build, ...key]);
 }

--- a/packages/server/internal/cache-provider.js
+++ b/packages/server/internal/cache-provider.js
@@ -1,0 +1,305 @@
+// @flow
+//
+// Internal to `@uniflowed/server`: the seam a durable cache is written to.
+//
+// `./cache-store.js` ends by saying what it is not: "in memory, in one
+// process… what would fix it is a durable store behind this same seam, which
+// is an adapter's job". This file is that seam, and it is deliberately the
+// smallest one that can be correct — five methods over strings, no filesystem,
+// no Node types, and nothing an adapter has to import from here to implement.
+//
+// # What a provider is, and what it is not
+//
+// A provider is a **key-value store of already-encoded entries**. It is not a
+// cache: it does not decide what is stale, it does not decide what to evict
+// before its own limits force it to, and it never runs a fill. Every one of
+// those five answers stays in `./cache-store.js`, where they are written down,
+// and a provider that re-answered any of them would be a second cache
+// disagreeing with the first.
+//
+// The division is worth stating the other way round too, because it is what
+// makes a three-line Redis provider possible: uf owns *when* an entry may be
+// used and *what an entry is on the wire*; the provider owns *where the bytes
+// go*. So an adapter writes `GET`, `SET`, `DEL` and two index operations, and
+// inherits stale-while-revalidate, coalescing and the request-state refusal
+// without having heard of any of them.
+//
+// # Why uf owns the encoding and the provider does not
+//
+// The route cache's value is `{status, headers, body}` where `body` is a
+// `Uint8Array`, and `JSON.stringify` turns that into `{"0":60,"1":33,…}` — a
+// document that round-trips into an object with six thousand numeric keys and
+// no error anywhere. Leaving the encoding to each provider would mean every
+// provider discovering that separately, and two of them getting it differently
+// wrong. So [`encodeCacheValue`] is the one answer, every provider stores the
+// string it is given, and a value that cannot survive the trip is **refused at
+// the boundary rather than mangled through it**: see [`encodeCacheValue`] for
+// the list and for why `Date` is on it.
+//
+// A refusal is not a failed request. `./cache-store.js` reports it through
+// `onError` and keeps the entry in memory — the same tolerance
+// `@uniflowed/host`'s transform cache has, for the same reason: a cache that
+// cannot be written is a slower answer, never a wrong one.
+//
+// # The build identity is not here, and that is deliberate
+//
+// `./cache-key.js` says where it is: "the day an adapter offers a store that
+// survives a restart, this key gains a generation — the build id — before that
+// store is written to". The key a provider receives has already been through
+// [`hashDurableCacheKey`], so it already carries the build that produced the
+// entry, and a provider cannot forget to include it because it never had the
+// choice. That is why there is no `build` on this type: an input every
+// implementation must handle identically is an input none of them should hold.
+
+/** One stored answer, as it survives a process. */
+export type DurableCacheEntry = {|
+  /** The value, through [`encodeCacheValue`]. Opaque to the provider. */
+  readonly value: string,
+  readonly storedAt: number,
+  readonly revalidateAt: number,
+  readonly expiresAt: number,
+  /** What `invalidateTag` matches on. */
+  readonly tags: $ReadOnlyArray<string>,
+  /** What `invalidatePath` matches on. */
+  readonly path: string | null,
+|};
+
+/**
+ * Somewhere entries outlive the process.
+ *
+ * Five methods, all asynchronous, none of them optional. Asynchronous because
+ * the implementations worth having are a disk, a socket and an HTTP request,
+ * and an interface that let one of them be synchronous would be an interface
+ * the other two cannot satisfy. Not optional because a provider missing one is
+ * a cache that silently stops invalidating, which is the failure the whole
+ * seam exists to make impossible — a method that is expensive for some
+ * implementation is still a method it has to answer, and answering it badly is
+ * that implementation's decision to defend rather than uf's to guess.
+ *
+ * Nothing here throws for a miss. A `read` that finds nothing answers `null`,
+ * and a `remove` for a key that is not there is not an error — both are
+ * ordinary in a store several processes are writing to at once.
+ *
+ * A provider *may* throw for a real failure — a disk that is full, a Redis
+ * that is gone — and the store treats that the way it treats a failed
+ * background refresh: reported through `onError`, and the request answered
+ * from the render rather than from the cache.
+ */
+export type CacheProvider = {
+  /**
+   * What this provider is, for a log and for `uf explain`.
+   *
+   * Required so that "the cache is durable" is a claim somebody can check from
+   * outside the process rather than a promise in a config file.
+   */
+  readonly name: string,
+  /** The entry under `key`, or `null`. Never throws for a miss. */
+  read(key: string): Promise<DurableCacheEntry | null>,
+  /** Put `entry` under `key`, replacing whatever was there. */
+  write(key: string, entry: DurableCacheEntry): Promise<void>,
+  /** Drop `key`. Not an error when there was nothing under it. */
+  remove(key: string): Promise<void>,
+  /** Expire every entry carrying `tag`. Answers how many went. */
+  invalidateTag(tag: string): Promise<number>,
+  /** Expire every entry filled for `path`. Answers how many went. */
+  invalidatePath(path: string): Promise<number>,
+  /** Drop everything. For a test, and for a host tearing a store down. */
+  clear(): Promise<void>,
+  ...
+};
+
+/** Raised when a value cannot be stored durably without being changed. */
+export class UnserialisableCacheValueError extends Error {
+  /** What was in the way, e.g. `Date`. */
+  kind: string;
+
+  constructor(kind: string, at: string) {
+    super(
+      `@uniflowed/server: a durable cache entry cannot hold ${kind}, at ${at}. ` +
+        "An in-memory entry is the value itself and a durable one is a copy of it, so " +
+        "anything that would come back as something else is refused here rather than " +
+        "stored as whatever JSON happened to make of it. The entry stays in memory.",
+    );
+    this.name = "UnserialisableCacheValueError";
+    this.kind = kind;
+  }
+}
+
+/** The marker key a tagged member carries. */
+const MARKER = "$uf";
+
+/**
+ * A value as one string, or a refusal.
+ *
+ * JSON, with one addition and one rule, over a walk of uf's own rather than
+ * `JSON.stringify`'s replacer.
+ *
+ * The addition is `Uint8Array`, which is what a rendered document's body is and
+ * which plain JSON turns into an object of six thousand numeric keys with no
+ * error anywhere.
+ *
+ * The rule is that **anything JSON would change on the way through is
+ * refused**. `JSON.stringify` drops a function from an object without saying
+ * so, turns a `Date` into a string through its `toJSON`, and turns a `Map` into
+ * `{}` — and `./cache-key.js` has already argued this exact point about
+ * `@uniflowed/query`'s key: a serialisation that quietly does something is a
+ * trap you are told to avoid rather than prevented from writing. In memory none
+ * of it matters, because the entry *is* the value. Durably it is the difference
+ * between the answer a route was cached with and a different answer wearing the
+ * same name, so it throws and `./cache-store.js` keeps the entry in memory
+ * instead.
+ *
+ * # Why the walk is written out and not a replacer
+ *
+ * Two reasons, and the second one was a bug before it was a reason.
+ *
+ * A replacer is handed a member *after* `toJSON` has run, so a `Date` arrives
+ * as a string and the refusal above cannot see it. Reaching back through the
+ * replacer's `this` for the original works and is the sort of thing that is
+ * true until somebody tidies it.
+ *
+ * And escaping has to be top-down. An object that would decode as one of uf's
+ * own tagged shapes is wrapped in another one — see [`tagged`] — and
+ * `JSON.parse`'s reviver runs *bottom-up*, so it would unwrap the inner shape
+ * before it ever saw the wrapper and hand back something that was never stored.
+ * A walk that controls its own order has no such corner.
+ *
+ * `undefined` is not refused: it is a value a loader legitimately produces, and
+ * wrapping in `{v: …}` rather than stringifying the value directly is what
+ * makes it survive.
+ */
+export function encodeCacheValue(value: mixed): string {
+  return JSON.stringify({ v: pack(value, new Set(), "the value") });
+}
+
+/** The value [`encodeCacheValue`] wrote. */
+export function decodeCacheValue(text: string): mixed {
+  return unpack(JSON.parse(text).v);
+}
+
+/** One value on the way out, with everything under it. */
+function pack(value: mixed, open: Set<mixed>, at: string): mixed {
+  if (value instanceof Uint8Array) {
+    return { [MARKER]: "bytes", data: base64Of(value) };
+  }
+  const refused = unstorable(value);
+  if (refused != null) {
+    throw new UnserialisableCacheValueError(refused, at);
+  }
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+  if (open.has(value)) {
+    // `JSON.stringify` raises on a cycle too. Named here so the message is
+    // about a cache entry rather than about converting circular structures.
+    throw new UnserialisableCacheValueError("a cycle", at);
+  }
+  open.add(value);
+  let packed: mixed;
+  if (Array.isArray(value)) {
+    packed = value.map((member: mixed, index: number) => pack(member, open, `${at}[${index}]`));
+  } else {
+    const members: { [string]: mixed } = {};
+    for (const key of Object.keys(value)) {
+      const member = pack(value[key], open, `${at}.${key}`);
+      // What `JSON.stringify` does with an undefined property, kept: a member
+      // that is not there and a member that is `undefined` are the same object
+      // as far as anything reading this back is concerned.
+      if (member !== undefined) members[key] = member;
+    }
+    packed = tagged(members) ? { [MARKER]: "escaped", data: members } : members;
+  }
+  open.delete(value);
+  return packed;
+}
+
+/** One value on the way back in, with everything under it. */
+function unpack(node: mixed): mixed {
+  if (node == null || typeof node !== "object") {
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node.map(unpack);
+  }
+  const marker = node[MARKER];
+  if (marker === "bytes" && typeof node.data === "string") {
+    return bytesOf(node.data);
+  }
+  if (marker === "escaped" && node.data != null && typeof node.data === "object") {
+    // One level, and the members of what is inside rather than the thing
+    // itself: what is inside *is* a tagged shape, and looking at it again is
+    // exactly the mistake this wrapper exists to prevent.
+    return members(node.data);
+  }
+  return members(node);
+}
+
+/** Every member of `node`, unpacked, as a plain object. */
+function members(node: $FlowFixMe): { [string]: mixed } {
+  const out: { [string]: mixed } = {};
+  for (const key of Object.keys(node)) {
+    out[key] = unpack(node[key]);
+  }
+  return out;
+}
+
+/**
+ * Whether `members` would come back as something uf put there.
+ *
+ * A JSON API is entitled to a field called `$uf`, and an entry containing one
+ * is entitled to be cached, so an object that happens to look like one of the
+ * two shapes above is wrapped in an `escaped` one on the way out and unwrapped
+ * on the way in. Only the exact shapes count: `{$uf: "posts"}` is nobody's
+ * marker and travels untouched.
+ */
+function tagged(members: { [string]: mixed }): boolean {
+  const marker = members[MARKER];
+  return marker === "bytes" || marker === "escaped";
+}
+
+/**
+ * What is in the way of storing `value` durably, or `null`.
+ *
+ * Named types rather than "not a plain object", so the message says what to do
+ * about it. A `Date` in a cached payload becomes an ISO string; storing it and
+ * handing back the string is the bug, and `String(date)` at the call is the
+ * fix — the same advice `./cache-key.js` gives about a key member.
+ */
+function unstorable(value: mixed): string | null {
+  const type = typeof value;
+  if (type === "function") return "a function";
+  if (type === "symbol") return "a symbol";
+  if (type === "bigint") return "a bigint";
+  if (value instanceof Date) return "a Date";
+  if (value instanceof Map) return "a Map";
+  if (value instanceof Set) return "a Set";
+  if (value instanceof RegExp) return "a RegExp";
+  return null;
+}
+
+/**
+ * Bytes as base64, without `Buffer`.
+ *
+ * `btoa` and a binary string rather than `Buffer.from`, because this module is
+ * reached from a worker as readily as from Node and the whole claim of
+ * `./fetch.js` is that the application half holds no Node types. Chunked so a
+ * megabyte document does not become a million-argument `apply`.
+ */
+function base64Of(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let at = 0; at < bytes.length; at += chunk) {
+    binary += String.fromCharCode.apply(null, (bytes.subarray(at, at + chunk): $FlowFixMe));
+  }
+  return btoa(binary);
+}
+
+/** The bytes base64 `text` spells. */
+function bytesOf(text: string): Uint8Array {
+  const binary = atob(text);
+  const bytes = new Uint8Array(binary.length);
+  for (let at = 0; at < binary.length; at += 1) {
+    bytes[at] = binary.charCodeAt(at);
+  }
+  return bytes;
+}

--- a/packages/server/internal/cache-store.js
+++ b/packages/server/internal/cache-store.js
@@ -9,10 +9,12 @@
 // # 1. What is a key
 //
 // A list of strings, hashed by [`./cache-key.js`], which argues at length why
-// it is narrower than `@uniflowed/query`'s and why it carries no build
-// identity where the two disk caches do. Read that file first; the short
-// version is that this store cannot outlive the process, so the identity of
-// the code that filled an entry is a constant rather than an input.
+// it is narrower than `@uniflowed/query`'s. Read that file first. In memory
+// the identity of the code that filled an entry is a constant rather than an
+// input, because an in-memory entry cannot outlive the process that filled it;
+// **durably it is the first member of the key**, because a durable entry can,
+// and a deploy that served the previous build's documents under the new
+// build's URLs would be the two disk caches' lesson learned a third time.
 //
 // # 2. What is an entry
 //
@@ -59,6 +61,12 @@
 // that will not exit, and the two costs it saves — memory held by entries
 // nobody reads — are bounded by `maxEntries` anyway.
 //
+// A durable provider evicts on its own terms as well, and it has to: uf's
+// `maxEntries` is a bound on this process's memory and says nothing about a
+// disk four processes share. What a provider may **not** do is decide that an
+// entry is stale — that is question 3 and it is answered here, from the entry's
+// own timestamps, whichever store the entry came out of.
+//
 // # 5. What happens to a request that arrives while an entry is being filled
 //
 // It joins. One fill per key: the second caller awaits the first caller's
@@ -75,20 +83,43 @@
 //
 // # Where it lives, said plainly
 //
-// In memory, in one process. Four server processes behind a load balancer have
-// four of these and they disagree; a restart empties it; `revalidateTag` in
-// one process does not reach the other three. That is the honest state of it
-// today and it is written here, in `docs/architecture.md`, and in the
-// package's own documentation rather than implied away. What would fix it is a
-// durable store behind this same seam, which is an adapter's job — and per the
-// deployment rules a target that cannot provide one has to say so rather than
-// quietly degrade. `resolve` is the whole seam: anything that can answer it
-// can be the store.
+// In memory by default, in one process: four server processes behind a load
+// balancer have four of these and they disagree, a restart empties it, and
+// `revalidateTag` in one of them does not reach the other three. That is still
+// what a store constructed with nothing looks like, and it is still the
+// default, because persistence is a thing to opt into and not a thing to find
+// out about.
+//
+// A store constructed with a `provider` is the other half, and it is what makes
+// the existing machinery incremental static regeneration rather than a
+// per-process accelerator. `./cache-provider.js` is the seam — five methods
+// over strings — and `../cache-filesystem.js` is one implementation of it; a
+// deployment adapter with a Redis or a KV namespace writes its own and uf never
+// learns which. Then: a restart finds the entries where it left them, four
+// processes read one store, and `revalidateTag` in any of them takes the entry
+// out of the store all four fill from.
+//
+// Memory stays in front of it, and stays exactly what it was — an L1 whose five
+// answers are the five above. Two consequences worth stating rather than
+// discovering:
+//
+// * An entry another process **already holds in memory** is not reached by this
+//   process's `revalidateTag`. It is gone from the shared store, so nothing
+//   fills from it again and no process without a copy can serve it; a process
+//   with a copy serves it until its own `revalidate`, which is the number the
+//   application named as how stale that page may be. Bounded, and by the
+//   application's own statement rather than by uf's convenience.
+// * A durable write does not block the answer. It is tracked, reported through
+//   `onError` when it fails, and awaited by [`CacheStore.settled`] — which
+//   `../cache.js` hands to the request so a host that freezes its process the
+//   moment a response is written does not freeze it mid-write.
 
 import { AsyncLocalStorage } from "node:async_hooks";
 
 import type { CacheKey } from "./cache-key.js";
-import { hashCacheKey } from "./cache-key.js";
+import { hashCacheKey, hashDurableCacheKey } from "./cache-key.js";
+import type { CacheProvider } from "./cache-provider.js";
+import { decodeCacheValue, encodeCacheValue } from "./cache-provider.js";
 
 /** How long an entry stays fresh, and how long it may be served at all. */
 export type CacheLifetime = {|
@@ -140,6 +171,26 @@ export type CacheStats = {|
   readonly fills: number,
   readonly evictions: number,
   readonly invalidations: number,
+  /**
+   * Entries this process took out of a durable provider rather than rendering.
+   *
+   * Counted separately from `hits` rather than folded into them, because the
+   * two answer different questions: `hits` is whether the cache is working and
+   * this is whether *persistence* is — a process that restarts into a warm
+   * store and one that restarts into an empty one look identical on `hits`
+   * alone, and which of the two happened is the whole claim of a durable cache.
+   * Always zero with no provider.
+   */
+  readonly restored: number,
+  /**
+   * Entries this process handed to a durable provider. Zero with none.
+   *
+   * Counted when the write is started rather than when it lands, because it is
+   * not awaited — see [`CacheStore.persist`] — and a counter that waited would
+   * be a counter that made the request wait. A write that then failed is
+   * reported through `onError`, which is where a failure belongs.
+   */
+  readonly persisted: number,
 |};
 
 /**
@@ -175,9 +226,45 @@ export type CacheStoreOptions = {|
    * Where a background refresh's failure goes.
    *
    * It has nowhere else to go: nobody is awaiting it, so without this it is an
-   * unhandled rejection that takes the process down on a strict runtime.
+   * unhandled rejection that takes the process down on a strict runtime. A
+   * durable write's failure and a value that cannot be encoded go here too, for
+   * the same reason and with the same consequence: the answer was correct, the
+   * cache is colder than it meant to be, and nothing that a request can see
+   * changed.
    */
   readonly onError?: (error: mixed) => void,
+  /**
+   * Somewhere entries outlive this process.
+   *
+   * Absent is the default and is the whole store as it was: memory, one
+   * process, emptied by a restart. Present makes it incremental static
+   * regeneration — see the module header — and obliges `build` below.
+   *
+   * A provider is an object rather than a name, and that is the replaceability
+   * red line rather than a convenience. `docs/red-lines.md` line 3 says every
+   * built-in provider must be replaceable and that "a provider a project can
+   * replace has to be a name it can write"; here the *host* writes it, in
+   * JavaScript, at the point it constructs the store — so a deployment adapter
+   * with a Redis, a KV namespace or an S3 bucket puts it behind this seam
+   * without uf shipping a release, an enumeration, or the word Redis.
+   */
+  readonly provider?: CacheProvider,
+  /**
+   * The identity of the build whose code fills these entries.
+   *
+   * Required whenever `provider` is given, refused as empty, and unused
+   * without one. `./cache-key.js` argues why at length: a durable entry
+   * outlives the build that produced it, so the build is the first member of
+   * every durable key, and a deploy therefore reads a cold cache rather than
+   * the previous build's documents.
+   *
+   * Two processes of the *same* build must agree on it — that is what makes
+   * four instances one cache — so it is minted once where a build is minted and
+   * carried in the artefact, not generated per process. `uf build` writes one;
+   * `UF_BUILD_ID` overrides it, exactly as it does for the build id
+   * `crates/uf_rsc` derives server action ids from.
+   */
+  readonly build?: string,
 |};
 
 /**
@@ -194,6 +281,51 @@ export type CacheScope = {|
   /** Set when something decided this answer must not be stored, and why. */
   denied: string | null,
 |};
+
+/**
+ * What one owned fill turned out to be, reported back out of the promise.
+ *
+ * A mutable box, and it exists because a `Promise` carries one thing and this
+ * needs two: the value, which the joiners in the in-flight map are also
+ * awaiting, and where it came from, which only the caller that owns the fill
+ * reports. `null` means the fill actually rendered.
+ */
+type FillAttempt = {| restored: "hit" | "stale" | null |};
+
+/** The five methods a durable provider owes, checked once when it is wired. */
+const PROVIDER_METHODS = ["read", "write", "remove", "invalidateTag", "invalidatePath", "clear"];
+
+/**
+ * Refuse a provider that cannot answer the seam, at the line that wired it.
+ *
+ * Checked at construction rather than at the first call, which is the opposite
+ * of what `../fetch.js` does with `app.runMiddleware` and is the opposite for a
+ * reason. A missing `runMiddleware` is a server bundle that is wrong for every
+ * request, so the first request finds it and the stack says where. A missing
+ * `invalidateTag` is a store that answers every request perfectly and silently
+ * stops invalidating — nothing fails, and the symptom is a stale page hours
+ * later in a process nobody is watching. That one has to be found where it was
+ * written.
+ */
+function assertProvider(provider: CacheProvider): void {
+  if (typeof provider.name !== "string" || provider.name === "") {
+    throw new TypeError(
+      "@uniflowed/server: a durable cache provider needs a `name`, so that what is holding " +
+        "the entries is something a log can say rather than something a reader has to infer.",
+    );
+  }
+  const methods: { readonly [string]: mixed } = (provider: $FlowFixMe);
+  for (const method of PROVIDER_METHODS) {
+    if (typeof methods[method] !== "function") {
+      throw new TypeError(
+        `@uniflowed/server: the cache provider ${JSON.stringify(provider.name)} has no ` +
+          `${method}(). All of ${PROVIDER_METHODS.join(", ")} are required — a provider ` +
+          "missing one is a cache that answers every request and quietly stops doing one " +
+          "of the things a cache is for. See internal/cache-provider.js.",
+      );
+    }
+  }
+}
 
 const scopes: AsyncLocalStorage<CacheScope> = new AsyncLocalStorage();
 
@@ -247,9 +379,19 @@ function millis(seconds: number, name: string): number {
 export class CacheStore {
   readonly entries: Map<string, CacheEntry<mixed>> = new Map();
   readonly filling: Map<string, Promise<mixed>> = new Map();
+  /**
+   * Durable work started and not finished.
+   *
+   * A set rather than a count, so [`settled`] can await the actual promises
+   * instead of polling a number, and so a store with nothing outstanding
+   * settles without yielding at all.
+   */
+  readonly writing: Set<Promise<mixed>> = new Set();
   now: () => number;
   maxEntries: number;
   onError: (error: mixed) => void;
+  provider: CacheProvider | null;
+  build: string | null;
   hits: number = 0;
   staleServed: number = 0;
   misses: number = 0;
@@ -257,6 +399,8 @@ export class CacheStore {
   fills: number = 0;
   evictions: number = 0;
   invalidations: number = 0;
+  restored: number = 0;
+  persisted: number = 0;
 
   constructor(options?: CacheStoreOptions) {
     this.now = options?.now ?? Date.now;
@@ -273,9 +417,34 @@ export class CacheStore {
           "no entries is a store that only costs.",
       );
     }
+    const provider = options?.provider ?? null;
+    this.provider = provider;
+    this.build = options?.build ?? null;
+    if (provider != null) {
+      assertProvider(provider);
+      // Here rather than at the first durable write, and it is the one place
+      // this store refuses instead of degrading. `@uniflowed/host`'s transform
+      // cache, faced with a host that cannot name its compiler, reads nothing
+      // and writes nothing — "slower, never wrong" — because it discovers the
+      // identity at run time and may legitimately not find one. This does not
+      // discover anything: a host passed a provider and forgot the build, on
+      // purpose, once, in a line of wiring. Falling back to memory there would
+      // turn a fixable typo into a deployment that quietly is not what it says
+      // it is, and per the deployment rules a target that cannot provide a
+      // durable store has to say so rather than degrade.
+      if (typeof this.build !== "string" || this.build === "") {
+        throw new TypeError(
+          `@uniflowed/server: a store with a durable provider (${provider.name}) needs ` +
+            "`build`, the identity of the build whose code fills its entries, and it is " +
+            `${JSON.stringify(this.build)}. A durable entry outlives the build that wrote ` +
+            "it, so without one a deploy serves the previous build's documents under the " +
+            "new build's URLs.",
+        );
+      }
+    }
   }
 
-  /** How many entries are held. */
+  /** How many entries are held in memory. */
   size(): number {
     return this.entries.size;
   }
@@ -290,7 +459,76 @@ export class CacheStore {
       fills: this.fills,
       evictions: this.evictions,
       invalidations: this.invalidations,
+      restored: this.restored,
+      persisted: this.persisted,
     };
+  }
+
+  /**
+   * Every durable write and invalidation this store has started.
+   *
+   * A durable write does not block the answer — a reader waiting on a disk for
+   * a document it already has in its hand is paying for somebody else's next
+   * request — so the work outlives the response, and something has to be able
+   * to wait for it. Two callers do: a test that wants to see the entry land,
+   * and a host whose process stops the moment a response is written, which is
+   * every serverless one. `../cache.js` gives it to the request through
+   * `after()`, so `settle()` covers it wherever a host settles.
+   *
+   * Resolves immediately with no provider, and loops rather than awaiting once
+   * because an invalidation started while this was waiting is work this promise
+   * is also about.
+   */
+  async settled(): Promise<void> {
+    while (this.writing.size > 0) {
+      await Promise.all(Array.from(this.writing));
+    }
+  }
+
+  /**
+   * Run `operation` against the provider, outside anybody's request.
+   *
+   * The single place durable work is started, so there is one answer to what
+   * happens when it fails and one place that answer is written: it goes to
+   * `onError` and nothing a request can see changes. That is the same
+   * disposition [`refresh`] has and it rests on the same fact — the answer
+   * this cache exists to speed up has already been produced correctly, so a
+   * store that could not keep it is slower rather than wrong.
+   */
+  durably(operation: (provider: CacheProvider) => Promise<mixed>): void {
+    const provider = this.provider;
+    if (provider == null) {
+      return;
+    }
+    let running: Promise<mixed>;
+    try {
+      running = operation(provider);
+    } catch (error) {
+      // A provider that throws synchronously is a provider, not an exception
+      // to the rule about them.
+      this.onError(error);
+      return;
+    }
+    const tracked = running.catch((error: mixed) => {
+      this.onError(error);
+    });
+    this.writing.add(tracked);
+    void tracked.then(() => {
+      this.writing.delete(tracked);
+    });
+  }
+
+  /**
+   * The name this key has in a durable store.
+   *
+   * Separate from [`hashCacheKey`]'s answer rather than replacing it, because
+   * the two name entries in two stores with two lifetimes: memory is emptied by
+   * the restart that the durable store exists to survive, so putting the build
+   * in the in-memory key would cost a string concatenation per lookup to
+   * distinguish entries that cannot coexist.
+   */
+  durableKey(key: CacheKey): string {
+    return hashDurableCacheKey(this.build ?? "", key);
   }
 
   /**
@@ -299,13 +537,19 @@ export class CacheStore {
    * For a test and for a report. Nothing on the answering path uses it: a read
    * that finds an expired entry has to drop it, and a method that promises not
    * to would be a second, subtly different read.
+   *
+   * Memory only, and synchronous because of it. A durable entry this process
+   * has not read yet is not an entry this process has; asking the provider here
+   * would make a method whose whole purpose is to observe without changing
+   * anything into one that reaches over a network.
    */
   peek(key: CacheKey): CacheEntry<mixed> | null {
     return this.entries.get(hashCacheKey(key)) ?? null;
   }
 
-  /** Forget one entry. Answers whether there was one. */
+  /** Forget one entry, here and durably. Answers whether there was one here. */
   forget(key: CacheKey): boolean {
+    this.durably((provider) => provider.remove(this.durableKey(key)));
     return this.entries.delete(hashCacheKey(key));
   }
 
@@ -313,6 +557,7 @@ export class CacheStore {
   clear(): void {
     this.entries.clear();
     this.filling.clear();
+    this.durably((provider) => provider.clear());
   }
 
   /**
@@ -320,6 +565,24 @@ export class CacheStore {
    *
    * The whole seam. Every one of the five answers above is in this method, and
    * the order of the branches is the order the contract states them in.
+   *
+   * # Where the durable store went in, and why it went there
+   *
+   * After memory and after the in-flight map, before the fill. Memory first
+   * because it is free and the answer is the same; the in-flight map before the
+   * provider because a durable read is exactly the kind of wait a second caller
+   * must not duplicate.
+   *
+   * That ordering forced the shape of the rest of this method. The durable read
+   * is asynchronous, so it cannot sit between "nothing in memory" and "claim the
+   * key" as a plain `await` would — two callers would both find memory empty,
+   * both find the in-flight map empty, both go to the disk, and both then
+   * render, which is answer 5 broken by the change meant to make the store
+   * better. So the claim is made *first*, synchronously, over a promise that
+   * does the durable read and the fill together: [`fillThrough`]. What that
+   * call learned about where the value came from comes back on `attempt`,
+   * because a promise can carry a value and this method has to report an
+   * outcome as well.
    */
   async resolve<T>(request: CacheRequest, produce: () => Promise<T>): Promise<CacheResult<T>> {
     const hash = hashCacheKey(request.key);
@@ -355,9 +618,9 @@ export class CacheStore {
       return { value, outcome: "coalesced", stored: false };
     }
 
-    this.misses += 1;
     const scope = newScope(request);
-    const filling = this.fill(hash, request, scope, produce);
+    const attempt: FillAttempt = { restored: null };
+    const filling = this.fillThrough(hash, request, scope, attempt, produce);
     this.filling.set(hash, filling);
     let value: T;
     try {
@@ -369,11 +632,114 @@ export class CacheStore {
         this.filling.delete(hash);
       }
     }
+
+    if (attempt.restored === "hit") {
+      this.hits += 1;
+      return { value, outcome: "hit", stored: false };
+    }
+    if (attempt.restored === "stale") {
+      // The refresh is started here rather than inside `fillThrough`, and the
+      // two lines above are the reason: [`refresh`] declines while the key is
+      // being filled, and until the `finally` ran this call *was* the fill. A
+      // refresh started from in there would have found the map occupied by
+      // itself and quietly not happened.
+      this.staleServed += 1;
+      this.refresh(hash, request, produce);
+      return { value, outcome: "stale", stored: false };
+    }
+
+    this.misses += 1;
     return {
       value,
       outcome: scope.denied == null && scope.lifetime != null ? "miss" : "uncacheable",
       stored: this.entries.has(hash),
     };
+  }
+
+  /**
+   * The durable store, then a fill: what one caller does once it owns the key.
+   *
+   * Answers the value either way, so that a second caller joining through the
+   * in-flight map gets the same thing whichever half produced it — a joiner
+   * cannot tell a disk read from a render, and should not be able to.
+   *
+   * With no provider this is [`fill`] with one comparison in front of it, which
+   * is the shape the default store keeps: nothing about a memory-only cache got
+   * slower to make a durable one possible.
+   */
+  async fillThrough<T>(
+    hash: string,
+    request: CacheRequest,
+    scope: CacheScope,
+    attempt: FillAttempt,
+    produce: () => Promise<T>,
+  ): Promise<T> {
+    if (this.provider != null) {
+      const entry = await this.restore(hash, request);
+      if (entry != null) {
+        attempt.restored = this.now() < entry.revalidateAt ? "hit" : "stale";
+        return (entry.value: $FlowFixMe);
+      }
+    }
+    return this.fill(hash, request, scope, produce);
+  }
+
+  /**
+   * The entry a provider is holding for this key, promoted into memory.
+   *
+   * `null` for every way there is not one: nothing stored, an entry past its
+   * `expiresAt`, a provider that failed, or a value that will not decode. The
+   * last two go to `onError` and then read as a miss, which is the disposition
+   * the whole durable half has — a store that cannot answer costs a render.
+   *
+   * **Staleness is decided here and not by the provider.** The timestamps come
+   * out of the record exactly as they went in, so an entry written by another
+   * process is judged by the same clock arithmetic as one this process wrote,
+   * and a provider has no way to hand back something it considers fresh that
+   * this store considers expired. That is question 3 staying answered in one
+   * place across a seam.
+   */
+  async restore(hash: string, request: CacheRequest): Promise<CacheEntry<mixed> | null> {
+    const provider = this.provider;
+    if (provider == null) {
+      return null;
+    }
+    const key = this.durableKey(request.key);
+    let record;
+    try {
+      record = await provider.read(key);
+    } catch (error) {
+      this.onError(error);
+      return null;
+    }
+    if (record == null) {
+      return null;
+    }
+    if (this.now() >= record.expiresAt) {
+      // The same rule memory has — a read that finds an expired entry drops it
+      // — pointed at the provider, so an entry nobody comes back for is not
+      // left for the provider's own bound to notice eventually.
+      this.durably((durable) => durable.remove(key));
+      return null;
+    }
+    let value: mixed;
+    try {
+      value = decodeCacheValue(record.value);
+    } catch (error) {
+      this.onError(error);
+      return null;
+    }
+    const entry: CacheEntry<mixed> = {
+      value,
+      storedAt: record.storedAt,
+      revalidateAt: record.revalidateAt,
+      expiresAt: record.expiresAt,
+      tags: record.tags,
+      path: record.path,
+    };
+    this.restored += 1;
+    this.store(hash, entry);
+    return entry;
   }
 
   /**
@@ -407,15 +773,59 @@ export class CacheStore {
           "before it is stale.",
       );
     }
-    this.store(hash, {
+    const entry: CacheEntry<mixed> = {
       value,
       storedAt,
       revalidateAt: storedAt + revalidate,
       expiresAt: storedAt + expire,
       tags: Array.from(new Set(scope.tags)),
       path: request.path ?? null,
-    });
+    };
+    this.store(hash, entry);
+    this.persist(request, entry);
     return value;
+  }
+
+  /**
+   * Write an entry through to the provider, if there is one.
+   *
+   * Not awaited, and that is the trade this method exists to make in one place.
+   * The caller is holding the answer already — a rendered document, whole, in
+   * memory — and making it wait on a disk or a network round trip would charge
+   * this request for the *next* request's saving. So the write is started,
+   * tracked in `writing`, and awaited by whoever has a reason to: a test, or a
+   * host whose process may stop the moment the response is written.
+   *
+   * A value that cannot be encoded is not a failed request and not a failed
+   * fill. It is reported through `onError` and the entry stays in memory,
+   * exactly as `@uniflowed/host`'s transform cache tolerates a directory it
+   * cannot write — the answer was produced correctly and only its keeping
+   * failed. `./cache-provider.js` argues what "cannot be encoded" covers and
+   * why it is a refusal rather than a best effort.
+   */
+  persist(request: CacheRequest, entry: CacheEntry<mixed>): void {
+    if (this.provider == null) {
+      return;
+    }
+    let value: string;
+    try {
+      value = encodeCacheValue(entry.value);
+    } catch (error) {
+      this.onError(error);
+      return;
+    }
+    const key = this.durableKey(request.key);
+    this.persisted += 1;
+    this.durably((provider) =>
+      provider.write(key, {
+        value,
+        storedAt: entry.storedAt,
+        revalidateAt: entry.revalidateAt,
+        expiresAt: entry.expiresAt,
+        tags: entry.tags,
+        path: entry.path,
+      }),
+    );
   }
 
   /**
@@ -499,13 +909,32 @@ export class CacheStore {
    * header argues: a tag is invalidated because somebody changed the thing it
    * names, so the entry is known wrong rather than possibly old, and there is
    * no window in which serving it is acceptable.
+   *
+   * # The count, and the two things it counts
+   *
+   * The number is what went **here**, synchronously, and it stays that with a
+   * provider attached rather than becoming a promise: a mutation handler that
+   * has to `await` an invalidation to learn a number is a handler that now
+   * waits on a disk before it can answer, and nothing it does with the number
+   * is worth that. The durable half is started beside it and finishes with the
+   * request — see [`durably`] and [`settled`].
+   *
+   * The two are different quantities and the difference is real. This process
+   * may hold three entries under `posts` while the shared store holds forty,
+   * and after this call both are gone from the shared store; a *fourth*
+   * process holding its own copy in memory keeps serving it until its own
+   * `revalidate`, because nothing here can reach into another process's memory
+   * and this store does not pretend otherwise. The module header states that
+   * window and why it is the application's own number.
    */
   revalidateTag(tag: string): number {
+    this.durably((provider) => provider.invalidateTag(tag));
     return this.expireWhere((entry) => entry.tags.includes(tag));
   }
 
-  /** Expire every entry filled for `path`. Answers how many. */
+  /** Expire every entry filled for `path`, here and durably. Answers how many here. */
   revalidatePath(path: string): number {
+    this.durably((provider) => provider.invalidatePath(path));
     return this.expireWhere((entry) => entry.path === path);
   }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
     ".": "./index.js",
     "./bun": "./bun.js",
     "./cache": "./cache.js",
+    "./cache/filesystem": "./cache-filesystem.js",
     "./edge": "./edge.js",
     "./events": "./events.js",
     "./fetch": "./fetch.js",
@@ -29,6 +30,7 @@
   },
   "files": [
     "bun.js",
+    "cache-filesystem.js",
     "cache.js",
     "edge.js",
     "events.js",

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -39,6 +39,7 @@
 // Rust side reads a config that may hold functions and plugin instances: the
 // one host that can evaluate the file evaluates it.
 
+import { randomUUID } from "node:crypto";
 import { createServer as createHttpServer } from "node:http";
 import { builtinModules, register } from "node:module";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -52,11 +53,14 @@ import { send, toRequest } from "./internal/http.js";
 import { withProjectConfig } from "./merge.js";
 import { VIRTUAL, scanRoutes } from "./internal/routes.js";
 import {
+  BUILD_ID_FILE,
   assetsFromManifest,
+  buildIdentity,
   createPrerenderGate,
   createServeHandler,
   loadBuild,
   nodeListener,
+  providerSpecifier,
   withRequest,
 } from "./internal/serve.js";
 
@@ -112,6 +116,33 @@ run().catch((error) => {
   emit("error", errorEvent(error));
   process.exit(1);
 });
+
+/**
+ * What this build is called, for anything that outlives it.
+ *
+ * `UF_BUILD_ID` when it is set, and a fresh random name otherwise — which is
+ * `crates/uf_rsc`'s `BuildId::from_env_or_generate` exactly, reading the same
+ * variable, because it is the same question asked by a different half of the
+ * toolchain. Two artefacts that have to *be* one build say so with the
+ * variable; everything else gets a name no other build has.
+ *
+ * Minted once per build and written into the build, never per process. Four
+ * servers started from one artefact are one build and must share one cache;
+ * generating this where the server starts would give them four, which is worse
+ * than none at all — four copies of everything written into one directory and
+ * none of them read.
+ *
+ * Not a hash of the output. A content hash would be reproducible, which is
+ * appealing and wrong here: two builds with identical client bundles can have
+ * different server behaviour — a loader's body moves and no asset hash does —
+ * and a cache keyed by one would serve the old loader's documents. A name that
+ * changes whenever the build ran is the conservative direction to be wrong in.
+ */
+function mintBuildId() {
+  const named = process.env.UF_BUILD_ID;
+  if (typeof named === "string" && named.trim() !== "") return named.trim();
+  return randomUUID().replaceAll("-", "");
+}
 
 /** Load `uf.config.js`, reporting where it was found. */
 async function loadConfig() {
@@ -560,6 +591,13 @@ async function build() {
       },
     },
   });
+  // What this build is, beside the bundle it is about. One line, written by
+  // every build and read by nothing unless a project turned a durable cache on
+  // — at which point it is the thing that stops a deploy answering the new
+  // build's URLs with the previous build's documents. See
+  // `packages/server/internal/cache-key.js`, which argues the whole of it, and
+  // `internal/serve.js`'s `buildIdentity`, which is what reads this.
+  writeFileSync(path.join(serverDir, BUILD_ID_FILE), `${mintBuildId()}\n`);
 
   // 3. Which routes this build renders when, and every route it renders now.
   //
@@ -975,8 +1013,8 @@ async function compile() {
  */
 const ADAPTERS = {
   node: {
-    entries: (document, cache) => ({
-      handler: handlerEntrySource(document, cache, NODE_CAPABILITIES),
+    entries: (document, cache, build) => ({
+      handler: handlerEntrySource(document, cache, NODE_CAPABILITIES, build),
       server: nodeEntrySource("./handler.js"),
     }),
   },
@@ -995,8 +1033,8 @@ const ADAPTERS = {
   // nobody here. `edge` pays that price because it must: there is no
   // `node:stream` in a Worker.
   bun: {
-    entries: (document, cache) => ({
-      handler: handlerEntrySource(document, cache, BUN_CAPABILITIES),
+    entries: (document, cache, build) => ({
+      handler: handlerEntrySource(document, cache, BUN_CAPABILITIES, build),
       server: bunEntrySource("./handler.js"),
     }),
   },
@@ -1005,14 +1043,14 @@ const ADAPTERS = {
   // output rather than anything the bundler produces — see `uf_cli`'s
   // `commands::deploy`.
   container: {
-    entries: (document, cache) => ({
-      handler: handlerEntrySource(document, cache, NODE_CAPABILITIES),
+    entries: (document, cache, build) => ({
+      handler: handlerEntrySource(document, cache, NODE_CAPABILITIES, build),
       server: nodeEntrySource("./handler.js"),
     }),
   },
   edge: {
-    entries: (document, cache) => ({
-      handler: handlerEntrySource(document, cache, EDGE_CAPABILITIES),
+    entries: (document, cache, build) => ({
+      handler: handlerEntrySource(document, cache, EDGE_CAPABILITIES, build),
       worker: workerEntrySource("./handler.js"),
     }),
     // `workerd` first, so React resolves to the build that has
@@ -1020,10 +1058,16 @@ const ADAPTERS = {
     // after it are Vite's own SSR defaults, kept so a dependency with no
     // worker condition still resolves the way it does for every other target.
     conditions: ["workerd", "worker", "edge-light", "browser", "module", "import", "default"],
+    // A Worker has no filesystem, so uf's built-in durable provider cannot run
+    // here. Refused by name at the build rather than linked into a bundle that
+    // fails on its first `node:fs` import — the deployment rule is that a
+    // target which cannot provide a durable store says so, and this is the one
+    // target that cannot.
+    filesystem: false,
   },
   serverless: {
-    entries: (document, cache) => ({
-      handler: handlerEntrySource(document, cache, SERVERLESS_CAPABILITIES),
+    entries: (document, cache, build) => ({
+      handler: handlerEntrySource(document, cache, SERVERLESS_CAPABILITIES, build),
       lambda: lambdaEntrySource("./handler.js"),
     }),
   },
@@ -1140,7 +1184,22 @@ async function deploy() {
   // misbehaves.
   mkdirSync(work, { recursive: true });
   const document = assetsFromManifest(readManifest(outDir));
-  const entries = shape.entries(document, config.app?.rendering?.cache);
+  // Whatever `build` above minted, so a durable cache in the deployed artefact
+  // is keyed by the build that produced it and not by the moment it was
+  // packaged. Read rather than minted again for exactly that reason: a second
+  // `randomUUID()` here would key the adapter's copy differently from the one
+  // `uf start` serves out of `.uf/build/`, which is two caches for one build.
+  const buildId = await buildIdentity(root, path.join(".uf", "build", "server"));
+  const cacheConfig = config.app?.rendering?.cache;
+  if (shape.filesystem === false && cacheConfig?.store === "filesystem") {
+    throw new Error(
+      `uf: rendering.cache.store is "filesystem" and \`--adapter ${adapter}\` has no ` +
+        "filesystem. Name a module exporting `createCacheProvider` instead — a KV " +
+        "namespace or a Redis behind the same seam — or leave the store in memory. See " +
+        "docs/app/guide/cache.",
+    );
+  }
+  const entries = shape.entries(document, cacheConfig, buildId);
   const input = {};
   for (const name of Object.keys(entries)) {
     writeFileSync(path.join(work, `${name}.js`), entries[name]);
@@ -1230,8 +1289,22 @@ async function deploy() {
  * re-exported above — a module-level singleton belongs to whichever copy of the
  * package a bundler happened to give it, and the copy that matters is the one
  * the application resolved. See ubugeeei-prod/uf#277 and #389.
+ *
+ * # And where a durable store is named
+ *
+ * `rendering.cache.store` is the fifth key, and it is the one that turns the
+ * store into a shared one: `"filesystem"` links uf's built-in provider, and
+ * anything else is a module specifier the project wrote, imported here by name
+ * so the bundler links it like any other dependency of the application. Neither
+ * appears at all when the key is absent, which is what a default project keeps.
+ *
+ * `build` is baked in beside it, and it is the reason this can be an `import`
+ * at all rather than something read at boot: the build id is a fact about the
+ * artefact being written, known here and nowhere later. `internal/serve.js`'s
+ * `buildIdentity` is where it came from and
+ * `packages/server/internal/cache-key.js` is why it exists.
  */
-function handlerEntrySource(document, cache, capabilities) {
+function handlerEntrySource(document, cache, capabilities, build) {
   const route = cache?.route === true;
   const fetchCache = cache?.fetch === true;
   // Nothing at all when both switches are off, so a default project's
@@ -1239,6 +1312,7 @@ function handlerEntrySource(document, cache, capabilities) {
   // generated output nobody asked for is the second half of the complaint
   // #277 makes about the first half.
   const store = route || fetchCache;
+  const durable = store ? durableStoreSource(root, cache, build) : null;
   const options = [
     "app",
     `document: ${JSON.stringify(document)}`,
@@ -1246,19 +1320,29 @@ function handlerEntrySource(document, cache, capabilities) {
     "capabilities",
   ].join(", ");
   const cacheImport = store ? 'import { createCacheStore } from "@uniflowed/server/cache";\n' : "";
+  const providerImport = durable == null ? "" : `${durable.import}\n`;
   const from = JSON.stringify(capabilities.module);
   const capabilityImport = `import { ${capabilities.name} } from ${from};`;
   return `// Generated by \`uf build --adapter\`. Not checked in, not edited.
 import { createFetchHandler } from "@uniflowed/server/fetch";
-${cacheImport}${capabilityImport}
+${cacheImport}${providerImport}${capabilityImport}
 import * as app from ${JSON.stringify(VIRTUAL.server)};
 
 ${
   store
-    ? `// \`rendering.cache\` from uf.config.js. One store per process: it is
+    ? `// \`rendering.cache\` from uf.config.js. ${
+        durable == null
+          ? `One store per process: it is
 // emptied by a restart and is not shared with any other instance of this
-// application. See ubugeeei-prod/uf#277.
-const cache = { store: createCacheStore(), route: ${String(route)}, fetch: ${String(fetchCache)} };
+// application.`
+          : `Entries are kept by ${durable.what},
+// under this build's identity, so a restart finds them where it left them and
+// every process of this deployment reads one store — and \`revalidateTag\` in
+// any of them takes an entry out of the store all of them fill from.`
+      } See ubugeeei-prod/uf#277.
+const cache = { store: createCacheStore(${
+        durable == null ? "" : `{ provider: ${durable.provider}, build: ${JSON.stringify(build)} }`
+      }), route: ${String(route)}, fetch: ${String(fetchCache)} };
 
 `
     : ""
@@ -1275,6 +1359,57 @@ export const beginRequest = app.beginRequest;
 
 export default { fetch, beginRequest };
 `;
+}
+
+/**
+ * The import and the expression that give a generated handler a durable store.
+ *
+ * `null` for `"memory"` and for a project that said nothing, which is every
+ * project until one asks: persistence is a second opt-in on top of `route` and
+ * `fetch`, not something a build decides on a project's behalf.
+ *
+ * The directory is baked in as written rather than resolved here, and that is
+ * deliberate. This function runs on the machine doing the build; the path has
+ * to mean something on the machine doing the *serving*, which may be a
+ * container with one writable mount or a Lambda with only `/tmp`. A relative
+ * one is resolved against the working directory at boot, by the provider, where
+ * the answer is a fact rather than a guess.
+ *
+ * The specifier is resolved against the project for the same reason
+ * `internal/serve.js`'s `providerSpecifier` does it: `"./cache/redis.js"` in
+ * `uf.config.js` is relative to the project, and this file is written into
+ * `.uf/deploy/work/`, where that path means nothing. Absolute is safe here
+ * because the bundler inlines the module rather than emitting the specifier.
+ *
+ * @param {string} root
+ * @param {{store?: string, storeDir?: string}} cache
+ * @param {string | null} build
+ */
+function durableStoreSource(root, cache, build) {
+  const named = cache?.store ?? "memory";
+  if (named === "memory") return null;
+  if (build == null) {
+    throw new Error(
+      `uf: rendering.cache.store is ${JSON.stringify(named)}, which keeps entries between ` +
+        "restarts, and this build has no identity to key them by. Run `uf build` so one is " +
+        "written, or set UF_BUILD_ID. Without one the deployment would answer this build's " +
+        "URLs with the previous build's documents.",
+    );
+  }
+  const directory = JSON.stringify(cache?.storeDir ?? path.join(".uf", "cache", "route"));
+  if (named === "filesystem") {
+    return {
+      import: 'import { createFilesystemCache } from "@uniflowed/server/cache/filesystem";',
+      provider: `createFilesystemCache({ directory: ${directory} })`,
+      what: "uf's filesystem provider",
+    };
+  }
+  const from = JSON.stringify(providerSpecifier(root, named));
+  return {
+    import: `import { createCacheProvider } from ${from};`,
+    provider: `createCacheProvider({ build: ${JSON.stringify(build)}, directory: ${directory} })`,
+    what: `${named}'s provider`,
+  };
 }
 
 /**

--- a/packages/vite/internal/serve.js
+++ b/packages/vite/internal/serve.js
@@ -100,23 +100,88 @@ function deployment() {
  * reporting that it expired nothing. A project that turned the cache off should
  * be told that it did, not handed a cache that quietly does nothing.
  *
- * One store per server process, built when the handler is, which is the whole
- * of what "in memory, per process" means in practice: `uf preview` and
- * `uf start` each hold one, and two of them running at once share nothing.
+ * One store per server process, built when the handler is. With no
+ * `rendering.cache.store` that is the whole of what "in memory, per process"
+ * means in practice: `uf preview` and `uf start` each hold one, and two of them
+ * running at once share nothing. With one, the two processes share whatever the
+ * provider is in front of — see [`providerFor`].
  *
- * The store's own options are not configurable from `uf.config.js` and are not
- * named here: `rendering.cache` has four keys and no fifth, and a parameter
- * threaded through for a setting nobody can set would be the shape of
- * configurability with none of the substance.
+ * The store's remaining options are still not configurable from `uf.config.js`
+ * and are still not named here: `maxEntries` and `now` are facts about one
+ * process's heap and one process's clock, and a parameter threaded through for
+ * a setting nobody can set would be the shape of configurability with none of
+ * the substance.
  *
- * @param {{route?: boolean, fetch?: boolean} | undefined} declared
+ * @param {{route?: boolean, fetch?: boolean, store?: string, storeDir?: string} | undefined} declared
  * @param {(options?: object) => object} createCacheStore
+ * @param {{root: string, build: string | null}} where
  */
-function cacheFor(declared, createCacheStore) {
+async function cacheFor(declared, createCacheStore, where) {
   const route = declared?.route === true;
   const fetchCache = declared?.fetch === true;
   if (!route && !fetchCache) return undefined;
-  return { store: createCacheStore(), route, fetch: fetchCache };
+  const provider = await providerFor(declared, where);
+  const store =
+    provider == null ? createCacheStore() : createCacheStore({ provider, build: where.build });
+  return { store, route, fetch: fetchCache };
+}
+
+/**
+ * The durable provider `rendering.cache.store` names, or `null` for memory.
+ *
+ * Three answers, and the third is the one that matters to
+ * `docs/red-lines.md`'s third line. `"memory"` — the default, and what every
+ * project that says nothing gets — keeps the store exactly as it was.
+ * `"filesystem"` is uf's built-in, and it is a convenience rather than an
+ * architecture. Anything else is a **module specifier**, resolved from the
+ * project, exporting `createCacheProvider`: the same shape `builder.module`
+ * has, chosen for the same reason that document gives — "a provider a project
+ * can replace has to be a name it can write, and an enum with one variant
+ * cannot become one without a release of uf".
+ *
+ * So a project with a Redis, a KV namespace or an S3 bucket writes twenty lines
+ * against `@uniflowed/server/cache`'s `CacheProvider` type, names the module
+ * here, and uf never learns which of those it was.
+ *
+ * # Why a missing build identity is a refusal
+ *
+ * Because the alternatives are both worse. Falling back to memory would give a
+ * project that asked for a cache surviving restarts one that does not, and the
+ * symptom is a `MISS` on every cold request — indistinguishable from a cache
+ * that is simply cold. Generating an identity per process would be worse again:
+ * four servers would write four copies of everything into one directory and
+ * read none of each other's. The deployment rules say a target that cannot
+ * provide a durable store has to say so, and this is a host saying so.
+ *
+ * @param {{store?: string, storeDir?: string} | undefined} declared
+ * @param {{root: string, build: string | null}} where
+ */
+async function providerFor(declared, { root, build }) {
+  const named = declared?.store ?? "memory";
+  if (named === "memory") return null;
+  if (build == null) {
+    throw new Error(
+      `uf: rendering.cache.store is ${JSON.stringify(named)}, which keeps entries between ` +
+        "restarts, and there is no build identity to key them by. `uf build` writes one " +
+        "beside the server bundle; set UF_BUILD_ID to name it yourself. Without one, a " +
+        "deploy would answer the new build's URLs with the previous build's documents.",
+    );
+  }
+  const directory = path.resolve(root, declared?.storeDir ?? path.join(".uf", "cache", "route"));
+  if (named === "filesystem") {
+    const { createFilesystemCache } = await import("@uniflowed/server/cache/filesystem");
+    return createFilesystemCache({ directory });
+  }
+  const provider = await import(providerSpecifier(root, named));
+  const create = provider.createCacheProvider ?? provider.default;
+  if (typeof create !== "function") {
+    throw new Error(
+      `uf: rendering.cache.store names ${JSON.stringify(named)}, which exports no ` +
+        "`createCacheProvider`. A durable cache provider is a module exporting that " +
+        "function; see @uniflowed/server/cache's CacheProvider type for what it returns.",
+    );
+  }
+  return create({ build, directory });
 }
 
 /**
@@ -147,7 +212,63 @@ export async function loadBuild({ root, outDir, serverDir }) {
   const manifest = JSON.parse(await readFile(manifestFile, "utf8"));
   const entry = await import(pathToFileURL(entryFile).href);
   await deployment();
-  return { entry, assets: assetsFromManifest(manifest), distDir };
+  const build = await buildIdentity(root, serverDir);
+  return { entry, assets: assetsFromManifest(manifest), distDir, root, build };
+}
+
+/**
+ * What `import()` should be given for a provider a project named.
+ *
+ * A relative path in `uf.config.js` is relative to *the project*, which is what
+ * anybody writing `"./cache/redis.js"` means and is not what `import()` from
+ * this module would do — it would look beside `@uniflowed/vite`, find nothing,
+ * and report a missing module the config file does not mention. `builder.module`
+ * settled the same question the same way in `uf_cli`'s `project_directory`.
+ *
+ * A bare specifier is left alone: `"@acme/uf-cache-redis"` is a package, and
+ * resolving it is Node's job and not this function's.
+ *
+ * @param {string} root
+ * @param {string} named
+ */
+export function providerSpecifier(root, named) {
+  if (!named.startsWith(".") && !path.isAbsolute(named)) return named;
+  return pathToFileURL(path.resolve(root, named)).href;
+}
+
+/** What `uf build` writes its identity into, beside the server bundle. */
+export const BUILD_ID_FILE = "uf-build-id";
+
+/**
+ * The identity of the build being served, or `null`.
+ *
+ * Only a durable cache reads it, and only a durable cache needs it: an entry
+ * that cannot outlive the process cannot outlive the build either, so every
+ * command that keeps its cache in memory is entitled to `null` here and never
+ * looks. `packages/server/internal/cache-key.js` argues the rest.
+ *
+ * `UF_BUILD_ID` first, then the file `uf build` wrote. The environment wins for
+ * the reason it wins in `crates/uf_rsc`'s `BuildId::from_env_or_generate`,
+ * which reads the same variable for the same kind of fact: a deployment that
+ * needs two artefacts to *be* one build — a blue/green pair, a rebuild of a
+ * tagged commit — has no other way to say so.
+ *
+ * `null` rather than a generated fallback, and that is the whole point of the
+ * function. A per-process identity would give four servers four caches with a
+ * shared disk between them, which is worse than four memories: it would write
+ * four copies of everything and read none of them. Whoever asked for a durable
+ * store is told there is no build to key it by, and gets to fix it.
+ */
+export async function buildIdentity(root, serverDir) {
+  const named = process.env.UF_BUILD_ID;
+  if (typeof named === "string" && named !== "") return named;
+  try {
+    const file = path.join(path.resolve(root, serverDir), BUILD_ID_FILE);
+    const value = (await readFile(file, "utf8")).trim();
+    return value === "" ? null : value;
+  } catch {
+    return null;
+  }
 }
 
 async function readable(file, message) {
@@ -309,20 +430,29 @@ export async function beginRequest(entry, request) {
  * the point where four switches that used to reach a JSON file and nothing else
  * become a store a request can hit. See ubugeeei-prod/uf#277.
  *
- * @param {{entry: object, assets: object, cache?: object}} build
+ * `root` and `build` come with it, and only the cache reads either: `root` is
+ * where a `storeDir` is resolved from and `build` is what a durable entry is
+ * keyed by. Both are `undefined` for a caller that constructs a handler by
+ * hand, which is the memory-only store and needs neither.
+ *
+ * @param {{entry: object, assets: object, cache?: object, root?: string, build?: string | null}} build
  */
-export function createApplicationHandler({ entry, assets, cache }) {
-  const ready = deployment().then(({ createFetchHandler, createCacheStore, nodeCapabilities }) =>
-    createFetchHandler({
-      app: entry,
-      document: assets,
-      cache: cacheFor(cache, createCacheStore),
-      // `uf preview` and `uf start` are a Node process with a socket, which is
-      // what a deployed `--adapter node` build is too — so a route handler
-      // that streams events answers the same way in the preview it is checked
-      // in and in the deployment it ends up as. See `withRequest` above.
-      capabilities: nodeCapabilities(),
-    }),
+export function createApplicationHandler({ entry, assets, cache, root, build }) {
+  const ready = deployment().then(
+    async ({ createFetchHandler, createCacheStore, nodeCapabilities }) =>
+      createFetchHandler({
+        app: entry,
+        document: assets,
+        cache: await cacheFor(cache, createCacheStore, {
+          root: root ?? process.cwd(),
+          build: build ?? null,
+        }),
+        // `uf preview` and `uf start` are a Node process with a socket, which is
+        // what a deployed `--adapter node` build is too — so a route handler
+        // that streams events answers the same way in the preview it is checked
+        // in and in the deployment it ends up as. See `withRequest` above.
+        capabilities: nodeCapabilities(),
+      }),
   );
   return async function handle(request) {
     return (await ready)(request);
@@ -352,11 +482,11 @@ export function createStaticHandler({ root }) {
  * project whose handler path collides with a file in `public/` behaves one way
  * when it is checked and the other way when it is deployed.
  *
- * @param {{entry: object, assets: object, distDir: string, cache?: object}} build
+ * @param {{entry: object, assets: object, distDir: string, cache?: object, root?: string, build?: string | null}} build
  */
-export function createServeHandler({ entry, assets, distDir, cache }) {
+export function createServeHandler({ entry, assets, distDir, cache, root, build }) {
   const serveStatic = createStaticHandler({ root: distDir });
-  const application = createApplicationHandler({ entry, assets, cache });
+  const application = createApplicationHandler({ entry, assets, cache, root, build });
   return async function handle(request) {
     return (await serveStatic(request)) ?? (await application(request));
   };

--- a/tests/library/cache.test.js
+++ b/tests/library/cache.test.js
@@ -28,6 +28,11 @@
 // manifest — `refuses_a_cache_switch_uf_does_not_implement` is that assertion,
 // and it belongs there because it is a fact about loading a config file.
 
+import fs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
+import { pathToFileURL } from "node:url";
+
 import { describe, expect, it } from "@uniflowed/test";
 
 import {
@@ -36,10 +41,13 @@ import {
   cacheTag,
   createCacheStore,
   createCachedFetch,
+  decodeCacheValue,
+  encodeCacheValue,
   noStore,
   revalidatePath,
   revalidateTag,
 } from "@uniflowed/server/cache";
+import { createFilesystemCache } from "@uniflowed/server/cache/filesystem";
 import { cookies, draftMode, headers } from "@uniflowed/server";
 import { createDispatcher } from "@uniflowed/router/handler";
 import { createFetchHandler } from "@uniflowed/server/fetch";
@@ -49,7 +57,7 @@ import { beginRequest } from "@uniflowed/server/host";
 // `uf preview` and `uf start` build their handler with, and it is the only
 // place `rendering.cache` becomes a store for those two commands, so it is
 // reached by path here for the same reason it is there.
-import { createApplicationHandler } from "../../packages/vite/internal/serve.js";
+import { createApplicationHandler, providerSpecifier } from "../../packages/vite/internal/serve.js";
 
 const assets = { scripts: ["/assets/client.js"], styles: [], preloads: [] };
 
@@ -176,6 +184,92 @@ function servingWith(options: mixed, cacheOptions?: {| route?: boolean, fetch?: 
     cache: { store, route: cacheOptions?.route ?? true, fetch: cacheOptions?.fetch ?? false },
   });
   return { app, handle, store, time };
+}
+
+/**
+ * A durable provider that is a `Map`, so a test can be about the seam.
+ *
+ * Almost every assertion below is about what the *store* does with a provider —
+ * when it reads one, what it writes, what it invalidates — and none of that is
+ * a fact about a disk. A `Map` shared between two stores is two processes with
+ * one cache between them, which is the arrangement the whole feature is for,
+ * expressed in a way a test can drive without a filesystem.
+ *
+ * `reads` and `writes` are counted because "the second store did not render"
+ * and "the second store read the shared entry" are two different claims and
+ * only the second one is what a durable cache promises.
+ */
+function fakeProvider(): $FlowFixMe {
+  const entries: Map<string, mixed> = new Map();
+  const provider: $FlowFixMe = {
+    name: "fake",
+    entries,
+    reads: 0,
+    writes: 0,
+    failures: 0,
+    /** Set to a message to make every read and write throw. */
+    broken: null,
+    async read(key: string) {
+      provider.reads += 1;
+      if (provider.broken != null) throw new Error(provider.broken);
+      return entries.get(key) ?? null;
+    },
+    async write(key: string, entry: mixed) {
+      provider.writes += 1;
+      if (provider.broken != null) throw new Error(provider.broken);
+      entries.set(key, entry);
+    },
+    async remove(key: string) {
+      entries.delete(key);
+    },
+    async invalidateTag(tag: string) {
+      return drop(entries, (entry) => entry.tags.includes(tag));
+    },
+    async invalidatePath(path: string) {
+      return drop(entries, (entry) => entry.path === path);
+    },
+    async clear() {
+      entries.clear();
+    },
+  };
+  return provider;
+}
+
+/** Take every entry `matches` describes out of `entries`, counting them. */
+function drop(entries: Map<string, $FlowFixMe>, matches: ($FlowFixMe) => boolean): number {
+  let dropped = 0;
+  for (const [key, entry] of Array.from(entries.entries())) {
+    if (matches(entry)) {
+      entries.delete(key);
+      dropped += 1;
+    }
+  }
+  return dropped;
+}
+
+/**
+ * A directory that goes away with the test.
+ *
+ * `mkdtemp` rather than a fixed path under the repository, because two of these
+ * tests run at once in different workers and a shared directory would make one
+ * of them read the other's entries — which is the very thing being tested, from
+ * the wrong direction.
+ */
+function tempDirectory(): string {
+  return fs.mkdtempSync(nodePath.join(os.tmpdir(), "uf-cache-"));
+}
+
+/** A store over `provider`, with an injectable clock and a stated build. */
+function durableStore(provider: mixed, options?: {| now?: () => number, build?: string |}) {
+  return createCacheStore({
+    now: options?.now,
+    provider: (provider: $FlowFixMe),
+    build: options?.build ?? "build-one",
+    // Collected rather than printed: several of these tests make a provider
+    // fail on purpose, and a suite that prints a stack per deliberate failure
+    // teaches its reader to skip the output.
+    onError: () => {},
+  });
 }
 
 describe("the key", () => {
@@ -1033,5 +1127,635 @@ describe("what rendering.cache reaches", () => {
     await serve(handle, app, "/posts");
 
     expect(app.renders.length).toBe(2);
+  });
+});
+
+// The rest of this file is the half of the contract that only exists once an
+// entry can outlive the process that filled it. `packages/server/cache.js`'s
+// header used to end by naming what it did not have — "a durable store behind
+// `resolve`, which is an adapter's to provide" — and these are the promises
+// that sentence turned into.
+//
+// Almost all of it is driven through a `Map` behind the provider seam rather
+// than through a disk, on purpose: what is being checked is what the *store*
+// does with a provider, and one `Map` shared by two stores is two processes
+// sharing one cache with nothing else in the way. The filesystem provider gets
+// its own tests, further down, because it is one implementation of the seam and
+// not the seam.
+
+describe("a durable store", () => {
+  it("is not one unless a host asked for it", async () => {
+    const store = createCacheStore({ now: clock().now });
+
+    await store.resolve({ key: ["a"], lifetime: { revalidate: 60 } }, async () => "one");
+    await store.settled();
+
+    // Persistence is a second opt-in on top of the first. A project that turned
+    // the route cache on and said nothing else has exactly the store it had
+    // before any of this existed.
+    expect(store.stats().persisted).toBe(0);
+    expect(store.stats().restored).toBe(0);
+  });
+
+  it("refuses a provider with no build to key its entries by", () => {
+    // The one place the store refuses rather than degrading. A host passed a
+    // provider on purpose, in one line of wiring; falling back to memory would
+    // turn a typo into a deployment that is not what it says it is, and
+    // generating an identity per process would be worse — four servers writing
+    // four copies into one store and reading none of them.
+    expect(() => createCacheStore({ provider: fakeProvider() })).toThrow(/build/);
+    expect(() => createCacheStore({ provider: fakeProvider(), build: "" })).toThrow(/build/);
+  });
+
+  it("refuses a provider that cannot answer the whole seam", () => {
+    const provider: $FlowFixMe = fakeProvider();
+    delete provider.invalidateTag;
+
+    // Checked where it is wired rather than at the first call, because the
+    // symptom otherwise is a cache that answers every request perfectly and
+    // silently stops invalidating.
+    expect(() => createCacheStore({ provider, build: "b" })).toThrow(/invalidateTag/);
+    expect(() => createCacheStore({ provider: { name: "half", read() {} }, build: "b" })).toThrow(
+      /read|write/,
+    );
+  });
+
+  it("keeps an entry across a restart", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const before = durableStore(provider, { now: time.now });
+
+    await before.resolve({ key: ["route", "/posts"], lifetime: { revalidate: 60 } }, async () => ({
+      title: "one",
+    }));
+    await before.settled();
+
+    // A second store over the same provider and nothing else: a process that
+    // restarted, or the fourth server behind the load balancer.
+    const after = durableStore(provider, { now: time.now });
+    let rendered = 0;
+    const result = await after.resolve(
+      { key: ["route", "/posts"], lifetime: { revalidate: 60 } },
+      async () => {
+        rendered += 1;
+        return { title: "two" };
+      },
+    );
+
+    expect(result.outcome).toBe("hit");
+    expect(result.value).toEqual({ title: "one" });
+    expect(rendered).toBe(0);
+    expect(after.stats().restored).toBe(1);
+  });
+
+  it("keys entries by the build, so a deploy does not read the last one's", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const old = durableStore(provider, { now: time.now, build: "build-one" });
+    await old.resolve(
+      { key: ["route", "/posts"], lifetime: { revalidate: 600 } },
+      async () => "old",
+    );
+    await old.settled();
+
+    const deployed = durableStore(provider, { now: time.now, build: "build-two" });
+    const result = await deployed.resolve(
+      { key: ["route", "/posts"], lifetime: { revalidate: 600 } },
+      async () => "new",
+    );
+    await deployed.settled();
+
+    // The whole of `internal/cache-key.js`'s argument, as one assertion: the
+    // entry is still in the store and under a different name, so a deploy is a
+    // cold cache rather than the previous build's documents answering the new
+    // build's URLs.
+    expect(result.value).toBe("new");
+    expect(deployed.stats().restored).toBe(0);
+    expect(provider.entries.size).toBe(2);
+  });
+
+  it("stores nothing durably that it would not store in memory", async () => {
+    const provider = fakeProvider();
+    const store = durableStore(provider, { now: clock().now });
+
+    await store.resolve({ key: ["a"] }, async () => "no lifetime");
+    await store.resolve({ key: ["b"], lifetime: { revalidate: 60 } }, async () => {
+      noStore("this one asked not to be");
+      return "denied";
+    });
+    await store.settled();
+
+    // "No entry is stored without a stated lifetime" is a rule about the cache,
+    // not about where the cache keeps things, so it holds on both sides of the
+    // seam and there is no configuration that opens a hole in it.
+    expect(provider.entries.size).toBe(0);
+    expect(store.stats().persisted).toBe(0);
+  });
+
+  it("brings a document's bytes back as bytes", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const before = durableStore(provider, { now: time.now });
+    const body = new TextEncoder().encode("<!doctype html><p>hello</p>");
+
+    await before.resolve({ key: ["route", "/"], lifetime: { revalidate: 60 } }, async () => ({
+      status: 200,
+      headers: { "x-thing": "1" },
+      body,
+    }));
+    await before.settled();
+
+    const after = durableStore(provider, { now: time.now });
+    const result = await after.resolve(
+      { key: ["route", "/"], lifetime: { revalidate: 60 } },
+      async () => ({ status: 500, headers: {}, body: new Uint8Array() }),
+    );
+
+    // A rendered document is a `Uint8Array`, and plain JSON turns one into an
+    // object of numeric keys with no error anywhere. That is why the encoding
+    // is uf's and not each provider's.
+    expect(result.value.body instanceof Uint8Array).toBe(true);
+    expect(new TextDecoder().decode(result.value.body)).toBe("<!doctype html><p>hello</p>");
+    expect(result.value.headers).toEqual({ "x-thing": "1" });
+  });
+
+  it("refuses a value it cannot bring back unchanged, and keeps it in memory", async () => {
+    const provider = fakeProvider();
+    const failures = [];
+    const store = createCacheStore({
+      now: clock().now,
+      provider: (provider: $FlowFixMe),
+      build: "b",
+      onError: (error) => {
+        failures.push(error);
+      },
+    });
+
+    const first = await store.resolve({ key: ["a"], lifetime: { revalidate: 60 } }, async () => ({
+      at: new Date(0),
+    }));
+    await store.settled();
+    const second = await store.resolve({ key: ["a"], lifetime: { revalidate: 60 } }, async () => ({
+      at: new Date(1),
+    }));
+
+    // A `Date` goes out through `toJSON` and comes back a string, which is a
+    // different answer wearing the same name. Refused rather than stored — and
+    // refused is not failed: the request got its value and the entry is in
+    // memory exactly as it always was.
+    expect(provider.entries.size).toBe(0);
+    expect(failures.length).toBe(1);
+    expect(String(failures[0])).toMatch(/Date/);
+    expect(second.outcome).toBe("hit");
+    expect(second.value).toBe(first.value);
+  });
+
+  it("answers from the render when the provider is broken, and says so", async () => {
+    const provider = fakeProvider();
+    provider.broken = "the disk is gone";
+    const failures = [];
+    const store = createCacheStore({
+      now: clock().now,
+      provider: (provider: $FlowFixMe),
+      build: "b",
+      onError: (error) => {
+        failures.push(error);
+      },
+    });
+
+    const result = await store.resolve(
+      { key: ["a"], lifetime: { revalidate: 60 } },
+      async () => "rendered",
+    );
+    await store.settled();
+
+    // Slower, never wrong: a store that cannot reach its provider costs a
+    // render and reports both halves of why, and nothing a request can see
+    // changed.
+    expect(result.value).toBe("rendered");
+    expect(result.outcome).toBe("miss");
+    expect(failures.length).toBe(2);
+  });
+
+  it("serves a durable entry inside its window and refreshes behind it", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const before = durableStore(provider, { now: time.now });
+    await before.resolve(
+      { key: ["a"], lifetime: { revalidate: 60, expire: 600 } },
+      async () => "old",
+    );
+    await before.settled();
+
+    time.advance(120);
+    const after = durableStore(provider, { now: time.now });
+    let rendered = 0;
+    const result = await after.resolve(
+      { key: ["a"], lifetime: { revalidate: 60, expire: 600 } },
+      async () => {
+        rendered += 1;
+        return "new";
+      },
+    );
+    await settled();
+    await after.settled();
+
+    // Staleness is decided from the entry's own timestamps whichever store
+    // wrote them, so a process that has just started reads an entry another
+    // process filled two minutes ago as exactly two minutes old.
+    expect(result.outcome).toBe("stale");
+    expect(result.value).toBe("old");
+    expect(rendered).toBe(1);
+    expect(after.peek(["a"])?.value).toBe("new");
+  });
+
+  it("cannot serve a durable entry past expire", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const before = durableStore(provider, { now: time.now });
+    await before.resolve({ key: ["a"], lifetime: { revalidate: 60 } }, async () => "old");
+    await before.settled();
+
+    time.advance(61);
+    const after = durableStore(provider, { now: time.now });
+    const result = await after.resolve(
+      { key: ["a"], lifetime: { revalidate: 60 } },
+      async () => "new",
+    );
+    await after.settled();
+
+    expect(result.value).toBe("new");
+    expect(after.stats().restored).toBe(0);
+    // Dropped on the read that found it, which is the rule memory has, pointed
+    // at the provider — then rewritten by the fill, so there is one entry and
+    // it is this one.
+    expect(provider.entries.size).toBe(1);
+  });
+
+  it("goes to the provider once for two callers who both missed memory", async () => {
+    const provider = fakeProvider();
+    const store = durableStore(provider, { now: clock().now });
+    let rendered = 0;
+    const produce = async () => {
+      rendered += 1;
+      return "one";
+    };
+
+    const [first, second] = await Promise.all([
+      store.resolve({ key: ["a"], lifetime: { revalidate: 60 } }, produce),
+      store.resolve({ key: ["a"], lifetime: { revalidate: 60 } }, produce),
+    ]);
+
+    // The answer that made the durable read asynchronous: the key is claimed
+    // before the first `await`, so a second caller joins rather than making its
+    // own trip to the disk and then its own render.
+    expect(rendered).toBe(1);
+    expect(provider.reads).toBe(1);
+    expect(first.outcome).toBe("miss");
+    expect(second.outcome).toBe("coalesced");
+  });
+
+  it("round-trips what an entry may hold, and nothing it may not", () => {
+    const value = { list: [1, "two", null, true], nested: { bytes: new Uint8Array([1, 2, 3]) } };
+    const back: $FlowFixMe = decodeCacheValue(encodeCacheValue(value));
+
+    expect(back.list).toEqual([1, "two", null, true]);
+    expect(Array.from(back.nested.bytes)).toEqual([1, 2, 3]);
+    // An ordinary object entitled to a field called `$uf`. Escaped rather than
+    // rejected, because a JSON API is allowed to use that name.
+    expect(decodeCacheValue(encodeCacheValue({ $uf: "mine" }))).toEqual({ $uf: "mine" });
+    expect(decodeCacheValue(encodeCacheValue(undefined))).toBe(undefined);
+    expect(() => encodeCacheValue({ go: () => {} })).toThrow(/function/);
+    expect(() => encodeCacheValue(new Map())).toThrow(/Map/);
+  });
+});
+
+describe("invalidating a durable store", () => {
+  it("takes the entry out of the store every process fills from", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const one = durableStore(provider, { now: time.now });
+    const two = durableStore(provider, { now: time.now });
+
+    await one.resolve(
+      { key: ["route", "/posts"], lifetime: { revalidate: 600 }, tags: ["posts"] },
+      async () => "old",
+    );
+    await one.settled();
+
+    // The mutation happens in the process that did not fill the entry, which is
+    // the case that could not work at all before a shared store existed.
+    two.revalidateTag("posts");
+    await two.settled();
+
+    // A third process, which never held a copy: what it reads is what the
+    // shared store holds, and the shared store no longer holds the entry.
+    const three = durableStore(provider, { now: time.now });
+    let rendered = 0;
+    const result = await three.resolve(
+      { key: ["route", "/posts"], lifetime: { revalidate: 600 }, tags: ["posts"] },
+      async () => {
+        rendered += 1;
+        return "new";
+      },
+    );
+
+    expect(provider.entries.size).toBe(1);
+    expect(result.value).toBe("new");
+    expect(rendered).toBe(1);
+    expect(three.stats().restored).toBe(0);
+  });
+
+  it("reaches the shared store by path too", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const one = durableStore(provider, { now: time.now });
+    const two = durableStore(provider, { now: time.now });
+
+    await one.resolve(
+      { key: ["route", "/posts"], lifetime: { revalidate: 600 }, path: "/posts" },
+      async () => "old",
+    );
+    await one.settled();
+
+    // Nothing in this process's memory carries the path, so the count is zero
+    // and the invalidation is entirely the shared half.
+    expect(two.revalidatePath("/posts")).toBe(0);
+    await two.settled();
+
+    expect(provider.entries.size).toBe(0);
+  });
+
+  it("answers with what went here, having taken out what is shared", async () => {
+    const provider = fakeProvider();
+    const time = clock();
+    const one = durableStore(provider, { now: time.now });
+    const two = durableStore(provider, { now: time.now });
+
+    for (const key of [["a"], ["b"], ["c"]]) {
+      await one.resolve({ key, lifetime: { revalidate: 600 }, tags: ["posts"] }, async () => "v");
+    }
+    await one.settled();
+    // Two of the three are read into the second process as well, so the two
+    // stores hold different amounts of the same shared set.
+    await two.resolve(
+      { key: ["a"], lifetime: { revalidate: 600 }, tags: ["posts"] },
+      async () => "v",
+    );
+    await two.resolve(
+      { key: ["b"], lifetime: { revalidate: 600 }, tags: ["posts"] },
+      async () => "v",
+    );
+
+    const dropped = two.revalidateTag("posts");
+    await two.settled();
+
+    // The number is this process's memory, synchronously, because a mutation
+    // handler should not wait on a disk to learn an integer it is going to put
+    // in a log. The invalidation is the larger, shared thing beside it.
+    expect(dropped).toBe(2);
+    expect(provider.entries.size).toBe(0);
+  });
+});
+
+describe("the route cache, on a disk", () => {
+  it("answers a restarted process from what the last one rendered", async () => {
+    const directory = tempDirectory();
+    const build = "build-one";
+    const first = appWith({
+      render: () => {
+        cacheLife({ revalidate: 60 });
+      },
+    });
+    const before = createApplicationHandler({
+      entry: first,
+      assets,
+      root: directory,
+      build,
+      cache: { route: true, store: "filesystem", storeDir: directory },
+    });
+    const cold = await serve(before, first, "/posts");
+
+    // A different handler over a different store and the same directory: the
+    // process restarted, or this is the second of four behind a load balancer.
+    const second = appWith({
+      render: () => {
+        cacheLife({ revalidate: 60 });
+      },
+    });
+    const after = createApplicationHandler({
+      entry: second,
+      assets,
+      root: directory,
+      build,
+      cache: { route: true, store: "filesystem", storeDir: directory },
+    });
+    const warm = await serve(after, second, "/posts");
+
+    expect(cold.headers.get("x-uf-cache")).toBe("MISS");
+    expect(warm.headers.get("x-uf-cache")).toBe("HIT");
+    expect(second.renders.length).toBe(0);
+    // Byte for byte the document the first process produced, which is what
+    // `Uint8Array` support in the encoding exists to make true.
+    expect(await warm.text()).toBe("<!doctype html><p>/posts</p><b>1</b>");
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("does not answer the next build from the last build's documents", async () => {
+    const directory = tempDirectory();
+    const render = () => {
+      cacheLife({ revalidate: 600 });
+    };
+    const first = appWith({ render });
+    await serve(
+      createApplicationHandler({
+        entry: first,
+        assets,
+        root: directory,
+        build: "build-one",
+        cache: { route: true, store: "filesystem", storeDir: directory },
+      }),
+      first,
+      "/posts",
+    );
+
+    const second = appWith({ render });
+    const deployed = await serve(
+      createApplicationHandler({
+        entry: second,
+        assets,
+        root: directory,
+        build: "build-two",
+        cache: { route: true, store: "filesystem", storeDir: directory },
+      }),
+      second,
+      "/posts",
+    );
+
+    expect(deployed.headers.get("x-uf-cache")).toBe("MISS");
+    expect(second.renders.length).toBe(1);
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("keeps two searches apart on disk as it does in memory", async () => {
+    const directory = tempDirectory();
+    const provider = createFilesystemCache({ directory });
+    const store = createCacheStore({ provider, build: "b", now: clock().now });
+
+    await store.resolve(
+      { key: ["route", "/posts", "?page=1"], lifetime: { revalidate: 60 } },
+      async () => "one",
+    );
+    await store.resolve(
+      { key: ["route", "/posts", "?page=2"], lifetime: { revalidate: 60 } },
+      async () => "two",
+    );
+    await store.settled();
+
+    const restarted = createCacheStore({ provider, build: "b", now: clock().now });
+    const page2 = await restarted.resolve(
+      { key: ["route", "/posts", "?page=2"], lifetime: { revalidate: 60 } },
+      async () => "rendered again",
+    );
+
+    expect(page2.value).toBe("two");
+    expect(provider.name).toBe("filesystem");
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("takes a tag out of the directory, not only out of this process", async () => {
+    const directory = tempDirectory();
+    const provider = createFilesystemCache({ directory });
+    const one = createCacheStore({ provider, build: "b", now: clock().now, onError: () => {} });
+    const two = createCacheStore({ provider, build: "b", now: clock().now, onError: () => {} });
+
+    await one.resolve(
+      { key: ["route", "/posts"], lifetime: { revalidate: 600 }, tags: ["posts"], path: "/posts" },
+      async () => "old",
+    );
+    await one.settled();
+    expect(fs.readdirSync(directory).filter((name) => name.endsWith(".json")).length).toBe(1);
+
+    two.revalidateTag("posts");
+    await two.settled();
+
+    // Both halves of the entry, gone from the directory the other three
+    // processes fill from.
+    expect(fs.readdirSync(directory)).toEqual([]);
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("bounds the directory rather than growing forever", async () => {
+    const directory = tempDirectory();
+    const provider = createFilesystemCache({ directory, maxEntries: 2 });
+    const store = createCacheStore({ provider, build: "b", now: clock().now, onError: () => {} });
+
+    for (const key of ["a", "b", "c", "d"]) {
+      await store.resolve({ key: [key], lifetime: { revalidate: 600 } }, async () => key);
+      await store.settled();
+    }
+
+    // Nothing in a content-addressed cache ever removes an entry, so a
+    // directory only grows unless something bounds it — the lesson
+    // ubugeeei-prod/uf#218 records about the transform cache, applied here.
+    const records = fs.readdirSync(directory).filter((name) => name.endsWith(".json"));
+    const bodies = fs.readdirSync(directory).filter((name) => name.endsWith(".bin"));
+    expect(records.length).toBe(2);
+    expect(bodies.length).toBe(2);
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+describe("what rendering.cache.store reaches", () => {
+  it("refuses a durable store with no build identity to key it by", async () => {
+    const directory = tempDirectory();
+    const app = appWith({});
+    const handle = createApplicationHandler({
+      entry: app,
+      assets,
+      root: directory,
+      cache: { route: true, store: "filesystem" },
+    });
+
+    // A host saying so rather than degrading quietly, which is what the
+    // deployment rules require of a target that cannot provide a durable store.
+    await expect(serve(handle, app, "/posts")).rejects.toThrow(/build identity/);
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("takes a module specifier, so a provider need not be one uf ships", async () => {
+    const directory = tempDirectory();
+    const module = nodePath.join(directory, "provider.mjs");
+    // A provider written by a project, in twenty lines, against the type
+    // `@uniflowed/server/cache` exports. Named in `uf.config.js` and imported
+    // by name — which is red line 3's "a name it can write", and is how a Redis
+    // or a KV namespace goes behind this seam without uf shipping either.
+    fs.writeFileSync(
+      module,
+      `const entries = new Map();
+export function createCacheProvider() {
+  return {
+    name: "in-a-module",
+    async read(key) { return entries.get(key) ?? null; },
+    async write(key, entry) { entries.set(key, entry); },
+    async remove(key) { entries.delete(key); },
+    async invalidateTag() { return 0; },
+    async invalidatePath() { return 0; },
+    async clear() { entries.clear(); },
+  };
+}
+`,
+    );
+
+    const app = appWith({
+      render: () => {
+        cacheLife({ revalidate: 60 });
+      },
+    });
+    const handle = createApplicationHandler({
+      entry: app,
+      assets,
+      root: directory,
+      build: "build-one",
+      // Relative to the *project*, which is what somebody writing this in
+      // `uf.config.js` means and is not what `import()` from inside
+      // `@uniflowed/vite` would do on its own.
+      cache: { route: true, store: "./provider.mjs" },
+    });
+
+    await serve(handle, app, "/posts");
+    const second = await serve(handle, app, "/posts");
+
+    expect(second.headers.get("x-uf-cache")).toBe("HIT");
+    expect(app.renders.length).toBe(1);
+    expect(providerSpecifier(directory, "./provider.mjs")).toBe(pathToFileURL(module).href);
+    // A package name is Node's to resolve and is left exactly as written.
+    expect(providerSpecifier(directory, "@acme/uf-cache-redis")).toBe("@acme/uf-cache-redis");
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("keeps memory as the default, so nothing persists unasked", async () => {
+    const app = appWith({
+      render: () => {
+        cacheLife({ revalidate: 60 });
+      },
+    });
+    const directory = tempDirectory();
+    const handle = createApplicationHandler({
+      entry: app,
+      assets,
+      root: directory,
+      build: "build-one",
+      cache: { route: true },
+    });
+
+    await serve(handle, app, "/posts");
+    await serve(handle, app, "/posts");
+
+    // The store still works — one render for two requests — and left nothing
+    // anywhere. Persistence is opted into by name and by nothing else.
+    expect(app.renders.length).toBe(1);
+    expect(fs.readdirSync(directory)).toEqual([]);
+    fs.rmSync(directory, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Closes part of ubugeeei-prod/uf#277 — piece 5, "a store behind a seam".

`packages/server/cache.js` ended by naming what it did not have:

> In memory, in one process. Four processes behind a load balancer hold four of
> these and disagree; a restart empties it; `revalidateTag` in one of them does
> not reach the other three. That is the whole truth about it today and there is
> no configuration that changes it. **What would is a durable store behind
> `resolve`, which is an adapter's to provide.**

This is that store. **uf already had almost all of ISR's semantics** — a stated
lifetime, `revalidate`/`expire` with a stale-while-revalidate refresh behind the
reader, one fill per key, and on-demand invalidation by tag and by path. What it
lacked was an entry outliving the process that filled it. With that, the route
cache *is* incremental static regeneration: a URL rendered once, served from a
store every instance shares, refreshed behind a reader inside its window, and
dropped the moment a mutation says it is wrong.

## The seam

`packages/server/internal/cache-provider.js` — six methods over strings, all
asynchronous, none optional:

```js
export type CacheProvider = {
  readonly name: string,
  read(key: string): Promise<DurableCacheEntry | null>,
  write(key: string, entry: DurableCacheEntry): Promise<void>,
  remove(key: string): Promise<void>,
  invalidateTag(tag: string): Promise<number>,
  invalidatePath(path: string): Promise<number>,
  clear(): Promise<void>,
  ...
};
```

A provider decides **where bytes go** and nothing else. It never decides what is
stale, what to evict, or when to fill — all five of the contract's answers stay
in `internal/cache-store.js`, judged from the entry's own timestamps whichever
store the entry came out of, so they cannot come out subtly different behind one
provider than behind another. None of the methods is optional, because a
provider missing `invalidateTag` is a cache that answers every request perfectly
and silently stops invalidating; that is checked when the store is constructed,
not at the first call.

Memory stays in front of it and stays exactly what it was. The durable read sits
after the memory lookup and after the in-flight map — which forced the one
structural change to `resolve`: the miss path now claims the key *synchronously*
over a single promise that does the durable read and the fill together, because
two callers that both found memory empty must not both go to the disk and then
both render. That is answer 5 of the contract, kept.

`packages/server/cache-filesystem.js` is the one built-in implementation. An
entry is two files — a small record and the encoded body — so a tag invalidation
reads a few hundred bytes per entry instead of a few hundred kilobytes. A tag
*index* was considered and rejected: it is a second source of truth several
processes write at once, and an invalidation that misses an entry because an
index was stale is exactly the bug a cache must not have. The directory is
bounded by count, expired entries first, then least-recently-written — the
lesson #218 records about the transform cache.

## How an adapter plugs in its own

Two ways, and the second is the one `docs/red-lines.md` line 3 is about.

**Directly**, which is what a target with a binding rather than a package does:

```js
createCacheStore({ provider: myKvProvider, build: BUILD_ID });
```

`CacheProvider`, `DurableCacheEntry`, `encodeCacheValue` and `decodeCacheValue`
are public from `@uniflowed/server/cache`, so a provider is written against the
package's front door rather than by reaching into `internal/`.

**By name**, through `rendering.cache.store`, which is a *module specifier* and
not an enumeration — the same shape `builder.module` has, for the reason that
document gives: "a provider a project can replace has to be a name it can write,
and an enum with one variant cannot become one without a release of uf". uf never
learns whether it was Redis, a KV namespace or an S3 bucket:

```js
cache: { route: true, store: "./cache/redis.js" }
```

A relative specifier resolves against the project, following `uf_cli`'s
`project_directory` for `builder.module`.

`--adapter edge` **refuses** `"filesystem"` at the build rather than linking
`node:fs` into a Worker that would fail on its first request — the deployment
rule that a target which cannot provide a durable store says so rather than
degrading quietly.

## Build identity

`internal/cache-key.js` had already written down what would have to happen:

> The day an adapter offers a store that survives a restart, this key gains a
> generation — the build id — before that store is written to, because on that
> day the entry outlives the build and every word of those two headers applies.

So it does. `hashDurableCacheKey(build, key)` puts the build in as the first
member of the key — a member, not a joined prefix, for the same reason
`hashCacheKey` refuses a separator — and a deploy therefore reads a *cold* cache
rather than answering the new build's URLs with the previous build's documents.

`uf build` mints one and writes it beside the server bundle
(`.uf/build/server/uf-build-id`); `uf preview`, `uf start` and the generated
`handler.js` read it. `UF_BUILD_ID` overrides it — the same variable
`crates/uf_rsc`'s `BuildId::from_env_or_generate` reads, for the same kind of
fact: two artefacts that have to *be* one build (a blue/green pair, a rebuild of
a tagged commit) have no other way to say so.

It is minted per **build**, never per process. Four servers started from one
artefact are one build and must share one cache; generating it where a server
starts would give them four, which is worse than none — four copies of
everything written into one store and none of them read. A store handed a
provider and no build is refused where it is constructed, and the host wiring
refuses rather than falling back to memory, because a project that asked for a
cache surviving restarts and silently got one that does not sees nothing but a
`MISS` on every cold request.

Following the two disk caches' precedent (`crates/uf_check`'s cache and
`@uniflowed/host`'s transform cache): "a process that cannot name its own binary
reads nothing and writes nothing… slower, never wrong." The difference here is
that nothing is discovered at run time — a host passes a provider on purpose, in
one line of wiring — so this refuses at that line instead of shrugging.

## What stays opt-in

Everything that was, and one thing more.

- **Nothing caches without a stated lifetime.** Unchanged, and it holds on both
  sides of the seam: a fill with no lifetime and a fill that called `noStore`
  write nothing durably, asserted by a test.
- **`route` and `fetch` still default to `false`**, and `data`/`actions` are
  still refused by name.
- **Persistence is a second opt-in on top of the first.** `rendering.cache.store`
  is absent by default and means memory, in one process, exactly as before. A
  default project's generated `handler.js` is byte-for-byte the file it was.
- **A render that read the request is still never stored.**

## Invalidation reaches the shared store

`revalidateTag` and `revalidatePath` drop the matching entries from this
process's memory *and* from the store every process fills from. The durable half
is not awaited on the answering path — a reader must not wait on a disk for a
document it is already holding — so it is tracked and handed to the request:
`CacheStore.settled()` is registered with `after()`, which is where a worker
gives `ctx.waitUntil` its promise. Without that, a host that freezes the process
the moment a response is written drops the write, and that host is every
serverless one.

The returned count stays synchronous and stays this process's memory, because a
mutation handler should not wait on a disk to learn an integer it is going to put
in a log. What that does *not* reach is stated rather than implied, in the code
and in the guide: an entry another process is already holding in memory is gone
from the shared store but served by that process until its own `revalidate` — the
number the page itself named as how stale it may be.

## Values on the wire

uf owns the encoding, not each provider: a rendered document's body is a
`Uint8Array`, and plain JSON turns one into an object of six thousand numeric
keys with no error anywhere. Anything JSON would silently change on the way
through — a `Date` through its `toJSON`, a `Map`, a dropped function — is refused
at the boundary, reported through `onError`, and the entry stays in memory. A
cache that cannot be written is a slower answer, never a wrong one, which is the
transform cache's disposition.

## Config

`rendering.cache.store` and `rendering.cache.storeDir`, in
`packages/config/internal/schema.js` and in `crates/uf_config`'s `CacheConfig`
(`the_flow_schema_declares_every_key_uf_reads` gates the two agreeing). Both
reach `dist/uf-build-manifest.json` for a deploy step that has to provision the
store. Rust validates neither value: a module specifier is resolved from the
project by the host that constructs the store, which is the only place it means
anything.

## Follow-up, not in this PR

**Prerendering into the store.** `uf build` already prerenders routes into
`dist/`; seeding the durable store from that prerender would make the *first*
request to a cold URL a read rather than a render, which is the remaining half of
ISR. Today the first request to each URL renders and every request after it is
the cache. It is named as not-done in `docs/app/guide/cache` under "What is not
here", and doing it well is a separate change — this one is what turns the
existing cache into ISR at all.

## Verification

`uf run test:lib` — 2729 passed, 0 failed, 1 skipped. `tests/library/cache.test.js`
goes from 45 to 69 tests; every one of the original 45 still passes. The new ones
are four `describe`s: the durable store's behaviour driven through a `Map` behind
the seam (a restart, two processes, build keying, bytes, refusals, coalescing
over a durable read), invalidation reaching a shared store, the route cache over
the real filesystem provider end to end, and what `rendering.cache.store` reaches
including a provider written in a module uf never heard of.

`uf fmt --check` clean, `uf lint` 0 errors, `cargo fmt --check` clean,
`cargo test -p uf_config` 97 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791521398&installation_model_id=422833&pr_number=704&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F704&signature=4245e675753c2987c1a49908f8b5467b9a912c5e70625c144fccd2f5470cf697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->