### PR TITLE
feat(upstream, check): patches the sync applies, and the inference fix one was waiting for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,11 @@ jobs:
       # It reads the two files rather than asking npm to regenerate one, so
       # nothing but these cases says it works.
       - run: ./target/release/uf run lockfile:test
+      # And that the patch step in `tools/upstream/sync.sh` still refuses every
+      # way a patch to the Flow port could go missing. It is the one check here
+      # whose subject fails silently: a dropped patch to a type checker
+      # compiles, passes, and changes what `uf check` answers.
+      - run: ./target/release/uf run upstream:patches:test
       # And that every shell script in the repository parses under the shell
       # this runner uses. `uf@0.0.0-alpha.8` published all seventeen packages
       # and the release was reported as failed, over a `verify-npm.sh` that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,15 @@ instead of the full 190 MB repository. `uf_flow` builds against that port,
 which is not published to crates.io. The sync is idempotent, so re-run it after
 pulling a submodule bump — `uf run setup` does.
 
+It then applies `tools/upstream/patches/flow` on top, so **a checkout is the
+pinned commit plus those patches** — fixes to the port that uf needs and
+`facebook/flow` has not taken yet. `upstream/flow` shows as modified in
+`git status` for that reason; never commit the submodule pointer in that state.
+The sync owns that work tree and restores it whenever it finds a change no
+patch accounts for, so snapshot an edit made directly in `upstream/flow` into a
+patch file before running anything that syncs. That directory's README is the
+whole procedure for adding, refreshing and deleting one.
+
 ## Commit Style
 
 Use focused conventional commits, for example:

--- a/README.md
+++ b/README.md
@@ -411,9 +411,10 @@ dependency, so cargo cannot build `uf` until the submodule is checked out, and
 `uf run` needs a built `uf`.
 
 `tools/upstream/sync.sh` checks out only `rust_port/` from a shallow, blobless
-clone of Meta's official Flow Rust port, which is not published to crates.io.
-Nothing builds without it: `uf` parses and type-checks Flow with that port and
-has no second backend.
+clone of Meta's official Flow Rust port, which is not published to crates.io,
+and applies `tools/upstream/patches/flow` on top — fixes uf needs that
+`facebook/flow` has not taken yet. Nothing builds without it: `uf` parses and
+type-checks Flow with that port and has no second backend.
 
 `rust-toolchain.toml` pins `nightly-2026-08-01`. That is a requirement rather
 than a preference — 23 crates in the port declare `#![feature(box_patterns)]`,

--- a/crates/uf_check/tests/known_bugs.rs
+++ b/crates/uf_check/tests/known_bugs.rs
@@ -8,8 +8,10 @@
 //! cargo test -p uf_check --test known_bugs -- --ignored
 //! ```
 //!
-//! When one is fixed, delete the `#[ignore]`. When all of them are, delete the
-//! file — its job is to be empty.
+//! When one is fixed, delete the `#[ignore]` — and if the fix is a patch to the
+//! port, move the test to `crates/uf_check/tests/upstream_patches.rs`, which is
+//! where a test that pins a patch lives. When all of them are gone, delete this
+//! file: its job is to be empty.
 //!
 //! The defects below are not `uf`'s. This crate is an embedding: it hands
 //! Flow's own inference a source and converts the diagnostics back, and it owns
@@ -29,25 +31,16 @@
 //! That rules out an alternative that would otherwise be open: the Rust port
 //! being an unfaithful port. It is faithful here. The typing rule is what is
 //! wrong, in Flow, in both of its implementations — so the fix belongs in
-//! Meta's repository and nowhere in this one.
+//! Meta's repository.
 //!
-//! It cannot be fixed here, and it must not be fixed in `upstream/flow` either:
-//! that submodule is checked out fresh by `tools/upstream/sync.sh`, which has
-//! no patch step, so a diff in it is deleted by the next sync. The change
-//! belongs upstream in Meta's repository, and these tests are what says when it
-//! has arrived.
-//!
-//! # ubugeeei-prod/uf#205: `match` over a generic union
-//!
-//! The shape of that change was measured rather than guessed. Letting a
-//! `GenericT` reach the match-argument collector is necessary but not
-//! sufficient: on its own it makes `match (x: T)` over `T extends "a" | "b"`
-//! report `match-not-exhaustive` and both literal arms unused, because the
-//! exhaustiveness analysis then has an opaque value where it used to have the
-//! bound's members. The analysis has to keep unwrapping the variable and the
-//! *value union* has to remember it, so that `ValueUnion::to_type` — which is
-//! also what a pattern binding's type comes from — can wrap it back up. That
-//! is the same unwrap/filter/re-wrap `predicate_kit` already does for `switch`.
+//! Until it lands there it can be carried here, which is the one thing that
+//! changed since this file was written: `tools/upstream/patches/flow` is
+//! applied to the submodule by `tools/upstream/sync.sh` on every checkout, and
+//! that directory's README says how a patch is added, refreshed and — the part
+//! that matters — deleted. **ubugeeei-prod/uf#205 left this file that way**:
+//! its reproductions pass now, and they live in
+//! `crates/uf_check/tests/upstream_patches.rs` beside the patch that fixes
+//! them. What is left below is the defect no patch has been written for.
 //!
 //! # ubugeeei-prod/uf#300: a spread in a conditional type's tuple pattern
 //!
@@ -133,104 +126,6 @@ fn assert_clean(path: &str, source: &str) {
             .iter()
             .map(|diagnostic| (diagnostic.code, diagnostic.message_text()))
             .collect::<Vec<_>>()
-    );
-}
-
-/// The control for ubugeeei-prod/uf#205: reading the same tag with `switch`.
-///
-/// Not ignored, because it passes. It is here so that a change which "fixes"
-/// `match` by making both of them lose the type variable cannot pass as a fix.
-#[test]
-fn switch_over_a_generic_union_refines_the_payload_to_the_type_variable() {
-    assert_clean(
-        "with_switch.js",
-        concat!(
-            "// @flow\n",
-            "type Box<out T> =\n",
-            "  | { readonly kind: \"one\", readonly value: T }\n",
-            "  | { readonly kind: \"none\" };\n",
-            "\n",
-            "export function withSwitch<T, U>(box: Box<T>, change: (T) => U): ?U {\n",
-            "  switch (box.kind) {\n",
-            "    case \"one\":\n",
-            "      return change(box.value);\n",
-            "    default:\n",
-            "      return null;\n",
-            "  }\n",
-            "}\n",
-        ),
-    );
-}
-
-/// ubugeeei-prod/uf#205 — a `match` object pattern over a generic container
-/// binds the payload as `mixed`, where `switch` on the same tag binds it as
-/// the type variable.
-///
-/// `change(value)` is rejected with "unknown [1] is incompatible with empty
-/// [2]": `unknown` is how Flow prints `mixed`, and `empty` is the lower bound
-/// of the `T` in `change`'s parameter. Both are what a `GenericT` decays to
-/// once its identity has been dropped and only its bounds are left.
-///
-/// The identity is dropped when the subject is turned into the value union
-/// that drives exhaustiveness. `Root::MatchCaseRoot` resolves a case's bindings
-/// through `exhaustive::filter_by_pattern_union`
-/// (`upstream/flow/rust_port/crates/flow_typing/src/env_resolution.rs:1340`),
-/// whose `value_union_builder::of_type_inner`
-/// (`.../flow_typing_utils/src/exhaustive.rs:931`) concretizes each member with
-/// `ConcretizeForMatchArg`. That concretization has no rule for `GenericT`, so
-/// it falls through to the generic-erasing catch-all
-/// (`.../flow_typing_flow_js/src/flow_js/dispatch.rs:9439`) — which sits above
-/// the arm that collects a match argument, at 10314 — and the collector
-/// receives the bound. `ValueUnion::to_type` then rebuilds a type out of what
-/// survived, and `T` is not in it.
-///
-/// `switch` refines through `predicate_kit` instead, and that path *does* have
-/// the rule: `concretize_and_run_predicate`
-/// (`.../flow_typing_utils/src/predicate_kit.rs:269`) unwraps a `GenericT` at
-/// line 288, runs the predicate against the bound, and wraps every surviving
-/// type back up in the same generic. That asymmetry is the whole bug.
-#[test]
-#[ignore = "ubugeeei-prod/uf#205, upstream — `flow check` 0.330.0 agrees with uf"]
-fn match_over_a_generic_union_binds_the_payload_as_the_type_variable() {
-    assert_clean(
-        "with_match.js",
-        concat!(
-            "// @flow\n",
-            "type Box<out T> =\n",
-            "  | { readonly kind: \"one\", readonly value: T }\n",
-            "  | { readonly kind: \"none\" };\n",
-            "\n",
-            "export function withMatch<T, U>(box: Box<T>, change: (T) => U): ?U {\n",
-            "  return match (box) {\n",
-            "    {kind: \"one\", value: const value} => change(value),\n",
-            "    _ => null,\n",
-            "  };\n",
-            "}\n",
-        ),
-    );
-}
-
-/// ubugeeei-prod/uf#205, smaller than the report: neither the union nor the
-/// object is needed.
-///
-/// A single-arm `match` that binds the subject itself loses `T` the same way,
-/// which is what says the defect is in how a pattern's subject is turned into a
-/// value union rather than in object patterns or in tag refinement. Kept
-/// alongside the filed reproduction because it is the one to fix against: it
-/// reaches the same code with nothing else in the way.
-#[test]
-#[ignore = "ubugeeei-prod/uf#205, upstream — `flow check` 0.330.0 agrees with uf"]
-fn match_binding_a_bare_generic_subject_keeps_the_type_variable() {
-    assert_clean(
-        "bare_generic.js",
-        concat!(
-            "// @flow\n",
-            "export function apply<T, U>(value: T, change: (T) => U): U {\n",
-            "  return match (value) {\n",
-            "    const bound => change(bound),\n",
-            "  };\n",
-            "}\n",
-        ),
     );
 }
 

--- a/crates/uf_check/tests/upstream_patches.rs
+++ b/crates/uf_check/tests/upstream_patches.rs
@@ -1,0 +1,170 @@
+//! What `tools/upstream/patches/flow` buys, and what a dropped patch costs.
+//!
+//! Every patch in that directory has a test here. It is the other half of the
+//! mechanism: the sync makes a patch impossible to skip, and these say what
+//! the answers would be if one were. They pass, and a patch that stops being
+//! applied turns them red rather than quietly changing what `uf check` says.
+//!
+//! When a patch lands upstream and the submodule is bumped past it, the patch
+//! file goes and **these tests stay** — they are what proves the fix survived
+//! the bump.
+//!
+//! ```sh
+//! cargo test -p uf_check --test upstream_patches
+//! ```
+//!
+//! # 0001: a match argument keeps its type variable
+//!
+//! ubugeeei-prod/uf#205. `match (box) { {kind: "one", value: const value} =>
+//! change(value) }` over a `Box<out T>` bound `value` as `mixed` — printed as
+//! `unknown` — where `switch` on the same tag bound it as `T`. `change(value)`
+//! was then rejected with "unknown [1] is incompatible with empty [2]": both
+//! sides of that are a type variable reduced to its bounds.
+//!
+//! The identity was dropped when the subject became the value union that
+//! drives exhaustiveness. `value_union_builder::of_type_inner` concretizes
+//! each member with `ConcretizeForMatchArg`, and `handle_generic`
+//! (`flow_typing_flow_js/src/flow_js/helpers.rs`) lists three concretization
+//! kinds and not that one — so a `GenericT` fell through to the
+//! generic-erasing catch-all in `dispatch.rs`, which sits *above* the arm that
+//! collects a match argument. `switch` worked, and this is the whole
+//! asymmetry, because its collector sits *below* that catch-all and
+//! `predicate_kit::concretize_and_run_predicate` unwraps the variable, filters
+//! the bound and wraps every survivor back up.
+//!
+//! Letting a `GenericT` reach the collector is necessary and not sufficient,
+//! which is what `match_over_a_bounded_type_variable_is_still_exhaustive`
+//! below is here to say: with only the `dispatch.rs` arm, that test reports
+//! `match-not-exhaustive` with both literal arms unused, because the
+//! exhaustiveness analysis then has an opaque value where it used to have the
+//! bound's members. So the patch also teaches the value union to remember the
+//! variable it unwrapped, and `ValueUnion::to_type` — which is where a pattern
+//! binding's type comes from — to wrap it back up.
+//!
+//! Both of these were measured against `flow` itself before the patch was
+//! written: `flow-bin@0.330.0`, the release `upstream/flow` is pinned to,
+//! reported the same diagnostics as `uf check` through `flow focus-check`. The
+//! defect is Flow's typing rule rather than an unfaithful port, which is why
+//! the patch is a stopgap and the fix belongs in Meta's repository.
+
+#![cfg(feature = "upstream-typecheck")]
+
+use uf_check::{CheckLimits, Source, TypeDiagnostic, check_source};
+
+/// Tests must not race the wall clock; a loaded CI box is not a type error.
+fn check(path: &str, source: &str) -> Vec<TypeDiagnostic> {
+    check_source(
+        Source::new(path, source),
+        &[],
+        &CheckLimits::default().without_timeout(),
+    )
+    .expect("the checker runs")
+}
+
+fn assert_clean(path: &str, source: &str) {
+    let diagnostics = check(path, source);
+
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics, got {:#?}",
+        diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.code, diagnostic.message_text()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// 0001 — the reproduction ubugeeei-prod/uf#205 was filed with.
+#[test]
+fn match_over_a_generic_union_binds_the_payload_as_the_type_variable() {
+    assert_clean(
+        "with_match.js",
+        concat!(
+            "// @flow\n",
+            "type Box<out T> =\n",
+            "  | { readonly kind: \"one\", readonly value: T }\n",
+            "  | { readonly kind: \"none\" };\n",
+            "\n",
+            "export function withMatch<T, U>(box: Box<T>, change: (T) => U): ?U {\n",
+            "  return match (box) {\n",
+            "    {kind: \"one\", value: const value} => change(value),\n",
+            "    _ => null,\n",
+            "  };\n",
+            "}\n",
+        ),
+    );
+}
+
+/// 0001 — the same defect with nothing else in the way.
+///
+/// Neither the union nor the object is needed: a single-arm `match` that binds
+/// the subject itself lost `T` too, which is what said the defect was in how a
+/// pattern's subject becomes a value union rather than in object patterns or
+/// in tag refinement. It is the smallest thing the patch has to keep working.
+#[test]
+fn match_binding_a_bare_generic_subject_keeps_the_type_variable() {
+    assert_clean(
+        "bare_generic.js",
+        concat!(
+            "// @flow\n",
+            "export function apply<T, U>(value: T, change: (T) => U): U {\n",
+            "  return match (value) {\n",
+            "    const bound => change(bound),\n",
+            "  };\n",
+            "}\n",
+        ),
+    );
+}
+
+/// 0001 — the half of the patch that is not the `dispatch.rs` arm.
+///
+/// A `match` over a type variable bounded by a union of literals has to stay
+/// exhaustive. An earlier attempt that only let the `GenericT` reach the
+/// collector made this report `match-not-exhaustive` with both literal arms
+/// unused, because the exhaustiveness analysis then holds an opaque value
+/// where it used to hold the bound's members.
+///
+/// So this is not a control that happens to pass: it is the assertion that
+/// the value union still unwraps the variable to analyse it, and only wraps
+/// it back up on the way to a binding.
+#[test]
+fn match_over_a_bounded_type_variable_is_still_exhaustive() {
+    assert_clean(
+        "exhaustive.js",
+        concat!(
+            "// @flow\n",
+            "export function name<T extends \"a\" | \"b\">(tag: T): string {\n",
+            "  return match (tag) {\n",
+            "    \"a\" => \"first\",\n",
+            "    \"b\" => \"second\",\n",
+            "  };\n",
+            "}\n",
+        ),
+    );
+}
+
+/// 0001 — `switch` on the same tag, which was never broken.
+///
+/// A patch that "fixed" `match` by making both of them lose the type variable
+/// would pass every test above. This is what stops that.
+#[test]
+fn switch_over_a_generic_union_refines_the_payload_to_the_type_variable() {
+    assert_clean(
+        "with_switch.js",
+        concat!(
+            "// @flow\n",
+            "type Box<out T> =\n",
+            "  | { readonly kind: \"one\", readonly value: T }\n",
+            "  | { readonly kind: \"none\" };\n",
+            "\n",
+            "export function withSwitch<T, U>(box: Box<T>, change: (T) => U): ?U {\n",
+            "  switch (box.kind) {\n",
+            "    case \"one\":\n",
+            "      return change(box.value);\n",
+            "    default:\n",
+            "      return null;\n",
+            "  }\n",
+            "}\n",
+        ),
+    );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,28 @@ Measured against `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`:
 reach outside `rust_port` into `lib/`, `prelude/`, and `tslib/`, so
 `tools/upstream/sync.sh` checks those out too and asserts they arrived.
 
+### Patches to the port
+
+A checkout of `upstream/flow` is the pinned commit **plus**
+`tools/upstream/patches/flow`. The sync applies every patch in that directory
+after checking the submodule out, so a fix uf needs and `facebook/flow` has not
+taken yet survives a re-sync instead of being deleted by it —
+[#205](https://github.com/ubugeeei-prod/uf/issues/205) was open on that gap
+alone, with a root cause and a working diff and nowhere to keep them, and
+[#707](https://github.com/ubugeeei-prod/uf/issues/707) is the mechanism.
+
+They are a stopgap with an expiry date, not a fork. The directory's README is
+the contract; the properties worth knowing here are that a patch which does not
+apply **stops the sync**, and therefore the build, and therefore every job. A
+patch quietly dropped from a type checker is otherwise invisible: nothing fails
+to compile, no test goes red, and `uf check` answers differently than it did
+yesterday. The sync also refuses a patch the pinned commit already contains,
+which is how the day it can be deleted announces itself.
+
+Each patch has a test in `crates/uf_check/tests/upstream_patches.rs` that fails
+without it, and `tools/upstream/test-patches.sh` covers the mechanism itself
+against every way a patch could go missing.
+
 The submodule costs one gate. `cargo-semver-checks` builds its baseline from a
 copy of each crate, outside the workspace, where the relative path to
 `upstream/flow` no longer resolves — and a path dependency is relative by

--- a/tools/upstream/patches/flow/0001-match-arg-keeps-its-type-variable.patch
+++ b/tools/upstream/patches/flow/0001-match-arg-keeps-its-type-variable.patch
@@ -1,0 +1,264 @@
+Subject: a match argument keeps its type variable instead of decaying to its bound
+
+Issue: ubugeeei-prod/uf#205
+Upstream: not filed with facebook/flow yet
+Submodule: 81b0c2a3dd591c66c51167aac341d851932bd9c5
+
+A `match` pattern binding over a generic container came out as `mixed` --
+printed as `unknown` -- where `switch` on the same tag came out as the type
+variable:
+
+    type Box<out T> = { readonly kind: "one", readonly value: T };
+    function f<T, U>(box: Box<T>, change: (T) => U): U {
+      return match (box) { {kind: "one", value: const value} => change(value) };
+    }
+    // error: Cannot call change with value bound to the first parameter
+    //        because unknown [1] is incompatible with empty [2].
+
+Both sides of that error are a type variable reduced to its bounds: `unknown`
+is `T`'s upper bound and `empty` is the lower bound of the `T` in `change`'s
+parameter.
+
+The identity is dropped when the subject becomes the value union that drives
+exhaustiveness. `value_union_builder::of_type_inner` concretizes each member
+with `ConcretizeForMatchArg`, and `handle_generic` (flow_js/helpers.rs) lists
+three concretization kinds and not that one -- so a `GenericT` falls through to
+the generic-erasing catch-all in dispatch.rs, which sits *above* the arm that
+collects a match argument. That is the whole asymmetry with `switch`, whose
+collector sits below the same catch-all: `predicate_kit` gets the `GenericT`,
+unwraps it, filters the bound and wraps every survivor back up.
+
+So the patch is three changes and not one, because the first alone is a
+regression:
+
+  * dispatch.rs collects a `GenericT` for `ConcretizeForMatchArg` above the
+    catch-all, the way the predicate collector below it already receives one.
+  * match_pattern_ir.rs gives `ValueUnion` a `generics` field -- the variables
+    its values were unwrapped out of -- and has `to_type`, which is where a
+    pattern binding's type comes from, wrap them back on.
+  * exhaustive.rs unwraps a `GenericT` in the builder, recording it there, and
+    carries the record through `filter_values_by_patterns`.
+
+With only the first, `match (tag: T)` over `T extends "a" | "b"` reports
+match-not-exhaustive with both literal arms unused, because the exhaustiveness
+analysis then holds an opaque value where it used to hold the bound's members.
+`crates/uf_check/tests/upstream_patches.rs` pins that case alongside the three
+this fixes, so the dead end is not rediscovered.
+
+Measured against `flow` itself before it was written: `flow-bin@0.330.0`, the
+release this submodule commit is pinned to, reports the same diagnostics as
+`uf check` through `flow focus-check`. The port is faithful here and Flow's
+typing rule is what is wrong, which is why this is a stopgap -- delete it when
+`facebook/flow` takes the fix and the submodule is bumped past it.
+
+diff --git a/rust_port/crates/flow_typing_flow_js/src/flow_js/dispatch.rs b/rust_port/crates/flow_typing_flow_js/src/flow_js/dispatch.rs
+index 4b4237f22..97516f1c0 100644
+--- a/rust_port/crates/flow_typing_flow_js/src/flow_js/dispatch.rs
++++ b/rust_port/crates/flow_typing_flow_js/src/flow_js/dispatch.rs
+@@ -9436,6 +9436,19 @@ fn __flow_impl<'cx>(
+             })));
+             continue_(cx, env, trace, &generic, cont)?;
+         }
++        // A match argument keeps its type variable, the way the predicate
++        // collector below already does: the exhaustiveness analysis unwraps it
++        // itself, and a pattern binding needs the variable back afterwards.
++        (
++            TypeInner::GenericT(..),
++            UseTInner::ConcretizeT(box ConcretizeTData {
++                kind: ConcretizationKind::ConcretizeForMatchArg { .. },
++                collector,
++                ..
++            }),
++        ) => {
++            collector.add(l.dupe());
++        }
+         (TypeInner::GenericT(box GenericTData { reason, bound, .. }), _) => {
+             let repos = helpers::reposition_reason(cx, env, None, reason, false, bound)?;
+             rec_flow(cx, env, trace, (&repos, u))?;
+diff --git a/rust_port/crates/flow_typing_loc_env/src/match_pattern_ir.rs b/rust_port/crates/flow_typing_loc_env/src/match_pattern_ir.rs
+index 2553c0b4c..5d40cfbd9 100644
+--- a/rust_port/crates/flow_typing_loc_env/src/match_pattern_ir.rs
++++ b/rust_port/crates/flow_typing_loc_env/src/match_pattern_ir.rs
+@@ -23,8 +23,10 @@ use flow_parser::loc::Loc;
+ use flow_parser_utils_output::js_layout_generator;
+ use flow_typing_type::type_::BigIntLiteral;
+ use flow_typing_type::type_::EnumConcreteInfo;
++use flow_typing_type::type_::GenericTData;
+ use flow_typing_type::type_::NumberLiteral;
+ use flow_typing_type::type_::Type;
++use flow_typing_type::type_::TypeInner;
+ 
+ pub type PatternAstList = Vec<(MatchPattern<ALoc, (ALoc, Type)>, /* guarded */ bool)>;
+ 
+@@ -1049,6 +1051,11 @@ pub mod value_union {
+         pub objects: FlowVector<value_object::ValueObject<'cx, CX>>,
+         pub enum_unknown_members: FlowVector<(Reason, LeafSet)>,
+         pub inexhaustible: FlowVector<Type>,
++        /// The type variables the values below were unwrapped out of,
++        /// outermost first. A `GenericT` has no structure to match on, so the
++        /// builder strips it and analyses its bound; `to_type` puts it back,
++        /// so a binding keeps the type variable instead of its bound.
++        pub generics: FlowVector<GenericTData>,
+     }
+ 
+     impl<'cx, CX: Clone> ValueUnion<'cx, CX> {
+@@ -1060,6 +1067,7 @@ pub mod value_union {
+                 objects: FlowVector::default(),
+                 enum_unknown_members: FlowVector::default(),
+                 inexhaustible: FlowVector::default(),
++                generics: FlowVector::default(),
+             }
+         }
+ 
+@@ -1071,6 +1079,7 @@ pub mod value_union {
+                 objects,
+                 enum_unknown_members,
+                 inexhaustible,
++                generics: _,
+             } = self;
+             leafs.is_empty()
+                 && tuples.is_empty()
+@@ -1091,6 +1100,7 @@ pub mod value_union {
+                 objects,
+                 enum_unknown_members,
+                 inexhaustible,
++                generics: _,
+             } = self;
+             leafs.is_empty()
+                 && tuples.is_empty()
+@@ -1108,6 +1118,7 @@ pub mod value_union {
+                 mut objects,
+                 mut enum_unknown_members,
+                 mut inexhaustible,
++                generics,
+             } = vu1;
+             let Self {
+                 leafs: leafs2,
+@@ -1116,6 +1127,7 @@ pub mod value_union {
+                 objects: objects2,
+                 enum_unknown_members: enum_unknown_members2,
+                 inexhaustible: inexhaustible2,
++                generics: generics2,
+             } = vu2;
+ 
+             leafs.extend(leafs2);
+@@ -1124,6 +1136,19 @@ pub mod value_union {
+             objects.append(objects2.into());
+             enum_unknown_members.append(enum_unknown_members2.into());
+             inexhaustible.append(inexhaustible2.into());
++            // Two sides under the same type variables stay under them. Two
++            // sides under different ones have no single variable to be under,
++            // and re-wrapping in either would name the wrong one, so the union
++            // of `{k: "a", v: T}` and `{k: "b", v: U}` keeps neither.
++            let generics = if generics == generics2 {
++                generics
++            } else if generics.is_empty() {
++                generics2
++            } else if generics2.is_empty() {
++                generics
++            } else {
++                FlowVector::default()
++            };
+             Self {
+                 leafs,
+                 tuples,
+@@ -1131,6 +1156,7 @@ pub mod value_union {
+                 objects,
+                 enum_unknown_members,
+                 inexhaustible,
++                generics,
+             }
+         }
+ 
+@@ -1142,6 +1168,7 @@ pub mod value_union {
+                 objects,
+                 enum_unknown_members,
+                 inexhaustible,
++                generics: _,
+             } = self;
+ 
+             //   let (tuples_exact, tuples_inexact) =
+@@ -1224,6 +1251,7 @@ pub mod value_union {
+                 objects,
+                 enum_unknown_members,
+                 inexhaustible,
++                generics,
+             } = self;
+ 
+             let all_possible_types: Vec<Type> = [
+@@ -1248,7 +1276,17 @@ pub mod value_union {
+             ]
+             .concat();
+ 
+-            type_util::union_of_ts(r, all_possible_types, None)
++            if all_possible_types.is_empty() {
++                return type_util::union_of_ts(r, all_possible_types, None);
++            }
++            let t = type_util::union_of_ts(r, all_possible_types, None);
++            // Innermost first, so the outermost variable ends up outermost.
++            generics.iter().rev().fold(t, |bound, generic| {
++                Type::new(TypeInner::GenericT(Box::new(GenericTData {
++                    bound,
++                    ..generic.clone()
++                })))
++            })
+         }
+ 
+         pub fn select(&self, cx: &CX, selector: &Selector<ALoc, ALoc>) -> Option<Self> {
+diff --git a/rust_port/crates/flow_typing_utils/src/exhaustive.rs b/rust_port/crates/flow_typing_utils/src/exhaustive.rs
+index 691e4baac..2463c81d6 100644
+--- a/rust_port/crates/flow_typing_utils/src/exhaustive.rs
++++ b/rust_port/crates/flow_typing_utils/src/exhaustive.rs
+@@ -1212,6 +1212,18 @@ mod value_union_builder {
+                         value_union.inexhaustible.push(t.dupe());
+                     }
+                 },
++                // A type variable has no structure of its own to match on, so
++                // the analysis runs over its bound. The variable is recorded
++                // rather than dropped: `ValueUnion::to_type` puts it back, and
++                // without that a pattern binding comes out as the bound.
++                TypeInner::GenericT(box generic) => {
++                    value_union.generics.push(generic.clone());
++                    let repositioned = flow_typing_type::type_util::mod_reason_of_t(
++                        &|_| generic.reason.dupe(),
++                        &generic.bound,
++                    );
++                    value_union = of_type_inner(cx, value_union, &repositioned);
++                }
+                 _ => {
+                     value_union.inexhaustible.push(t.dupe());
+                 }
+@@ -1442,6 +1454,7 @@ fn filter_values_by_patterns<'cx>(
+         objects: value_objects,
+         enum_unknown_members,
+         inexhaustible,
++        generics,
+     } = value_union;
+     let pattern_union::PatternUnion {
+         leafs: pattern_leafs,
+@@ -1586,6 +1599,9 @@ fn filter_values_by_patterns<'cx>(
+         objects: objects_left.into_iter().collect(),
+         enum_unknown_members: enum_unknown_members.dupe(),
+         inexhaustible: inexhaustible.dupe(),
++        // Filtering narrows what the type variable stands for; it does not
++        // stop it being that variable.
++        generics: generics.dupe(),
+     };
+     // Mixed/any
+     let mixed_used_pattern_locs = match is_object_subtype_of_inexhaustible(inexhaustible) {
+@@ -1614,6 +1630,7 @@ fn filter_values_by_patterns<'cx>(
+                 objects: objects_matched.into_iter().collect(),
+                 enum_unknown_members: FlowVector::default(),
+                 inexhaustible: FlowVector::default(),
++                generics: generics.dupe(),
+             };
+             Ok(FilterUnionResult {
+                 value_left,
+@@ -2323,6 +2340,7 @@ pub fn analyze<'cx>(
+             objects,
+             enum_unknown_members,
+             inexhaustible,
++            generics: _,
+         } = &value_left;
+         let mut examples: Vec<(FlowSmolStr, Vec<Reason>)> = Vec::new();
+         let mut asts: Vec<(Loc, ast::match_pattern::MatchPattern<Loc, Loc>)> = Vec::new();

--- a/tools/upstream/patches/flow/README.md
+++ b/tools/upstream/patches/flow/README.md
@@ -1,0 +1,122 @@
+# Patches to `upstream/flow`
+
+Fixes to Meta's Flow Rust port that uf needs and `facebook/flow` has not taken
+yet. `tools/upstream/sync.sh` applies every `*.patch` in this directory to the
+`upstream/flow` submodule after checking it out, so **a checkout is the pinned
+commit plus these patches** — on a laptop, in every CI job, and after
+`uf run setup`.
+
+They are a stopgap with an expiry date, not a fork. Each one is a diff small
+enough to read in a review, against a named issue, and the first thing to try
+for any of them is still to get it upstream.
+
+[ubugeeei-prod/uf#707](https://github.com/ubugeeei-prod/uf/issues/707) is why
+this directory exists and what it is designed against.
+
+## The rules the sync enforces
+
+- **Everything here is applied.** The directory is the list; there is no
+  second file to forget a patch in. A `*.patch` that does not apply stops the
+  sync, which stops the build, which stops every job. A patch quietly dropped
+  from a type checker is invisible — the compiler is happy, the tests are
+  green, the answers are wrong — so it is made impossible rather than
+  unlikely.
+- **Names are `NNNN-what-it-does.patch`**, four digits. That is the order they
+  apply in, and it is the same order in every locale. Anything else in this
+  directory except this README is refused rather than ignored.
+- **Each one carries `Issue:`** in a header above the diff, or the sync
+  refuses it. A patch to somebody else's type checker has to say whose bug it
+  is, or nobody can tell a fix that has landed upstream from one that has not.
+- **Re-running the sync is free.** A patch already in the work tree is left
+  alone — not rewritten — so cargo does not rebuild the port every time
+  someone runs `tools/upstream/sync.sh`.
+
+## Adding one
+
+```sh
+# 1. Make the change in the submodule.
+$EDITOR upstream/flow/rust_port/crates/...
+
+# 2. Write it out. `git -C` so the paths are relative to the submodule root.
+git -C upstream/flow diff > tools/upstream/patches/flow/0002-what-it-does.patch
+
+# 3. Put a header on top of the diff — everything above the first `diff --git`
+#    line is ignored by `git apply` and is where the explanation goes.
+```
+
+0001 is the worked example. `Issue:` is the only line the sync insists on; the
+rest are there because the person who inherits this will not have the issue
+open:
+
+```
+Subject: one line, what the patch does
+
+Issue: ubugeeei-prod/uf#NNN
+Upstream: <link to the facebook/flow PR, or "not filed yet">
+Submodule: <the full commit this was made against>
+
+Why it exists, what it changes, and what would have to be true for it to be
+deleted.
+```
+
+Then `tools/upstream/sync.sh`, and the test that fails without the patch —
+`crates/uf_check/tests/upstream_patches.rs`.
+
+## Removing one
+
+**Deleting the file is the whole procedure.** The next sync sees the work tree
+carrying a change no patch claims, restores the submodule to the pinned commit
+and re-applies what is left.
+
+Delete it when the fix lands upstream and the submodule is bumped past it, and
+the sync will tell you when that day arrives rather than leaving the patch to
+sit here applying to nothing:
+
+```
+upstream sync failed: tools/upstream/patches/flow/0001-....patch has landed upstream.
+The pinned commit already contains this patch, so it has nothing left to do.
+Delete it, in the same change as the bump that made it redundant:
+
+    git rm tools/upstream/patches/flow/0001-....patch
+```
+
+A bump that takes the fix in a different shape gets the other failure — the
+patch no longer applies — and that message names both possibilities, because
+from the outside they look the same:
+
+```
+upstream sync failed: tools/upstream/patches/flow/0001-....patch does not apply.
+...
+  * It landed upstream and the submodule was bumped past it. Delete
+    tools/upstream/patches/flow/0001-....patch, and the test that pins the bug it fixed.
+  * The code around it moved. Refresh it against the new commit: ...
+```
+
+A patch's other half is a test in this repository that fails without it —
+`crates/uf_check/tests/upstream_patches.rs` for the ones here. When the patch
+goes, **that test stays**: it is what says the fix survived the bump. Only its
+`#[ignore]`, if it has one, goes with the patch.
+
+`tools/upstream/test-patches.sh` runs the mechanism against every way a patch
+can go missing, on a scratch submodule. `uf run upstream:patches:test`.
+
+## Refreshing one after a submodule bump
+
+```sh
+git -C upstream/flow apply --3way tools/upstream/patches/flow/0001-....patch
+# resolve the conflicts in upstream/flow, then
+git -C upstream/flow diff > tools/upstream/patches/flow/0001-....patch
+# and put the header back on top
+```
+
+## Two things to know
+
+`upstream/flow` shows as modified in `git status` whenever a patch is applied.
+That is the mechanism working, not a checkout to clean up. Never commit the
+submodule pointer to a patched state — the pin is a `facebook/flow` commit, and
+the patches are here.
+
+The sync owns that work tree. It restores it whenever it finds a change no
+patch accounts for, so an edit made directly in `upstream/flow` lives until the
+next sync and no longer. Snapshot it into a patch file here before running
+anything that syncs, `uf run setup` included.

--- a/tools/upstream/sync.sh
+++ b/tools/upstream/sync.sh
@@ -13,12 +13,17 @@
 #
 # Every cargo invocation in this workspace needs the submodule present, because
 # Cargo resolves path dependencies even when the feature that uses them is off.
+#
+# After the checkout, `tools/upstream/patches/flow/` is applied on top — see
+# `apply_patches` below and that directory's README. A checkout is the pinned
+# commit *plus* those patches, always, on every machine and in every CI job.
 set -eu
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
 submodule_path="upstream/flow"
+patch_dir="tools/upstream/patches/flow"
 
 # `rust_port` holds the crates, but several of them reach outside it with
 # `include_str!`: `flow_flowlib` embeds Flow's own library definitions from
@@ -31,6 +36,32 @@ submodule_path="upstream/flow"
 # and without them a type checker knows what a `Map` is and not what a
 # `document` is. `uf_check` embeds them from there.
 sparse_subtrees="rust_port lib prelude tslib evals/flow-typed/environment"
+
+# Applying a patch leaves the submodule's work tree modified, and `git
+# submodule update` checks a moved pin out with a plain `git checkout`, which
+# refuses to overwrite a modified file. A bump would therefore fail on the
+# patched files with a message about local changes rather than about patches.
+#
+# Two cheap reads say whether the pin moved; `restore_submodule` below is what
+# makes the checkout possible, and the patch step puts the patches back on the
+# new commit — or says which one stopped applying, which is exactly the report
+# a bump wants.
+restore_submodule() {
+  # Only the sparse cone is in the work tree, and `checkout -- .` restores
+  # what is there rather than materializing what is not. It is a stat walk
+  # over an index that is already warm: about 20 ms on this checkout.
+  git -C "$submodule_path" checkout --quiet -- . 2>/dev/null || :
+  # And the files a patch *added*, which `checkout` leaves behind because
+  # they are untracked. Without `-x`, so a `target/` somebody built inside
+  # the submodule survives: this restores the port, not the disk.
+  git -C "$submodule_path" clean --quiet --force -d 2>/dev/null || :
+}
+
+pinned=$(git ls-files --stage -- "$submodule_path" | awk '$1 == "160000" { print $2 }')
+current=$(git -C "$submodule_path" rev-parse HEAD 2>/dev/null || echo '')
+if [ -n "$current" ] && [ -n "$pinned" ] && [ "$current" != "$pinned" ]; then
+  restore_submodule
+fi
 
 git submodule update --init --depth 1 --filter=blob:none "$submodule_path"
 # shellcheck disable=SC2086 # deliberate word splitting: one argument per subtree
@@ -56,7 +87,193 @@ if [ ! -d "$submodule_path/tslib" ]; then
   exit 1
 fi
 
-printf 'upstream/flow ready at %s\n' "$(git -C "$submodule_path" rev-parse --short HEAD)"
+# --- patches ------------------------------------------------------------------
+#
+# `tools/upstream/patches/flow/` holds fixes to the port that uf needs and
+# `facebook/flow` has not taken yet. They are applied here, so a checkout is
+# the pinned commit *plus* those patches — on a laptop, in every CI job, and
+# after `uf run setup`, with no way to end up with one and not the other.
+#
+# The rules this step is built around, in the order they matter:
+#
+# 1. **Nothing is skipped quietly.** Every `*.patch` in the directory is
+#    applied. There is no list of patches to apply, because a list is a second
+#    place to forget one; the directory *is* the list. A patch that does not
+#    apply stops the sync, and therefore stops the build, and therefore stops
+#    every job. A dropped patch to a type checker would otherwise be invisible:
+#    the compiler is happy, the tests are green, and the answers are wrong.
+# 2. **Idempotent.** A patch already in the work tree is left alone. The check
+#    is `git apply --reverse --check`, which asks the tree rather than a stamp
+#    file, so it cannot say "applied" about a tree that is not.
+# 3. **Cheap when there is nothing to do.** Leaving an applied patch alone
+#    means not rewriting the file, which means not giving it a new mtime,
+#    which means cargo does not rebuild the port. That is the whole reason
+#    this is not simply "restore the tree and re-apply everything": correct,
+#    and it would recompile the port on every sync.
+#
+# Removing a patch is deleting the file. The next sync notices the work tree
+# still carries it, restores the tree, and re-applies what is left — and when
+# a bump brings a commit that already contains a patch, the sync says so rather
+# than leaving it here applying to nothing. Refreshing one after a bump is
+# `git -C upstream/flow diff`; the README in that directory is the contract,
+# and ubugeeei-prod/uf#707 is why any of this exists.
+patch_count=0
+for entry in "$patch_dir"/*; do
+  [ -e "$entry" ] || continue # the unmatched glob, when there are no patches
+  case "${entry##*/}" in
+    README.md) continue ;;
+    # Four digits, so the order is the filename and is the same in every
+    # locale. A patch that depends on an earlier one sorts after it.
+    [0-9][0-9][0-9][0-9]-*.patch) ;;
+    *)
+      cat >&2 <<EOF
+upstream sync failed: $entry is not a patch this step would apply.
+
+Files in $patch_dir are named NNNN-what-it-does.patch, and everything that is
+not README.md is applied in that order. A file with another name would sit
+next to the patches looking like one and never be applied, which is the single
+failure this step exists to prevent, so it is refused instead.
+EOF
+      exit 1
+      ;;
+  esac
+
+  # Reviewability, made mechanical: a patch to somebody else's type checker
+  # has to say whose bug it is, or the next person to read it cannot tell a
+  # fix that has landed upstream from one that has not.
+  if ! grep -q '^Issue:[[:space:]]*[^[:space:]]' "$entry"; then
+    cat >&2 <<EOF
+upstream sync failed: $entry has no \`Issue:\` line.
+
+Every patch carries one in the header above the diff, naming the issue it
+exists for, so that it can be deleted with confidence when that issue closes.
+See $patch_dir/README.md.
+EOF
+    exit 1
+  fi
+
+  # A patch git cannot even parse would otherwise surface as a raw git error
+  # from the middle of the step below, where it reads as a broken sync rather
+  # than as a broken file.
+  if ! git apply --numstat -- "$entry" > /dev/null 2>&1; then
+    cat >&2 <<EOF
+upstream sync failed: $entry is not a diff git can read.
+
+Patches here are what \`git -C $submodule_path diff\` writes, with a header
+above them. See $patch_dir/README.md.
+EOF
+    exit 1
+  fi
+
+  patch_count=$((patch_count + 1))
+done
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/uf-upstream-patch.XXXXXX")
+trap 'rm -rf "$work"' EXIT INT TERM
+
+# What the patches claim, against what the work tree actually carries. Anything
+# in the second that is not in the first is a patch that used to be here and
+# was deleted, or a hand edit — either way the tree is no longer the pinned
+# commit plus this directory, and the honest repair is to rebuild it from both.
+#
+# This runs when the directory is *empty* too, and that case is the whole
+# reason it is not folded into the loop below: deleting the file is the
+# documented way to remove a patch, and a work tree that kept carrying one uf
+# no longer ships would be the same invisibility from the other direction.
+for entry in "$patch_dir"/[0-9][0-9][0-9][0-9]-*.patch; do
+  [ -e "$entry" ] || continue
+  git -C "$submodule_path" apply --numstat -- "$repo_root/$entry" | cut -f3
+done | sort -u > "$work/claimed"
+
+git -C "$submodule_path" -c core.quotepath=false \
+  status --porcelain --untracked-files=all |
+  cut -c4- | sort -u > "$work/present"
+
+if [ -n "$(comm -13 "$work/claimed" "$work/present")" ]; then
+  printf 'upstream/flow: work tree carries changes no patch claims, rebuilding it\n'
+  restore_submodule
+fi
+
+if [ "$patch_count" -gt 0 ]; then
+  for entry in "$patch_dir"/[0-9][0-9][0-9][0-9]-*.patch; do
+    # The day this is all supposed to end, and it has to be said out loud or
+    # nobody ever says it: the *pinned commit* already contains the patch.
+    # `--cached` asks the index, which is the commit, rather than the work
+    # tree, which is the commit plus whatever has been applied to it — so this
+    # is true only when upstream took the fix and the submodule was bumped
+    # past it. Left alone it would sit in the directory forever, applying to
+    # nothing and read by nobody as still needed.
+    if git -C "$submodule_path" apply --cached --reverse --check -- "$repo_root/$entry" 2>/dev/null; then
+      cat >&2 <<EOF
+
+upstream sync failed: $entry has landed upstream.
+
+  $(grep -m1 '^Issue:' "$entry")
+  submodule at $(git -C "$submodule_path" rev-parse --short HEAD)
+
+The pinned commit already contains this patch, so it has nothing left to do.
+Delete it, in the same change as the bump that made it redundant:
+
+    git rm $entry
+
+The test that pins the bug it fixed stays — it is what says the fix survived
+the bump — and if it is still \`#[ignore]\`d, that goes with the patch.
+EOF
+      exit 1
+    fi
+
+    # Already there, byte for byte. Not touching the file is what keeps cargo
+    # from rebuilding the port on every sync.
+    if git -C "$submodule_path" apply --reverse --check -- "$repo_root/$entry" 2>/dev/null; then
+      continue
+    fi
+
+    if git -C "$submodule_path" apply -- "$repo_root/$entry" 2>"$work/why"; then
+      printf 'upstream/flow: applied %s\n' "${entry##*/}"
+      continue
+    fi
+
+    # Loud, and specific about which of the two answers this wants. The work
+    # tree goes back to the pinned commit first, so that the sentence below is
+    # true and nothing downstream compiles a half-patched type checker.
+    restore_submodule
+    cat >&2 <<EOF
+
+upstream sync failed: $entry does not apply.
+
+  $(grep -m1 '^Issue:' "$entry")
+  submodule at $(git -C "$submodule_path" rev-parse --short HEAD)
+
+git apply said:
+
+$(sed 's/^/  /' "$work/why")
+
+Nothing was skipped and nothing is half-applied — $submodule_path has been put
+back to the pinned commit, unpatched, and no build will run until this is
+resolved. A patch stops applying for two reasons, and they want opposite
+answers:
+
+  * It landed upstream and the submodule was bumped past it. Delete
+    $entry, and the test that pins the bug it fixed.
+  * The code around it moved. Refresh it against the new commit:
+
+      git -C $submodule_path apply --3way $repo_root/$entry
+      # resolve, then
+      git -C $submodule_path diff > $entry
+      # and put the header back on top
+
+$patch_dir/README.md has the long version.
+EOF
+    exit 1
+  done
+fi
+
+if [ "$patch_count" -eq 0 ]; then
+  printf 'upstream/flow ready at %s\n' "$(git -C "$submodule_path" rev-parse --short HEAD)"
+else
+  printf 'upstream/flow ready at %s + %d patch(es) from %s\n' \
+    "$(git -C "$submodule_path" rev-parse --short HEAD)" "$patch_count" "$patch_dir"
+fi
 
 # The rest of `upstream/` is pinned by commit in `tools/upstream/repos.txt`
 # rather than tracked as submodules, for the reason that file gives: nothing in

--- a/tools/upstream/test-patches.sh
+++ b/tools/upstream/test-patches.sh
@@ -1,0 +1,301 @@
+#!/bin/sh
+# `sync.sh`'s patch step, against the ways a patch can go missing.
+#
+# The step exists because a patch to a type checker that is quietly not applied
+# is the worst failure this repository has: nothing fails to compile, no test
+# goes red, and `uf check` answers differently than it did yesterday. So what
+# is worth testing is not that the patches in `tools/upstream/patches/flow`
+# apply — the sync proves that in every job — but that each way one could be
+# skipped is refused, and named precisely enough that the reader knows which
+# file to open.
+#
+# It runs against a scratch superproject with a scratch submodule rather than
+# against `upstream/flow`, so it is hermetic, costs about a second, and can
+# make a patch fail on purpose without touching a 40 MB checkout.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+script="$repo_root/tools/upstream/sync.sh"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-upstream-patches.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+# A submodule cloned from a path needs this, and `git submodule update` clones
+# in a child process — the environment form is the one children inherit.
+GIT_CONFIG_COUNT=1
+GIT_CONFIG_KEY_0=protocol.file.allow
+GIT_CONFIG_VALUE_0=always
+export GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+
+fail() {
+  echo "test-upstream-patches: FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+# A repository shaped like `facebook/flow` as far as the sync can tell: the
+# files it asserts are present, and one it can be asked to patch.
+fake_flow() {
+  upstream="$work/flow.git"
+  rm -rf "$upstream"
+  mkdir -p "$upstream/rust_port/crates" "$upstream/lib" "$upstream/prelude" \
+    "$upstream/tslib" "$upstream/evals/flow-typed/environment"
+  echo '[workspace]' > "$upstream/rust_port/Cargo.toml"
+  echo 'fn dispatch() -> &str { "the bound" }' > "$upstream/rust_port/crates/dispatch.rs"
+  for f in lib/core.js lib/react.js prelude/prelude.js tslib/index.js \
+    evals/flow-typed/environment/dom.js \
+    evals/flow-typed/environment/bom.js \
+    evals/flow-typed/environment/node.js
+  do
+    echo '// upstream' > "$upstream/$f"
+  done
+  git -C "$upstream" init --quiet
+  git -C "$upstream" config user.email test@example.com
+  git -C "$upstream" config user.name test
+  git -C "$upstream" config uploadpack.allowfilter true
+  git -C "$upstream" add -A
+  git -C "$upstream" commit --quiet -m upstream
+}
+
+# ... and a superproject shaped like this one: the sync, a patch directory,
+# and the submodule at `upstream/flow`.
+scratch() {
+  root="$work/repo"
+  rm -rf "$root"
+  mkdir -p "$root/tools/upstream/patches/flow"
+  git -C "$root" init --quiet
+  git -C "$root" config user.email test@example.com
+  git -C "$root" config user.name test
+  cp "$script" "$root/tools/upstream/sync.sh"
+  git -C "$root" submodule --quiet add "$work/flow.git" upstream/flow
+  git -C "$root" add -A
+  git -C "$root" commit --quiet -m scratch
+}
+
+# The patch every case below starts from: one hunk, one file, a header that
+# says what it is for.
+write_patch() {
+  cat > "$root/tools/upstream/patches/flow/$1" <<'PATCH'
+Subject: dispatch returns the type variable rather than its bound
+
+Issue: ubugeeei-prod/uf#205
+Upstream: not filed yet
+
+The scratch stand-in for a real fix to the port.
+
+diff --git a/rust_port/crates/dispatch.rs b/rust_port/crates/dispatch.rs
+--- a/rust_port/crates/dispatch.rs
++++ b/rust_port/crates/dispatch.rs
+@@ -1 +1 @@
+-fn dispatch() -> &str { "the bound" }
++fn dispatch() -> &str { "the type variable" }
+PATCH
+}
+
+run() {
+  set +e
+  out="$(cd "$root" && ./tools/upstream/sync.sh 2>&1)"
+  status=$?
+  set -e
+}
+
+patched() {
+  grep -q 'the type variable' "$root/upstream/flow/rust_port/crates/dispatch.rs"
+}
+
+# A refusal that does not name the file is a refusal the reader has to guess
+# from, which for a directory of near-identical patches is no help at all.
+refuses() {
+  name="$1"
+  needle="$2"
+  [ "$status" -ne 0 ] || fail "$name was accepted: $out"
+  case "$out" in
+    *"$needle"*) ;;
+    *) fail "$name is refused without naming \`$needle\`: $out" ;;
+  esac
+  pass "$name"
+}
+
+fake_flow
+
+# --- a patch is applied, and saying so is part of applying it ----------------
+scratch
+write_patch 0001-dispatch.patch
+run
+[ "$status" -eq 0 ] || fail "a good patch was refused: $out"
+patched || fail "the patch was not applied: $out"
+case "$out" in
+  *"1 patch(es)"*) ;;
+  *) fail "the sync does not say how many patches it applied: $out" ;;
+esac
+pass "a patch is applied, and the sync says how many"
+
+# --- and re-running neither re-applies it nor rewrites the file --------------
+# The mtime is the assertion, not a detail of it: rewriting a file cargo has
+# already compiled rebuilds the port, and the port is most of the build. A
+# patch step that costs a full rebuild per sync would be turned off.
+before="$(ls -l "$root/upstream/flow/rust_port/crates/dispatch.rs")"
+run
+[ "$status" -eq 0 ] || fail "the second sync failed: $out"
+patched || fail "the second sync dropped the patch: $out"
+[ "$before" = "$(ls -l "$root/upstream/flow/rust_port/crates/dispatch.rs")" ] ||
+  fail "the second sync rewrote an already-patched file, which rebuilds the port"
+pass "re-running leaves an applied patch, and its mtime, alone"
+
+# --- deleting the file removes the patch -------------------------------------
+# The whole documented procedure for a fix that landed upstream. If the work
+# tree kept carrying it, uf would be building against a patch no longer in the
+# repository, which is the same invisibility from the other direction.
+rm "$root/tools/upstream/patches/flow/0001-dispatch.patch"
+run
+[ "$status" -eq 0 ] || fail "the sync failed after a patch was deleted: $out"
+patched && fail "a deleted patch is still in the work tree: $out"
+pass "deleting the file un-applies the patch on the next sync"
+
+# --- the pin moves under a patched work tree ---------------------------------
+# `git submodule update` checks a moved pin out with a plain `git checkout`,
+# which refuses to overwrite a modified file — so a bump would otherwise fail
+# on the patched files, with a message about local changes and nothing about
+# patches. The sync has to unpatch before it checks out and patch after.
+scratch
+write_patch 0001-dispatch.patch
+run
+[ "$status" -eq 0 ] || fail "the first sync failed: $out"
+echo '// upstream, later' > "$upstream/lib/core.js"
+git -C "$upstream" commit --quiet -am 'a commit that does not touch the patched file'
+bumped="$(git -C "$upstream" rev-parse HEAD)"
+git -C "$root" update-index --cacheinfo "160000,$bumped,upstream/flow"
+run
+[ "$status" -eq 0 ] || fail "a bump under a patched work tree failed: $out"
+patched || fail "the bump dropped the patch: $out"
+[ "$(git -C "$root/upstream/flow" rev-parse HEAD)" = "$bumped" ] ||
+  fail "the bump did not take: $out"
+pass "a submodule bump unpatches, checks out, and patches again"
+
+# --- and takes the patch with it when the fix has landed ---------------------
+# The day this mechanism is supposed to end. The bump brings a commit that
+# already has the fix, the patch stops applying, and the sync says so instead
+# of building against a port nobody has read.
+echo 'fn dispatch() -> &str { "the type variable" }' > "$upstream/rust_port/crates/dispatch.rs"
+git -C "$upstream" commit --quiet -am 'upstream takes the fix'
+landed="$(git -C "$upstream" rev-parse HEAD)"
+git -C "$root" update-index --cacheinfo "160000,$landed,upstream/flow"
+run
+refuses "a bump onto a commit that already has the fix" "has landed upstream"
+case "$out" in
+  *"git rm "*) ;;
+  *) fail "the refusal does not say to delete the patch: $out" ;;
+esac
+pass "and says to delete the patch rather than to fix it"
+
+# The two cases above moved the stand-in upstream forward; put it back, so the
+# cases below start from the same commit the ones above did.
+fake_flow
+
+# --- a patch that does not apply stops everything ----------------------------
+scratch
+write_patch 0001-dispatch.patch
+# The context the patch expects is gone, the way it would be after a bump onto
+# a commit that rewrote the function — or took the fix.
+sed -i.bak 's/the bound/something else/' "$root/upstream/flow/rust_port/crates/dispatch.rs"
+rm -f "$root/upstream/flow/rust_port/crates/dispatch.rs.bak"
+run
+refuses "a patch that no longer applies" "0001-dispatch.patch"
+case "$out" in
+  *"ubugeeei-prod/uf#205"*) ;;
+  *) fail "the failure does not name the issue the patch is for: $out" ;;
+esac
+case "$out" in
+  *"landed upstream"*) ;;
+  *) fail "the failure does not say a patch can be deleted rather than fixed: $out" ;;
+esac
+pass "the failure names the issue and both ways out"
+
+# --- and leaves nothing half-applied -----------------------------------------
+# Two patches, the second broken. The first must not survive: a work tree that
+# is the pinned commit plus *some* of the patches is the state nothing else in
+# this repository could detect.
+scratch
+write_patch 0001-dispatch.patch
+cat > "$root/tools/upstream/patches/flow/0002-broken.patch" <<'PATCH'
+Subject: a hunk with no matching context
+
+Issue: ubugeeei-prod/uf#205
+
+diff --git a/rust_port/crates/dispatch.rs b/rust_port/crates/dispatch.rs
+--- a/rust_port/crates/dispatch.rs
++++ b/rust_port/crates/dispatch.rs
+@@ -1 +1 @@
+-fn dispatch() -> &str { "a line that is not there" }
++fn dispatch() -> &str { "unreachable" }
+PATCH
+run
+[ "$status" -ne 0 ] || fail "a broken second patch was accepted: $out"
+patched && fail "the first patch was left applied after the second failed: $out"
+pass "a failure leaves the work tree unpatched, not half-patched"
+
+# --- a file that is not named like a patch is refused, not ignored -----------
+# The case the whole design turns on. `0001-dispatch.patch.orig`, `fix.diff`,
+# `0001-dispatch.patch.rej` — every one of them sits in the directory looking
+# like a patch and would never be applied.
+scratch
+write_patch 0001-dispatch.patch
+cp "$root/tools/upstream/patches/flow/0001-dispatch.patch" \
+  "$root/tools/upstream/patches/flow/fix.diff"
+run
+refuses "a file in the directory that is not NNNN-*.patch" "fix.diff"
+
+scratch
+write_patch 0001-dispatch.patch
+cp "$root/tools/upstream/patches/flow/0001-dispatch.patch" \
+  "$root/tools/upstream/patches/flow/0002-dispatch.patch.orig"
+run
+refuses "an editor backup left beside a patch" "0002-dispatch.patch.orig"
+
+# --- a patch with no issue is refused ----------------------------------------
+# It is the line that lets the next person delete it. Without one, a patch
+# outlives the bug it was written for and nobody can prove it.
+scratch
+write_patch 0001-dispatch.patch
+grep -v '^Issue:' "$root/tools/upstream/patches/flow/0001-dispatch.patch" \
+  > "$work/anon" && mv "$work/anon" "$root/tools/upstream/patches/flow/0001-dispatch.patch"
+run
+refuses "a patch with no \`Issue:\` line" "Issue:"
+
+# --- and one git cannot read ------------------------------------------------
+scratch
+cat > "$root/tools/upstream/patches/flow/0001-prose.patch" <<'PATCH'
+Subject: notes, not a diff
+
+Issue: ubugeeei-prod/uf#205
+
+I meant to write the diff here and did not.
+PATCH
+run
+refuses "a patch file with no diff in it" "0001-prose.patch"
+
+# --- README.md is the one thing that may sit beside them ---------------------
+scratch
+write_patch 0001-dispatch.patch
+echo '# Patches' > "$root/tools/upstream/patches/flow/README.md"
+run
+[ "$status" -eq 0 ] || fail "the README beside the patches was refused: $out"
+patched || fail "the README stopped the patch from applying: $out"
+pass "README.md is the one file that may sit beside the patches"
+
+# --- an empty directory is a sync with no patch step -------------------------
+# Where this repository is on the day the last patch lands upstream, and the
+# state the step has to stay silent and cheap in.
+scratch
+run
+[ "$status" -eq 0 ] || fail "a sync with no patches failed: $out"
+case "$out" in
+  *"patch(es)"*) fail "a sync with no patches talks about patches: $out" ;;
+  *) ;;
+esac
+pass "no patches is a quiet sync"
+
+echo "test-upstream-patches: every case passed"

--- a/uf.config.js
+++ b/uf.config.js
@@ -101,6 +101,17 @@ export default defineConfig({
     // until the submodule is checked out, and `uf run` needs a built `uf`.
     // One command breaks that circle, and it is in CONTRIBUTING.md.
     "upstream:sync": "tools/upstream/sync.sh",
+    // The sync applies `tools/upstream/patches/flow` to the submodule after
+    // checking it out, so a checkout is the pinned `facebook/flow` commit plus
+    // the fixes uf needs and upstream has not taken. That step is worth a test
+    // of its own because its failure mode is silence: a patch to a type checker
+    // that is quietly not applied compiles, passes, and answers differently.
+    // Every way one could go missing is a case in the script, against a scratch
+    // submodule rather than the 40 MB one.
+    "upstream:patches:test": {
+      command: "tools/upstream/test-patches.sh",
+      inputs: ["tools/upstream/sync.sh", "tools/upstream/test-patches.sh"],
+    },
     // React's compiler crates, Relay's compiler crates, and React Native's
     // codegen and Libraries — pinned in `tools/upstream/repos.txt`, fetched on
     // request rather than in every job because nothing in the cargo graph
@@ -728,6 +739,7 @@ export default defineConfig({
         "manifests",
         "lockfile",
         "lockfile:test",
+        "upstream:patches:test",
         "install:banner",
         "scripts:parse",
         "scripts:parse:test",


### PR DESCRIPTION
## Summary

`tools/upstream/sync.sh` checked `upstream/flow` out and applied nothing to it, so a fix
to Meta's Flow Rust port could not be kept anywhere. #205 found the root cause of its own
defect, wrote the diff, measured it, and **reverted it** for that reason; #300 and the
profiling half of #678 are behind the same wall. #707 is the mechanism this adds; #205 is
the first patch it carries.

### The patch step

`tools/upstream/patches/flow` is applied after the checkout, so **a checkout is the pinned
commit plus those patches** — on a laptop, in every CI job, and after `uf run setup`.

The failure it is designed against is not a patch that does not apply. It is one that is
*quietly not applied*: nothing fails to compile, no test goes red, and `uf check` answers
differently than it did yesterday.

- **The directory is the list.** Every `NNNN-*.patch` is applied in that order. A file in
  there with any other name is refused rather than ignored — a `0001-x.patch.orig` beside
  the patches would never be applied and would look exactly like one that was. A `series`
  file would be a second place to forget a patch, so there isn't one.
- **Each patch carries an `Issue:` line** above the diff, or the sync refuses it.
- **Three questions per patch**, in this order:

  | | asked as | means |
  | --- | --- | --- |
  | the *pinned commit* has it | `git apply --cached --reverse --check` | it landed upstream — stop and say `git rm` it |
  | the *work tree* has it | `git apply --reverse --check` | applied; touch nothing, keep the mtime |
  | it applies | `git apply` | apply it |
  | neither | — | restore the submodule, then stop, naming the patch, its issue and both ways out |

  Asking the tree rather than a stamp file is what makes "applied" impossible to claim
  about a tree that is not. Not rewriting an already-applied file is what keeps a sync from
  costing a full rebuild of the port.
- **Before that loop**, the tree's modified paths are reconciled against the paths the
  patches claim, so a patch *deleted* from the directory stops being carried — the one case
  a per-patch loop cannot see, and the whole documented procedure for removing one.
- A **submodule bump** unpatches before `git submodule update` (a plain `git checkout`
  refuses to overwrite a modified file) and patches after.

A warm sync with one patch applied costs **0.17 s** and writes nothing. The shallow,
blobless, sparse `rust_port/` checkout is untouched.

`tools/upstream/test-patches.sh` runs the mechanism against every way a patch can go
missing, on a scratch superproject with a scratch submodule, and is wired into `ci`. The
subject of this check fails silently, so nothing but the cases says it works — and it
caught two real holes while it was being written: a deleted patch that stayed in the work
tree, and a patch that had landed upstream and was kept anyway.

```
  ok  a patch is applied, and the sync says how many
  ok  re-running leaves an applied patch, and its mtime, alone
  ok  deleting the file un-applies the patch on the next sync
  ok  a submodule bump unpatches, checks out, and patches again
  ok  a bump onto a commit that already has the fix
  ok  and says to delete the patch rather than to fix it
  ok  a patch that no longer applies
  ok  the failure names the issue and both ways out
  ok  a failure leaves the work tree unpatched, not half-patched
  ok  a file in the directory that is not NNNN-*.patch
  ok  an editor backup left beside a patch
  ok  a patch with no `Issue:` line
  ok  a patch file with no diff in it
  ok  README.md is the one file that may sit beside the patches
  ok  no patches is a quiet sync
```

### 0001 — #205, the diff that had nowhere to live

Confirmed at the source before writing anything. `handle_generic`
(`flow_js/helpers.rs:623`) lists `ConcretizeForOperatorsChecking`,
`ConcretizeForComputedObjectKeys` and `ConcretizeForOptionalChain` — and not
`ConcretizeForMatchArg` — so a `GenericT` falls to the generic-erasing catch-all at
`dispatch.rs:9439`, which sits **above** the match-argument collector at `:10314` and
**below** the predicate collector at `:8620`. That asymmetry is the whole bug, and `switch`
works for exactly that reason.

Letting the `GenericT` through is necessary and not sufficient, which was measured rather
than taken on trust: with only the `dispatch.rs` arm, `match (tag: T)` over
`T extends "a" | "b"` reports `match-not-exhaustive` with both literal arms unused. So the
value union also remembers the variable it unwrapped and `ValueUnion::to_type` — where a
pattern binding's type comes from — puts it back.

```diff
- error[incompatible-type]: Cannot call change with value bound to the first
-   parameter because unknown [1] is incompatible with empty [2].
+ ✓ no problems
```

`match_over_a_bounded_type_variable_is_still_exhaustive` in
`crates/uf_check/tests/upstream_patches.rs` pins the dead end so it is not rediscovered,
and the `switch` control is there so a "fix" that made both lose the variable cannot pass.

**It also removes a false positive from a package this repository ships.** `unwrap<T>` in
`packages/state/internal/composed.js:819` matches over `Loadable<T>` and bound `data` as
`unknown`. Across the nine `tests/type-tests` fixtures and the packages they pull in, that
is the *only* diagnostic that moves: 143 before, 142 after, every fixture still agreeing
with its own `// expect:` markers.

### What this does not do

**#300 is untouched.** It is a different site — `mk_tuple_type_with_env` builds a spread
pattern as an `EvalT` with a `SpreadTupleType` destructor instead of a `TupleAT`, so the
leading `infer` is pinned to an unannotated `infer`'s declared `mixed` — and it needs its
own patch. `crates/uf_check/tests/known_bugs.rs` keeps it, ignored, with its analysis, and
`tests/type-tests/server-actions.js` still pins `TwoFormsFitTheWire` as accepted-and-should-not-be.
That file is unchanged and its seven markers still all report.

`known_bugs.rs` hands #205 over to `upstream_patches.rs`, which is where a test that pins a
patch lives: it **stays** when the patch is deleted, because it is what says the fix
survived the bump.

Closes #205.

## Verification

```sh
tools/upstream/sync.sh
```

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p uf_check` — 217 passed, 2 ignored (both #300)
- [x] `tools/upstream/test-patches.sh` — 15 cases
- [x] `tools/ci/scripts-parse.sh` — 40 scripts parse under dash
- [x] the nine `tests/type-tests` fixtures against their `// expect:` markers, patched and
      unpatched, with the one difference named above

Run on `nightly-2026-08-01` per `rust-toolchain.toml`. `cargo test --workspace` was not run
here — this machine has no `deno`, and it is what the `Test` job is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
