### PR TITLE
feat(config, router): one shell, and the routes a browser cannot render

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -52,6 +52,7 @@ use crate::ui::Ui;
 mod guards;
 mod library;
 mod site;
+mod spa;
 
 /// How many assets `--size-report` names before the list is cut off.
 const LARGEST_ASSETS_SHOWN: usize = 20;
@@ -279,6 +280,28 @@ pub(crate) fn build(
     // without evaluating a module. Checked here rather than in the builder for
     // exactly that reason — see `refuse_unanswerable_actions`.
     refuse_unanswerable_actions(plan, &rsc, adapter, standalone)?;
+    // And everything else that needs one, for the one plan whose builder will
+    // never find it. The other three prerender something, so a page that reads
+    // a request throws while it is being rendered and the build says so; a
+    // shell build renders no route at all, so the same page would build,
+    // deploy, and fail in a browser. See [`spa`].
+    //
+    // Not lifted by `--adapter` or `--compile`, unlike the actions above, and
+    // the difference is which declaration each is about. `staticBuild` is a
+    // claim about the *artefact*, so a build that also emits a server has
+    // honoured it; `modes: ["csr"]` is a claim about the **routes** — that
+    // every one of them is rendered in a browser — and that is still true
+    // inside a Worker or an executable, because neither of them writes the
+    // per-route documents the shell exists instead of.
+    if plan.prerender() == Prerender::Shell {
+        spa::refuse(
+            &resolved.root,
+            &routes,
+            &server_modules,
+            &rsc.graph,
+            &plan.because(),
+        )?;
+    }
 
     progress.tick("building with vite");
     let vite = timer.measure("vite", || -> Result<ViteBuild> {
@@ -523,6 +546,7 @@ pub(crate) fn build(
         Prerender::Everything => "every route prerendered",
         Prerender::Possible => "prerendered where it can be, the rest per request",
         Prerender::Nothing => "nothing prerendered; every route per request",
+        Prerender::Shell => "one shell prerendered; every route rendered in the browser",
     };
     // And what it decided about the other axis. A row rather than a line only
     // when it is not the default: `app.rendering.navigation` is `client` in

--- a/crates/uf_cli/src/commands/build/spa.rs
+++ b/crates/uf_cli/src/commands/build/spa.rs
@@ -1,0 +1,288 @@
+//! What a single-page build cannot answer, refused before it is built.
+//!
+//! `app.rendering.modes: ["csr"]` writes one shell and renders every route in
+//! the browser. There is no server anywhere in that deployment — not at build
+//! time, because no route is prerendered, and not afterwards, because no server
+//! bundle survives — so anything in the project that only a server can do is a
+//! hole in the application with nothing between it and the first visitor.
+//!
+//! The other rendering plans find these the way they can afford to. Under
+//! `Prerender::Everything` the builder discovers them by *trying*: it renders
+//! every route, and a page that calls `cookies()` throws where there is no
+//! request. Under `Prerender::Shell` nothing is rendered at all, so the same
+//! page would build cleanly, deploy cleanly, and fail in a browser — which is
+//! the failure ubugeeei-prod/uf#336 and ubugeeei-prod/uf#385 are both about,
+//! moved one step later and made invisible.
+//!
+//! So it is answered statically, from the analysis `uf build` has already run.
+//! `crates/uf_rsc` resolves the module graph and already answers "is this
+//! reachable from here" for server-only imports — the same question this asks
+//! with the two halves swapped, because under `csr` the server graph *is* the
+//! browser's. Inventing a second walk over the same imports would be a second
+//! answer to a question that has one.
+//!
+//! # What counts
+//!
+//! * a `_uf.route.js`, which answers a request rather than rendering, and a
+//!   `_uf.middleware.js`, which runs before one is answered. Neither has a
+//!   process to run in;
+//! * any module the application reaches that imports a **server-only package**
+//!   — `@uniflowed/server`, `@uniflowed/db`, `server-only` — or is named
+//!   `*.server.js`. `cookies()`, `headers()` and `draftMode()` come from the
+//!   first of those, so "a loader that reads the request" is this case rather
+//!   than a case of its own: reading a request needs a request, and a document
+//!   rendered in a browser was not one.
+//!
+//! A server action is **not** here, and that is deliberate rather than an
+//! omission: `refuse_unanswerable_actions` in the parent module already refuses
+//! every callable one for any plan that emits no server, which a `csr` plan
+//! does not. Repeating it would report one fault twice with two fixes.
+//!
+//! # Why the route and not only the file
+//!
+//! A module path is where the code is; a route is what a visitor asks for and
+//! what a person recognises. So a finding a route reaches is reported as both,
+//! and one that no route's page reaches — a layout, most often, which no page
+//! imports — is reported by its file, because naming a route it does not belong
+//! to would be worse than naming none.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use anyhow::{Result, bail};
+use camino::Utf8Path;
+use uf_router::{Route, ServerModule, ServerModuleKind};
+use uf_rsc::{ModuleId, RscGraph, SERVER_ONLY_SUFFIX, is_server_only_specifier};
+
+use crate::support::{plural, relative_to};
+
+/// How many findings a refusal lists before it stops.
+///
+/// The same ceiling `deploy::static_host` uses, for the same reason: a project
+/// that has just written `["csr"]` wants to see the shape of what it costs,
+/// and a hundred lines of it is a wall rather than a list.
+const SHOWN: usize = 20;
+
+/// One thing this deployment has and cannot run.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Unanswerable {
+    /// The route path, when one reaches it.
+    pub(crate) route: Option<String>,
+    /// The file, relative to the project root.
+    pub(crate) file: String,
+    /// What is wrong with it, as a clause following "because".
+    pub(crate) because: String,
+}
+
+impl Unanswerable {
+    /// The line a refusal prints for this finding.
+    fn line(&self) -> String {
+        match &self.route {
+            Some(route) => format!("  {route} ({}) — {}", self.file, self.because),
+            None => format!("  {} — {}", self.file, self.because),
+        }
+    }
+}
+
+/// Everything a `csr` build would deploy with nothing to answer it.
+///
+/// Sorted, because two builds of the same tree that list the same findings in
+/// two orders is a message nobody can diff. Routes first — `Option<String>`
+/// orders `None` last — so the lines a person recognises are at the top.
+pub(crate) fn unanswerable(
+    root: &Utf8Path,
+    routes: &[Route],
+    server_modules: &[ServerModule],
+    graph: &RscGraph,
+) -> Vec<Unanswerable> {
+    let mut found = Vec::new();
+
+    for module in server_modules {
+        found.push(Unanswerable {
+            route: Some(match module.kind {
+                // A middleware guards a subtree rather than a URL that is
+                // necessarily served, and is reported the way
+                // `deploy::static_host` reports one: by the subtree.
+                ServerModuleKind::Middleware => {
+                    format!("{}/*", if module.path == "/" { "" } else { &module.path })
+                }
+                ServerModuleKind::RouteHandler => module.path.to_string(),
+            }),
+            file: relative_to(root, &module.file),
+            because: match module.kind {
+                ServerModuleKind::RouteHandler => String::from(
+                    "it is a route handler, and a handler answers a request rather than \
+                     rendering a page",
+                ),
+                ServerModuleKind::Middleware => String::from(
+                    "a middleware runs before a request is answered, and nothing in this \
+                     deployment answers one",
+                ),
+            },
+        });
+    }
+
+    // Every module the application reaches that only a server can evaluate,
+    // and the reason each is one. Computed once for the whole graph rather than
+    // per route, because a helper five routes share is one fault.
+    let offenders = server_only_modules(graph);
+    if offenders.is_empty() {
+        found.sort();
+        return found;
+    }
+
+    // Which of them each route's page reaches. A route is what a person
+    // recognises, so the walk is from the pages outwards rather than from the
+    // offenders back.
+    let mut attributed: BTreeSet<ModuleId> = BTreeSet::new();
+    for route in routes {
+        let Some(page) = graph.module_id(relative_to(root, &route.page)) else {
+            continue;
+        };
+        for id in reachable(graph, page) {
+            let Some(reason) = offenders.get(&id) else {
+                continue;
+            };
+            attributed.insert(id);
+            let file = graph
+                .module_by_id(id)
+                .map_or_else(String::new, |module| module.path.to_string());
+            found.push(Unanswerable {
+                route: Some(route.path.to_string()),
+                file,
+                because: reason.clone(),
+            });
+        }
+    }
+
+    // And the ones no page reaches. A layout is the ordinary case — a page does
+    // not import the layout it renders inside — and reporting it under a route
+    // it does not belong to would be a worse answer than reporting it under
+    // none.
+    for (id, reason) in &offenders {
+        if attributed.contains(id) {
+            continue;
+        }
+        let Some(module) = graph.module_by_id(*id) else {
+            continue;
+        };
+        found.push(Unanswerable {
+            route: None,
+            file: module.path.to_string(),
+            because: reason.clone(),
+        });
+    }
+
+    found.sort();
+    found.dedup();
+    found
+}
+
+/// Refuse the build, or let it through.
+///
+/// Before the bundle rather than after it, for the reason the RSC diagnostics
+/// are: a project that has to change what it deploys is not going to be helped
+/// by thirty seconds of bundling first.
+pub(crate) fn refuse(
+    root: &Utf8Path,
+    routes: &[Route],
+    server_modules: &[ServerModule],
+    graph: &RscGraph,
+    because: &str,
+) -> Result<()> {
+    let findings = unanswerable(root, routes, server_modules, graph);
+    if findings.is_empty() {
+        return Ok(());
+    }
+    let mut message = format!(
+        "{} {} this project {} a server, and {because}",
+        findings.len(),
+        plural(findings.len(), "thing"),
+        if findings.len() == 1 { "needs" } else { "need" },
+    );
+    for finding in findings.iter().take(SHOWN) {
+        message.push('\n');
+        message.push_str(&finding.line());
+    }
+    if findings.len() > SHOWN {
+        message.push_str(&format!(
+            "\n  … and {} more",
+            findings.len().saturating_sub(SHOWN)
+        ));
+    }
+    message.push_str(
+        "\n\nA single-page build renders every route in the browser, and a browser has no \
+         request to read and no handler to run. Take these out, or allow `\"ssg\"` or \
+         `\"ssr\"` in `app.rendering.modes` and deploy a build that has a server in it.",
+    );
+    bail!("{message}")
+}
+
+/// Modules only a server can evaluate, by id, with the reason each one is.
+///
+/// Reachability is the filter that makes this a fact about *this application*
+/// rather than about the directory: a module nothing imports is dead code, and
+/// refusing a build over code that never runs is a refusal nobody can act on
+/// except by deleting a file they were not using.
+fn server_only_modules(graph: &RscGraph) -> BTreeMap<ModuleId, String> {
+    let mut found = BTreeMap::new();
+    for module in graph.modules() {
+        if !module.reachability.is_reachable() {
+            continue;
+        }
+        // Through the graph's own lookup rather than by constructing an id from
+        // the loop index. The two agree today; only one of them is a promise
+        // `uf_rsc` has made, and an index cast into an opaque handle is the
+        // kind of shortcut that is right until the module list is filtered.
+        let Some(id) = graph.module_id(&module.path) else {
+            continue;
+        };
+        if module.path.as_str().ends_with(SERVER_ONLY_SUFFIX) {
+            found.insert(
+                id,
+                format!("its name ends in `{SERVER_ONLY_SUFFIX}`, which says it runs on a server"),
+            );
+            continue;
+        }
+        if let Some(specifier) = module
+            .external_imports
+            .iter()
+            .find(|specifier| is_server_only_specifier(specifier))
+        {
+            found.insert(
+                id,
+                format!(
+                    "it imports `{specifier}`, which only runs on a server — `cookies()`, \
+                     `headers()` and `draftMode()` all read a request, and there is none"
+                ),
+            );
+        }
+    }
+    found
+}
+
+/// Every module reachable from `start`, including it.
+///
+/// Breadth-first over the graph's own `imports`, which is the resolved edge
+/// list `uf_rsc` already computed. A second resolver here would be a second
+/// answer to "what does this module import", and the two would drift the first
+/// time an alias or an extension rule changed.
+fn reachable(graph: &RscGraph, start: ModuleId) -> BTreeSet<ModuleId> {
+    let mut seen = BTreeSet::new();
+    let mut queue = VecDeque::new();
+    seen.insert(start);
+    queue.push_back(start);
+    while let Some(id) = queue.pop_front() {
+        let Some(module) = graph.module_by_id(id) else {
+            continue;
+        };
+        for next in &module.imports {
+            if seen.insert(*next) {
+                queue.push_back(*next);
+            }
+        }
+    }
+    seen
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_cli/src/commands/build/spa/tests.rs
+++ b/crates/uf_cli/src/commands/build/spa/tests.rs
@@ -1,0 +1,217 @@
+//! What a single-page build refuses, and — the half that matters more — what
+//! it does not.
+//!
+//! A refusal that fires on a project it should have built is worse than no
+//! refusal at all: it is a rule people learn to work around. So each case that
+//! is refused has a partner here that is not.
+
+use camino::Utf8PathBuf;
+use compact_str::CompactString;
+use uf_router::{Route, ServerModule, ServerModuleKind};
+use uf_rsc::{EntryKind, ModuleEnvironment, RscGraph, RscGraphBuilder, RscModuleInput};
+
+use super::{Unanswerable, refuse, unanswerable};
+
+const ROOT: &str = "/project";
+
+fn route(path: &str, directory: &str) -> Route {
+    Route {
+        path: path.into(),
+        directory: Utf8PathBuf::from(format!("{ROOT}/{directory}")),
+        page: Utf8PathBuf::from(format!("{ROOT}/{directory}/_uf.page.js")),
+        params: Vec::new(),
+        has_layout: false,
+        middleware: Vec::new(),
+    }
+}
+
+fn server_module(path: &str, file: &str, kind: ServerModuleKind) -> ServerModule {
+    ServerModule {
+        path: CompactString::from(path),
+        file: Utf8PathBuf::from(format!("{ROOT}/{file}")),
+        kind,
+    }
+}
+
+fn module(path: &str) -> RscModuleInput {
+    RscModuleInput::new(path, ModuleEnvironment::Server)
+}
+
+fn found(routes: &[Route], modules: &[ServerModule], graph: &RscGraph) -> Vec<Unanswerable> {
+    unanswerable(ROOT.into(), routes, modules, graph)
+}
+
+/// A project whose home page reads the request, through one helper.
+///
+/// Through a helper rather than directly, because that is the case a check on
+/// the page's own imports would miss and the one this is for: `cookies()` is
+/// nearly always called from a module the page imports rather than from the
+/// page.
+fn reads_the_request() -> RscGraph {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(module("app/_uf.page.js").with_import("../session.js"));
+    builder.add_module(module("session.js").with_import("@uniflowed/server"));
+    builder.add_entry("app/_uf.page.js", EntryKind::Server);
+    builder.build()
+}
+
+#[test]
+fn a_route_whose_loader_reads_the_request_is_named() {
+    let graph = reads_the_request();
+    let findings = found(&[route("/", "app")], &[], &graph);
+
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0].route.as_deref(), Some("/"));
+    assert_eq!(findings[0].file, "session.js");
+    assert!(
+        findings[0].because.contains("@uniflowed/server"),
+        "{}",
+        findings[0].because
+    );
+}
+
+#[test]
+fn the_refusal_names_the_route_and_quotes_the_setting() {
+    // The requirement in one assertion: found at build time, and said in words
+    // that identify what to go and look at.
+    let graph = reads_the_request();
+    let error = refuse(
+        ROOT.into(),
+        &[route("/", "app")],
+        &[],
+        &graph,
+        "`app.rendering.modes` is `[\"csr\"]`",
+    )
+    .unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("app.rendering.modes"), "{message}");
+    assert!(message.contains("session.js"), "{message}");
+    assert!(message.contains("ssr"), "{message}");
+}
+
+#[test]
+fn a_project_that_reads_no_request_builds() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(module("app/_uf.page.js").with_import("../format.js"));
+    builder.add_module(module("format.js"));
+    builder.add_entry("app/_uf.page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    assert_eq!(found(&[route("/", "app")], &[], &graph), Vec::new());
+    refuse(ROOT.into(), &[route("/", "app")], &[], &graph, "because").unwrap();
+}
+
+#[test]
+fn a_server_only_module_nothing_imports_is_not_a_refusal() {
+    // Dead code. Refusing over a module that never runs is a refusal whose
+    // only fix is deleting a file the project was not using, and the analysis
+    // already knows the difference.
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(module("app/_uf.page.js"));
+    builder.add_module(module("old/session.js").with_import("@uniflowed/server"));
+    builder.add_entry("app/_uf.page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    assert_eq!(found(&[route("/", "app")], &[], &graph), Vec::new());
+}
+
+#[test]
+fn a_module_named_server_js_counts_too() {
+    // The other half of `uf_rsc`'s rule, and the one a specifier check misses:
+    // `*.server.js` is server-only by name rather than by what it imports.
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(module("app/_uf.page.js").with_import("../orders.server.js"));
+    builder.add_module(module("orders.server.js"));
+    builder.add_entry("app/_uf.page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    let findings = found(&[route("/", "app")], &[], &graph);
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0].file, "orders.server.js");
+    assert!(
+        findings[0].because.contains(".server.js"),
+        "{}",
+        findings[0].because
+    );
+}
+
+#[test]
+fn a_module_no_page_reaches_is_reported_by_its_file() {
+    // A layout is the ordinary case: no page imports the layout it renders
+    // inside, so the walk from the pages never arrives. Naming a route it does
+    // not belong to would be a worse answer than naming none.
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(module("app/_uf.page.js"));
+    builder.add_module(module("app/_uf.layout.js").with_import("@uniflowed/server"));
+    builder.add_entry("app/_uf.page.js", EntryKind::Server);
+    builder.add_entry("app/_uf.layout.js", EntryKind::Server);
+    let graph = builder.build();
+
+    let findings = found(&[route("/", "app")], &[], &graph);
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0].route, None);
+    assert_eq!(findings[0].file, "app/_uf.layout.js");
+}
+
+#[test]
+fn a_route_handler_and_a_middleware_are_both_refused() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(module("app/_uf.page.js"));
+    builder.add_entry("app/_uf.page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    let findings = found(
+        &[route("/", "app")],
+        &[
+            server_module(
+                "/api",
+                "app/api/_uf.route.js",
+                ServerModuleKind::RouteHandler,
+            ),
+            server_module(
+                "/dashboard",
+                "app/dashboard/_uf.middleware.js",
+                ServerModuleKind::Middleware,
+            ),
+        ],
+        &graph,
+    );
+
+    let subjects = findings
+        .iter()
+        .map(|finding| finding.route.clone().unwrap_or_default())
+        .collect::<Vec<_>>();
+    // The middleware by the subtree it guards, the way `deploy::static_host`
+    // reports one: it runs for a page, for a handler, and for a path under it
+    // that is neither.
+    assert!(subjects.contains(&String::from("/api")), "{subjects:?}");
+    assert!(
+        subjects.contains(&String::from("/dashboard/*")),
+        "{subjects:?}"
+    );
+}
+
+#[test]
+fn one_helper_two_routes_is_reported_for_both() {
+    // Not deduplicated down to the module: the reader is deciding what to do
+    // about an application, and "these two routes cannot be rendered in a
+    // browser" is the shape of that decision.
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(module("app/_uf.page.js").with_import("../session.js"));
+    builder.add_module(module("app/orders/_uf.page.js").with_import("../../session.js"));
+    builder.add_module(module("session.js").with_import("@uniflowed/server"));
+    builder.add_entry("app/_uf.page.js", EntryKind::Server);
+    builder.add_entry("app/orders/_uf.page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    let findings = found(
+        &[route("/", "app"), route("/orders", "app/orders")],
+        &[],
+        &graph,
+    );
+
+    assert_eq!(findings.len(), 2, "{findings:?}");
+    assert_eq!(findings[0].route.as_deref(), Some("/"));
+    assert_eq!(findings[1].route.as_deref(), Some("/orders"));
+}

--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -953,6 +953,11 @@ fn prerender_stage(resolved: &ResolvedConfig) -> Stage {
              request"
                 .to_string()
         }
+        Prerender::Shell => {
+            "one shell, which is no route's document: `app.rendering.modes` is [\"csr\"], so \
+             every route is resolved and rendered in the browser"
+                .to_string()
+        }
     };
     Stage {
         name: "prerender",

--- a/crates/uf_cli/src/commands/serve.rs
+++ b/crates/uf_cli/src/commands/serve.rs
@@ -49,7 +49,7 @@
 
 use anyhow::{Result, bail};
 use camino::Utf8Path;
-use uf_config::{RenderingPlan, load_config};
+use uf_config::{Prerender, RenderingPlan, load_config};
 use uf_term::{KeyValue, Status, Tone};
 
 use crate::commands::builder;
@@ -311,6 +311,18 @@ fn driver_args(
     let mut args = vec![String::from("--out-dir"), out_dir.to_owned()];
     if !plan.emits_a_server() {
         args.push(String::from("--static-build"));
+    }
+    // The rewrite rule a single-page deployment cannot work without, asked for
+    // by name rather than inferred from `--static-build`: a `build.staticBuild`
+    // project has a document per route and wants a 404 for a URL it does not
+    // have, and a `["csr"]` project has one document and wants it served for
+    // every URL. Both emit no server, so the flag they share cannot tell them
+    // apart. Without this, `uf preview` would 404 every path but `/` on a build
+    // that a correctly configured host serves completely — a preview that is
+    // wrong about the deployment, which is the one thing this command must not
+    // be.
+    if plan.prerender() == Prerender::Shell {
+        args.push(String::from("--spa-fallback"));
     }
     if let Some(bind) = host {
         args.push(String::from("--host"));

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -5812,6 +5812,94 @@ fn allowing_ssr_beside_ssg_builds_the_same_project() {
     );
 }
 
+/// `rendering.modes: ["csr"]` is a single-page application: one document.
+///
+/// The whole of what the plan produces, asserted against a real build rather
+/// than against the plan that describes it. Three things have to be true at
+/// once and each of them is a different half of the toolchain: the driver
+/// writes the shell instead of running the prerender, the shell is *empty* —
+/// no route rendered into it — and the server bundle is gone, because a build
+/// with no route to render per request has nothing to run.
+#[test]
+fn allowing_only_csr_writes_one_empty_shell() {
+    if !fixture_ready() {
+        return;
+    }
+    let project = Project::new(&minimal_app());
+    project.write(
+        "uf.config.js",
+        &config_with("  app: { rendering: { modes: [\"csr\"] } },\n"),
+    );
+
+    let (succeeded, said) = build_output(project.path());
+    assert!(succeeded, "{said}");
+
+    let index = fs::read_to_string(project.path().join("dist/index.html")).unwrap();
+    // The root is there and nothing is in it. `home` is what `minimal_app`'s
+    // page renders, so its absence is the assertion that no route was
+    // prerendered into the document a visitor gets first.
+    assert!(index.contains("id=\"uf-root\""), "{index}");
+    assert!(
+        !index.contains("home"),
+        "the shell carries a route's markup:\n{index}"
+    );
+    // And the fallback, which is what a static host serves for every URL that
+    // is not `/` — which under this plan is every URL the application has.
+    let not_found = fs::read_to_string(project.path().join("dist/404.html")).unwrap();
+    assert_eq!(not_found, index, "the fallback is not the shell");
+    // No server anywhere: not in the output, and not left behind beside it.
+    assert!(
+        !project.path().join(".uf/build/server/server.js").exists(),
+        "a single-page build left a server bundle:\n{said}"
+    );
+    assert!(
+        said.contains("browser"),
+        "the build did not say what it did:\n{said}"
+    );
+}
+
+/// The refusal a single-page build has to make for itself.
+///
+/// Every other plan prerenders something, so a page that reads a request is
+/// found by *trying* to render it. This one renders nothing, so the same page
+/// would build, deploy, and fail in a browser — which is why the check is
+/// static and why it is worth an integration test rather than only the unit
+/// tests in `commands::build::spa`: the thing that could break is the wiring
+/// between the analysis and the plan, not the walk.
+#[test]
+fn a_route_that_reads_the_request_fails_a_csr_build() {
+    if !fixture_ready() {
+        return;
+    }
+    let mut files = minimal_app();
+    files.push((
+        "app/orders/_uf.page.js",
+        "// @flow\nimport * as React from \"@uniflowed/react\";\nimport { cookies } from \"@uniflowed/server\";\n\nexport component Orders() {\n  return <main>{cookies().get(\"who\")?.value ?? \"nobody\"}</main>;\n}\n",
+    ));
+    let project = Project::new(&files);
+    project.write(
+        "uf.config.js",
+        &config_with("  app: { rendering: { modes: [\"csr\"] } },\n"),
+    );
+
+    let (succeeded, said) = build_output(project.path());
+    assert!(!succeeded, "the build should have refused:\n{said}");
+    assert!(said.contains("/orders"), "the route is not named:\n{said}");
+    assert!(
+        said.contains("@uniflowed/server"),
+        "what makes it a server's is not named:\n{said}"
+    );
+    assert!(
+        said.contains("app.rendering.modes"),
+        "the declaration that caused it is not quoted:\n{said}"
+    );
+    // Before the bundle, like every other refusal in this family.
+    assert!(
+        !project.path().join("dist/index.html").exists(),
+        "a refused build wrote a document anyway"
+    );
+}
+
 /// `rendering.modes: ["ssr"]` used to mean SSG, because SSG was all there was.
 #[test]
 fn allowing_only_ssr_prerenders_nothing() {

--- a/crates/uf_config/src/app.rs
+++ b/crates/uf_config/src/app.rs
@@ -611,8 +611,10 @@ impl Default for ReactConfig {
 pub struct RenderingConfig {
     /// The rendering strategies this project will deploy, in no order.
     ///
-    /// The default is all four, which is "decide per route and deploy a
-    /// server" — the behaviour every uf project had before anything read this.
+    /// The default is the four that decide per route, which together mean
+    /// "decide per route and deploy a server" — the behaviour every uf project
+    /// had before anything read this. [`RenderingMode::Csr`] is deliberately
+    /// not among them and says why on itself.
     pub modes: Vec<RenderingMode>,
     /// What happens when a visitor follows a link.
     ///
@@ -698,13 +700,17 @@ impl Navigation {
 
 /// One rendering strategy a project may allow.
 ///
-/// Two of the four are implemented, and the enum keeps all four because the
-/// list is an allowlist: naming a strategy uf cannot do yet permits something
-/// that never happens, which costs nothing, where *removing* the name would
-/// make today's `uf.config.js` files fail to parse. What is refused is a list
-/// that allows **only** unimplemented strategies — see
+/// Three of the five are implemented, and the enum keeps the other two because
+/// the list is an allowlist: naming a strategy uf cannot do yet permits
+/// something that never happens, which costs nothing, where *removing* the name
+/// would make today's `uf.config.js` files fail to parse. What is refused is a
+/// list that allows **only** unimplemented strategies — see
 /// [`crate::ConfigError::NoImplementedRenderingMode`] — because that is a
 /// project asking for a build uf cannot produce at all.
+///
+/// [`Csr`](Self::Csr) is the value that does not behave like the others, and
+/// its own documentation says why: it is not a per-route answer, so it is the
+/// one value that cannot share a list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RenderingMode {
@@ -719,6 +725,32 @@ pub enum RenderingMode {
     /// selected. `rendering.cache` and ubugeeei-prod/uf#277 are the half of it
     /// that exists.
     Isr,
+    /// Rendered in the browser, from one shell prerendered at build time.
+    /// **Implemented.**
+    ///
+    /// A single-page application. The build writes one document — an empty root
+    /// and the script and stylesheet tags — and the client router resolves and
+    /// renders every route from there. No route gets a document of its own, and
+    /// no server renders one.
+    ///
+    /// # Why it cannot share a list
+    ///
+    /// Every other value answers "where does *this route's* document come
+    /// from", which is what makes a list of them a set the build picks from per
+    /// route. This one answers "where does every route come from" with a single
+    /// document that belongs to no route, and once it is chosen there is no
+    /// per-route decision left. `["csr", "ssg"]` is therefore a project asking
+    /// for a build that both writes a document per route and does not, and its
+    /// two honest readings — "prerender what you can and fall back to the
+    /// shell" and "the shell, and never mind the rest of the list" — are
+    /// different applications. So it is refused rather than resolved by
+    /// precedence; see [`crate::ConfigError::CsrIsNotOneOfSeveral`].
+    ///
+    /// It is also **not in the default list**, which every other value is. The
+    /// default means "decide per route and deploy a server", and a build that
+    /// quietly decided to be a single-page application because nothing forbade
+    /// it would be the largest semantic change a default has ever made.
+    Csr,
 }
 
 impl RenderingMode {
@@ -730,6 +762,7 @@ impl RenderingMode {
             Self::Ssr => "ssr",
             Self::Ssg => "ssg",
             Self::Isr => "isr",
+            Self::Csr => "csr",
         }
     }
 
@@ -740,7 +773,18 @@ impl RenderingMode {
     /// nothing else is refused, and this is the predicate that decides it.
     #[must_use]
     pub const fn is_implemented(self) -> bool {
-        matches!(self, Self::Ssr | Self::Ssg)
+        matches!(self, Self::Ssr | Self::Ssg | Self::Csr)
+    }
+
+    /// Whether this value is the whole application's answer rather than one
+    /// route's.
+    ///
+    /// One value, and a predicate rather than a comparison, because the
+    /// refusal, the plan and the message that explains them all have to agree
+    /// about which value it is.
+    #[must_use]
+    pub const fn is_exclusive(self) -> bool {
+        matches!(self, Self::Csr)
     }
 }
 

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -1735,6 +1735,35 @@ pub enum ConfigError {
          this project's routes need."
     )]
     StaticBuildWithoutSsg { path: Utf8PathBuf },
+    /// `csr` in a list with anything else.
+    ///
+    /// Every other mode answers "where does this route's document come from",
+    /// which is what makes the list a set the build picks from per route. `csr`
+    /// answers it for the whole application with one document that is no
+    /// route's, so a list holding it and something else has two readings —
+    /// "prerender what you can and fall back to the shell", and "the shell, and
+    /// never mind the rest" — that are different applications. Whichever were
+    /// read second would silently win, which is the failure
+    /// ubugeeei-prod/uf#385 is about with different keys.
+    #[error(
+        "{path}: app.rendering.modes is [{modes}], and `csr` cannot share the list. It renders \
+         every route in the browser from one shell, where the others write a document per \
+         route — so a build cannot pick between them per route, which is what this list is \
+         for. Write `[\"csr\"]` for a single-page application, or drop it."
+    )]
+    CsrIsNotOneOfSeveral { path: Utf8PathBuf, modes: String },
+    /// `build.staticBuild` in a `csr` project.
+    ///
+    /// `staticBuild` is "prerender every route and emit no server bundle", and
+    /// `csr` prerenders no route at all. The second half of the two agrees and
+    /// the first half cannot, so this is a project that has asked for every
+    /// route to be prerendered by a build that writes one document.
+    #[error(
+        "{path}: build.staticBuild prerenders every route, and app.rendering.modes is \
+         [\"csr\"], which prerenders none — the build writes one shell and the browser renders \
+         the routes. A `csr` build already emits no server, so drop `staticBuild`."
+    )]
+    CsrWithStaticBuild { path: Utf8PathBuf },
     /// `build.lib` in a project whose file-system router is on.
     ///
     /// One project is one kind of build. `app.router.enabled` is what says

--- a/crates/uf_config/src/rendering.rs
+++ b/crates/uf_config/src/rendering.rs
@@ -59,6 +59,19 @@ pub enum Prerender {
     /// setting was accepted and silently meant [`Self::Possible`], which is
     /// the one behaviour the list could not select.
     Nothing,
+    /// No route, and one document that is not a route: the shell.
+    ///
+    /// `modes: ["csr"]`. The build writes a single document with an empty root
+    /// and the script tags, and the browser resolves and renders every route
+    /// from it — a single-page application.
+    ///
+    /// It is not [`Self::Nothing`] with a different name, and the difference is
+    /// what happens to a request the deployment cannot match. `Nothing` has a
+    /// server, so every URL is answered by rendering it; this has a file, so
+    /// every URL is answered by the *same* file and the answer is decided in
+    /// the browser. That is why a route that can only be answered by a server
+    /// is refused under this and not under that one.
+    Shell,
 }
 
 impl Prerender {
@@ -69,6 +82,7 @@ impl Prerender {
             Self::Everything => "everything",
             Self::Possible => "possible",
             Self::Nothing => "nothing",
+            Self::Shell => "shell",
         }
     }
 }
@@ -129,6 +143,25 @@ impl RenderingPlan {
         // caller already asks for, and a second `config.app.rendering.…` read
         // at each of them is how two readers of one file come apart.
         let navigation = config.app.rendering.navigation;
+
+        // `csr` before everything, including `staticBuild`, because it is the
+        // one value that is not a per-route answer: a project that named it has
+        // said the whole application is rendered in the browser, and `check`
+        // has already refused it beside anything that would disagree. Deciding
+        // it here rather than in the match below keeps the match about the two
+        // questions it has always been about.
+        if modes.iter().any(|mode| mode.is_exclusive()) {
+            return Self {
+                prerender: Prerender::Shell,
+                // No server, and this is the declaration rather than
+                // `staticBuild`'s: there is nothing for a server to render,
+                // because no route has a document and the one document has no
+                // route.
+                server: false,
+                source: PlanSource::Modes,
+                navigation,
+            };
+        }
 
         // `staticBuild` first, because it is the stronger claim: it is about
         // the artefact rather than about the routes, and a project that has
@@ -247,6 +280,10 @@ impl RenderingPlan {
                 Prerender::Nothing => String::from(
                     "`app.rendering.modes` does not allow `ssg`, so this build prerenders nothing",
                 ),
+                Prerender::Shell => String::from(
+                    "`app.rendering.modes` is `[\"csr\"]`, so this build writes one shell and \
+                     every route is rendered in the browser",
+                ),
                 _ => String::from(
                     "`app.rendering.modes` does not allow `ssr`, so every route has to be \
                      prerendered",
@@ -264,11 +301,13 @@ impl RenderingPlan {
 /// find out at the file it wrote rather than in the deployment where it was
 /// not honoured.
 ///
-/// Two refusals, and neither is "you named a mode uf has not written".
+/// Four refusals, and none of them is "you named a mode uf has not written".
 /// `modes` is an allowlist, so `["ssg", "isr"]` permits a strategy that never
 /// gets selected, which changes nothing and is worth no error. What is refused
-/// is a list that leaves the build with nothing it can do, and a `staticBuild`
-/// that the same file's `modes` forbids.
+/// is a list that leaves the build with nothing it can do, a `staticBuild` that
+/// the same file's `modes` forbids, and the two shapes `csr` cannot be in — it
+/// is the one value that is not a per-route answer, so it is the one value a
+/// list cannot hold *alongside* something else.
 pub(crate) fn check(path: &Utf8Path, config: &UniflowedConfig) -> Result<(), ConfigError> {
     let modes = &config.app.rendering.modes;
     if !modes.iter().any(|mode| mode.is_implemented()) {
@@ -280,6 +319,28 @@ pub(crate) fn check(path: &Utf8Path, config: &UniflowedConfig) -> Result<(), Con
                 .collect::<Vec<_>>()
                 .join(", "),
         });
+    }
+    // Before the `staticBuild` check below, and the order is the message
+    // rather than the outcome. A `["csr"]` project with `staticBuild: true`
+    // fails either way; told by the `ssg` rule it would be advised to add
+    // `"ssg"` to the list, which is advice to build a different application.
+    if modes.iter().any(|mode| mode.is_exclusive()) {
+        if modes.len() > 1 {
+            return Err(ConfigError::CsrIsNotOneOfSeveral {
+                path: path.to_path_buf(),
+                modes: modes
+                    .iter()
+                    .map(|mode| mode.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            });
+        }
+        if config.build.static_build {
+            return Err(ConfigError::CsrWithStaticBuild {
+                path: path.to_path_buf(),
+            });
+        }
+        return Ok(());
     }
     if config.build.static_build && !modes.contains(&RenderingMode::Ssg) {
         return Err(ConfigError::StaticBuildWithoutSsg {

--- a/crates/uf_config/src/rendering/tests.rs
+++ b/crates/uf_config/src/rendering/tests.rs
@@ -129,6 +129,85 @@ fn static_build_with_no_ssg_is_the_contradiction_that_is_refused() {
 }
 
 #[test]
+fn csr_alone_writes_one_shell_and_no_server() {
+    let config = with_modes(&[RenderingMode::Csr]);
+    check(Utf8Path::new("uf.config.js"), &config).unwrap();
+    let plan = RenderingPlan::resolve(&config);
+    assert_eq!(plan.prerender(), Prerender::Shell);
+    assert!(!plan.emits_a_server());
+    // Not `is_static_only`: nothing has to be prerenderable, because nothing is
+    // prerendered. The refusal a `csr` build makes is a different one.
+    assert!(!plan.is_static_only());
+    assert_eq!(plan.source().key(), Some("app.rendering.modes"));
+    assert!(plan.because().contains("shell"), "{}", plan.because());
+}
+
+#[test]
+fn csr_is_not_in_the_default_list() {
+    // The whole of why: a default that could select it would make a build
+    // decide to be a single-page application because nothing forbade it.
+    let plan = RenderingPlan::resolve(&UniflowedConfig::default());
+    assert_eq!(plan.prerender(), Prerender::Possible);
+    assert!(
+        !UniflowedConfig::default()
+            .app
+            .rendering
+            .modes
+            .contains(&RenderingMode::Csr)
+    );
+}
+
+#[test]
+fn csr_beside_another_mode_is_refused() {
+    for other in [
+        RenderingMode::Ssg,
+        RenderingMode::Ssr,
+        RenderingMode::Ppr,
+        RenderingMode::Isr,
+    ] {
+        let config = with_modes(&[RenderingMode::Csr, other]);
+        let error = check(Utf8Path::new("uf.config.js"), &config).unwrap_err();
+        assert!(
+            matches!(error, ConfigError::CsrIsNotOneOfSeveral { .. }),
+            "{other:?}: {error}"
+        );
+        let message = error.to_string();
+        assert!(message.contains("csr"), "{message}");
+        assert!(message.contains(other.as_str()), "{message}");
+    }
+}
+
+#[test]
+fn csr_with_static_build_is_refused_in_its_own_words() {
+    // Both refusals are available for this file and only one of them is any
+    // use: the `ssg` rule would tell a single-page project to add `"ssg"` to
+    // the list, which is advice to build a different application.
+    let mut config = with_modes(&[RenderingMode::Csr]);
+    config.build.static_build = true;
+    let error = check(Utf8Path::new("uf.config.js"), &config).unwrap_err();
+    assert!(
+        matches!(error, ConfigError::CsrWithStaticBuild { .. }),
+        "{error}"
+    );
+    assert!(error.to_string().contains("drop `staticBuild`"), "{error}");
+}
+
+#[test]
+fn csr_composes_with_navigation_the_way_everything_else_does() {
+    // A single-page application navigates in the browser by construction, and
+    // the config can still say `document`. Not refused, because it is not a
+    // contradiction: every link fetches the shell again and the browser renders
+    // the route from it, which works and is a slow way to have an SPA. A
+    // refusal here would be uf deciding that a working deployment is a mistake.
+    let mut config = with_modes(&[RenderingMode::Csr]);
+    config.app.rendering.navigation = Navigation::Document;
+    check(Utf8Path::new("uf.config.js"), &config).unwrap();
+    let plan = RenderingPlan::resolve(&config);
+    assert_eq!(plan.prerender(), Prerender::Shell);
+    assert!(!plan.ships_a_client_router());
+}
+
+#[test]
 fn navigation_is_the_client_router_unless_a_project_says_otherwise() {
     let plan = RenderingPlan::resolve(&UniflowedConfig::default());
     assert_eq!(plan.navigation(), Navigation::Client);

--- a/docs/app/guide/rendering/_uf.page.mdx
+++ b/docs/app/guide/rendering/_uf.page.mdx
@@ -21,6 +21,9 @@ prerendered, a route with parameters is prerendered when its page exports
 `generateStaticParams`, and anything left over is rendered per request. The
 [config reference](/reference/config) has the table.
 
+One value in that list is not a per-route answer and cannot share it: `"csr"`
+is a single-page application, and it is [below](#csr-a-single-page-application).
+
 `app.rendering.navigation` says what happens next, and it is one answer for the
 whole application:
 
@@ -113,7 +116,105 @@ without uf being involved: the browser's scroll restoration, the browser's
 history, the browser's handling of a middle click, and one less thing that can
 be wrong.
 
-## When to choose it
+## `csr`: a single-page application
+
+The complement of document navigation, on the other axis. Where
+`navigation: "document"` keeps every document and takes the router away, `csr`
+keeps the router and takes every document away:
+
+```js
+// uf.config.js
+export default defineConfig({
+  app: {
+    rendering: {
+      modes: ["csr"],
+    },
+  },
+});
+```
+
+`uf build` then writes **one** document — an empty root, the stylesheets and
+the module script — and the client router resolves and renders every route from
+it. No route is prerendered, no server renders one, and no server bundle
+survives the build.
+
+`"csr"` cannot share the list. Every other value answers "where does *this
+route's* document come from", which is what makes the list a set the build
+picks from per route; this one answers it for the whole application with a
+document that belongs to no route, and once it is chosen there is no per-route
+decision left. `["csr", "ssg"]` is refused while the config is read, because its
+two honest readings — "prerender what you can and fall back to the shell" and
+"the shell, and never mind the rest" — are different applications. It is also
+not in the default list, which everything else is: a build that decided to be a
+single-page application because nothing forbade it would be the largest
+semantic change a default has ever made.
+
+### The two files, and the rule your host needs
+
+The build writes the shell twice:
+
+| File | What serves it |
+| --- | --- |
+| `index.html` | the host, for `/` |
+| `404.html` | the host, for every path it has no file for |
+
+The second is the one that matters. Under this plan `/orders` has no file, so a
+plain static host would 404 it — a `dist/` with a hole in it. Writing the shell
+as the error document covers the hosts that have one (GitHub Pages, Netlify,
+an S3 bucket with an error document), and the 404 status it comes with is the
+right status for a URL this application does not have — the not-found boundary
+is what the browser then renders into it. A host with a proper SPA rewrite
+serves `index.html` and never looks at `404.html`.
+
+`uf preview` applies that rewrite itself, so the preview is right about a
+deployment that is configured, rather than right about one nobody does.
+
+### A route that needs a server is refused
+
+Every other plan finds these by trying: a build that prerenders a page calls
+`cookies()` where there is no request, and the render fails with the route
+named. This plan renders nothing, so the same page would build, deploy, and
+fail in a browser.
+
+So `uf build` refuses it before the bundle, from the server-component analysis
+it has already run, naming the route:
+
+```text
+2 things this project needs a server, and `app.rendering.modes` is ["csr"], so
+this build writes one shell and every route is rendered in the browser
+  /orders (session.js) — it imports `@uniflowed/server`, which only runs on a
+    server — `cookies()`, `headers()` and `draftMode()` all read a request, and
+    there is none
+  /api — it is a route handler, and a handler answers a request rather than
+    rendering a page
+```
+
+Four things count: a `_uf.route.js`, a `_uf.middleware.js`, a callable server
+action, and any module the application reaches that imports a server-only
+package (`@uniflowed/server`, `@uniflowed/db`, `server-only`) or is named
+`*.server.js`. Dead code does not: a module nothing imports is not a reason to
+refuse a build.
+
+A module no page reaches — a layout, most often, because no page imports the
+layout it renders inside — is named by its file rather than by a route, because
+naming a route it does not belong to would be worse than naming none.
+
+### What it costs
+
+**The document says nothing.** No `<title>`, no description, no content. A
+crawler that runs no JavaScript sees an empty page for every URL, and a reader
+sees nothing until the bundle has loaded and the route has resolved. That is
+what a single-page application is, and it is why this is a declaration a project
+makes rather than something a build falls back to.
+
+**The loader runs in the browser.** There was no server render to run it in, so
+every route's data is fetched after the bundle has loaded — which is a round
+trip after a round trip.
+
+If either of those is unacceptable for some routes and not others, the answer
+is not this mode: it is `["ssg"]` or the default, which decide per route.
+
+## When to choose document navigation
 
 - The site is documents — a manual, a blog, a marketing site — and the client
   router is buying an animation nobody asked for.

--- a/docs/app/reference/config/_uf.page.mdx
+++ b/docs/app/reference/config/_uf.page.mdx
@@ -98,10 +98,24 @@ a process.
 | contains `ssg` and `ssr` (the default) | Prerenders what it can; the rest are rendered by `uf start`, `uf preview` or a deploy adapter |
 | `["ssg"]` | Prerenders everything, and **fails**, naming the route, if anything can only be answered per request |
 | `["ssr"]` | Prerenders nothing. Every route is rendered per request |
+| `["csr"]` | Prerenders one shell that is no route's document, and the browser renders every route from it |
 
 `ppr` and `isr` are **Planned**. Naming one alongside an implemented mode is
 allowed and selects nothing; a list that names *only* planned modes is refused
 while the config is read, because there is no build behind it.
+
+`csr` is the one value that **cannot share the list**. The others answer "where
+does this route's document come from", which is what makes the list a set the
+build picks from per route; `csr` answers it for the whole application with a
+document that belongs to no route, so there is no per-route decision left to
+make. `["csr", "ssg"]` is refused while the config is read, and so is `csr`
+beside `build.staticBuild`, which prerenders every route where this prerenders
+none. It is also the one value **not in the default list**. A `csr` build
+refuses, by name and before the bundle, any route that needs a server — a route
+handler, a middleware, a callable server action, or a module the application
+reaches that imports `@uniflowed/server`, `@uniflowed/db` or `server-only`. The
+[guide](/guide/rendering) has the two files it writes and the rewrite rule a
+host needs.
 
 Three things can only be answered per request, and under `["ssg"]` each is an
 error naming the route: a page with parameters and no `generateStaticParams`, a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -960,8 +960,8 @@ entirely — see [The other build: a library](#the-other-build-a-library).
 The third pass has three answers per route, not two, and which ones a project
 allows is `app.rendering.modes` and `build.staticBuild`. `uf` resolves those
 two together into a *rendering plan* (`uf_config`'s `RenderingPlan`) and hands
-the builder one word — `everything`, `possible` or `nothing` — because they
-only mean something read together and three commands read them.
+the builder one word — `everything`, `possible`, `nothing` or `shell` — because
+they only mean something read together and three commands read them.
 
 | Route | Answer |
 | --- | --- |
@@ -977,6 +977,18 @@ error** naming it and both ways out, because there is no process to render it
 and a `dist/` with a hole in it is a 404 nobody sees until the deploy. Under
 `nothing` no document is written at all, which is what `["ssr"]` has always
 claimed to mean and, until it was read, did not.
+
+`shell` — `rendering.modes: ["csr"]` — is the plan that is not per-route at
+all: no route is rendered, and the build writes one document that belongs to no
+route (an empty root, the stylesheets, the module script) to both `index.html`
+and `404.html`, so a static host answers `/` from the first and every other URL
+from the second. The client entry then `render`s rather than hydrating, because
+no markup was written for it to attach to. Every row of the table above that
+says "per request" is a **build error** under this plan too, and so is any
+module the application reaches that imports a server-only package: nothing here
+renders, so nothing here would have discovered them, and the failure would have
+been a browser's rather than a build's. `uf preview` applies the SPA rewrite
+(`--spa-fallback`) so that the preview matches a host that is configured.
 
 `build.staticBuild` additionally removes `.uf/build/server/` once the last
 document is written: the bundle is a build intermediate — the prerender renders
@@ -1106,7 +1118,7 @@ Optional; a builder that transforms nothing needs neither.
 | `dev` | `--root --mode [--host --port --strict-port]` | Serves the project, rendering every navigation |
 | `build` | `--root --mode --out-dir --prerender --because [--static-build]` | Writes the client bundle, the server bundle and the prerendered documents |
 | `library` | `--root --mode --out-dir --entry… --format… [--external…]` | Writes one module per entry per format, for a project that is a library |
-| `preview` | `--root --mode --out-dir [--host --port --strict-port --static-build]` | Serves the build through the builder's own preview server |
+| `preview` | `--root --mode --out-dir [--host --port --strict-port --static-build --spa-fallback]` | Serves the build through the builder's own preview server |
 | `start` | `--root --out-dir [--host --port]` | Serves the build with no bundler in the process |
 | `compile` | `--root --mode --out-dir --assets --bundle` | Links the application into one module, for `uf build --compile` |
 | `deploy` | `--root --mode --out-dir --adapter --work --output` | Links the application into a directory to copy |
@@ -1116,7 +1128,12 @@ Optional; a builder that transforms nothing needs neither.
 `env.active`; the `.env` files it selected have already been read, by uf, into
 the driver's environment. `--prerender` is the rendering plan above and
 `--because` is the sentence to quote when refusing, so a refusal in the builder
-names the same config key a refusal in uf does. `UF_BINARY` names the `uf` that
+names the same config key a refusal in uf does. `--spa-fallback` reaches
+`preview` only, and is asked for by name rather than inferred from
+`--static-build`: a `build.staticBuild` project has a document per route and
+wants a 404 for a URL it does not have, and a `["csr"]` project has one document
+and wants it served for every URL, so the flag they share cannot tell them
+apart. `UF_BINARY` names the `uf` that
 started it, and `UF_RSC_MANIFEST` the server-component analysis.
 
 **What the driver says**, one JSON object per line, `{"event": "...", ...}`:

--- a/packages/config/internal/schema.js
+++ b/packages/config/internal/schema.js
@@ -359,7 +359,11 @@ export type UniflowedConfig = {
       readonly enabled?: boolean,
     },
     readonly rendering?: {
-      readonly modes?: $ReadOnlyArray<"ppr" | "ssr" | "ssg" | "isr">,
+      // `"csr"` is the one value that cannot share the list: it renders every
+      // route in the browser from one shell, where the others write a document
+      // per route, so there is no per-route choice left for the list to hold.
+      // `["csr"]` is a single-page application; see docs/app/guide/rendering.
+      readonly modes?: $ReadOnlyArray<"ppr" | "ssr" | "ssg" | "isr" | "csr">,
       // What the browser does when a visitor follows a link, which is a
       // different question from `modes` rather than a fifth value in it:
       // `modes` says where a document comes from, per route, and this says

--- a/packages/router/client.js
+++ b/packages/router/client.js
@@ -1,6 +1,13 @@
 // @flow
 //
-// Hydrating the document in the browser.
+// Starting the application in the browser.
+//
+// Two entry points, and which one `virtual:uf/client` calls is decided by
+// `app.rendering.modes`. `hydrate` is the one every uf build has used: a server
+// or a prerender wrote the markup, and React attaches to it. `render` is for
+// `["csr"]`, where the build wrote one shell with an empty root and nothing has
+// been rendered anywhere yet; see its own comment for why that is not `hydrate`
+// with a flag.
 //
 // `virtual:uf/client` calls `hydrate` with the app root and the route table.
 // The current route's chunks are loaded and its embedded loader data read
@@ -72,16 +79,18 @@
 
 import * as React from "react";
 import { StrictMode, startTransition } from "react";
-import { hydrateRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 
 import {
   type AppProps,
   type Navigation,
   type RouteTable,
+  RedirectError,
   hasClientPage,
   installNavigation,
   installRoutes,
   matchRoute,
+  resolveFailure,
   resolveMatch,
 } from "./internal/runtime.js";
 import { DATA_ID, ROOT_ID } from "./internal/document.js";
@@ -170,4 +179,86 @@ export async function hydrate(options: {|
     const { reportDevtools } = await import("./internal/devtools.js");
     reportDevtools(window);
   }
+}
+
+/**
+ * Render the current route into an empty shell.
+ *
+ * The single-page entry point: `app.rendering.modes: ["csr"]` writes one
+ * document with an empty root and no markup in it, and this is what fills it.
+ *
+ * # Why it is not `hydrate` with a flag
+ *
+ * Because hydration is React comparing what it renders against what a server
+ * sent, and here no server sent anything. `hydrateRoot` against an empty
+ * container is a mismatch on the first node of every page — React would report
+ * it, throw the shell away and render from scratch, which is this function
+ * with a warning in front of it. `createRoot` says what is actually happening:
+ * the browser is the only renderer this application has.
+ *
+ * Three more things follow from there, and each of them is a line below rather
+ * than an omission:
+ *
+ *   * **The loader runs here.** `resolveMatch` fetches the route's modules and
+ *     runs its loader in the browser, because there was no server render to run
+ *     it in and no `<script id="__uf_data">` for it to have left an answer in.
+ *   * **A URL that matches nothing is the not-found boundary**, resolved the
+ *     way a server resolves it. The host served this shell for a URL it had no
+ *     file for, so "nothing matched" is a perfectly ordinary arrival here
+ *     rather than the exception it is during hydration.
+ *   * **A redirect is the browser's.** `redirect()` from a loader throws before
+ *     anything is rendered; on a server that becomes a 307 and here it becomes
+ *     `location.replace`, which is the same instruction to the same browser.
+ */
+export async function render(options: {|
+  readonly App: React.ComponentType<AppProps>,
+  readonly routes: RouteTable["routes"],
+  readonly notFound: RouteTable["notFound"],
+  readonly errors: RouteTable["errors"],
+  readonly strictMode?: boolean,
+  readonly navigation?: Navigation,
+|}): Promise<void> {
+  const table: RouteTable = {
+    routes: options.routes,
+    notFound: options.notFound,
+    errors: options.errors,
+  };
+  installRoutes(table);
+  installNavigation(options.navigation ?? "client");
+
+  const url = window.location.pathname + window.location.search;
+  let resolved;
+  try {
+    resolved = await resolveMatch(table, url);
+  } catch (error) {
+    if (error instanceof RedirectError) {
+      window.location.replace(error.to);
+      return;
+    }
+    // The error boundary, chosen the same way the server chooses it. A throw
+    // from a loader is a page that cannot render, and rendering the boundary is
+    // what this application has instead of a 500.
+    resolved = await resolveFailure(table, url, error);
+  }
+
+  const { App } = options;
+  // An element, and never `document` — which is the other difference from
+  // `hydrate` above. `hydrateRoot` takes a document, because an app whose root
+  // layout renders `<html>` owns the whole of one and the server wrote it;
+  // `createRoot` does not, because creating a root *is* replacing the
+  // container's children and the container here would be the document. The
+  // shell always writes this element, so its absence means the document being
+  // rendered into is not one this build produced.
+  const container = document.getElementById(ROOT_ID);
+  if (container == null) {
+    throw new Error(
+      `@uniflowed/router: no #${ROOT_ID} in this document, so there is nothing to render into. ` +
+        "A single-page build writes the shell that carries it; this document came from " +
+        "somewhere else.",
+    );
+  }
+  const tree = <App url={url} initial={resolved} />;
+  createRoot(container).render(
+    options.strictMode === true ? <StrictMode>{tree}</StrictMode> : tree,
+  );
 }

--- a/packages/router/server.js
+++ b/packages/router/server.js
@@ -465,6 +465,36 @@ function redirectDocument(error: RedirectError): RenderResult {
  * carried two of them, one in each place, and only one was where a browser
  * looks. Hoisting the rendered one leaves the metadata with a single source.
  */
+/**
+ * The document a single-page build writes, and the only one it writes.
+ *
+ * `app.rendering.modes: ["csr"]` renders no route at build time: the client
+ * router resolves and renders every one of them in the browser, so what the
+ * build has to leave behind is the *chrome* — the stylesheets, the module
+ * script, and the empty root the client renders into. That is exactly
+ * [`shellFor`]'s three strings with nothing between them, which is why this is
+ * three concatenations rather than a fourth shape of document to keep in step
+ * with the other three.
+ *
+ * No React runs. There is nothing to render: no URL has been asked for, and
+ * whatever this document is served for is decided by the host rather than by
+ * this build.
+ *
+ * # What it costs, said here because it is not visible from the file
+ *
+ * The document has no `<title>`, no `<meta name="description">` and no content.
+ * A crawler that runs no JavaScript sees an empty page for **every** URL, and a
+ * reader sees nothing until the bundle has loaded and the route has resolved.
+ * That is what a single-page application is, and it is why `modes: ["csr"]` is
+ * a declaration a project makes rather than something a build falls back to.
+ * A project that wants a document per route has `ssg`, and one that wants a
+ * document per request has `ssr`.
+ */
+export function shellDocument(assets: RenderAssets): string {
+  const shell = shellFor(assets);
+  return `${shell.open}${shell.body}${shell.close}`;
+}
+
 function shellFor(assets: RenderAssets): DocumentShell {
   const head = headTags(assets);
   return {

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -423,6 +423,30 @@ async function preview() {
   if (handle != null) {
     server.middlewares.use(answer(server));
   }
+  // The rewrite rule a single-page deployment needs, in the one place uf can
+  // apply one. A `["csr"]` build writes `index.html` and nothing else that is a
+  // page, so a file server answers `/` and 404s every other URL — and this
+  // preview exists to be believed about the deployment. A host serving that
+  // build has to send unmatched paths to the shell, so a preview that did not
+  // would be right about a deployment nobody is doing.
+  //
+  // Behind the static middleware, which is what makes it a *fallback*: a real
+  // file still wins, so `/assets/client.js` is still the chunk and not the
+  // shell. And `Accept: text/html` only, so a `fetch` for a missing JSON file
+  // gets a 404 rather than a document — the failure mode of a fallback that
+  // answers everything is a parse error two layers away from the missing file.
+  if (flag("--spa-fallback")) {
+    const shell = path.resolve(root, inline.build.outDir, "index.html");
+    server.middlewares.use((request, response, next) => {
+      if (request.method !== "GET" && request.method !== "HEAD") return next();
+      if (!(request.headers.accept ?? "").includes("text/html")) return next();
+      if (!existsSync(shell)) return next();
+      response.statusCode = 200;
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.end(request.method === "HEAD" ? undefined : readFileSync(shell));
+      return undefined;
+    });
+  }
 
   const urls = server.resolvedUrls ?? { local: [], network: [] };
   emit("listening", {
@@ -657,11 +681,50 @@ async function build() {
   // host would then serve uf's error page to every visitor who mistyped a URL,
   // and nothing between the throw and the deploy would have mentioned it.
   let attempted = pages.length;
+  // The single-page build's whole output, written here because it is the one
+  // document this build has and the loop above had no route to write it for.
+  //
+  // Twice, to two names, and the second is the load-bearing one. `index.html`
+  // is what a host serves for `/`; `404.html` is what a static host serves for
+  // every path it has no file for, which under this plan is *every other URL
+  // in the application*. Without it a deployment of `dist/` answers `/` and
+  // 404s `/orders` — a build with a hole in it, found from a 404, which is the
+  // failure ubugeeei-prod/uf#336 is about wearing a different hat.
+  //
+  // It is still the host's rewrite rule that makes this correct, and the two
+  // files are what uf can do without one: a host with a proper SPA fallback
+  // serves `index.html` and never looks at `404.html`, and a host with only an
+  // error document (Pages, Netlify, an S3 bucket) serves `404.html` and gets
+  // the same bytes with a 404 status — which is the right status for a URL
+  // this application does not have, and the not-found boundary is what the
+  // browser then renders into it.
+  if (prerender === "shell") {
+    const html = server.shellDocument(assets);
+    for (const [file, url, status] of [
+      ["index.html", "/", 200],
+      ["404.html", "/404", 404],
+    ]) {
+      const target = path.join(outDir, file);
+      writeFileSync(target, html);
+      attempted += 1;
+      emit("page", {
+        url,
+        file: path.relative(root, target),
+        status,
+        bytes: Buffer.byteLength(html),
+      });
+    }
+  }
   // Not for a build that prerenders nothing. `404.html` is a file a static
   // host serves for every path it has no file for, and a project whose
   // `rendering.modes` allows only `ssr` has no such host: its not-found
   // boundary is rendered per request, by the server, with the right status.
-  if (prerender !== "nothing" && server.notFound.some((boundary) => boundary.path === "/")) {
+  //
+  // Nor for a shell build, which has just written its own: the boundary this
+  // would render is one the *browser* renders in that plan, and a document
+  // holding the framework's 404 markup would be served in place of the shell
+  // for every URL the host could not match.
+  else if (prerender !== "nothing" && server.notFound.some((boundary) => boundary.path === "/")) {
     attempted += 1;
     // `/404` rather than `/__uf_not_found__`: the internal path is how the
     // router is asked, and the file the reader is looking for is `404.html`.
@@ -1536,6 +1599,15 @@ function readManifest(outDir) {
 async function renderingPlan(server, prerender) {
   const urls = [];
   const perRequest = [];
+
+  // One document, and it is no route's, so there is no route to ask anything
+  // about. `perRequest` is empty rather than "every route": nothing here is
+  // left for a server — the browser answers all of it — and listing routes
+  // under a heading that means "these need a process" would be a build
+  // describing itself wrongly to `uf`, which prints that list.
+  if (prerender === "shell") {
+    return { urls: [], perRequest: [] };
+  }
 
   // Nothing is prerendered and nothing is refused, so no page module is
   // loaded: a project that renders everything per request should not pay for

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -142,6 +142,13 @@ export default function uniflowed(options = {}) {
   // at. Anything but `"document"` is the client router, which is what every
   // project that has not heard of the key has.
   const navigation = app.rendering?.navigation === "document" ? "document" : "client";
+  // Whether this application starts by attaching to markup or by rendering
+  // into an empty root. `["csr"]` is the only list that means the second, and
+  // `uf` refuses that value beside any other while the config is read — so the
+  // question here is "is it in the list", not "is it the only thing in it",
+  // and a driver started by hand on a config `uf` never validated gets the same
+  // answer for the same reason a project would want.
+  const mount = (app.rendering?.modes ?? []).includes("csr") ? "render" : "hydrate";
 
   const accessibility = ufConfig.accessibility ?? {};
 
@@ -151,6 +158,7 @@ export default function uniflowed(options = {}) {
       appEntry,
       strictMode,
       navigation,
+      mount,
       command: options.command,
       accessibility,
     }),
@@ -165,7 +173,15 @@ export default function uniflowed(options = {}) {
   ];
 }
 
-function flowPlugin({ routerRoot, appEntry, strictMode, navigation, command, accessibility }) {
+function flowPlugin({
+  routerRoot,
+  appEntry,
+  strictMode,
+  navigation,
+  mount,
+  command,
+  accessibility,
+}) {
   let root = process.cwd();
   let isProduction = false;
   /**
@@ -373,6 +389,7 @@ function flowPlugin({ routerRoot, appEntry, strictMode, navigation, command, acc
         return clientModuleSource(entryPath, {
           strictMode: strictMode && !isProduction,
           navigation,
+          mount,
         });
       }
       if (id === resolved(VIRTUAL.server)) return serverModuleSource(entryPath);
@@ -702,6 +719,30 @@ function flowPlugin({ routerRoot, appEntry, strictMode, navigation, command, acc
                 return true;
               }
               if (notDocument != null) return false;
+
+              // A single-page project's deployment answers every navigation
+              // with the same empty shell, so this does too. Rendering the
+              // route here instead would have been the better-looking dev
+              // server and the wrong one: a page that only works because the
+              // server rendered it would work all through development and be
+              // blank the day it shipped. It is the same argument
+              // `app.rendering.navigation` makes about a link, one level up.
+              //
+              // The three steps above still ran — the guard, the action, the
+              // handler — and each of them is something `uf build` refuses in
+              // a `["csr"]` project by name. A dev server that skipped them
+              // would hide the very thing the build is going to stop.
+              if (mount === "render") {
+                response.statusCode = 200;
+                response.setHeader("content-type", "text/html; charset=utf-8");
+                const shell = entry.shellDocument({
+                  scripts: [devUrlFor(VIRTUAL.client)],
+                  styles: [],
+                  preloads: [],
+                });
+                response.end(await devServer.transformIndexHtml(url, shell));
+                return true;
+              }
 
               const result = await entry.render(
                 url,

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -818,16 +818,33 @@ export default routes;
  * `navigation: "client"`, so the module a default project gets is byte for
  * byte the one it got before this option existed.
  *
+ * # And whether it hydrates at all
+ *
+ * `mount` is the third generated constant and the one that changes which
+ * function is imported. A `["csr"]` build wrote one shell with an empty root,
+ * so there is no markup to attach to and `render` is what starts the
+ * application; every other build has markup, and `hydrate` attaches to it.
+ *
+ * One import or the other, rather than one import and a branch, because they
+ * are two different React entry points: a bundle that mounts by hydrating has
+ * no reason to carry `createRoot`, and a bundle that renders has none to carry
+ * `hydrateRoot`. Which one is in the module decides which one is in the build.
+ *
  * @param {string} appEntry the project's `app.js`, as an import specifier
- * @param {{ strictMode?: boolean, navigation?: "client" | "document" }} [options]
+ * @param {{
+ *   strictMode?: boolean,
+ *   navigation?: "client" | "document",
+ *   mount?: "hydrate" | "render",
+ * }} [options]
  */
 export function clientModuleSource(appEntry, options = {}) {
   const strictMode = options.strictMode === true ? ", strictMode: true" : "";
   const navigation = options.navigation === "document" ? ', navigation: "document"' : "";
-  return `import { hydrate } from "@uniflowed/router/client";
+  const mount = options.mount === "render" ? "render" : "hydrate";
+  return `import { ${mount} } from "@uniflowed/router/client";
 import { routes, notFound, errors } from ${JSON.stringify(VIRTUAL.routes)};
 import App from ${JSON.stringify(appEntry)};
-hydrate({ App, routes, notFound, errors${strictMode}${navigation} });
+${mount}({ App, routes, notFound, errors${strictMode}${navigation} });
 `;
 }
 
@@ -862,6 +879,12 @@ hydrate({ App, routes, notFound, errors${strictMode}${navigation} });
  * a host is one or the other: a server streams, a build writes files. See the
  * header of `packages/router/server.js` for why React needs both told apart.
  *
+ * `shellDocument` is the third and is neither: it renders no route, because a
+ * `["csr"]` build has none to render at build time. It is re-exported straight
+ * from the router rather than closed over the table, which says the true thing
+ * about it — the shell is a function of the assets alone, and the route table
+ * has nothing to do with a document that is no route's.
+ *
  * `beginRequest` is the fourth, and it is re-exported rather than imported by
  * the host for a reason that is easy to get wrong: `@uniflowed/server` keeps
  * the request in an `AsyncLocalStorage` held by *its module*, and a bundled
@@ -893,6 +916,7 @@ export { beginRequest } from "@uniflowed/router/server";
 const renderer = createRenderer({ App, routes, notFound, errors });
 export const render = renderer.render;
 export const prerender = renderer.prerender;
+export { shellDocument } from "@uniflowed/router/server";
 export const dispatch = createDispatcher({ handlers });
 export const callAction = createActionDispatcher({ actions });
 export const runMiddleware = createMiddlewareRunner({ middleware });

--- a/tests/library/single-page.test.js
+++ b/tests/library/single-page.test.js
@@ -1,0 +1,250 @@
+// @flow
+//
+// `app.rendering.modes: ["csr"]`: one shell, and the browser renders the rest.
+//
+// Every other rendering plan writes markup somewhere — a build writes a
+// document per route, a server writes one per request — and the browser's job
+// is to attach to it. This one writes a document that is no route's: the
+// stylesheets, the module script, and an empty root. So the two halves below
+// are the two things that have no counterpart anywhere else in uf.
+//
+// **The shell.** It has to be empty, and "empty" is an assertion rather than an
+// observation: a shell that accidentally carried a route's markup would be a
+// document served for *every* URL with one route's content baked into it, and
+// the only symptom is the wrong page appearing for a moment on every other one.
+//
+// **The mount.** `render` rather than `hydrate`, because hydration is React
+// comparing what it renders against markup a server sent and there is none.
+// The tests below are written from the shell outwards for that reason: the
+// document a test starts from is the one `shellDocument` produced, so what is
+// being proved is that the two halves of this plan fit each other rather than
+// that each half does what its own comment says.
+
+import * as React from "@uniflowed/react";
+import { useState } from "@uniflowed/react";
+import { act, cleanup, userEvent } from "@uniflowed/react-testing";
+import { afterEach, describe, expect, it } from "@uniflowed/test";
+
+import { installDom } from "../../packages/react-testing/internal/dom.js";
+import { installNavigation, redirect, routerView } from "../../packages/router/internal/runtime.js";
+import { clientModuleSource } from "../../packages/vite/internal/routes.js";
+
+// ---------------------------------------------------------------------------
+// The generated entry
+// ---------------------------------------------------------------------------
+
+describe("the client entry a single-page build gets", () => {
+  it("hydrates by default, which is what every other plan wants", () => {
+    const source = clientModuleSource("/app.js");
+
+    expect(source).toContain('import { hydrate } from "@uniflowed/router/client";');
+    expect(source).not.toContain("render(");
+  });
+
+  it("renders when the build wrote a shell", () => {
+    const source = clientModuleSource("/app.js", { mount: "render" });
+
+    // One import or the other, rather than one import and a branch: which
+    // function is in the module decides whether `createRoot` or `hydrateRoot`
+    // is in the bundle.
+    expect(source).toContain('import { render } from "@uniflowed/router/client";');
+    expect(source).not.toContain("hydrate");
+    expect(source).toContain("render({ App, routes, notFound, errors });");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The shell, and what renders into it
+// ---------------------------------------------------------------------------
+
+async function clientModule() {
+  installDom();
+  return import("@uniflowed/router/client");
+}
+
+async function serverModule() {
+  installDom();
+  return import("@uniflowed/router/server");
+}
+
+const ASSETS = {
+  scripts: ["/assets/client.js"],
+  styles: ["/assets/app.css"],
+  preloads: [],
+};
+
+let built: mixed = null;
+
+function tables() {
+  if (built != null) {
+    return built;
+  }
+
+  component Home() {
+    const [count, setCount] = useState<number>(0);
+    return (
+      <section>
+        <h1>home</h1>
+        <output>{count}</output>
+        <button type="button" onClick={() => setCount(count + 1)}>
+          add one
+        </button>
+      </section>
+    );
+  }
+
+  component Missing() {
+    return <h1>nothing here</h1>;
+  }
+
+  const home = {
+    path: "/",
+    params: [],
+    mdx: false,
+    file: "app/_uf.page.js",
+    page: () => Promise.resolve({ default: Home }),
+    layouts: [],
+    loading: [],
+  };
+  const away = {
+    path: "/away",
+    params: [],
+    mdx: false,
+    file: "app/away/_uf.page.js",
+    // A loader that redirects, which on a server is a 307 before a byte is
+    // written and here has to become the browser's own navigation. It is an
+    // export of the page *module*, the way a project writes one, rather than a
+    // field on the route record.
+    page: () => Promise.resolve({ default: Home, loader: () => redirect("/") }),
+    layouts: [],
+    loading: [],
+  };
+  const notFound = [
+    {
+      path: "/",
+      mdx: false,
+      file: "app/_uf.not-found.js",
+      page: () => Promise.resolve({ default: Missing }),
+      layouts: [],
+    },
+  ];
+
+  built = { routes: [home, away], notFound };
+  return built;
+}
+
+/** Put the shell a `["csr"]` build writes into the live DOM, and go to `url`. */
+async function serveShell(url: string): Promise<string> {
+  const { shellDocument } = await serverModule();
+  const html = shellDocument(ASSETS);
+  globalThis.document.documentElement.innerHTML = html
+    .replace(/^[\s\S]*?<html[^>]*>/, "")
+    .replace(/<\/html>\s*$/, "");
+  globalThis.window.history.pushState(null, "", url);
+  return html;
+}
+
+async function renderHere(): Promise<void> {
+  const { render } = await clientModule();
+  const { routes, notFound } = tables();
+  await act(async () => {
+    await render({ App: routerView("./app"), routes, notFound, errors: [] });
+  });
+}
+
+function ufRoot(): Element | null {
+  return globalThis.document.getElementById("uf-root");
+}
+
+afterEach(() => {
+  if (globalThis.document == null) {
+    return;
+  }
+  cleanup();
+  globalThis.document.body.replaceChildren();
+  installNavigation("client");
+});
+
+describe("the shell a single-page build writes", () => {
+  it("carries the assets and an empty root", async () => {
+    const html = await serveShell("/");
+
+    expect(html).toContain('<link rel="stylesheet" href="/assets/app.css">');
+    expect(html).toContain('<script type="module" src="/assets/client.js"></script>');
+    // The assertion the whole plan rests on: nothing between the root's tags.
+    // A shell with a route's markup in it is served for every URL.
+    expect(html).toContain('<div id="uf-root"></div>');
+  });
+
+  it("says nothing a crawler could read, which is the cost", async () => {
+    // Written down as a test rather than only in the guide. A document with no
+    // title and no content is what `["csr"]` means, and the day it stops being
+    // true — because something started rendering into the shell — is a day
+    // this plan has quietly become a different one.
+    const html = await serveShell("/");
+
+    expect(html).not.toContain("<title>");
+    expect(html).not.toContain("home");
+  });
+});
+
+describe("rendering into it", () => {
+  it("renders the route and it is interactive", async () => {
+    await serveShell("/");
+    expect(ufRoot()?.textContent).toBe("");
+
+    await renderHere();
+
+    expect(ufRoot()?.textContent).toContain("home");
+    const button = ufRoot()?.querySelector("button");
+    if (button == null) {
+      throw new Error(`no button in:\n${ufRoot()?.innerHTML ?? "(no root)"}`);
+    }
+    await act(async () => {
+      await userEvent.click(button);
+    });
+    expect(ufRoot()?.querySelector("output")?.textContent).toBe("1");
+  });
+
+  it("renders the not-found boundary for a URL the application does not have", async () => {
+    // The ordinary arrival rather than the exception: a static host served this
+    // shell as its error document, so "nothing matched" is most of what this
+    // entry point sees.
+    await serveShell("/no-such-page");
+
+    await renderHere();
+
+    expect(ufRoot()?.textContent).toContain("nothing here");
+  });
+
+  it("hands a redirect from a loader to the browser", async () => {
+    // On a server this is a 307 before a byte is written. There is no response
+    // to put a status on here, so the same instruction has to reach the same
+    // browser a different way.
+    await serveShell("/away");
+    const replaced: Array<string> = [];
+    const location = globalThis.window.location;
+    const original = location.replace;
+    Object.defineProperty(location, "replace", {
+      configurable: true,
+      writable: true,
+      value: (to: string) => {
+        replaced.push(String(to));
+      },
+    });
+
+    try {
+      await renderHere();
+    } finally {
+      Object.defineProperty(location, "replace", {
+        configurable: true,
+        writable: true,
+        value: original,
+      });
+    }
+
+    expect(replaced).toEqual(["/"]);
+    // And nothing was rendered: the browser is leaving.
+    expect(ufRoot()?.textContent).toBe("");
+  });
+});


### PR DESCRIPTION
The complement of [#702](https://github.com/ubugeeei-prod/uf/pull/702), on the other axis. Where `navigation: "document"` keeps
every document and takes the router away, this keeps the router and takes every
document away.

## The design decision: a `RenderingMode`, unlike MPA

MPA was not a rendering mode because it does not answer "where does a document
come from". SPA **is**, and it is the answer uf's list did not have: the
document is a shell, and the route is rendered in the browser. So it is
`RenderingMode::Csr`, selected by `RenderingPlan` as a fourth `Prerender` —
`Shell`.

It is the one value that **cannot share the list**, and that is a property of
the value rather than an exception carved for it. The others answer the question
*per route*, which is what makes a list of them a set the build picks from; this
one answers it for the whole application with a document that belongs to no
route, and once it is chosen there is no per-route decision left to make.
`["csr", "ssg"]` therefore has two honest readings — "prerender what you can and
fall back to the shell" and "the shell, and never mind the rest of the list" —
which are different applications, so it is refused rather than resolved by
precedence. `csr` beside `build.staticBuild` is refused too, and in its own
words: the `ssg` rule would otherwise have told a single-page project to add
`"ssg"` to its list, which is advice to build a different application.

It is also the only value **not in the default list**. A build that decided to
be a single-page application because nothing forbade it would be the largest
semantic change a default has ever made.

## What the build writes

One document, twice:

| File | What serves it |
| --- | --- |
| `index.html` | the host, for `/` |
| `404.html` | the host, for every path it has no file for |

The second is the load-bearing one. Under this plan `/orders` has no file, so a
plain static host would 404 it — a `dist/` with a hole in it, which is
[#336](https://github.com/ubugeeei-prod/uf/issues/336) wearing a different hat.
Writing the shell as the error document covers every host that has one, and the
404 status it comes with is the right status for a URL this application does not
have; the not-found boundary is what the browser then renders into it. A host
with a proper SPA rewrite serves `index.html` and never looks at `404.html`.

`uf preview` applies that rewrite itself, behind the static middleware and for
`Accept: text/html` only. Without it the preview would 404 every path but `/` on
a build a configured host serves completely — a preview that is wrong about the
deployment, which is the one thing that command must not be. It is a new driver
flag (`--spa-fallback`) rather than an inference from `--static-build`, because
a `staticBuild` project has a document per route and *wants* the 404;
`docs/architecture.md`'s builder contract is updated.

## `render`, not `hydrate`

`hydrateRoot` against an empty container is a mismatch on the first node of
every page: React would report it, throw the shell away and render from
scratch — which is `createRoot` with a warning in front of it. So
`@uniflowed/router/client` gains `render`, and the generated entry imports one
function or the other. That is also what keeps `createRoot` out of every other
build's bundle and `hydrateRoot` out of this one.

Three things follow and each is handled rather than omitted: the loader runs in
the browser, a URL that matches nothing renders the not-found boundary (the
ordinary arrival here, since the host served this shell as its error document),
and a `redirect()` from a loader becomes `location.replace`.

**`uf dev` serves the shell too.** Rendering the route there would have been the
better-looking dev server and the wrong one: a page that only works because the
server rendered it would work all through development and be blank the day it
shipped. The guard, the action and the handler still run in dev — each is
something the build is about to refuse by name, and a dev server that skipped
them would hide it.

## The refusal, from `uf_rsc`

> a route that needs a server must be refused at build time with a message
> naming the route

Every other plan finds these by *trying*: a prerender calls `cookies()` where
there is no request and fails with the route named. This plan renders nothing,
so the same page would build cleanly, deploy cleanly, and fail in a browser.

`crates/uf_rsc` already answers "is this reachable from here" for server-only
imports, so `commands::build::spa` walks that graph rather than inventing a
second one — the same question with the halves swapped, because under `csr` the
server graph *is* the browser's. Four things count: a `_uf.route.js`, a
`_uf.middleware.js`, a callable server action (already refused by
`refuse_unanswerable_actions`, since this plan emits no server — repeating it
would report one fault twice with two fixes), and any module the application
reaches that imports `@uniflowed/server`, `@uniflowed/db` or `server-only`, or
is named `*.server.js`.

Dead code does not count: a module nothing imports is a refusal whose only fix
is deleting a file the project was not using. A module no page reaches — a
layout, most often, because no page imports the layout it renders inside — is
reported by its file rather than under a route it does not belong to.

Unlike the server-action refusal, `--adapter` and `--compile` do **not** lift
this one. `staticBuild` is a claim about the artefact, so a build that also
emits a server has honoured it; `modes: ["csr"]` is a claim about the *routes* —
that every one is rendered in a browser — and that stays true inside a Worker.

## The honest limit

The shell has no `<title>`, no description and no content: a crawler that runs
no JavaScript sees an empty page for every URL, and the loader runs after the
bundle has loaded, which is a round trip after a round trip. That is what a
single-page application is. It is in the guide under a heading of its own, and
`single-page.test.js` asserts it — the day something starts rendering into the
shell is the day this plan has quietly become a different one.

## Tests

- `crates/uf_config/src/rendering/tests.rs` — `["csr"]` selects `Shell` and no
  server; it is not in the default list; it is refused beside each of the other
  four modes and beside `staticBuild`, in its own words.
- `crates/uf_cli/src/commands/build/spa/tests.rs` — a loader that reads the
  request through a helper is named with its route; the refusal quotes the
  setting; a project that reads no request builds; dead code is not a refusal;
  `*.server.js` counts; a layout is reported by its file; a handler and a
  middleware are both refused, the middleware by the subtree it guards.
- `crates/uf_cli/tests/vite.rs` — a real `["csr"]` build writes an *empty*
  shell to both names, leaves no server bundle, and says what it did; a real
  project whose page imports `@uniflowed/server` is refused before the bundle
  with the route named.
- `tests/library/single-page.test.js` — the generated entry imports `render` and
  not `hydrate`; the shell carries the assets and an empty root and nothing a
  crawler could read; rendering into it produces an interactive route, a
  not-found boundary for an unknown URL, and a `location.replace` for a
  redirecting loader.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p uf_config` — 104 passed; `-p uf_cli --lib` 454 passed; the two
  new `tests/vite.rs` cases pass. One pre-existing failure in that file,
  `compile_refuses_a_native_addon_and_names_it`, reproduces on `main` with this
  branch stashed (it cannot resolve `@uniflowed/vite` from its temp fixture) and
  is unrelated.
- `uf run test:lib` — 2741 passed, 0 failed, 1 skipped (81 files), rebased onto
  `main` after #702 and #703 landed
- `uf fmt --check`, `uf lint` (0 errors), `docs:build` and the docs link check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791522720&installation_model_id=422833&pr_number=706&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F706&signature=2cc7b6a0193808e667bd97bf69f735cbd50fc1e5887e3e747769eab6fb760b21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->