### PR TITLE
feat(std): the six Go standard library modules JavaScript does not have

### DIFF
--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -230,6 +230,12 @@ export const sections: $ReadOnlyArray<Section> = [
         blurb:
           "MessageFormat 2 with typed arguments, the subset uf implements, and where the type system stops.",
       },
+      {
+        href: "/reference/std",
+        title: "Standard library",
+        blurb:
+          "The Go standard library modules JavaScript does not have, and the measurements behind why they are JavaScript.",
+      },
     ],
   },
 ];

--- a/docs/app/reference/packages/_uf.page.mdx
+++ b/docs/app/reference/packages/_uf.page.mdx
@@ -27,7 +27,7 @@ on every file.
 | `@uniflowed/jsx-runtime` | The JSX runtime uf compiles to |
 | `@uniflowed/react-compiler` | The official React Compiler, wired for uf |
 | `@uniflowed/runtime` | Host capabilities, resolved at run time |
-| `@uniflowed/std` | The standard library |
+| `@uniflowed/std` | [The standard library](/reference/std): the parts of Go's that JavaScript does not have |
 
 ## Application
 

--- a/docs/app/reference/std/_uf.page.mdx
+++ b/docs/app/reference/std/_uf.page.mdx
@@ -1,0 +1,182 @@
+---
+title: "Standard library · uf"
+description: "The Go standard library modules JavaScript does not have, and the measurements behind why they are JavaScript."
+---
+
+<p className="eyebrow">Reference</p>
+
+# @uniflowed/std
+
+<div className="lede">
+Go's standard library is the benchmark: a language whose batteries are actually
+included. `@uniflowed/std` is the parts of it JavaScript does not have, written
+in Flow, one export path per module so a program pays only for what it imports.
+</div>
+
+```js
+// @flow
+import { as, is, wrap } from "@uniflowed/std/errors";
+import { Group } from "@uniflowed/std/sync";
+import { withTimeout, background } from "@uniflowed/std/context";
+
+const [ctx, cancel] = withTimeout(background(), 5_000);
+try {
+  const group = new Group({ limit: 8 });
+  for (const id of ids) group.go((signal) => fetchRow(id, signal));
+  return await group.wait();
+} catch (failure) {
+  if (is(failure, ctx.err())) return cached;
+  throw wrap("loading the dashboard", failure);
+} finally {
+  cancel();
+}
+```
+
+## What ships today
+
+Six modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+brings in a hex codec and nothing else.
+
+| Import | Go's name | What it is |
+| --- | --- | --- |
+| `@uniflowed/std/errors` | `errors` | `wrap`, `is`, `as`, `join`, `unwrap`, `chain` over `Error.cause` |
+| `@uniflowed/std/sync` | `sync`, `errgroup` | `WaitGroup`, `Mutex`, `Semaphore`, `once`, `Group` |
+| `@uniflowed/std/context` | `context` | Cancellation, deadlines and typed values over `AbortSignal` |
+| `@uniflowed/std/bytes` | `bytes` | Searching, splitting and joining `Uint8Array`, plus `Builder` |
+| `@uniflowed/std/heap` | `container/heap` | A binary heap with a comparator |
+| `@uniflowed/std/hex` | `encoding/hex` | `encode`, `decode`, `isValid`, `dump` |
+
+The root `@uniflowed/std` is unchanged: it is a declaration surface whose
+functions raise `NativeRuntimeRequiredError`, and it is not what these six are.
+Everything above runs.
+
+## The types are the point
+
+Every generic here infers at the call site, with no annotation and no `any`
+underneath, and that claim is tested rather than asserted:
+`tests/type-tests/std-inference.js` is a file of deliberate misuses, and
+`uf check` has to report every one of them and nothing else.
+
+```js
+const queue = new Heap((a, b) => a.due - b.due);   // Heap<Job>, from the comparator
+const next = queue.pop();                          // Job | void
+
+const TRACE = key<string>("trace-id");
+withValue(ctx, TRACE, 7);                          // refused: 7 is not a string
+traced.value(TRACE);                               // string | void
+
+as(failure, HttpError)?.status;                    // number, from the class alone
+```
+
+## Cancellation: why not just `AbortSignal`
+
+Every context *has* one — `ctx.signal()` is what goes to `fetch` — so this
+composes with the platform rather than competing with it. What it adds is the
+three things `AbortSignal` does not have: a tree, so cancelling a request
+cancels everything it started; deadlines that only ever shorten, so a library
+cannot buy itself more time than its caller allowed; and typed request-scoped
+values.
+
+`AbortSignal.any` and `AbortSignal.timeout` cover parts of the first two, and
+they are the newest things on the interface — Node, Deno, Bun and workerd gained
+them at different times. Nothing here uses either.
+
+**One thing it asks of you that Go does not.** A deadline is a `setTimeout`, and
+on Node a pending timer keeps the process alive. There is no runtime-agnostic
+`unref` — Deno and browsers have none — so the `cancel` that `withTimeout` hands
+back has to be called, in a `finally`, on the happy path too.
+
+## Where it runs
+
+Everything here is pure Flow over the web platform: `Uint8Array`,
+`TextEncoder`/`TextDecoder`, `AbortController`, `Promise`, `setTimeout`. No
+`node:` import, no native binding, no `Buffer`.
+
+| Host | `errors` | `sync` | `context` | `bytes` | `heap` | `hex` |
+| --- | --- | --- | --- | --- | --- | --- |
+| Node.js | yes | yes | yes | yes | yes | yes |
+| Bun | yes | yes | yes | yes | yes | yes |
+| Deno | yes | yes | yes | yes | yes | yes |
+| Edge / workers | yes | yes | yes | yes | yes | yes |
+
+That table is a claim about what the code uses, not a matrix of green test runs:
+uf's own suite runs on Node, and [Hosts](/guide/hosts) is the honest account of
+which runtimes have a test that starts them. `AggregateError`, which
+`errors.join` returns, is the newest thing any of these touches; it has been in
+every one of those runtimes since 2020.
+
+## Why this is JavaScript and not Rust
+
+uf is a native toolchain, so "should this be native" is a fair question for
+every module. It was measured rather than guessed, and the answer for these six
+is no.
+
+The comparison is against Node's own C++ implementations of the same
+operations — `Buffer#toString("hex")`, `Buffer#equals`, `Buffer#indexOf` —
+reached across the same kind of JavaScript-to-native boundary a binding would
+use. That makes it a measurement of what native buys, not an estimate of it.
+Node 24 on an M-series laptop, nanoseconds per call:
+
+| Operation | Size | This, in JS | Node, native | Native is |
+| --- | --- | --- | --- | --- |
+| `hex.encode` | 16 B | 83 ns | 40 ns | 2.1x faster |
+| `hex.encode` | 1 MiB | 1.69 ms | 0.26 ms | 6.5x faster |
+| `hex.decode` | 16 B | 80 ns | 72 ns | 1.1x faster |
+| `hex.decode` | 1 MiB | 4.54 ms | 0.66 ms | 6.8x faster |
+| `bytes.equal` | 16 B | 14 ns | 25 ns | **1.8x slower** |
+| `bytes.equal` | 64 B | 59 ns | 30 ns | 2.0x faster |
+| `bytes.equal` | 1 MiB | 0.89 ms | 0.02 ms | 42x faster |
+| `bytes.indexOf` | 1 KiB | 324 ns | 69 ns | 4.7x faster |
+| `bytes.indexOf` | 1 MiB | 332 µs | 21 µs | 16x faster |
+
+Three things follow from that table, and only the third is about speed.
+
+**The boundary is not free, and below a few dozen bytes it is the whole bill.**
+`bytes.equal` on sixteen bytes is *faster* in JavaScript than the native call
+that does the same thing, because comparing sixteen bytes takes less time than
+crossing into C++ to do it. Most calls to most of these functions are small: a
+32-byte digest, a four-byte delimiter, a header value.
+
+**There is no binding to cross anyway.** There is no N-API and no WebAssembly
+crate anywhere in this repository. "Native" for a `@uniflowed/std` module is not
+a build flag; it is a layer that does not exist yet, and the first module to
+need one should be the module that pays for it.
+
+**A native module would not be runtime-agnostic.** An N-API addon runs on Node
+and Bun and not on Deno or the edge, which is [red line
+6](https://github.com/ubugeeei-prod/uf/blob/main/docs/red-lines.md). A
+WebAssembly module runs everywhere and copies its arguments across the
+boundary — which, for a function whose argument *is* a byte buffer, is the cost
+the native implementation was supposed to save.
+
+So the effort went where it was measurable instead. Each of these is one
+implementation of the same function against another, both in JavaScript:
+
+| Change | Effect |
+| --- | --- |
+| `hex.encode` writing ASCII bytes and decoding once, above 128 B | 43 MB/s → 620 MB/s |
+| `hex.encode` appending to a string, below 128 B | 520 ns → 150 ns on a 32 B digest |
+| `bytes.indexOf` scanning for the first byte natively | 8–10x over the naive double loop |
+| `bytes.Builder` over re-allocating per chunk | 11x at 100 chunks, 825x at 10,000 |
+| `heap` over sorting on every insert | 161x at 1,000 items, 507x at 10,000 |
+
+The last two are not micro-optimisations. They are the difference between
+linear and quadratic, which is the difference between a service that is fine in
+staging and one that falls over in production.
+
+## What is not here yet
+
+Named because the list is the plan, not because the omissions are accidents.
+The next tranche is `io` reader and writer interfaces, `encoding/csv`,
+`encoding/base32`, `container/list`, `hash/crc32` and `hash/fnv`,
+`path/filepath`, and `time` durations and tickers. `sync.RWMutex` is deliberately
+absent: readers and writers cannot run at the same time in one runtime, so it
+would buy a fairness policy and nothing else, and it should arrive with the
+workload that needs one.
+
+Much of Go's standard library is not missing at all and will not be
+reimplemented here — `strings`, `math`, `encoding/json`, `time`'s formatting,
+`regexp`, `sort` (`Array.prototype.sort` has been stable since ES2019) and
+`net/url` all have platform answers that are better than a port would be. And
+some of it cannot exist on a runtime-agnostic module at all: `os/exec`,
+`net`'s raw sockets, `syscall`, `runtime`, and anything that needs a thread.

--- a/docs/app/reference/std/_uf.page.mdx
+++ b/docs/app/reference/std/_uf.page.mdx
@@ -92,18 +92,22 @@ Everything here is pure Flow over the web platform: `Uint8Array`,
 `TextEncoder`/`TextDecoder`, `AbortController`, `Promise`, `setTimeout`. No
 `node:` import, no native binding, no `Buffer`.
 
-| Host | `errors` | `sync` | `context` | `bytes` | `heap` | `hex` |
-| --- | --- | --- | --- | --- | --- | --- |
-| Node.js | yes | yes | yes | yes | yes | yes |
-| Bun | yes | yes | yes | yes | yes | yes |
-| Deno | yes | yes | yes | yes | yes | yes |
-| Edge / workers | yes | yes | yes | yes | yes | yes |
+| Host | Status | How that was established |
+| --- | --- | --- |
+| Node.js | **runs** | The suite: 61 assertions over all six modules, in `tests/library/std.test.js` |
+| Bun 1.3.13 | **runs** | Eighteen smoke assertions over all six, by hand, through `@uniflowed/host/bun-preload` |
+| Deno | expected | Not run. Inference from the API surface, below |
+| Edge / workers | expected | Not run. Same |
 
-That table is a claim about what the code uses, not a matrix of green test runs:
-uf's own suite runs on Node, and [Hosts](/guide/hosts) is the honest account of
-which runtimes have a test that starts them. `AggregateError`, which
-`errors.join` returns, is the newest thing any of these touches; it has been in
-every one of those runtimes since 2020.
+The bottom two rows say "expected" rather than "yes" on purpose, and the
+distinction is the one
+[`docs/hosts.md`](https://github.com/ubugeeei-prod/uf/blob/main/docs/hosts.md)
+exists to make: a row nothing has started the runtime for is a claim, not a
+result. What the claim rests on is that nothing here imports `node:` anything,
+touches `Buffer`, or reads `process`, and that `AggregateError` — the newest
+platform feature any of it needs, returned by `errors.join` — has been in all
+four runtimes since 2020. That is a good reason to expect it to work and it is
+not a test.
 
 ## Why this is JavaScript and not Rust
 

--- a/packages/std/bytes.js
+++ b/packages/std/bytes.js
@@ -1,0 +1,446 @@
+// @flow
+//
+// `@uniflowed/std/bytes`: Go's `bytes`, over `Uint8Array`.
+//
+// `String` has thirty-odd methods for searching, slicing and joining. Its
+// binary counterpart has `set`, `subarray` and `slice`, and everything else is
+// a loop somebody writes again:
+//
+// ```js
+// // Comparing two Uint8Arrays, as found in the wild.
+// if (JSON.stringify([...a]) === JSON.stringify([...b])) { ... }
+// ```
+//
+// That is not a caricature; it is what happens when the obvious thing is
+// missing. Every function here is a loop that is easy to write and easy to
+// write slightly wrong: a comparison that is quadratic, a search that misses a
+// match spanning the point where it restarted, a concatenation that copies the
+// whole buffer once per piece.
+//
+// # Views, not copies
+//
+// `split`, `trimPrefix` and `trimSuffix` return **views** into the input, the
+// way Go's `bytes.Split` returns subslices of the same backing array. Nothing
+// is copied and nothing is allocated but the view objects, which is what makes
+// splitting a megabyte on newlines cost the newlines rather than the megabyte.
+//
+// The consequence is the same as Go's: writing through one of those views
+// writes through to the original, and holding one keeps the whole original
+// buffer alive. Where a copy is wanted, `.slice()` on the result says so, at
+// the one call site that knows.
+//
+// [`concat`], [`join`], [`repeat`] and [`Builder.bytes`] allocate, because
+// there is nothing to be a view of.
+//
+// # Searching
+//
+// [`indexOf`] scans for the needle's first byte with `Uint8Array.prototype
+// .indexOf`, which is one native call rather than one interpreted loop
+// iteration per byte, and only then compares the rest. On the case that matters
+// — a needle whose first byte is rare in the haystack, which is nearly every
+// real delimiter — that is several times faster than the naive double loop, and
+// it is never slower by more than the cost of the calls it makes. It is not a
+// Boyer–Moore or a two-way search: those win on long needles, they need
+// preprocessing proportional to the needle, and the needles people actually
+// search binary data for are one to four bytes long.
+//
+// # What is not here
+//
+// Case folding, `Fields`, `Title`, and the rest of the half of Go's `bytes`
+// that is really about text. Bytes that are text should be decoded — the
+// platform has `TextDecoder` and it is faster than anything written here would
+// be — and the string methods that follow are better than their byte-wise
+// equivalents. This module is for the bytes that are not text.
+
+/** Lexicographic ordering, the way Go's `bytes.Compare` reports it. */
+export type Ordering = -1 | 0 | 1;
+
+/**
+ * Whether two buffers hold the same bytes.
+ *
+ * Length first, which settles the common case without touching a byte, and then
+ * a plain loop. Not constant time: this is for parsing and dispatch, and
+ * comparing a secret with it leaks where the difference is. `timingSafeEqual`
+ * in `@uniflowed/std` is the one for that.
+ */
+export function equal(a: Uint8Array, b: Uint8Array): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Order two buffers lexicographically, by byte and then by length.
+ *
+ * `-1`, `0` or `+1`, which is Go's `bytes.Compare` and is also exactly what
+ * `Array.prototype.sort` wants — so sorting a list of buffers is
+ * `list.sort(compare)` and nothing else.
+ *
+ * "Then by length" is the part worth stating: a prefix sorts before what it is
+ * a prefix of, so `[1, 2]` comes before `[1, 2, 0]`. Byte order is unsigned,
+ * because `Uint8Array` is.
+ */
+export function compare(a: Uint8Array, b: Uint8Array): Ordering {
+  const shared = Math.min(a.length, b.length);
+  for (let index = 0; index < shared; index += 1) {
+    if (a[index] !== b[index]) {
+      return a[index] < b[index] ? -1 : 1;
+    }
+  }
+  if (a.length === b.length) {
+    return 0;
+  }
+  return a.length < b.length ? -1 : 1;
+}
+
+/**
+ * The index of the first occurrence of `needle` in `haystack`, or `-1`.
+ *
+ * An empty needle is found at `from`, which is what `String.prototype.indexOf`
+ * does and what makes `split` on an empty separator terminate instead of
+ * looping.
+ *
+ * `from` is clamped rather than validated: a negative start means the
+ * beginning, and a start past the end means there is nothing left to find. A
+ * search is a question, and neither of those is a mistake worth an exception.
+ */
+export function indexOf(haystack: Uint8Array, needle: Uint8Array, from?: number): number {
+  const start = Math.max(0, from ?? 0);
+  if (needle.length === 0) {
+    return start <= haystack.length ? start : -1;
+  }
+  if (needle.length > haystack.length) {
+    return -1;
+  }
+  const first = needle[0];
+  const last = haystack.length - needle.length;
+  let at = start;
+  while (at <= last) {
+    // One native call finds the next candidate; the interpreted loop below runs
+    // only on positions whose first byte already matched. See the module header
+    // for why this beats the naive double loop on real delimiters.
+    const found = haystack.indexOf(first, at);
+    if (found < 0 || found > last) {
+      return -1;
+    }
+    if (matchesAt(haystack, needle, found)) {
+      return found;
+    }
+    at = found + 1;
+  }
+  return -1;
+}
+
+/**
+ * The index of the last occurrence of `needle` in `haystack`, or `-1`.
+ *
+ * `lastIndexOf` on the first byte, walking backwards, for the same reason
+ * [`indexOf`] scans forwards for it. An empty needle is found at the end.
+ */
+export function lastIndexOf(haystack: Uint8Array, needle: Uint8Array): number {
+  if (needle.length === 0) {
+    return haystack.length;
+  }
+  if (needle.length > haystack.length) {
+    return -1;
+  }
+  const first = needle[0];
+  let at = haystack.length - needle.length;
+  while (at >= 0) {
+    const found = haystack.lastIndexOf(first, at);
+    if (found < 0) {
+      return -1;
+    }
+    if (matchesAt(haystack, needle, found)) {
+      return found;
+    }
+    at = found - 1;
+  }
+  return -1;
+}
+
+/** Whether `needle` occurs anywhere in `haystack`. */
+export function contains(haystack: Uint8Array, needle: Uint8Array): boolean {
+  return indexOf(haystack, needle) >= 0;
+}
+
+/** Whether `bytes` starts with `prefix`. An empty prefix always matches. */
+export function hasPrefix(bytes: Uint8Array, prefix: Uint8Array): boolean {
+  return prefix.length <= bytes.length && matchesAt(bytes, prefix, 0);
+}
+
+/** Whether `bytes` ends with `suffix`. An empty suffix always matches. */
+export function hasSuffix(bytes: Uint8Array, suffix: Uint8Array): boolean {
+  return suffix.length <= bytes.length && matchesAt(bytes, suffix, bytes.length - suffix.length);
+}
+
+/**
+ * `bytes` without `prefix`, or `bytes` unchanged when it does not start with one.
+ *
+ * A view. Unchanged means the same object, so `trimPrefix(b, p) === b` answers
+ * "was there a prefix" without a second comparison.
+ */
+export function trimPrefix(bytes: Uint8Array, prefix: Uint8Array): Uint8Array {
+  return hasPrefix(bytes, prefix) && prefix.length > 0 ? bytes.subarray(prefix.length) : bytes;
+}
+
+/** `bytes` without `suffix`, or `bytes` unchanged. A view; see [`trimPrefix`]. */
+export function trimSuffix(bytes: Uint8Array, suffix: Uint8Array): Uint8Array {
+  return hasSuffix(bytes, suffix) && suffix.length > 0
+    ? bytes.subarray(0, bytes.length - suffix.length)
+    : bytes;
+}
+
+/**
+ * Split `bytes` on every occurrence of `separator`.
+ *
+ * Views into `bytes`, so this costs one object per piece rather than a copy of
+ * the input. `n` pieces for `n - 1` separators, including the empty pieces
+ * around a separator at either end — splitting `,a,` on `,` is three pieces,
+ * two of them empty, which is what every other `split` in the language does and
+ * what makes the round trip through [`join`] exact.
+ *
+ * An empty separator throws. `String.prototype.split("")` answers with the
+ * characters, and the byte-wise reading of that is "every byte its own piece",
+ * which is `Array.from(bytes)` and is not what anybody reaching for a delimiter
+ * meant. Answering the wrong question quietly is worse than refusing.
+ */
+export function split(bytes: Uint8Array, separator: Uint8Array): $ReadOnlyArray<Uint8Array> {
+  if (separator.length === 0) {
+    throw new Error("@uniflowed/std/bytes: split needs a non-empty separator");
+  }
+  const pieces: Array<Uint8Array> = [];
+  let start = 0;
+  let found = indexOf(bytes, separator, start);
+  while (found >= 0) {
+    pieces.push(bytes.subarray(start, found));
+    start = found + separator.length;
+    found = indexOf(bytes, separator, start);
+  }
+  // The tail, which is the whole input when there was no separator at all.
+  pieces.push(bytes.subarray(start));
+  return pieces;
+}
+
+/**
+ * Concatenate `pieces` with `separator` between them.
+ *
+ * The inverse of [`split`], exactly: `join(split(b, s), s)` holds the same
+ * bytes as `b` for every `b` and every non-empty `s`.
+ *
+ * One allocation. The total length is known before anything is copied, which is
+ * the whole reason to have this rather than a `reduce` that concatenates two
+ * buffers at a time — that version copies the accumulated prefix once per
+ * piece, so joining `n` pieces of `k` bytes moves `n²k/2` bytes instead of `nk`.
+ */
+export function join(pieces: $ReadOnlyArray<Uint8Array>, separator: Uint8Array): Uint8Array {
+  if (pieces.length === 0) {
+    return new Uint8Array(0);
+  }
+  let total = separator.length * (pieces.length - 1);
+  for (const piece of pieces) {
+    total += piece.length;
+  }
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (let index = 0; index < pieces.length; index += 1) {
+    if (index > 0 && separator.length > 0) {
+      out.set(separator, at);
+      at += separator.length;
+    }
+    out.set(pieces[index], at);
+    at += pieces[index].length;
+  }
+  return out;
+}
+
+/** Concatenate `pieces` with nothing between them. [`join`] with no separator. */
+export function concat(pieces: $ReadOnlyArray<Uint8Array>): Uint8Array {
+  return join(pieces, EMPTY);
+}
+
+/**
+ * `bytes` repeated `count` times.
+ *
+ * `count` must be a non-negative integer; zero gives an empty buffer. Doubling
+ * rather than appending, so a thousand repeats is ten copies of geometrically
+ * growing regions rather than a thousand copies of one.
+ */
+export function repeat(bytes: Uint8Array, count: number): Uint8Array {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(
+      `@uniflowed/std/bytes: repeat needs a non-negative integer, got ${String(count)}`,
+    );
+  }
+  const total = bytes.length * count;
+  const out = new Uint8Array(total);
+  if (total === 0) {
+    return out;
+  }
+  out.set(bytes, 0);
+  let filled = bytes.length;
+  while (filled < total) {
+    const take = Math.min(filled, total - filled);
+    out.set(out.subarray(0, take), filled);
+    filled += take;
+  }
+  return out;
+}
+
+/** `text` as UTF-8 bytes. `TextEncoder`, named the way the rest of this is. */
+export function fromUtf8(text: string): Uint8Array {
+  return ENCODER.encode(text);
+}
+
+/**
+ * `bytes` decoded as UTF-8.
+ *
+ * Lossy: an invalid sequence becomes U+FFFD rather than an error, which is what
+ * `TextDecoder` does by default and what a log line or an error message wants.
+ * Somewhere that must reject malformed input should construct its own
+ * `TextDecoder("utf-8", { fatal: true })` — that is a decision about the data,
+ * not about the encoding.
+ */
+export function toUtf8(bytes: Uint8Array): string {
+  return DECODER.decode(bytes);
+}
+
+/**
+ * A growable byte buffer.
+ *
+ * Go's `bytes.Buffer` on the write side, and the thing to reach for whenever a
+ * loop is building up bytes. The alternative people write — keeping an array of
+ * chunks and `concat`ing at the end — is fine; the one they write more often
+ * is re-allocating a `Uint8Array` per chunk, which is quadratic.
+ *
+ * ```js
+ * const out = new Builder();
+ * for (const record of records) {
+ *   out.writeUtf8(record.name);
+ *   out.writeByte(0x0a);
+ * }
+ * return out.bytes();
+ * ```
+ *
+ * Capacity doubles, so `n` bytes written in any number of calls costs `O(n)`
+ * copying in total, and the buffer never shrinks until [`reset`].
+ */
+export class Builder {
+  #buffer: Uint8Array;
+  #length: number = 0;
+
+  /**
+   * `capacity` is a hint: the builder grows past it and never below it.
+   *
+   * Passing the eventual size when it is known — a length prefix has just been
+   * read, say — removes every reallocation, which is the only reason the
+   * parameter exists.
+   */
+  constructor(capacity?: number) {
+    const initial = capacity == null || capacity < 1 ? 64 : Math.ceil(capacity);
+    this.#buffer = new Uint8Array(initial);
+  }
+
+  /** How many bytes have been written. */
+  length(): number {
+    return this.#length;
+  }
+
+  /** Append `bytes`. */
+  write(bytes: Uint8Array): void {
+    this.#reserve(bytes.length);
+    this.#buffer.set(bytes, this.#length);
+    this.#length += bytes.length;
+  }
+
+  /** Append one byte. Values outside 0–255 are truncated, as `Uint8Array` does. */
+  writeByte(byte: number): void {
+    this.#reserve(1);
+    this.#buffer[this.#length] = byte;
+    this.#length += 1;
+  }
+
+  /** Append `text` as UTF-8. */
+  writeUtf8(text: string): void {
+    this.write(fromUtf8(text));
+  }
+
+  /**
+   * A copy of what has been written.
+   *
+   * A copy rather than a view, and that is the safe default on purpose: the
+   * builder reallocates as it grows, so a view handed out before a `write` can
+   * end up looking at the buffer the builder abandoned — a bug that appears
+   * only when the next write happens to cross a capacity boundary, which is to
+   * say in production and not in the test. [`view`] is the same thing without
+   * the copy, for a caller that has read why.
+   */
+  bytes(): Uint8Array {
+    return this.#buffer.slice(0, this.#length);
+  }
+
+  /**
+   * What has been written, without copying it.
+   *
+   * Valid until the next write. Use it to hand the contents straight to
+   * something that reads them immediately — a hash, a socket write, a
+   * `TextDecoder` — and never to keep.
+   */
+  view(): Uint8Array {
+    return this.#buffer.subarray(0, this.#length);
+  }
+
+  /** Forget everything written, keeping the capacity for the next round. */
+  reset(): void {
+    this.#length = 0;
+  }
+
+  /** Make room for `more` bytes, doubling until there is. */
+  #reserve(more: number): void {
+    const needed = this.#length + more;
+    if (needed <= this.#buffer.length) {
+      return;
+    }
+    let capacity = this.#buffer.length;
+    while (capacity < needed) {
+      capacity *= 2;
+    }
+    const grown = new Uint8Array(capacity);
+    grown.set(this.#buffer.subarray(0, this.#length), 0);
+    this.#buffer = grown;
+  }
+}
+
+/**
+ * Whether `needle` sits at `at` in `haystack`.
+ *
+ * The bounds are the caller's to check — every caller here has already
+ * established them, and re-checking in the inner loop of a search is the one
+ * place it would be measurable.
+ */
+function matchesAt(haystack: Uint8Array, needle: Uint8Array, at: number): boolean {
+  for (let index = 0; index < needle.length; index += 1) {
+    if (haystack[at + index] !== needle[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** The empty separator [`concat`] joins with. One, because it never changes. */
+const EMPTY: Uint8Array = new Uint8Array(0);
+
+/** One encoder for the module: constructing one per call is most of the cost. */
+const ENCODER: TextEncoder = new TextEncoder();
+
+/** One decoder, for the same reason. */
+const DECODER: TextDecoder = new TextDecoder();

--- a/packages/std/context.js
+++ b/packages/std/context.js
@@ -189,7 +189,7 @@ export function background(): Context {
  * explains what happened.
  */
 export function withCancel(parent: Context): Cancellable {
-  const scope = new Scope(parent, parent.deadline());
+  const scope = new Scope(parent, parent.deadline(), null, true);
   return [scope, (reason?: mixed) => scope.end(reason ?? CANCELLED)];
 }
 
@@ -219,7 +219,7 @@ export function withTimeout(parent: Context, ms: number): Cancellable {
 export function withDeadline(parent: Context, at: number): Cancellable {
   const above = parent.deadline();
   const effective = above == null ? at : Math.min(above, at);
-  const scope = new Scope(parent, effective);
+  const scope = new Scope(parent, effective, null, true);
   const remaining = effective - Date.now();
   if (remaining <= 0) {
     scope.end(DEADLINE_EXCEEDED);
@@ -237,13 +237,20 @@ export function withDeadline(parent: Context, at: number): Cancellable {
  * pair. Storing is not mutation — `parent` cannot see the new value — so a
  * middleware that adds a value does not change what its caller reads.
  *
+ * It is also the cheap one. A value scope allocates no `AbortController`, no
+ * promise and no listener; `signal`, `err` and `done` are its parent's. That
+ * matters because the alternative leaks: a listener on a long-lived parent, one
+ * per short-lived child, is a memory profile shaped like a staircase, and a
+ * scope with no `cancel` has nobody to remove it. Go's `valueCtx` is the same
+ * shape for the same reason.
+ *
  * Values are for things that belong to the *request* rather than to the
  * function: a trace id, an authenticated user, a deadline-aware logger. A
  * parameter is better for everything else, because a parameter is checked at
  * every call and a context value is checked where it is read.
  */
 export function withValue<T>(parent: Context, key: Key<T>, value: T): Context {
-  return new Scope(parent, parent.deadline(), { key, value });
+  return new Scope(parent, parent.deadline(), { key, value }, false);
 }
 
 /**
@@ -257,7 +264,7 @@ export function withValue<T>(parent: Context, key: Key<T>, value: T): Context {
  * signal's own `reason` as the error.
  */
 export function fromSignal(signal: AbortSignal): Context {
-  const scope = new Scope(ROOT, null);
+  const scope = new Scope(ROOT, null, null, true);
   if (signal.aborted) {
     scope.end(signal.reason ?? CANCELLED);
   } else {
@@ -275,8 +282,16 @@ export function fromSignal(signal: AbortSignal): Context {
  * the lookup walk and the cancellation walk from drifting apart.
  */
 class Scope implements Context {
-  #parent: Context | null;
-  #controller: AbortController = new AbortController();
+  #parent: Context;
+  /**
+   * This scope's own cancellation, or `null` when it has none.
+   *
+   * `null` is a value scope: it ends exactly when its parent does, so giving it
+   * a controller of its own would mean a second signal to keep in step with the
+   * first, plus a listener on the parent that nothing ever removes. Delegating
+   * is both cheaper and the only version with no leak.
+   */
+  #controller: AbortController | null;
   #deadline: number | null;
   /**
    * The one value this scope stores, if it stores one.
@@ -292,17 +307,25 @@ class Scope implements Context {
   #error: mixed = null;
   #timer: TimeoutID | null = null;
   #detach: (() => void) | null = null;
-  #done: Promise<void>;
+  #done: Promise<void> | null = null;
   #settle: () => void = () => {};
 
   constructor(
     parent: Context,
     deadline: number | null,
-    entry?: { readonly key: mixed, readonly value: mixed },
+    entry: { readonly key: mixed, readonly value: mixed } | null,
+    cancellable: boolean,
   ) {
     this.#parent = parent;
     this.#deadline = deadline;
-    this.#entry = entry ?? null;
+    this.#entry = entry;
+    if (!cancellable) {
+      // A value scope. Everything but `value` is the parent's answer, so there
+      // is nothing to allocate and nothing to listen for.
+      this.#controller = null;
+      return;
+    }
+    this.#controller = new AbortController();
     this.#done = new Promise((resolve) => {
       this.#settle = resolve;
     });
@@ -326,15 +349,17 @@ class Scope implements Context {
   }
 
   signal(): AbortSignal {
-    return this.#controller.signal;
+    const controller = this.#controller;
+    return controller == null ? this.#parent.signal() : controller.signal;
   }
 
   err(): mixed {
-    return this.#error;
+    return this.#controller == null ? this.#parent.err() : this.#error;
   }
 
   done(): Promise<void> {
-    return this.#done;
+    const done = this.#done;
+    return done == null ? this.#parent.done() : done;
   }
 
   deadline(): number | null {
@@ -375,12 +400,14 @@ class Scope implements Context {
    * End this scope, once.
    *
    * Idempotent, because three things race to call it — the caller's `cancel`,
-   * the deadline, and the parent — and the first ending is the true one. It
-   * releases the timer and the parent listener before aborting, so the
-   * listeners this scope's own children run in are the only work left.
+   * the deadline, and the parent — and the first ending is the true one. A
+   * no-op on a value scope, which has no ending of its own. It releases the
+   * timer and the parent listener before aborting, so the listeners this
+   * scope's own children run in are the only work left.
    */
   end(reason: mixed): void {
-    if (this.#error != null) {
+    const controller = this.#controller;
+    if (controller == null || this.#error != null) {
       return;
     }
     this.#error = reason;
@@ -392,7 +419,7 @@ class Scope implements Context {
       this.#detach();
       this.#detach = null;
     }
-    this.#controller.abort(reason);
+    controller.abort(reason);
     this.#settle();
   }
 }

--- a/packages/std/context.js
+++ b/packages/std/context.js
@@ -1,0 +1,421 @@
+// @flow
+//
+// `@uniflowed/std/context`: Go's `context`, over `AbortSignal`.
+//
+// `AbortSignal` is the web platform's answer to cancellation and it is a good
+// one, so this does not replace it — every context here *has* one, and
+// `ctx.signal()` is what goes to `fetch`. What the platform does not have is
+// the three things Go's `context` adds around it:
+//
+// * **a tree.** Cancelling a request cancels everything it started, at any
+//   depth, without each layer having to remember what it handed down.
+// * **deadlines that compose.** A child may shorten a deadline and may not
+//   extend one, so a five-second handler cannot be made to wait ten by a
+//   library it called.
+// * **typed request-scoped values.** A trace id that reaches the bottom of the
+//   call stack without being a parameter on every function in between, and
+//   without being a global that two concurrent requests share.
+//
+// `AbortSignal.any` and `AbortSignal.timeout` cover parts of the first two.
+// They are also the two newest things on the interface — Deno, Bun, workerd and
+// Node gained them at different times — so a module that needs to run on all
+// of them cannot yet assume either. Nothing here uses them; a deadline is a
+// `setTimeout` and a tree is a listener, both of which have worked everywhere
+// for a decade.
+//
+// # The shape
+//
+// ```js
+// const [ctx, cancel] = withTimeout(background(), 5_000);
+// try {
+//   const response = await fetch(url, { signal: ctx.signal() });
+//   await handle(withValue(ctx, TRACE, id));
+// } finally {
+//   cancel();   // releases the timer; see "Timers" below
+// }
+// ```
+//
+// Every constructor returns `[context, cancel]` the way Go returns
+// `(ctx, cancel)`, because the two are always needed together and a `cancel`
+// that hangs off the context is a `cancel` any callee can reach.
+//
+// # Values are typed by their key
+//
+// ```js
+// const TRACE = key<string>("trace-id");
+// const traced = withValue(ctx, TRACE, requestId);
+// const id = traced.value(TRACE);       // string | void — inferred from TRACE
+// ```
+//
+// A `Key<T>` carries `T` and nothing else; two keys with the same name are
+// still different keys, because a key is compared by identity. That is what
+// makes this safe to use from a library: a key you did not export is a key
+// nobody else can read or overwrite, which is the property a bare string key on
+// a shared object does not have.
+//
+// # Timers
+//
+// `withTimeout` and `withDeadline` arm a `setTimeout`. On Node a pending timer
+// keeps the process alive, and there is no runtime-agnostic `unref` — Deno and
+// browsers do not have one — so **the `cancel` a deadline hands back has to be
+// called**, in a `finally`, even on the path where nothing went wrong. A
+// context that has been cancelled or has already fired holds no timer.
+//
+// This is the one place where this module asks something of the caller that Go
+// does not, and it is why `cancel` is returned rather than hidden.
+
+/**
+ * A key for one request-scoped value, carrying the type of that value.
+ *
+ * Opaque, so the only way to make one is [`key`], and invariant in `T` — `T`
+ * appears in both an argument and a return position of the carrier — because a
+ * `Key<Dog>` used to read a context that stored an `Animal` would be a lie in
+ * one direction and a `Key<Animal>` used to write a `Dog` would be a lie in the
+ * other.
+ */
+export opaque type Key<T> = { readonly name: string, readonly carrier: (T) => T };
+
+/**
+ * A cancellation scope: a signal, a deadline, and the values under it.
+ *
+ * An interface rather than a class, so the only contexts that exist are the
+ * ones the constructors below return. `new Context()` is not a thing a caller
+ * can write, which keeps "every context has a parent or is the root" true by
+ * construction rather than by convention.
+ */
+export interface Context {
+  /**
+   * The signal for this scope, aborted when it is cancelled.
+   *
+   * This is what goes to `fetch`, to an `addEventListener`, and to anything
+   * else that already speaks the platform's cancellation. It is aborted with
+   * the same error [`err`] reports, so `signal.reason` and `ctx.err()` never
+   * disagree.
+   */
+  signal(): AbortSignal;
+
+  /**
+   * Why this scope ended, or `null` while it is still live.
+   *
+   * [`CANCELLED`] or [`DEADLINE_EXCEEDED`] for the two ordinary endings, and
+   * whatever was passed to `cancel(reason)` when a caller supplied one. The
+   * two sentinels are values, so `errors.is(failure, CANCELLED)` finds one
+   * however deeply a caller wrapped it.
+   */
+  err(): mixed;
+
+  /**
+   * Resolves when this scope ends, and never if it does not.
+   *
+   * Go's `<-ctx.Done()`. A context with no cancellation — [`background`] — never
+   * resolves this, exactly as Go's nil channel never fires, so awaiting it
+   * alone is a hang. It is for racing: `Promise.race([work, ctx.done()])`.
+   */
+  done(): Promise<void>;
+
+  /**
+   * When this scope expires, as epoch milliseconds, or `null` for no deadline.
+   *
+   * The *effective* deadline, which is the earliest of this scope's and every
+   * scope above it.
+   */
+  deadline(): number | null;
+
+  /**
+   * The value stored under `key`, at the type the key names, or `undefined`.
+   *
+   * Looks up the chain: the nearest scope that stored something under this key
+   * wins, which is what lets a middleware shadow a value for the work below it
+   * without touching what its own caller sees.
+   */
+  value<T>(key: Key<T>): T | void;
+}
+
+/** How a cancellable scope is handed back: the context, and how to end it. */
+export type Cancellable = [Context, (reason?: mixed) => void];
+
+/**
+ * The reason a scope that was cancelled reports.
+ *
+ * A value rather than a class, so identity is the whole comparison and
+ * `errors.is` finds it through any amount of wrapping. Go's `context.Canceled`
+ * is a sentinel for the same reason.
+ */
+export const CANCELLED: Error = new Error("context cancelled");
+
+/** The reason a scope that ran out of time reports. Go's `DeadlineExceeded`. */
+export const DEADLINE_EXCEEDED: Error = new Error("context deadline exceeded");
+
+/**
+ * Make a key for a value of type `T`.
+ *
+ * ```js
+ * const TRACE = key<string>("trace-id");
+ * ```
+ *
+ * The name is for reading in a debugger and is not the identity: two keys made
+ * with the same name are different keys, and neither can read the other's
+ * value. Give the type argument explicitly — there is nothing else in the call
+ * for Flow to infer it from, and a key whose `T` was inferred as `empty` reads
+ * back as `empty` everywhere.
+ */
+export function key<T>(name: string): Key<T> {
+  return { name, carrier: (value) => value };
+}
+
+/**
+ * The root scope: never cancelled, no deadline, no values.
+ *
+ * Go's `context.Background()`, and used the same way — at the top of a request,
+ * a job, a `main`. One object, because it holds nothing that could differ
+ * between two of them.
+ */
+export function background(): Context {
+  return ROOT;
+}
+
+/**
+ * A scope that ends when the returned function is called, or when `parent` does.
+ *
+ * ```js
+ * const [ctx, cancel] = withCancel(parent);
+ * request.on("close", () => cancel());
+ * ```
+ *
+ * `cancel` is idempotent and safe to call after the scope has already ended,
+ * which is what makes it correct in a `finally`. Calling it with a reason ends
+ * the scope with that reason instead of [`CANCELLED`]; calling it after the
+ * scope has ended changes nothing, because the first ending is the one that
+ * explains what happened.
+ */
+export function withCancel(parent: Context): Cancellable {
+  const scope = new Scope(parent, parent.deadline());
+  return [scope, (reason?: mixed) => scope.end(reason ?? CANCELLED)];
+}
+
+/**
+ * A scope that ends `ms` from now, or when `parent` does, or on `cancel`.
+ *
+ * `withDeadline(parent, Date.now() + ms)`, which is how Go defines it too. See
+ * the module header on timers: the returned `cancel` releases the timer, and on
+ * Node a timer nobody released holds the process open until it fires.
+ */
+export function withTimeout(parent: Context, ms: number): Cancellable {
+  return withDeadline(parent, Date.now() + ms);
+}
+
+/**
+ * A scope that ends at `at`, or when `parent` does, or on `cancel`.
+ *
+ * `at` is epoch milliseconds — `Date.now()`'s units, and `Date.prototype`'s
+ * through `date.getTime()`.
+ *
+ * A deadline later than the parent's is ignored: the effective deadline is the
+ * earliest in the chain, so a callee cannot buy itself more time than its
+ * caller allowed. A deadline already in the past ends the scope immediately,
+ * rather than on the next turn of the event loop, so the code after it sees a
+ * context that is already done.
+ */
+export function withDeadline(parent: Context, at: number): Cancellable {
+  const above = parent.deadline();
+  const effective = above == null ? at : Math.min(above, at);
+  const scope = new Scope(parent, effective);
+  const remaining = effective - Date.now();
+  if (remaining <= 0) {
+    scope.end(DEADLINE_EXCEEDED);
+  } else {
+    scope.arm(remaining);
+  }
+  return [scope, (reason?: mixed) => scope.end(reason ?? CANCELLED)];
+}
+
+/**
+ * A scope like `parent` with one more value in it.
+ *
+ * No cancellation of its own: it ends exactly when `parent` does, and there is
+ * nothing to release, which is why this one returns a context rather than a
+ * pair. Storing is not mutation — `parent` cannot see the new value — so a
+ * middleware that adds a value does not change what its caller reads.
+ *
+ * Values are for things that belong to the *request* rather than to the
+ * function: a trace id, an authenticated user, a deadline-aware logger. A
+ * parameter is better for everything else, because a parameter is checked at
+ * every call and a context value is checked where it is read.
+ */
+export function withValue<T>(parent: Context, key: Key<T>, value: T): Context {
+  return new Scope(parent, parent.deadline(), { key, value });
+}
+
+/**
+ * Adopt an `AbortSignal` that somebody else owns.
+ *
+ * The bridge inwards: a server hands a handler `request.signal`, and this makes
+ * it the root of a context tree without the handler having to own the
+ * cancellation. There is no `cancel` because the signal's owner has it.
+ *
+ * An already-aborted signal produces an already-ended context, with the
+ * signal's own `reason` as the error.
+ */
+export function fromSignal(signal: AbortSignal): Context {
+  const scope = new Scope(ROOT, null);
+  if (signal.aborted) {
+    scope.end(signal.reason ?? CANCELLED);
+  } else {
+    signal.addEventListener("abort", () => scope.end(signal.reason ?? CANCELLED), { once: true });
+  }
+  return scope;
+}
+
+/**
+ * One node of the context tree.
+ *
+ * Every context except the root is one of these, whether it was made by
+ * `withCancel`, `withDeadline` or `withValue` — the three differ in what they
+ * arm and what they store, not in what they are, and one class is what keeps
+ * the lookup walk and the cancellation walk from drifting apart.
+ */
+class Scope implements Context {
+  #parent: Context | null;
+  #controller: AbortController = new AbortController();
+  #deadline: number | null;
+  /**
+   * The one value this scope stores, if it stores one.
+   *
+   * The key is held as `mixed` rather than as a `Key<something>`: `Key` is
+   * invariant, so there is no type a chain of scopes with different value types
+   * could all be, and a `Key<mixed>` is not comparable to the `Key<T>` a lookup
+   * arrives with. Identity is the whole comparison, and identity does not need
+   * a type — the type comes back at the `return`, which is where the phantom
+   * parameter is cashed in.
+   */
+  #entry: { readonly key: mixed, readonly value: mixed } | null;
+  #error: mixed = null;
+  #timer: TimeoutID | null = null;
+  #detach: (() => void) | null = null;
+  #done: Promise<void>;
+  #settle: () => void = () => {};
+
+  constructor(
+    parent: Context,
+    deadline: number | null,
+    entry?: { readonly key: mixed, readonly value: mixed },
+  ) {
+    this.#parent = parent;
+    this.#deadline = deadline;
+    this.#entry = entry ?? null;
+    this.#done = new Promise((resolve) => {
+      this.#settle = resolve;
+    });
+
+    const above = parent.signal();
+    if (above.aborted) {
+      this.end(above.reason ?? CANCELLED);
+      return;
+    }
+    // The listener is what makes cancellation reach the whole subtree, and
+    // removing it is what keeps a long-lived parent from accumulating one per
+    // short-lived child — the leak that makes a per-request context tree a
+    // memory profile shaped like a staircase.
+    const propagate = () => {
+      this.end(above.reason ?? CANCELLED);
+    };
+    above.addEventListener("abort", propagate, { once: true });
+    this.#detach = () => {
+      above.removeEventListener("abort", propagate);
+    };
+  }
+
+  signal(): AbortSignal {
+    return this.#controller.signal;
+  }
+
+  err(): mixed {
+    return this.#error;
+  }
+
+  done(): Promise<void> {
+    return this.#done;
+  }
+
+  deadline(): number | null {
+    return this.#deadline;
+  }
+
+  value<T>(wanted: Key<T>): T | void {
+    let scope: Context | null = this;
+    while (scope instanceof Scope) {
+      const entry = scope.#entry;
+      if (entry != null && entry.key === wanted) {
+        // The key is invariant in `T` and the only way to have stored under
+        // this key was `withValue<T>`, so the value is a `T`. Flow cannot carry
+        // that through a heterogeneous chain of scopes, which is exactly what
+        // the key's phantom type exists to make safe.
+        // $FlowFixMe[incompatible-type]
+        return entry.value as T;
+      }
+      scope = scope.#parent;
+    }
+    return undefined;
+  }
+
+  /**
+   * Arm the deadline timer.
+   *
+   * Separate from the constructor because only two of the three constructors
+   * want one, and because a deadline already in the past must end the scope
+   * synchronously rather than on the next tick.
+   */
+  arm(ms: number): void {
+    this.#timer = setTimeout(() => {
+      this.end(DEADLINE_EXCEEDED);
+    }, ms);
+  }
+
+  /**
+   * End this scope, once.
+   *
+   * Idempotent, because three things race to call it — the caller's `cancel`,
+   * the deadline, and the parent — and the first ending is the true one. It
+   * releases the timer and the parent listener before aborting, so the
+   * listeners this scope's own children run in are the only work left.
+   */
+  end(reason: mixed): void {
+    if (this.#error != null) {
+      return;
+    }
+    this.#error = reason;
+    if (this.#timer != null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+    if (this.#detach != null) {
+      this.#detach();
+      this.#detach = null;
+    }
+    this.#controller.abort(reason);
+    this.#settle();
+  }
+}
+
+/**
+ * The root: no parent, no deadline, and a signal that is never aborted.
+ *
+ * A module-level constant rather than a fresh object per `background()` call,
+ * because every one of them would be identical and every context tree would
+ * otherwise hold its own dead root.
+ */
+const ROOT: Context = {
+  signal: () => ROOT_CONTROLLER.signal,
+  err: () => null,
+  deadline: () => null,
+  // Never resolves, which is what "the root is never cancelled" means. Awaiting
+  // it alone hangs; it is here to be raced against.
+  done: () => NEVER,
+  value: <T>(_key: Key<T>): T | void => undefined,
+};
+
+/** The root's controller, never aborted, so `ROOT.signal()` is a real signal. */
+const ROOT_CONTROLLER: AbortController = new AbortController();
+
+/** The promise `ROOT.done()` hands back. One, because it never settles. */
+const NEVER: Promise<void> = new Promise(() => {});

--- a/packages/std/context.js
+++ b/packages/std/context.js
@@ -277,9 +277,11 @@ export function fromSignal(signal: AbortSignal): Context {
  * One node of the context tree.
  *
  * Every context except the root is one of these, whether it was made by
- * `withCancel`, `withDeadline` or `withValue` — the three differ in what they
- * arm and what they store, not in what they are, and one class is what keeps
- * the lookup walk and the cancellation walk from drifting apart.
+ * `withCancel`, `withDeadline`, `withValue` or `fromSignal`. They differ in
+ * whether they carry a cancellation of their own and in what they store, and
+ * one class rather than four is what keeps the lookup walk and the cancellation
+ * walk from drifting apart — `value` has to see through every kind of scope
+ * above it, and a second class is a kind the walk can forget about.
  */
 class Scope implements Context {
   #parent: Context;

--- a/packages/std/errors.js
+++ b/packages/std/errors.js
@@ -1,0 +1,347 @@
+// @flow
+//
+// `@uniflowed/std/errors`: Go's `errors`, over JavaScript's `cause`.
+//
+// JavaScript has had error chaining since ES2022 — `new Error(msg, { cause })`
+// — and nothing that reads one. So every codebase writes the same walk, badly:
+//
+// ```js
+// // The version everyone writes, and the three things wrong with it.
+// let e = error;
+// while (e) {
+//   if (e instanceof TimeoutError) return true;
+//   e = e.cause;
+// }
+// ```
+//
+// It loops forever on a cycle, it cannot see into an `AggregateError`, and it
+// is written once per predicate. Go solved this in `errors` and the answer
+// ports cleanly, because the two languages disagree about almost nothing here:
+// a wrapped error is an error that holds another, and the question a caller
+// asks is "is this *about* X", not "is this X".
+//
+// # The two questions, and why they are different functions
+//
+// `is` asks whether something in the chain **is a particular value** — a
+// sentinel. `as` asks whether something in the chain **is a particular class**,
+// and hands it back at that type so its fields can be read. Go splits them for
+// the same reason, and the split is what makes the second one typed:
+//
+// ```js
+// if (is(error, NOT_FOUND)) return null;              // a sentinel
+// const http = as(error, HttpError);                  // HttpError | null
+// if (http != null) retryAfter(http.status);          // .status is a number
+// ```
+//
+// `as` infers its result from the class it is handed. There is no annotation
+// at that call site and no `any` behind it: `tests/type-tests/std-errors.js`
+// fails the build if `as(error, HttpError)` ever starts typing as something a
+// caller has to cast.
+//
+// # What is walked
+//
+// The chain is a *tree*, not a list, because `join` exists. Each node
+// contributes its `cause` and, when it is an `AggregateError`, every entry of
+// its `errors` — which is what makes `is` work through a `Promise.all` that
+// collected several failures. The walk is breadth-first over that tree, it
+// visits every node once, and a cycle is a node it has already seen rather
+// than a hang. Depth is capped as a second line of defence; see `MAX_DEPTH`.
+//
+// # What this deliberately does not do
+//
+// It does not format. Go's `fmt.Errorf` is a formatter that happens to wrap,
+// and JavaScript already has template literals — `wrap(\`loading ${id}\`, e)`
+// needs no `%w`. It does not install itself on `Error.prototype`, so nothing
+// here changes how an error from somebody else's library behaves. And it does
+// not stringify the chain into the message: the cause is a value the chain
+// still holds, so a reporter can render it however it likes, and a message
+// that had already flattened its cause could not be walked at all.
+
+/**
+ * How deep a chain is followed before the walk gives up.
+ *
+ * The `seen` set already makes a cycle terminate, so this is not the cycle
+ * guard — it is the guard against a chain that is merely *enormous*, which is
+ * what a retry loop that wraps its own last failure produces. A thousand is
+ * far past any chain a person would write and far short of a stack anyone
+ * would notice.
+ */
+const MAX_DEPTH = 1000;
+
+/**
+ * An error that decides for itself what it matches.
+ *
+ * Go spells this `Is(error) bool`, and it exists for the case identity cannot
+ * cover: an error carrying an OS errno matches a sentinel for that errno
+ * without being that object. Implementing it is optional and nothing here
+ * requires it — a class with no `matches` is compared by identity, which is
+ * what a sentinel wants.
+ *
+ * It is `matches` rather than `is` because `is` is the name of the function
+ * asking the question, and an error whose method and the caller's verb are the
+ * same word reads as recursion in every stack trace that shows both.
+ */
+export interface Matcher {
+  matches(target: mixed): boolean;
+}
+
+/** Anything that could be an error: this module never assumes it was given one. */
+export type Chainable = mixed;
+
+/**
+ * Wrap `cause` in a new error that says what was being attempted.
+ *
+ * The equivalent of Go's `fmt.Errorf("...: %w", err)`, with the formatting left
+ * to the language that already has it. The result is an ordinary `Error`, so
+ * anything that logs errors logs this one, and `is`, `as` and `chain` see
+ * through it to what it holds.
+ *
+ * ```js
+ * try {
+ *   await readConfig(path);
+ * } catch (cause) {
+ *   throw wrap(`reading ${path}`, cause);
+ * }
+ * ```
+ */
+export function wrap(message: string, cause: Chainable): Error {
+  return new Error(message, { cause });
+}
+
+/**
+ * The error one level under `error`, or `undefined` when there is none.
+ *
+ * Go's `errors.Unwrap`. Rarely what a caller wants — `is` and `as` walk the
+ * whole chain, and a hand-written loop over `unwrap` is the code this module
+ * exists to delete — but it is here because a reporter that renders one frame
+ * at a time needs exactly this.
+ *
+ * `undefined` rather than `null`, because that is what reading `.cause` off an
+ * error without one gives, and a second spelling of "nothing" is a second
+ * check every caller has to write.
+ */
+export function unwrap(error: Chainable): mixed {
+  if (error == null || typeof error !== "object") {
+    return undefined;
+  }
+  // Reading a property off `mixed` needs the object to be typed as one that
+  // may have it; `cause` is optional on every error and absent on most values.
+  const holder = error as { readonly cause?: mixed, ... };
+  return holder.cause;
+}
+
+/**
+ * Whether anything in `error`'s chain is `target`.
+ *
+ * Identity, and then the error's own opinion: a node implementing
+ * [`Matcher`] is asked, which is how a class of errors matches a sentinel it
+ * merely carries. Both are tried at every node in the tree, so a sentinel
+ * three wraps down inside one branch of a `join` is still found.
+ *
+ * ```js
+ * export const CANCELLED: Error = new Error("cancelled");
+ * // ...
+ * if (is(failure, CANCELLED)) return;
+ * ```
+ *
+ * A `null` or `undefined` target matches nothing, deliberately: `is(e, e.cause)`
+ * on an error with no cause would otherwise be true for every unwrapped error
+ * in the program, which is the kind of accident that turns a `catch` into a
+ * silent `return`.
+ */
+export function is(error: Chainable, target: Chainable): boolean {
+  if (target == null) {
+    return false;
+  }
+  return walk(error, (node) => {
+    if (node === target) {
+      return true;
+    }
+    const matcher = asMatcher(node);
+    return matcher != null && matcher.matches(target) === true;
+  });
+}
+
+/**
+ * The first error in `error`'s chain that is an instance of `kind`, or `null`.
+ *
+ * Go's `errors.As`, which needs a pointer to a typed variable because Go has
+ * no way to return one; Flow does, so this returns the value at the type the
+ * class names and there is no out-parameter.
+ *
+ * ```js
+ * class HttpError extends Error {
+ *   status: number;
+ *   constructor(status: number) {
+ *     super(`HTTP ${status}`);
+ *     this.status = status;
+ *   }
+ * }
+ *
+ * const http = as(failure, HttpError);
+ * if (http != null && http.status === 429) {
+ *   // `http.status` is a number here, inferred from HttpError alone.
+ * }
+ * ```
+ *
+ * The first match in breadth-first order, which matters when a `join` holds two
+ * errors of the same class: the one that was joined first is the one returned,
+ * and that order is the order the caller wrote.
+ */
+export function as<T>(error: Chainable, kind: Class<T>): T | null {
+  let found: T | null = null;
+  walk(error, (node) => {
+    if (node instanceof kind) {
+      found = node;
+      return true;
+    }
+    return false;
+  });
+  return found;
+}
+
+/**
+ * One error standing for several, or `null` when there are none.
+ *
+ * Go's `errors.Join`. `null` for an empty list rather than an empty aggregate,
+ * and every nullish entry is dropped, so the shape a caller collects errors in
+ * — push on failure, nothing on success — needs no filtering before it gets
+ * here:
+ *
+ * ```js
+ * const failures = results.map((r) => r.error); // some are undefined
+ * const failed = join(...failures);
+ * if (failed != null) throw failed;
+ * ```
+ *
+ * The result is an `AggregateError`, which is the platform's own name for this
+ * and what `Promise.any` already throws — so a reporter that knows how to
+ * render one renders this too. `is` and `as` walk into every branch of it.
+ *
+ * A single error is returned as itself rather than wrapped in an aggregate of
+ * one. An aggregate of one says the caller collected a list, which is true, and
+ * costs every reader of the result a layer to see through, which is not worth
+ * it.
+ */
+export function join(...errors: $ReadOnlyArray<Chainable>): Error | null {
+  const present = errors.filter((error) => error != null);
+  if (present.length === 0) {
+    return null;
+  }
+  if (present.length === 1) {
+    const only = present[0];
+    if (only instanceof Error) {
+      return only;
+    }
+  }
+  return new AggregateError(present, `${String(present.length)} errors occurred`);
+}
+
+/**
+ * Every error reachable from `error`, in the order the walk finds them.
+ *
+ * `error` itself first, then its cause and its aggregate members, then theirs.
+ * For a chain with no branches this is exactly the list a hand-written
+ * `while (e) e = e.cause` produces, and unlike that loop it terminates on a
+ * cycle.
+ *
+ * For reporting, not for control flow: reaching into this array to decide what
+ * to do is `is` or `as` written out longhand, and both of those stop as soon as
+ * they have an answer.
+ */
+export function chain(error: Chainable): $ReadOnlyArray<mixed> {
+  const found: Array<mixed> = [];
+  walk(error, (node) => {
+    found.push(node);
+    return false;
+  });
+  return found;
+}
+
+/**
+ * `node` as a [`Matcher`], or `null` when it does not implement one.
+ *
+ * A property named `matches` that is not callable is not a matcher, and a
+ * value that reached here from JSON could easily have one — so the check is on
+ * the function, not on the name.
+ */
+function asMatcher(node: mixed): Matcher | null {
+  if (node == null || typeof node !== "object") {
+    return null;
+  }
+  const holder = node as { readonly matches?: mixed, ... };
+  if (typeof holder.matches !== "function") {
+    return null;
+  }
+  // The property is callable and takes the one argument the interface names;
+  // nothing weaker than a cast can say that about a `mixed`.
+  // $FlowFixMe[incompatible-type]
+  return node as Matcher;
+}
+
+/**
+ * Visit every error reachable from `error` until `found` says to stop.
+ *
+ * Breadth-first, because the two callers that stop early both want the
+ * *nearest* match: an `as` that returned the deepest `HttpError` in a chain
+ * would hand back the transport failure rather than the response the caller
+ * asked about.
+ *
+ * The queue holds nodes not yet visited and `seen` holds those already
+ * enqueued, which is what makes a cycle finite: `a.cause = b; b.cause = a` is
+ * two nodes and two visits. `seen` is keyed by identity, so two structurally
+ * identical errors are two nodes, which is right — they are two failures.
+ */
+function walk(error: Chainable, found: (node: mixed) => boolean): boolean {
+  const seen = new Set<mixed>();
+  let frontier: Array<mixed> = [error];
+  seen.add(error);
+  for (let depth = 0; depth < MAX_DEPTH && frontier.length > 0; depth += 1) {
+    const next: Array<mixed> = [];
+    for (const node of frontier) {
+      if (node == null) {
+        continue;
+      }
+      if (found(node)) {
+        return true;
+      }
+      for (const child of childrenOf(node)) {
+        if (child != null && !seen.has(child)) {
+          seen.add(child);
+          next.push(child);
+        }
+      }
+    }
+    frontier = next;
+  }
+  return false;
+}
+
+/**
+ * What hangs below one node: its cause, and an aggregate's members.
+ *
+ * Both, rather than one or the other. `AggregateError` accepts a `cause` like
+ * every other error, and an aggregate built by `join` inside a `catch` that
+ * itself wrapped something has both a list and a cause — dropping either is a
+ * branch of the tree that `is` would silently not search.
+ */
+function childrenOf(node: mixed): $ReadOnlyArray<mixed> {
+  if (node == null || typeof node !== "object") {
+    return [];
+  }
+  const holder = node as { readonly cause?: mixed, readonly errors?: mixed, ... };
+  const children: Array<mixed> = [];
+  if (holder.cause != null) {
+    children.push(holder.cause);
+  }
+  // `errors` on an `AggregateError`, and on anything else shaped like one:
+  // duck-typed rather than an `instanceof`, because an aggregate that crossed a
+  // realm — a worker, an iframe, a `structuredClone` — is not an instance of
+  // *this* realm's `AggregateError` and is still the same tree.
+  if (Array.isArray(holder.errors)) {
+    for (const child of holder.errors) {
+      children.push(child);
+    }
+  }
+  return children;
+}

--- a/packages/std/heap.js
+++ b/packages/std/heap.js
@@ -122,8 +122,13 @@ export class Heap<T> {
       return undefined;
     }
     const top = items[0];
-    const last = items.pop();
-    if (items.length > 0 && last !== undefined) {
+    // Read the last item before shortening the array rather than taking what
+    // `pop` hands back: on a `Heap<T | void>` the returned value is
+    // indistinguishable from "there was nothing there", and a heap whose
+    // elements may legitimately be `undefined` would leave a hole at the root.
+    const last = items[items.length - 1];
+    items.pop();
+    if (items.length > 0) {
       items[0] = last;
       this.#down(0);
     }

--- a/packages/std/heap.js
+++ b/packages/std/heap.js
@@ -1,0 +1,250 @@
+// @flow
+//
+// `@uniflowed/std/heap`: Go's `container/heap`, as a class with a comparator.
+//
+// A priority queue is the data structure JavaScript is missing that hurts most,
+// because the two things people reach for instead are both wrong in a way that
+// does not show up until the input grows:
+//
+// ```js
+// queue.push(job);
+// queue.sort(byPriority);      // O(n log n) per insert
+// const next = queue.shift();  // O(n) per removal
+// ```
+//
+// That is `O(n² log n)` to drain a queue that a heap drains in `O(n log n)`. It
+// is correct, it is two lines, and it is why a scheduler that was fine with a
+// hundred jobs falls over at ten thousand.
+//
+// # Why a class rather than Go's interface
+//
+// Go's `container/heap` asks the caller to implement `Len`, `Less`, `Swap`,
+// `Push` and `Pop` and then calls them, which is how Go writes a generic
+// container in a language that had no generics when the package was written. In
+// Flow it costs five methods to say what one comparator says, and the
+// comparator is the version that infers: `new Heap((a, b) => a.due - b.due)`
+// gives a `Heap` of whatever `a` and `b` are, with nothing annotated.
+//
+// # A heap is not stable
+//
+// Two items that compare equal come out in an order nothing promises, and that
+// order is not insertion order. This is a property of the structure and not
+// something an implementation can fix — the sift operations move equal elements
+// past each other. When ties matter, break them:
+//
+// ```js
+// let arrived = 0;
+// const queue = new Heap((a, b) => a.priority - b.priority || a.seq - b.seq);
+// queue.push({ ...job, seq: (arrived += 1) });
+// ```
+//
+// Which is two lines the caller writes rather than a counter every heap pays
+// for. `Array.prototype.sort` *is* stable, so a full sort is still the right
+// answer for a batch that is not a queue.
+//
+// # Cost
+//
+// `push` and `pop` are `O(log n)` with one comparison per level. [`peek`] and
+// [`size`] are `O(1)`. [`heapify`] builds from an existing array in `O(n)` —
+// genuinely linear, not `n log n` — which is the reason to have it rather than
+// pushing in a loop. One array holds everything; there are no nodes.
+
+/**
+ * How two items are ordered: negative if `a` comes first, positive if `b` does.
+ *
+ * The same contract as `Array.prototype.sort`'s comparator, so a comparator
+ * written for one works for the other. A comparator that is inconsistent — one
+ * where `compare(a, b)` and `compare(b, a)` agree on a sign — does not corrupt
+ * the heap's memory, but the order it produces means nothing.
+ */
+export type Compare<T> = (a: T, b: T) => number;
+
+/**
+ * A binary min-heap ordered by a comparator.
+ *
+ * "Min" is relative to the comparator: the item [`pop`] returns is the one that
+ * compares less than every other, so a comparator of `(a, b) => b - a` is a
+ * max-heap and no second class is needed.
+ *
+ * ```js
+ * const queue = new Heap<Job>((a, b) => a.due - b.due);
+ * queue.push(job);
+ * const next = queue.pop();   // Job | void
+ * ```
+ *
+ * `T` is inferred from the comparator, so the type argument above is
+ * documentation rather than a requirement.
+ */
+export class Heap<T> {
+  #items: Array<T>;
+  #compare: Compare<T>;
+
+  /**
+   * A heap ordered by `compare`, holding `initial` if any is given.
+   *
+   * `initial` is copied and then heapified in place, which is linear — see
+   * [`heapify`], the name that says so at the call site.
+   */
+  constructor(compare: Compare<T>, initial?: $ReadOnlyArray<T>) {
+    this.#compare = compare;
+    this.#items = initial == null ? [] : initial.slice();
+    for (let index = (this.#items.length >> 1) - 1; index >= 0; index -= 1) {
+      this.#down(index);
+    }
+  }
+
+  /** How many items are in the heap. */
+  size(): number {
+    return this.#items.length;
+  }
+
+  /** Whether the heap holds nothing. */
+  isEmpty(): boolean {
+    return this.#items.length === 0;
+  }
+
+  /** Add `item`. `O(log n)`. */
+  push(item: T): void {
+    this.#items.push(item);
+    this.#up(this.#items.length - 1);
+  }
+
+  /**
+   * Remove and return the least item, or `undefined` when the heap is empty.
+   *
+   * `T | void` rather than throwing, because "is there anything left" is the
+   * question a drain loop asks on every iteration and an exception is a poor
+   * way to answer a question that is asked in a condition.
+   */
+  pop(): T | void {
+    const items = this.#items;
+    if (items.length === 0) {
+      return undefined;
+    }
+    const top = items[0];
+    const last = items.pop();
+    if (items.length > 0 && last !== undefined) {
+      items[0] = last;
+      this.#down(0);
+    }
+    return top;
+  }
+
+  /** The least item without removing it, or `undefined`. `O(1)`. */
+  peek(): T | void {
+    return this.#items.length === 0 ? undefined : this.#items[0];
+  }
+
+  /**
+   * Replace the least item with `item` in one sift, and return what was there.
+   *
+   * A `pop` followed by a `push` does two sifts and briefly shrinks the array;
+   * this does one, which is worth having in the loop it exists for — merging
+   * `k` sorted streams, where every step takes the smallest head and puts back
+   * the next element of the stream it came from.
+   *
+   * On an empty heap this is a plain `push`, and returns `undefined`.
+   */
+  replace(item: T): T | void {
+    const items = this.#items;
+    if (items.length === 0) {
+      items.push(item);
+      return undefined;
+    }
+    const top = items[0];
+    items[0] = item;
+    this.#down(0);
+    return top;
+  }
+
+  /**
+   * Every item, in no particular order, as a copy.
+   *
+   * The heap's own array is a heap and not a sorted list — only the first
+   * element is guaranteed to be anything — so this is for inspection, and
+   * anything that needs them in order should [`drain`] instead.
+   */
+  toArray(): $ReadOnlyArray<T> {
+    return this.#items.slice();
+  }
+
+  /** Remove everything. */
+  clear(): void {
+    this.#items = [];
+  }
+
+  /**
+   * Every item in order, emptying the heap as it goes.
+   *
+   * A generator, so a caller that stops early — `for (const job of q.drain())
+   * { if (job.due > now) break; }` — pays only for what it took, and the rest
+   * stays in the heap. That is the difference from sorting: a drain that reads
+   * the first ten of a million costs `O(n + 10 log n)`, not `O(n log n)`.
+   */
+  *drain(): Generator<T, void, void> {
+    let next = this.pop();
+    while (next !== undefined) {
+      yield next;
+      next = this.pop();
+    }
+  }
+
+  /** Move the item at `at` up until its parent is not greater than it. */
+  #up(at: number): void {
+    const items = this.#items;
+    let index = at;
+    const item = items[index];
+    while (index > 0) {
+      const parent = (index - 1) >> 1;
+      if (this.#compare(item, items[parent]) >= 0) {
+        break;
+      }
+      items[index] = items[parent];
+      index = parent;
+    }
+    items[index] = item;
+  }
+
+  /** Move the item at `at` down until both children are not less than it. */
+  #down(at: number): void {
+    const items = this.#items;
+    const length = items.length;
+    let index = at;
+    const item = items[index];
+    for (;;) {
+      const left = index * 2 + 1;
+      if (left >= length) {
+        break;
+      }
+      const right = left + 1;
+      // The smaller child, because swapping with the larger one would leave it
+      // above its own sibling.
+      const child = right < length && this.#compare(items[right], items[left]) < 0 ? right : left;
+      if (this.#compare(items[child], item) >= 0) {
+        break;
+      }
+      items[index] = items[child];
+      index = child;
+    }
+    items[index] = item;
+  }
+}
+
+/**
+ * Build a heap from items already in hand, in `O(n)`.
+ *
+ * Sifting down from the middle of the array costs linear time in total, because
+ * most of the array is leaves and a leaf sifts zero levels. Pushing the same
+ * items one at a time costs `O(n log n)`, and the difference is the reason
+ * Go's `heap.Init` exists.
+ *
+ * ```js
+ * const queue = heapify(jobs, (a, b) => a.due - b.due);
+ * ```
+ *
+ * `items` is copied, so the caller's array is untouched and the heap owns what
+ * it holds.
+ */
+export function heapify<T>(items: $ReadOnlyArray<T>, compare: Compare<T>): Heap<T> {
+  return new Heap(compare, items);
+}

--- a/packages/std/hex.js
+++ b/packages/std/hex.js
@@ -1,0 +1,314 @@
+// @flow
+//
+// `@uniflowed/std/hex`: Go's `encoding/hex`.
+//
+// Hexadecimal is how bytes get written down — a digest in a lockfile, an ETag,
+// a key in a URL, a packet in a log — and JavaScript's answer is still
+// `Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("")`. That
+// line is correct and it is on a wiki somewhere in every company, because
+// `Uint8Array.prototype.toHex` is very new: Firefox 133 and Safari 18.2 at the
+// end of 2024, Chrome 140 and Deno 2.5 in September 2025, and **Node 25.0 in
+// October 2025** — one major version after the Node this repository's own suite
+// runs on. A module that has to run everywhere cannot call it yet, and this one
+// is what to import until it can.
+//
+// # Decoding is the half that needs care
+//
+// Encoding cannot fail. Decoding can, four ways, and the version people write
+// by hand — `parseInt(text.slice(i, i + 2), 16)` — reports none of them:
+// `parseInt("zz", 16)` is `NaN`, which becomes `0` on its way into a
+// `Uint8Array`, so a corrupted digest decodes to a *different valid-looking*
+// digest instead of an error. `parseInt("1z", 16)` is `1`, silently. So
+// [`decode`] rejects odd lengths and any byte that is not a hex digit, and says
+// which offset was wrong — the one piece of information that turns "the token
+// is bad" into "the token was truncated at 32 characters".
+//
+// # Case
+//
+// [`encode`] produces lowercase, which is what every checksum format, every Git
+// object id and Go itself produce. [`decode`] accepts either case, because the
+// inputs come from other people.
+//
+// # Cost
+//
+// Encoding has two paths and picks by length — see `DECODER_WINS_ABOVE`, which
+// is where appending to a string stops beating one trip through `TextDecoder`.
+// Decoding reads a 128-entry table rather than comparing ranges. Importing this
+// module allocates one `TextDecoder` and nothing else: both tables are built by
+// the first call that needs them, so a program that imports [`dump`] for a
+// debug path it never takes pays for nothing.
+//
+// That is about 200 MB/s encoding a 32-byte digest and 620 MB/s on a megabyte,
+// and about 200 to 250 MB/s decoding. Node's native `Buffer` is roughly six
+// times faster than either at a megabyte and about twice as fast on a digest,
+// which is a real gap and still not a reason to reach for a binding: see
+// `docs/app/reference/std` for the whole table and the argument.
+
+/**
+ * A hexadecimal string that could not be decoded.
+ *
+ * Carries the offset so a caller can say where, which is the whole reason this
+ * is a class rather than a message. Go's `hex.InvalidByteError` reports the
+ * byte; this reports the position too, because a malformed digest is usually
+ * truncated rather than mistyped and the position is what says so.
+ */
+export class InvalidHexError extends Error {
+  /** Index into the input string where decoding stopped. */
+  offset: number;
+
+  constructor(message: string, offset: number) {
+    super(message);
+    this.name = "InvalidHexError";
+    this.offset = offset;
+  }
+}
+
+/** How many characters `n` bytes encode to. Exactly `2n`. */
+export function encodedLength(n: number): number {
+  return n * 2;
+}
+
+/**
+ * How many bytes `n` characters decode to.
+ *
+ * `n / 2`, rounded down — but an odd `n` never decodes, so this rounding is for
+ * sizing a buffer before validating rather than a licence to ignore the
+ * remainder.
+ */
+export function decodedLength(n: number): number {
+  return n >> 1;
+}
+
+/**
+ * `bytes` as lowercase hexadecimal.
+ *
+ * ```js
+ * encode(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));   // "deadbeef"
+ * ```
+ */
+export function encode(bytes: Uint8Array): string {
+  const table = tables();
+  if (bytes.length < DECODER_WINS_ABOVE) {
+    // Short input: appending to a string beats going through `TextDecoder`,
+    // because the decoder costs about 500 ns before it looks at a byte and this
+    // path costs about 6 ns per byte. A 32-byte digest — the common case, and
+    // the one every ETag and content hash hits — is 150 ns here and 520 ns
+    // through the decoder.
+    let out = "";
+    for (let index = 0; index < bytes.length; index += 1) {
+      out += table.text[bytes[index]];
+    }
+    return out;
+  }
+  // Long input: write the digits as ASCII bytes and decode once, so the only
+  // string allocated is the answer. `TextDecoder` is UTF-8, and every byte
+  // written here is below 0x80, where UTF-8 and ASCII are the same encoding —
+  // so this needs no `latin1` decoder, which is the corner of the Encoding
+  // standard the edge runtimes do not all implement.
+  const out = new Uint8Array(bytes.length * 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    const pair = table.codes[bytes[index]];
+    out[index * 2] = pair >> 8;
+    out[index * 2 + 1] = pair & 0xff;
+  }
+  return DECODER.decode(out);
+}
+
+/**
+ * Decode hexadecimal text, or throw [`InvalidHexError`].
+ *
+ * Either case, no separators, no `0x` prefix, no whitespace — a decoder that
+ * strips things is a decoder that accepts two spellings of the same value, and
+ * a caller who wants to strip can strip.
+ *
+ * ```js
+ * decode("deadbeef");    // Uint8Array [222, 173, 190, 239]
+ * decode("dead beef");   // InvalidHexError at offset 4
+ * ```
+ */
+export function decode(text: string): Uint8Array {
+  if (text.length % 2 !== 0) {
+    throw new InvalidHexError(
+      `@uniflowed/std/hex: odd-length input (${String(text.length)} characters)`,
+      text.length,
+    );
+  }
+  const table = values();
+  const out = new Uint8Array(text.length >> 1);
+  for (let index = 0; index < out.length; index += 1) {
+    const high = digit(table, text.charCodeAt(index * 2));
+    const low = digit(table, text.charCodeAt(index * 2 + 1));
+    if (high < 0) {
+      throw invalid(text, index * 2);
+    }
+    if (low < 0) {
+      throw invalid(text, index * 2 + 1);
+    }
+    out[index] = (high << 4) | low;
+  }
+  return out;
+}
+
+/**
+ * Whether `text` would decode.
+ *
+ * For validating input at a boundary — a route parameter, a header — where the
+ * answer is a 400 rather than a decoded value, and where building an exception
+ * to throw it away is the expensive part.
+ */
+export function isValid(text: string): boolean {
+  if (text.length % 2 !== 0) {
+    return false;
+  }
+  const table = values();
+  for (let index = 0; index < text.length; index += 1) {
+    if (digit(table, text.charCodeAt(index)) < 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * `bytes` as a `hexdump -C` listing: offset, hex columns, and printable text.
+ *
+ * Go's `hex.Dump`, byte for byte, which means it is the format every
+ * `hexdump -C` and `xxd` reader already knows how to read:
+ *
+ * ```text
+ * 00000000  47 45 54 20 2f 20 48 54  54 50 2f 31 2e 31 0d 0a  |GET / HTTP/1.1..|
+ * 00000010  48 6f 73 74 3a 20 61 2e  62 0d 0a                 |Host: a.b..|
+ * ```
+ *
+ * The reason to have it rather than logging [`encode`]'s output is the right
+ * column: a protocol bug is almost always visible as text, and sixteen bytes
+ * per line makes an offset something a person can count to. It ends with a
+ * newline when there is anything to print, and is empty otherwise.
+ */
+export function dump(bytes: Uint8Array): string {
+  const table = tables().text;
+  const lines: Array<string> = [];
+  for (let start = 0; start < bytes.length; start += 16) {
+    const row = bytes.subarray(start, Math.min(start + 16, bytes.length));
+    const columns: Array<string> = [];
+    for (let index = 0; index < 16; index += 1) {
+      // The gap after eight columns is what makes a 16-byte line countable at a
+      // glance, and it is why the short last row still pads to full width.
+      columns.push(index < row.length ? table[row[index]] : "  ");
+      if (index === 7) {
+        columns.push("");
+      }
+    }
+    let text = "";
+    for (const byte of row) {
+      // Printable ASCII only. Anything else is a dot, including the bytes a
+      // terminal would act on — a dump that could move the cursor is a dump
+      // that can lie about what is in the buffer.
+      text += byte >= 0x20 && byte < 0x7f ? String.fromCharCode(byte) : ".";
+    }
+    lines.push(`${offset(start)}  ${columns.join(" ")}  |${text}|`);
+  }
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}
+
+/**
+ * Every byte's two hex digits, in the two shapes the two encode paths want.
+ *
+ * `text` is the pair as a string, which the short path appends. `codes` is the
+ * pair packed into one 16-bit value — first character in the high half — which
+ * the long path writes with two shifts and no string at all.
+ *
+ * Built lazily, so importing this module does no work: a shipped module that
+ * computes at import time is one a bundler cannot drop, and a program that
+ * imports [`dump`] for a debug path it never takes should pay for nothing. One
+ * null check per call, not per byte.
+ */
+function tables(): { readonly text: $ReadOnlyArray<string>, readonly codes: Uint16Array } {
+  const built = TABLES;
+  if (built != null) {
+    return built;
+  }
+  const text = new Array<string>(256);
+  const codes = new Uint16Array(256);
+  for (let value = 0; value < 256; value += 1) {
+    const high = DIGITS.charCodeAt(value >> 4);
+    const low = DIGITS.charCodeAt(value & 15);
+    text[value] = DIGITS[value >> 4] + DIGITS[value & 15];
+    codes[value] = (high << 8) | low;
+  }
+  const table = { text, codes };
+  TABLES = table;
+  return table;
+}
+
+/**
+ * The value of every ASCII char code as a hex digit, or `-1`, built once.
+ *
+ * A table rather than three range comparisons per character: decoding is the
+ * half that runs on untrusted input, so it is the half that runs on the long
+ * strings, and a lookup is one load where the comparisons are up to six
+ * branches the predictor cannot help with on mixed-case input.
+ */
+function values(): Int8Array {
+  const built = VALUES;
+  if (built != null) {
+    return built;
+  }
+  const table = new Int8Array(128).fill(-1);
+  for (let value = 0; value < 16; value += 1) {
+    table[DIGITS.charCodeAt(value)] = value;
+    table[UPPER.charCodeAt(value)] = value;
+  }
+  VALUES = table;
+  return table;
+}
+
+/**
+ * The value of one hex digit's char code, or `-1` when it is not one.
+ *
+ * The bound is checked rather than left to the typed array, because indexing a
+ * `Int8Array` past its end gives `undefined`, and `undefined < 0` is `false` —
+ * which would let every character above U+007F through as a valid digit.
+ */
+function digit(table: Int8Array, code: number): number {
+  return code < 128 ? table[code] : -1;
+}
+
+/** The error for a bad character, quoting it and naming where it was. */
+function invalid(text: string, at: number): InvalidHexError {
+  return new InvalidHexError(
+    `@uniflowed/std/hex: ${JSON.stringify(text[at])} at offset ${String(at)} is not a hex digit`,
+    at,
+  );
+}
+
+/** An eight-digit offset column, the width `hexdump -C` uses. */
+function offset(at: number): string {
+  return at.toString(16).padStart(8, "0");
+}
+
+/** One decoder for the module: the ASCII bytes [`encode`] builds go through it. */
+const DECODER: TextDecoder = new TextDecoder();
+
+/**
+ * Where appending to a string stops beating a trip through `TextDecoder`.
+ *
+ * Measured, not guessed: the decoder costs about 500 ns per call whatever the
+ * length, and the appending loop about 6 ns per byte, so they cross at around
+ * 128 bytes on Node 24 and Bun 1.3 on an M-series laptop. The exact point moves
+ * between engines; being within a factor of two of it is what matters, because
+ * the curve is flat on both sides of the crossing.
+ */
+const DECODER_WINS_ABOVE = 128;
+
+/** The encoding tables, or `null` until the first call builds them. */
+let TABLES: { readonly text: $ReadOnlyArray<string>, readonly codes: Uint16Array } | null = null;
+
+/** The decoding table, or `null` until the first call builds it. */
+let VALUES: Int8Array | null = null;
+
+/** Lowercase hex digits: the alphabet both tables are built from, and the output. */
+const DIGITS = "0123456789abcdef";
+
+/** The same digits uppercase, which [`decode`] accepts and never produces. */
+const UPPER = "0123456789ABCDEF";

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -11,10 +11,23 @@
     "directory": "packages/std"
   },
   "exports": {
-    ".": "./index.js"
+    ".": "./index.js",
+    "./bytes": "./bytes.js",
+    "./context": "./context.js",
+    "./errors": "./errors.js",
+    "./heap": "./heap.js",
+    "./hex": "./hex.js",
+    "./sync": "./sync.js",
+    "./package.json": "./package.json"
   },
   "files": [
-    "index.js"
+    "bytes.js",
+    "context.js",
+    "errors.js",
+    "heap.js",
+    "hex.js",
+    "index.js",
+    "sync.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/std/sync.js
+++ b/packages/std/sync.js
@@ -1,0 +1,509 @@
+// @flow
+//
+// `@uniflowed/std/sync`: Go's `sync` and `errgroup`, for one thread.
+//
+// JavaScript has no data races, so half of Go's `sync` package has no reason
+// to exist here — there is nothing to protect a `number` from. The other half
+// is about *ordering*, and that half is missing entirely:
+//
+// * "wait until these N things have finished" — `WaitGroup`
+// * "only one of these at a time" — `Mutex`
+// * "at most N of these at a time" — `Semaphore`
+// * "exactly once, however many callers race for it" — `once`
+// * "all of these, and stop everything on the first failure" — `Group`
+//
+// `await Promise.all` answers the first and none of the rest. A single-threaded
+// runtime interleaves at every `await`, so two `async` functions reading and
+// writing the same record *do* interleave, and every one of these is a real
+// hazard in a request handler rather than an import from a language with
+// threads.
+//
+// # Why not `Promise.all` for `Group`
+//
+// `Promise.all` rejects on the first failure and leaves the rest running, with
+// nothing to cancel them and nowhere for their failures to go — a task that
+// rejects after the `all` has already rejected is an unhandled rejection, which
+// on Node is a process that exits. `Promise.allSettled` fixes the reporting and
+// still runs everything. `Group` is the third thing: bounded concurrency, the
+// first failure cancels the rest through a signal every task is handed, and no
+// rejection is ever unobserved because each is attached the moment the task
+// starts.
+//
+// # Fairness
+//
+// Every queue here is FIFO. A waiter that arrived first is resumed first, so a
+// `Mutex` under continuous contention cannot starve anybody. That is a choice
+// rather than a consequence: resuming the most recent waiter is measurably
+// faster on some workloads, and a lock somebody waits on forever is worse than
+// one that is slightly slower for everybody.
+//
+// # Cost
+//
+// A `Mutex` or `Semaphore` with no contention costs one already-resolved
+// promise per acquisition and never touches the queue. Under contention it
+// costs one array entry and one promise per waiter. `WaitGroup.wait()` with a
+// counter already at zero returns an already-resolved promise and allocates no
+// waiter at all.
+
+/**
+ * What a caller does when it is finished with a lock or a permit.
+ *
+ * A function rather than a `release()` method on the lock, so the only way to
+ * release is to be holding the thing that was handed out — there is no
+ * `mutex.unlock()` for code that never locked it to call by mistake.
+ *
+ * Calling it twice releases once. That is not politeness: a `finally` that
+ * releases, inside a function whose body already released, would otherwise wake
+ * two waiters for one permit, and the second of them would run inside somebody
+ * else's critical section. It is the single most common way a hand-written
+ * semaphore goes wrong, so it is closed here rather than documented as a rule.
+ */
+export type Release = () => void;
+
+/**
+ * Wait for a set of tasks to finish, without collecting what they returned.
+ *
+ * Go's `sync.WaitGroup`, and the shape to reach for when the things being
+ * waited on are not a list you can map over — a stream of jobs, a fan-out
+ * started from inside a loop, work registered by a callback:
+ *
+ * ```js
+ * const group = new WaitGroup();
+ * for (const job of jobs) {
+ *   group.add(1);
+ *   run(job).finally(() => group.done());
+ * }
+ * await group.wait();
+ * ```
+ *
+ * `add` before starting the work and `done` when it finishes, both of them
+ * outside the task, which is what lets the counter go up from anywhere. When
+ * the tasks *are* a list and their results are wanted, [`Group`] is the better
+ * tool and `Promise.all` is often better still.
+ */
+export class WaitGroup {
+  /** Outstanding work. `wait` resolves when this reaches zero. */
+  #count: number = 0;
+  /** Callers parked in `wait`, resumed together when the counter empties. */
+  #waiting: Array<() => void> = [];
+
+  /**
+   * Add `delta` to the counter, defaulting to one.
+   *
+   * A negative delta is allowed — it is how `done` is implemented — and driving
+   * the counter below zero throws. Go panics for the same reason: a counter
+   * that has gone negative means a `done` without an `add`, so some *other*
+   * `wait` in the program has already been told the work was finished when it
+   * was not, and the failure has to be loud where it happened rather than
+   * silent where it is observed.
+   */
+  add(delta?: number): void {
+    const by = delta ?? 1;
+    const next = this.#count + by;
+    if (next < 0) {
+      throw new Error("@uniflowed/std/sync: WaitGroup counter went negative");
+    }
+    this.#count = next;
+    if (next === 0) {
+      this.#release();
+    }
+  }
+
+  /** Record one task as finished. `add(-1)`, spelled the way Go spells it. */
+  done(): void {
+    this.add(-1);
+  }
+
+  /** The number of tasks still outstanding. */
+  count(): number {
+    return this.#count;
+  }
+
+  /**
+   * Resolve once the counter is zero.
+   *
+   * Immediately when it is already zero, which is the case a `wait` on an empty
+   * group hits and is worth not allocating for. Several callers may wait at
+   * once and all are resumed together; a group whose counter returns to zero,
+   * rises and falls again resolves each `wait` at the first zero *after* that
+   * caller asked, which is the only reading that does not depend on scheduling.
+   */
+  wait(): Promise<void> {
+    if (this.#count === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.#waiting.push(resolve);
+    });
+  }
+
+  /** Resume everybody parked in `wait`. */
+  #release(): void {
+    const waiting = this.#waiting;
+    this.#waiting = [];
+    for (const resume of waiting) {
+      resume();
+    }
+  }
+}
+
+/**
+ * At most `permits` holders at a time, FIFO.
+ *
+ * Go has no `Semaphore` in `sync` — it has a buffered channel, which is the
+ * same thing — and `golang.org/x/sync/semaphore` is the name it goes by.
+ * The uses are the ones where unbounded concurrency is the bug: a fan-out over
+ * ten thousand URLs that opens ten thousand sockets, an import that runs one
+ * database query per row.
+ *
+ * ```js
+ * const limit = new Semaphore(8);
+ * await Promise.all(urls.map((url) => limit.withPermit(() => fetch(url))));
+ * ```
+ *
+ * [`Group`] is usually the better answer for exactly that example, because it
+ * also cancels the rest when one fails. Reach for the semaphore when the limit
+ * has to be shared between call sites that do not know about each other.
+ */
+export class Semaphore {
+  /** Permits not currently held. */
+  #free: number;
+  /** Callers parked in `acquire`, in arrival order. */
+  #waiting: Array<(release: Release) => void> = [];
+
+  constructor(permits: number) {
+    if (!Number.isInteger(permits) || permits < 1) {
+      throw new Error(
+        `@uniflowed/std/sync: a Semaphore needs at least one permit, got ${String(permits)}`,
+      );
+    }
+    this.#free = permits;
+  }
+
+  /** Permits available right now. Zero means the next `acquire` will wait. */
+  available(): number {
+    return this.#free;
+  }
+
+  /** Callers currently parked in `acquire`. */
+  waiting(): number {
+    return this.#waiting.length;
+  }
+
+  /**
+   * Take a permit, waiting if none is free, and return how to give it back.
+   *
+   * The caller is responsible for releasing, which means a `try`/`finally` —
+   * and [`withPermit`] is that `try`/`finally` written once. Reach for this
+   * directly only when the permit's lifetime is not a block: a stream that
+   * holds one until it is closed, say.
+   */
+  acquire(): Promise<Release> {
+    if (this.#free > 0) {
+      this.#free -= 1;
+      return Promise.resolve(this.#releaser());
+    }
+    return new Promise((resolve) => {
+      this.#waiting.push(resolve);
+    });
+  }
+
+  /**
+   * Run `task` holding a permit, and release it however `task` ends.
+   *
+   * The result is `task`'s, at `task`'s type: `withPermit(() => fetch(url))`
+   * is a `Promise<Response>` with nothing written down at the call site.
+   */
+  async withPermit<T>(task: () => Promise<T> | T): Promise<T> {
+    const release = await this.acquire();
+    try {
+      return await task();
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * One permit's worth of release, spent at most once.
+   *
+   * The `spent` flag is what makes a double release a no-op rather than a
+   * corrupted count; see [`Release`] for why that case is worth closing.
+   */
+  #releaser(): Release {
+    let spent = false;
+    return () => {
+      if (spent) {
+        return;
+      }
+      spent = true;
+      const next = this.#waiting.shift();
+      if (next === undefined) {
+        this.#free += 1;
+        return;
+      }
+      // The permit is handed straight to the next waiter rather than returned
+      // to the pool and taken again: a round trip through `#free` would let a
+      // caller arriving in between jump the queue, which is the starvation
+      // this class says it does not have.
+      next(this.#releaser());
+    };
+  }
+}
+
+/**
+ * One holder at a time.
+ *
+ * Go's `sync.Mutex`. A `Semaphore` of one, and a different name because the
+ * intent is different: a semaphore bounds a resource, a mutex protects an
+ * invariant. What it protects on a single-threaded runtime is a sequence of
+ * `await`s — a read-modify-write that yields in the middle is interleaved with
+ * every other copy of itself, and no amount of JavaScript's single-threadedness
+ * prevents that:
+ *
+ * ```js
+ * // Two concurrent callers here lose one increment, every time.
+ * const seen = await store.get(key);
+ * await store.set(key, seen + 1);
+ * ```
+ *
+ * There is no `RWMutex` here yet, deliberately: readers and writers cannot
+ * actually run at the same time in one runtime, so the only thing it would buy
+ * over this is a fairness policy, and it should be added when somebody has the
+ * workload that needs one.
+ */
+export class Mutex {
+  #semaphore: Semaphore = new Semaphore(1);
+
+  /** Whether the mutex is held right now. */
+  locked(): boolean {
+    return this.#semaphore.available() === 0;
+  }
+
+  /** Callers currently waiting for it. */
+  waiting(): number {
+    return this.#semaphore.waiting();
+  }
+
+  /** Take the lock, waiting if it is held, and return how to release it. */
+  lock(): Promise<Release> {
+    return this.#semaphore.acquire();
+  }
+
+  /**
+   * Run `task` holding the lock, and release it however `task` ends.
+   *
+   * The result is `task`'s, at `task`'s type.
+   *
+   * ```js
+   * await counters.withLock(async () => {
+   *   const seen = await store.get(key);
+   *   await store.set(key, seen + 1);
+   * });
+   * ```
+   *
+   * Not re-entrant: a `withLock` inside a `withLock` on the same mutex waits
+   * for a lock only its own caller can release, which is a deadlock. Go's mutex
+   * is not re-entrant either, and for the same reason — a re-entrant lock lets
+   * a function observe a half-finished invariant that its own caller was in the
+   * middle of restoring.
+   */
+  withLock<T>(task: () => Promise<T> | T): Promise<T> {
+    return this.#semaphore.withPermit(task);
+  }
+}
+
+/**
+ * Wrap `make` so it runs at most once, however many callers race for it.
+ *
+ * Go's `sync.Once`, as a function rather than a struct because JavaScript's
+ * answer to "the thing I want to do once" is almost always a value:
+ *
+ * ```js
+ * const connect = once(() => open(url));   // () => Promise<Connection>
+ * // ...
+ * const db = await connect();              // every caller gets the same one
+ * ```
+ *
+ * The result is whatever `make` returned, at its type, including when that is a
+ * promise: concurrent callers all receive the *same* promise, so `make` runs
+ * once even if every caller arrives before it settles. That is the property a
+ * hand-written `if (cached == null)` does not have, because the check and the
+ * assignment are separated by an `await`.
+ *
+ * # A failure is remembered
+ *
+ * If `make` throws or rejects, every later call throws or rejects with the same
+ * error rather than retrying. Go's `Once` behaves this way too, and it is the
+ * conservative reading: a "run once" that quietly becomes "run once per
+ * failure" is how a failing connection turns into a retry storm. Retrying is a
+ * policy, and a policy belongs in the caller — wrap the retry, not the `once`.
+ */
+export function once<T>(make: () => T): () => T {
+  let done = false;
+  let value: T;
+  let failure: mixed;
+  let failed = false;
+  return () => {
+    if (!done) {
+      done = true;
+      try {
+        value = make();
+      } catch (error) {
+        failed = true;
+        failure = error;
+      }
+    }
+    if (failed) {
+      throw failure;
+    }
+    return value;
+  };
+}
+
+/** What one of a [`Group`]'s tasks is handed. */
+export type Task<T> = (signal: AbortSignal) => Promise<T> | T;
+
+/** How a [`Group`] is bounded. */
+export type GroupOptions = {
+  /**
+   * How many tasks may run at once. Unbounded when absent.
+   *
+   * A limit is the reason to reach for a group over `Promise.all`, so it is
+   * worth setting even when the list is small today: the list that is fifty
+   * items in development is the one that is fifty thousand in production.
+   */
+  readonly limit?: number,
+};
+
+/**
+ * Run tasks together, bounded, and stop the rest when one fails.
+ *
+ * Go's `golang.org/x/sync/errgroup`, which is `WaitGroup` plus the two things
+ * every use of a wait group turns out to want: the first error, and a context
+ * that is cancelled when it happens.
+ *
+ * ```js
+ * const group = new Group<Row>({ limit: 8 });
+ * for (const id of ids) {
+ *   group.go((signal) => fetchRow(id, signal));
+ * }
+ * const rows = await group.wait();   // $ReadOnlyArray<Row>, in submission order
+ * ```
+ *
+ * `T` is inferred from the tasks, so `rows` is typed by what `fetchRow`
+ * returns and nothing is annotated at the call.
+ *
+ * # What happens on the first failure
+ *
+ * `wait` rejects with the first error, and every task still running is told to
+ * stop through the `signal` it was handed. Telling is all a group can do —
+ * JavaScript has no way to interrupt a function that ignores its signal — so a
+ * task that never looks at it runs to completion, and `wait` will have already
+ * rejected by then. Its result is discarded and its failure, if it has one, is
+ * observed here rather than becoming an unhandled rejection.
+ *
+ * A group is used once. After `wait` has been called, `go` throws rather than
+ * silently starting work nobody will ever look at.
+ */
+export class Group<T> {
+  #limit: Semaphore | null;
+  #settled: Array<Promise<void>> = [];
+  #results: Array<T> = [];
+  #started: number = 0;
+  #controller: AbortController = new AbortController();
+  #failure: { readonly error: mixed } | null = null;
+  #closed: boolean = false;
+
+  constructor(options?: GroupOptions) {
+    const limit = options?.limit;
+    this.#limit = limit == null ? null : new Semaphore(limit);
+  }
+
+  /**
+   * The signal every task is handed, aborted on the first failure.
+   *
+   * Exposed as well as passed so that work started *outside* a task — a shared
+   * stream, a timer — can be cancelled with the group.
+   */
+  signal(): AbortSignal {
+    return this.#controller.signal;
+  }
+
+  /**
+   * Start `task`, at the position in the results its call order gives it.
+   *
+   * Returns nothing: a group's results come back from `wait`, in submission
+   * order rather than completion order, so a caller reading `rows[3]` does not
+   * have to know which task happened to finish third.
+   */
+  go(task: Task<T>): void {
+    if (this.#closed) {
+      throw new Error("@uniflowed/std/sync: Group.go after wait; make a new Group");
+    }
+    // The slot is reserved by index before the task runs, and written when it
+    // finishes, so a task that finishes third still lands where its `go` put
+    // it. Nothing is pushed here: an array entry that held a placeholder would
+    // have to be typed `T | void`, which would put a `void` in the result type
+    // every caller reads — an internal hole is not worth a public one.
+    const index = this.#started;
+    this.#started += 1;
+    this.#settled.push(this.#run(task, index));
+  }
+
+  /** How many tasks have been started. */
+  started(): number {
+    return this.#started;
+  }
+
+  /**
+   * Wait for every task, and answer with their results or the first failure.
+   *
+   * Rejects with the first error any task raised. Resolves with one entry per
+   * `go`, in the order the `go` calls were made.
+   */
+  async wait(): Promise<$ReadOnlyArray<T>> {
+    this.#closed = true;
+    // Every entry resolves — `#run` catches — so this settles once all the
+    // tasks have finished, including the ones that ignored the abort.
+    await Promise.all(this.#settled);
+    const failure = this.#failure;
+    if (failure != null) {
+      throw failure.error;
+    }
+    // Nothing was skipped, because a skip only happens after a failure and a
+    // failure has already been thrown above. So every reserved index was
+    // written and the array is dense.
+    return this.#results;
+  }
+
+  /**
+   * One task, from permit to result, never rejecting.
+   *
+   * The returned promise resolving is what `wait` counts; the task's own
+   * failure is recorded rather than propagated, which is what keeps a failed
+   * task from being an unhandled rejection in the window between it failing and
+   * `wait` being awaited.
+   */
+  async #run(task: Task<T>, index: number): Promise<void> {
+    const limit = this.#limit;
+    const release = limit == null ? null : await limit.acquire();
+    try {
+      if (this.#controller.signal.aborted) {
+        // Somebody failed while this one was queued for a permit. Running it
+        // now would do work whose result `wait` has already decided to throw
+        // away, and would hold a permit somebody else could use to finish.
+        return;
+      }
+      this.#results[index] = await task(this.#controller.signal);
+    } catch (error) {
+      if (this.#failure == null) {
+        this.#failure = { error };
+        this.#controller.abort(error);
+      }
+    } finally {
+      if (release != null) {
+        release();
+      }
+    }
+  }
+}

--- a/packages/std/sync.js
+++ b/packages/std/sync.js
@@ -395,12 +395,18 @@ export type GroupOptions = {
  *
  * # What happens on the first failure
  *
- * `wait` rejects with the first error, and every task still running is told to
- * stop through the `signal` it was handed. Telling is all a group can do —
- * JavaScript has no way to interrupt a function that ignores its signal — so a
- * task that never looks at it runs to completion, and `wait` will have already
- * rejected by then. Its result is discarded and its failure, if it has one, is
- * observed here rather than becoming an unhandled rejection.
+ * Every task still running is told to stop, through the `signal` it was handed,
+ * and any task still queued for a permit is dropped without being started.
+ * Telling is all a group can do: JavaScript has no way to interrupt a function
+ * that ignores its signal.
+ *
+ * So `wait` still waits for every task, and rejects with the first error once
+ * the last one has finished. That is deliberate, and it is the difference from
+ * `Promise.all`: a `wait` that rejected while its tasks were still running
+ * would hand the caller a scope it believes is finished — which is how a test
+ * tears down the database its own fixtures are still writing to. The results
+ * of the tasks that finished after the failure are discarded, and their
+ * failures are observed here rather than becoming unhandled rejections.
  *
  * A group is used once. After `wait` has been called, `go` throws rather than
  * silently starting work nobody will ever look at.

--- a/tests/library/std.test.js
+++ b/tests/library/std.test.js
@@ -1,0 +1,859 @@
+// @flow
+//
+// `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
+//
+// Six modules, and what is asserted here is the property that makes each one
+// worth importing rather than the fact that it returns something. A `heap` that
+// pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
+// answers every question correctly until the one that matters; a `Group` that
+// leaves an unhandled rejection behind exits the process on Node. Each of those
+// is a test below.
+//
+// The negative type tests — that `as` narrows, that a `Key<string>` cannot read
+// a `number` — are not here, because no amount of running proves a program
+// would have been refused. They are in `tests/type-tests/std-inference.js`, and
+// the last `describe` runs them.
+
+import { describe, expect, it } from "@uniflowed/test";
+
+import {
+  Builder,
+  compare,
+  concat,
+  contains,
+  equal,
+  fromUtf8,
+  hasPrefix,
+  hasSuffix,
+  indexOf,
+  join,
+  lastIndexOf,
+  repeat,
+  split,
+  toUtf8,
+  trimPrefix,
+  trimSuffix,
+} from "@uniflowed/std/bytes";
+import {
+  CANCELLED,
+  DEADLINE_EXCEEDED,
+  background,
+  fromSignal,
+  key,
+  withCancel,
+  withDeadline,
+  withTimeout,
+  withValue,
+} from "@uniflowed/std/context";
+import { as, chain, is, join as joinErrors, unwrap, wrap } from "@uniflowed/std/errors";
+import { Heap, heapify } from "@uniflowed/std/heap";
+import { InvalidHexError, decode, dump, encode, isValid } from "@uniflowed/std/hex";
+import { Group, Mutex, Semaphore, WaitGroup, once } from "@uniflowed/std/sync";
+
+import { everyMisuseIsReported } from "./type-tests.js";
+
+/** Bytes from a list of numbers, which is what every fixture below wants. */
+const b = (...values: Array<number>): Uint8Array => new Uint8Array(values);
+
+/** A promise that settles after `ms`, for the deadline tests. */
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe("errors", () => {
+  class HttpError extends Error {
+    status: number;
+    constructor(status: number) {
+      super(`HTTP ${String(status)}`);
+      this.status = status;
+    }
+  }
+
+  it("finds a sentinel through any depth of wrapping", () => {
+    const sentinel = new Error("connection refused");
+    const failure = wrap("loading user 7", wrap("querying users", sentinel));
+
+    expect(is(failure, sentinel)).toBe(true);
+    expect(is(failure, new Error("connection refused"))).toBe(false);
+  });
+
+  it("returns the wrapped error at the type of the class it was asked for", () => {
+    const failure = wrap("rendering the page", new HttpError(429));
+
+    const http = as(failure, HttpError);
+    expect(http).not.toBe(null);
+    // The point of `as` over a hand-written `instanceof` walk: the field is
+    // reachable without a cast, and `tests/type-tests` proves it is typed.
+    expect(http?.status).toBe(429);
+    expect(as(failure, TypeError)).toBe(null);
+  });
+
+  it("terminates on a cycle instead of hanging", () => {
+    // The failure mode the hand-written `while (e) e = e.cause` loop has, and
+    // the reason this module exists rather than being three lines at each call
+    // site. A retry that wraps its own last failure builds this by accident.
+    const first: { cause?: mixed } = new Error("first");
+    const second = new Error("second", { cause: first });
+    first.cause = second;
+
+    expect(is(first, second)).toBe(true);
+    expect(is(first, new Error("elsewhere"))).toBe(false);
+    expect(chain(first)).toHaveLength(2);
+  });
+
+  it("searches every branch of a join, not just the first", () => {
+    const timeout = new Error("timed out");
+    const failure = joinErrors(new Error("disk full"), wrap("second shard", timeout));
+
+    expect(is(failure, timeout)).toBe(true);
+    expect(failure).toBeInstanceOf(AggregateError);
+  });
+
+  it("joins nothing to null and one error to itself", () => {
+    // `null` for nothing is what lets a caller collect optional failures and
+    // ask one question at the end; returning an empty aggregate would make
+    // "did anything fail" a length check.
+    expect(joinErrors()).toBe(null);
+    expect(joinErrors(null, undefined)).toBe(null);
+
+    const only = new Error("alone");
+    expect(joinErrors(only)).toBe(only);
+    expect(joinErrors(null, only, undefined)).toBe(only);
+  });
+
+  it("asks an error that has an opinion about what it matches", () => {
+    const SENTINEL = new Error("not found");
+    class Errno extends Error {
+      matches(target: mixed): boolean {
+        return target === SENTINEL;
+      }
+    }
+
+    expect(is(wrap("reading", new Errno("ENOENT")), SENTINEL)).toBe(true);
+    expect(is(wrap("reading", new Errno("ENOENT")), new Error("other"))).toBe(false);
+  });
+
+  it("never matches a nullish target", () => {
+    // Otherwise `is(e, e.cause)` on an unwrapped error would be true for every
+    // error in the program, because `undefined` is in every chain's tail.
+    expect(is(new Error("x"), null)).toBe(false);
+    expect(is(new Error("x"), undefined)).toBe(false);
+  });
+
+  it("unwraps exactly one level, and answers undefined at the bottom", () => {
+    const bottom = new Error("bottom");
+    expect(unwrap(wrap("top", bottom))).toBe(bottom);
+    expect(unwrap(bottom)).toBe(undefined);
+    expect(unwrap("not an error at all")).toBe(undefined);
+  });
+});
+
+describe("sync", () => {
+  describe("WaitGroup", () => {
+    it("resolves when the counter empties, and immediately when it is already zero", async () => {
+      const group = new WaitGroup();
+      let finished = false;
+
+      group.add(2);
+      const waited = group.wait().then(() => {
+        finished = true;
+      });
+
+      group.done();
+      await Promise.resolve();
+      expect(finished).toBe(false);
+      expect(group.count()).toBe(1);
+
+      group.done();
+      await waited;
+      expect(finished).toBe(true);
+
+      // A second wait on an empty group does not park.
+      await group.wait();
+    });
+
+    it("throws rather than letting the counter go negative", () => {
+      // A `done` without an `add` means some other `wait` has already been told
+      // the work finished. Failing here is the only place it can be seen.
+      const group = new WaitGroup();
+      expect(() => group.done()).toThrow();
+    });
+  });
+
+  describe("Mutex", () => {
+    it("serialises a read-modify-write that yields in the middle", async () => {
+      // The hazard that exists on a single-threaded runtime: two async
+      // functions interleave at the `await`, and one increment is lost.
+      const store = { count: 0 };
+      const unguarded = async () => {
+        const seen = store.count;
+        await sleep(1);
+        store.count = seen + 1;
+      };
+      await Promise.all([unguarded(), unguarded()]);
+      expect(store.count).toBe(1);
+
+      store.count = 0;
+      const mutex = new Mutex();
+      const guarded = () =>
+        mutex.withLock(async () => {
+          const seen = store.count;
+          await sleep(1);
+          store.count = seen + 1;
+        });
+      await Promise.all([guarded(), guarded()]);
+      expect(store.count).toBe(2);
+    });
+
+    it("releases once however many times the release is called", async () => {
+      const mutex = new Mutex();
+      const release = await mutex.lock();
+      expect(mutex.locked()).toBe(true);
+
+      release();
+      release();
+      release();
+
+      // Three releases for one lock must not have handed out two permits: if
+      // they had, both of these would be granted at once.
+      const first = await mutex.lock();
+      expect(mutex.locked()).toBe(true);
+      let second = false;
+      mutex.lock().then(() => {
+        second = true;
+      });
+      await sleep(1);
+      expect(second).toBe(false);
+      first();
+    });
+
+    it("releases the lock when the body throws", async () => {
+      const mutex = new Mutex();
+      await expect(
+        mutex.withLock(() => {
+          throw new Error("no");
+        }),
+      ).rejects.toThrow("no");
+      expect(mutex.locked()).toBe(false);
+    });
+  });
+
+  describe("Semaphore", () => {
+    it("never lets more than its permits run at once", async () => {
+      const limit = new Semaphore(3);
+      let running = 0;
+      let peak = 0;
+
+      await Promise.all(
+        Array.from({ length: 20 }, () =>
+          limit.withPermit(async () => {
+            running += 1;
+            peak = Math.max(peak, running);
+            await sleep(1);
+            running -= 1;
+          }),
+        ),
+      );
+
+      expect(peak).toBe(3);
+      expect(limit.available()).toBe(3);
+    });
+
+    it("wakes waiters in arrival order", async () => {
+      const limit = new Semaphore(1);
+      const order: Array<number> = [];
+      const held = await limit.acquire();
+
+      const waiters = [1, 2, 3].map((n) =>
+        limit.acquire().then((release) => {
+          order.push(n);
+          release();
+        }),
+      );
+      expect(limit.waiting()).toBe(3);
+
+      held();
+      await Promise.all(waiters);
+      // FIFO, so nobody can be starved by a stream of later arrivals.
+      expect(order).toEqual([1, 2, 3]);
+    });
+
+    it("refuses a semaphore that can never admit anybody", () => {
+      expect(() => new Semaphore(0)).toThrow();
+    });
+  });
+
+  describe("once", () => {
+    it("runs at most once and hands every caller the same value", () => {
+      let calls = 0;
+      const make = once(() => {
+        calls += 1;
+        return { id: calls };
+      });
+
+      const first = make();
+      expect(make()).toBe(first);
+      expect(make()).toBe(first);
+      expect(calls).toBe(1);
+    });
+
+    it("gives concurrent callers the same in-flight promise", async () => {
+      let calls = 0;
+      const connect = once(async () => {
+        calls += 1;
+        await sleep(5);
+        return "connection";
+      });
+
+      const [a, c] = await Promise.all([connect(), connect()]);
+      expect(a).toBe("connection");
+      expect(c).toBe("connection");
+      // The property a hand-written `if (cached == null)` does not have: the
+      // check and the assignment are separated by an `await`, so both callers
+      // pass the check.
+      expect(calls).toBe(1);
+    });
+
+    it("remembers a failure rather than retrying it", () => {
+      let calls = 0;
+      const make = once(() => {
+        calls += 1;
+        throw new Error("nope");
+      });
+
+      expect(() => make()).toThrow("nope");
+      expect(() => make()).toThrow("nope");
+      expect(calls).toBe(1);
+    });
+  });
+
+  describe("Group", () => {
+    it("returns results in submission order, not completion order", async () => {
+      const group = new Group<number>();
+      group.go(async () => {
+        await sleep(10);
+        return 1;
+      });
+      group.go(() => 2);
+      group.go(async () => {
+        await sleep(5);
+        return 3;
+      });
+
+      expect(await group.wait()).toEqual([1, 2, 3]);
+    });
+
+    it("bounds how many run at once", async () => {
+      const group = new Group<void>({ limit: 2 });
+      let running = 0;
+      let peak = 0;
+      for (let n = 0; n < 10; n += 1) {
+        group.go(async () => {
+          running += 1;
+          peak = Math.max(peak, running);
+          await sleep(1);
+          running -= 1;
+        });
+      }
+
+      await group.wait();
+      expect(peak).toBe(2);
+    });
+
+    it("tells the rest to stop when one fails, and reports the first failure", async () => {
+      const group = new Group<string>();
+      let aborted = false;
+
+      group.go(async (signal) => {
+        signal.addEventListener("abort", () => {
+          aborted = true;
+        });
+        await sleep(20);
+        return "slow";
+      });
+      group.go(async () => {
+        await sleep(1);
+        throw new Error("first");
+      });
+
+      await expect(group.wait()).rejects.toThrow("first");
+      expect(aborted).toBe(true);
+    });
+
+    it("observes a failure nobody was waiting for yet", async () => {
+      // The `Promise.all` hazard: a task that rejects before anything awaits
+      // the group is an unhandled rejection, which on Node exits the process.
+      const unhandled: Array<mixed> = [];
+      const watch = (reason: mixed) => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", watch);
+      try {
+        const group = new Group<void>();
+        group.go(() => Promise.reject(new Error("early")));
+        // Two macrotasks is well past the turn Node reports an unhandled
+        // rejection on.
+        await sleep(5);
+        await expect(group.wait()).rejects.toThrow("early");
+      } finally {
+        process.off("unhandledRejection", watch);
+      }
+      expect(unhandled).toEqual([]);
+    });
+
+    it("refuses to start work after wait", async () => {
+      const group = new Group<void>();
+      group.go(() => {});
+      await group.wait();
+      expect(() => group.go(() => {})).toThrow("after wait");
+    });
+  });
+});
+
+describe("context", () => {
+  it("cancels the whole subtree from the top", () => {
+    const [root, cancel] = withCancel(background());
+    const [child] = withCancel(root);
+    const [grandchild] = withCancel(child);
+
+    expect(grandchild.err()).toBe(null);
+    cancel();
+
+    expect(root.err()).toBe(CANCELLED);
+    expect(child.err()).toBe(CANCELLED);
+    expect(grandchild.err()).toBe(CANCELLED);
+    expect(grandchild.signal().aborted).toBe(true);
+  });
+
+  it("keeps the first ending rather than the last", () => {
+    const [ctx, cancel] = withCancel(background());
+    const reason = new Error("client went away");
+
+    cancel(reason);
+    cancel();
+
+    expect(ctx.err()).toBe(reason);
+  });
+
+  it("resolves done when the scope ends, and reports the reason on the signal too", async () => {
+    const [ctx, cancel] = withCancel(background());
+    let done = false;
+    const waiting = ctx.done().then(() => {
+      done = true;
+    });
+
+    expect(done).toBe(false);
+    cancel();
+    await waiting;
+    expect(done).toBe(true);
+    expect(ctx.signal().reason).toBe(CANCELLED);
+  });
+
+  it("expires on its deadline", async () => {
+    const [ctx, cancel] = withTimeout(background(), 5);
+    try {
+      await ctx.done();
+      expect(ctx.err()).toBe(DEADLINE_EXCEEDED);
+    } finally {
+      cancel();
+    }
+  });
+
+  it("lets a child shorten a deadline and not extend one", () => {
+    const at = Date.now() + 10_000;
+    const [outer, cancelOuter] = withDeadline(background(), at);
+    const [shorter, cancelShorter] = withDeadline(outer, at - 5_000);
+    const [longer, cancelLonger] = withDeadline(outer, at + 5_000);
+
+    try {
+      expect(outer.deadline()).toBe(at);
+      expect(shorter.deadline()).toBe(at - 5_000);
+      // The whole point: a library cannot buy itself more time than its caller
+      // allowed by asking for it.
+      expect(longer.deadline()).toBe(at);
+    } finally {
+      cancelOuter();
+      cancelShorter();
+      cancelLonger();
+    }
+  });
+
+  it("ends immediately on a deadline already in the past", () => {
+    const [ctx, cancel] = withDeadline(background(), Date.now() - 1);
+    try {
+      // Synchronously, so the line after the constructor sees a dead context
+      // rather than one that dies on the next tick.
+      expect(ctx.err()).toBe(DEADLINE_EXCEEDED);
+    } finally {
+      cancel();
+    }
+  });
+
+  it("is born cancelled under a parent that already ended", () => {
+    const [parent, cancel] = withCancel(background());
+    cancel();
+    const [child] = withCancel(parent);
+
+    expect(child.err()).toBe(CANCELLED);
+  });
+
+  it("reads a value from the nearest scope that stored one", () => {
+    const TRACE = key<string>("trace");
+    const USER = key<string>("user");
+
+    const base = withValue(background(), TRACE, "abc");
+    const inner = withValue(withValue(base, USER, "ada"), TRACE, "def");
+
+    expect(inner.value(TRACE)).toBe("def");
+    expect(inner.value(USER)).toBe("ada");
+    // Shadowing is one-way: what the caller sees is untouched.
+    expect(base.value(TRACE)).toBe("abc");
+    expect(base.value(USER)).toBe(undefined);
+    expect(background().value(TRACE)).toBe(undefined);
+  });
+
+  it("keys two values apart even when they share a name", () => {
+    // A key is compared by identity, which is what makes a key a library did
+    // not export unreadable by anybody else.
+    const mine = key<string>("id");
+    const theirs = key<string>("id");
+    const ctx = withValue(background(), mine, "mine");
+
+    expect(ctx.value(mine)).toBe("mine");
+    expect(ctx.value(theirs)).toBe(undefined);
+  });
+
+  it("adopts a signal somebody else owns", () => {
+    const controller = new AbortController();
+    const ctx = fromSignal(controller.signal);
+    const [child] = withCancel(ctx);
+
+    const reason = new Error("request closed");
+    controller.abort(reason);
+
+    expect(ctx.err()).toBe(reason);
+    expect(child.err()).toBe(reason);
+  });
+
+  it("adopts a signal that is already aborted", () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(fromSignal(controller.signal).err()).not.toBe(null);
+  });
+
+  it("never ends the root", () => {
+    expect(background().err()).toBe(null);
+    expect(background().deadline()).toBe(null);
+    expect(background().signal().aborted).toBe(false);
+    expect(background()).toBe(background());
+  });
+});
+
+describe("bytes", () => {
+  it("compares by byte and then by length", () => {
+    expect(equal(b(1, 2, 3), b(1, 2, 3))).toBe(true);
+    expect(equal(b(1, 2, 3), b(1, 2))).toBe(false);
+    expect(equal(b(), b())).toBe(true);
+
+    expect(compare(b(1, 2), b(1, 2))).toBe(0);
+    expect(compare(b(1, 2), b(1, 3))).toBe(-1);
+    // A prefix sorts before what it is a prefix of.
+    expect(compare(b(1, 2), b(1, 2, 0))).toBe(-1);
+    // Unsigned, so 0xff is the largest byte and not -1.
+    expect(compare(b(0xff), b(0x01))).toBe(1);
+
+    const sorted = [b(2), b(1, 1), b(1)].sort(compare);
+    expect(sorted.map((each) => Array.from(each))).toEqual([[1], [1, 1], [2]]);
+  });
+
+  it("finds a needle that restarts inside a partial match", () => {
+    // The bug the first-byte skip could have introduced: `aab` inside `aaab`
+    // begins at 1, which a scan that resumed after the failed match would miss.
+    expect(indexOf(b(0x61, 0x61, 0x61, 0x62), b(0x61, 0x61, 0x62))).toBe(1);
+    expect(indexOf(b(1, 2, 3), b(2, 3))).toBe(1);
+    expect(indexOf(b(1, 2, 3), b(3, 4))).toBe(-1);
+    expect(indexOf(b(1, 2, 3), b(1, 2, 3, 4))).toBe(-1);
+    expect(indexOf(b(1, 2, 1, 2), b(1, 2), 1)).toBe(2);
+    expect(lastIndexOf(b(1, 2, 1, 2), b(1, 2))).toBe(2);
+    expect(lastIndexOf(b(1, 2), b(3))).toBe(-1);
+
+    expect(contains(b(1, 2, 3), b(2))).toBe(true);
+    expect(hasPrefix(b(1, 2, 3), b(1, 2))).toBe(true);
+    expect(hasPrefix(b(1), b(1, 2))).toBe(false);
+    expect(hasSuffix(b(1, 2, 3), b(2, 3))).toBe(true);
+  });
+
+  it("treats an empty needle the way String.indexOf does", () => {
+    expect(indexOf(b(1, 2), b())).toBe(0);
+    expect(indexOf(b(1, 2), b(), 1)).toBe(1);
+    expect(indexOf(b(1, 2), b(), 9)).toBe(-1);
+    expect(lastIndexOf(b(1, 2), b())).toBe(2);
+  });
+
+  it("round-trips through split and join", () => {
+    const line = fromUtf8("alpha,beta,,gamma");
+    const comma = fromUtf8(",");
+    const pieces = split(line, comma);
+
+    expect(pieces.map(toUtf8)).toEqual(["alpha", "beta", "", "gamma"]);
+    expect(equal(join(pieces, comma), line)).toBe(true);
+    // Separators at either end produce the empty pieces around them, which is
+    // what makes the round trip exact rather than approximately right.
+    expect(split(fromUtf8(",a,"), comma).map(toUtf8)).toEqual(["", "a", ""]);
+    expect(split(fromUtf8("none"), comma).map(toUtf8)).toEqual(["none"]);
+  });
+
+  it("refuses to split on nothing", () => {
+    expect(() => split(b(1, 2), b())).toThrow("non-empty separator");
+  });
+
+  it("hands back views, not copies", () => {
+    const source = b(1, 2, 3, 4);
+    const trimmed = trimPrefix(source, b(1));
+
+    // Writing through the view writes through to the source, which is the
+    // documented consequence of not copying — and the reason the docs say to
+    // call `.slice()` when a copy is wanted.
+    trimmed[0] = 9;
+    expect(source[1]).toBe(9);
+
+    // No prefix means the same object, so identity answers "was there one".
+    expect(trimPrefix(source, b(7))).toBe(source);
+    expect(trimSuffix(source, b(7))).toBe(source);
+    expect(Array.from(trimSuffix(b(1, 2, 3), b(3)))).toEqual([1, 2]);
+  });
+
+  it("concatenates and repeats", () => {
+    expect(Array.from(concat([b(1), b(2, 3), b()]))).toEqual([1, 2, 3]);
+    expect(Array.from(concat([]))).toEqual([]);
+    expect(Array.from(repeat(b(1, 2), 3))).toEqual([1, 2, 1, 2, 1, 2]);
+    expect(Array.from(repeat(b(1), 0))).toEqual([]);
+    expect(() => repeat(b(1), -1)).toThrow();
+  });
+
+  it("round-trips UTF-8 including outside the basic plane", () => {
+    for (const text of ["", "ascii", "日本語", "🌱 seed"]) {
+      expect(toUtf8(fromUtf8(text))).toBe(text);
+    }
+  });
+
+  describe("Builder", () => {
+    it("grows past its capacity and keeps everything", () => {
+      const out = new Builder(2);
+      for (let n = 0; n < 100; n += 1) {
+        out.writeByte(n);
+      }
+      out.write(b(200, 201));
+      out.writeUtf8("hi");
+
+      const written = out.bytes();
+      expect(written).toHaveLength(104);
+      expect(Array.from(written.subarray(0, 3))).toEqual([0, 1, 2]);
+      expect(Array.from(written.subarray(100))).toEqual([200, 201, 0x68, 0x69]);
+      expect(out.length()).toBe(104);
+    });
+
+    it("hands back a copy from bytes and a view from view", () => {
+      const out = new Builder();
+      out.write(b(1, 2, 3));
+
+      const copied = out.bytes();
+      const viewed = out.view();
+      out.writeByte(4);
+
+      // The copy is what it was when it was taken; the view has moved on. This
+      // is why `bytes()` is the default and `view()` carries the warning.
+      expect(copied).toHaveLength(3);
+      expect(viewed).toHaveLength(3);
+      expect(out.length()).toBe(4);
+    });
+
+    it("keeps its capacity across a reset", () => {
+      const out = new Builder();
+      out.write(repeat(b(0), 500));
+      out.reset();
+
+      expect(out.length()).toBe(0);
+      expect(out.bytes()).toHaveLength(0);
+      out.writeByte(1);
+      expect(Array.from(out.bytes())).toEqual([1]);
+    });
+  });
+});
+
+describe("heap", () => {
+  it("pops in the comparator's order, not insertion order", () => {
+    const queue = new Heap<number>((x, y) => x - y);
+    for (const value of [5, 3, 8, 1, 9, 2]) {
+      queue.push(value);
+    }
+
+    expect(queue.size()).toBe(6);
+    expect(queue.peek()).toBe(1);
+    expect([...queue.drain()]).toEqual([1, 2, 3, 5, 8, 9]);
+    expect(queue.isEmpty()).toBe(true);
+    expect(queue.pop()).toBe(undefined);
+    expect(queue.peek()).toBe(undefined);
+  });
+
+  it("is a max-heap when the comparator is reversed", () => {
+    const queue = heapify([1, 4, 2, 8], (x, y) => y - x);
+    expect([...queue.drain()]).toEqual([8, 4, 2, 1]);
+  });
+
+  it("heapifies an existing array without disturbing it", () => {
+    const source = [9, 4, 7, 1, 8, 2, 6];
+    const queue = heapify(source, (x, y) => x - y);
+
+    expect([...queue.drain()]).toEqual([1, 2, 4, 6, 7, 8, 9]);
+    expect(source).toEqual([9, 4, 7, 1, 8, 2, 6]);
+  });
+
+  it("agrees with a full sort on a shuffled input", () => {
+    // The property test that would have caught a sift written the wrong way
+    // round: the heap and `Array.sort` are two independent implementations of
+    // the same order.
+    const values = Array.from({ length: 500 }, (_unused, index) => (index * 37) % 500);
+    const queue = heapify(values, (x, y) => x - y);
+    expect([...queue.drain()]).toEqual([...values].sort((x, y) => x - y));
+  });
+
+  it("replaces the top in one sift", () => {
+    const queue = heapify([1, 2, 3], (x, y) => x - y);
+
+    expect(queue.replace(10)).toBe(1);
+    expect(queue.size()).toBe(3);
+    expect(queue.peek()).toBe(2);
+    // On an empty heap it is a plain push.
+    const empty = new Heap<number>((x, y) => x - y);
+    expect(empty.replace(4)).toBe(undefined);
+    expect(empty.peek()).toBe(4);
+  });
+
+  it("stops where a caller stops, leaving the rest in the heap", () => {
+    const queue = heapify([1, 2, 3, 4, 5], (x, y) => x - y);
+    const taken: Array<number> = [];
+    for (const value of queue.drain()) {
+      if (value > 2) {
+        break;
+      }
+      taken.push(value);
+    }
+
+    expect(taken).toEqual([1, 2]);
+    // The one that ended the loop was taken; the rest were never touched.
+    expect(queue.size()).toBe(2);
+    expect(queue.peek()).toBe(4);
+  });
+
+  it("clears and reports what it holds", () => {
+    const queue = heapify([3, 1, 2], (x, y) => x - y);
+    expect([...queue.toArray()].sort((x, y) => x - y)).toEqual([1, 2, 3]);
+    queue.clear();
+    expect(queue.size()).toBe(0);
+  });
+});
+
+describe("hex", () => {
+  it("round-trips every byte value", () => {
+    const all = new Uint8Array(256);
+    for (let value = 0; value < 256; value += 1) {
+      all[value] = value;
+    }
+
+    const text = encode(all);
+    expect(text).toHaveLength(512);
+    expect(text.startsWith("000102")).toBe(true);
+    expect(text.endsWith("fdfeff")).toBe(true);
+    expect(equal(decode(text), all)).toBe(true);
+    expect(encode(new Uint8Array(0))).toBe("");
+    expect(decode("")).toHaveLength(0);
+  });
+
+  it("agrees with itself on both sides of the length its two paths split on", () => {
+    // `encode` appends to a string for short inputs and goes through a
+    // `TextDecoder` for long ones, because the two cross at about 128 bytes.
+    // A fork chosen by length is a fork that can disagree with itself, so this
+    // walks across it against a reference nobody would ship.
+    const reference = (input: Uint8Array): string =>
+      Array.from(input, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+    for (const size of [0, 1, 127, 128, 129, 1000]) {
+      const input = new Uint8Array(size);
+      for (let index = 0; index < size; index += 1) {
+        input[index] = (index * 37) & 0xff;
+      }
+      expect(encode(input)).toBe(reference(input));
+      expect(equal(decode(encode(input)), input)).toBe(true);
+    }
+  });
+
+  it("accepts either case and produces lowercase", () => {
+    expect(encode(b(0xde, 0xad))).toBe("dead");
+    expect(Array.from(decode("DEAD"))).toEqual([0xde, 0xad]);
+    expect(Array.from(decode("dEaD"))).toEqual([0xde, 0xad]);
+  });
+
+  it("names the offset of the first character that is not a hex digit", () => {
+    // The failure `parseInt` swallows: it answers `NaN`, which becomes zero on
+    // its way into a `Uint8Array`, so a corrupted digest silently decodes to a
+    // different valid-looking one.
+    try {
+      // Even length, so it gets past the length check and the offset is the
+      // character rather than the end.
+      decode("dead  beef");
+      throw new Error("decode should have refused");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidHexError);
+      expect(error.offset).toBe(4);
+    }
+
+    // An odd length is reported at the end, because that is where the missing
+    // digit would have been — a truncated token, which is the common case.
+    try {
+      decode("abc");
+      throw new Error("decode should have refused");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidHexError);
+      expect(error.message).toContain("odd-length");
+      expect(error.offset).toBe(3);
+    }
+
+    expect(isValid("abc")).toBe(false);
+    expect(isValid("dead  beef")).toBe(false);
+    expect(isValid("deadbeef")).toBe(true);
+    expect(isValid("")).toBe(true);
+  });
+
+  it("dumps in the format hexdump -C prints", () => {
+    const dumped = dump(fromUtf8("GET / HTTP/1.1\r\nHost: a.b\r\n"));
+
+    expect(dumped.split("\n")).toEqual([
+      "00000000  47 45 54 20 2f 20 48 54  54 50 2f 31 2e 31 0d 0a  |GET / HTTP/1.1..|",
+      "00000010  48 6f 73 74 3a 20 61 2e  62 0d 0a                 |Host: a.b..|",
+      "",
+    ]);
+    expect(dump(new Uint8Array(0))).toBe("");
+  });
+
+  it("never lets a byte in a dump move the cursor", () => {
+    // A dump that printed control characters could rewrite the line above it,
+    // which would make it lie about the buffer it was printing.
+    const dumped = dump(b(0x1b, 0x5b, 0x32, 0x4a));
+    expect(dumped.includes("")).toBe(false);
+    expect(dumped.trimEnd().endsWith("|.[2J|")).toBe(true);
+  });
+});
+
+describe("the types", () => {
+  it("reports every misuse in tests/type-tests/std-inference.js", () => {
+    // Running proves what the code does; only the checker can prove what a
+    // different program would have been refused. The fixture is that program.
+    everyMisuseIsReported({
+      fixture: "tests/type-tests/std-inference.js",
+      alongside: ["packages/std"],
+      atLeast: 20,
+    });
+  });
+});

--- a/tests/library/std.test.js
+++ b/tests/library/std.test.js
@@ -524,6 +524,33 @@ describe("context", () => {
     expect(ctx.value(theirs)).toBe(undefined);
   });
 
+  it("gives a value scope its parent's cancellation rather than one of its own", async () => {
+    // A value scope allocates no controller and registers no listener, because
+    // a listener on a long-lived parent with nobody to remove it is the leak
+    // that makes a per-request tree a staircase. What it costs instead is that
+    // `signal`, `err` and `done` have to be the parent's, exactly — and a
+    // second signal kept in step by hand is what this avoids having.
+    const TAG = key<string>("tag");
+    const [parent, cancel] = withCancel(background());
+    const tagged = withValue(parent, TAG, "v");
+
+    expect(tagged.signal()).toBe(parent.signal());
+    expect(tagged.err()).toBe(null);
+
+    let done = false;
+    const waiting = tagged.done().then(() => {
+      done = true;
+    });
+    cancel();
+    await waiting;
+
+    expect(done).toBe(true);
+    expect(tagged.err()).toBe(CANCELLED);
+    expect(tagged.signal().aborted).toBe(true);
+    // And the value survives the ending, because a reporter reads it after.
+    expect(tagged.value(TAG)).toBe("v");
+  });
+
   it("adopts a signal somebody else owns", () => {
     const controller = new AbortController();
     const ctx = fromSignal(controller.signal);

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -1,0 +1,188 @@
+// @flow
+//
+// What `@uniflowed/std` infers, and the test that says so.
+//
+// This file is *supposed* to fail `uf check`. The claim these six modules make
+// is that a generic container, a typed error walk and a typed context key all
+// come back at the type the *call site* implies, with nothing annotated and no
+// `any` underneath — and a claim about inference cannot be proved by running
+// anything. It is proved the only way it can be: by running the checker and
+// reading what it said.
+//
+// # How it is read
+//
+// A `// expect:` comment says that the line after it must be reported, and that
+// the report must contain that text. A line without one must not be reported at
+// all — so a change that makes any of these *stop* being an error fails the
+// test, and so does one that makes something else here start being one. The
+// tail of the file is the other half of the claim: every correct use is silent,
+// without which a package whose every export was `any` would pass this too.
+//
+// # Why it is checked with the package rather than on its own
+//
+// `uf check` builds its module map out of the files it is asked to check, and a
+// relative import that leaves that set resolves to an any-typed value — after
+// which every type below is `any`, every line passes, and the test would prove
+// the opposite of what it claims. So the test runs
+// `uf check tests/type-tests packages/std`, with both in one set.
+// `tests/type-tests/anchoring.js` says the rest of why these fixtures live here
+// rather than inside the packages they are about.
+
+import { Builder, compare, equal, split } from "../../packages/std/bytes.js";
+import { background, key, withCancel, withTimeout, withValue } from "../../packages/std/context.js";
+import { as, is, join, wrap } from "../../packages/std/errors.js";
+import { Heap, heapify } from "../../packages/std/heap.js";
+import { decode, encode } from "../../packages/std/hex.js";
+import { Group, Mutex, Semaphore, once } from "../../packages/std/sync.js";
+
+class HttpError extends Error {
+  status: number;
+  constructor(status: number) {
+    super("http");
+    this.status = status;
+  }
+}
+
+const failure: mixed = wrap("loading", new HttpError(429));
+
+// --- errors -----------------------------------------------------------------
+//
+// `as` is the export whose whole value is the type it hands back. If it came
+// back as `mixed` a caller would cast, and a cast is what this module exists to
+// remove.
+
+// expect: HttpError
+export const asIsNotANumber: number | null = as(failure, HttpError);
+
+// The field is reachable at the type the class declared it, without a cast.
+const found = as(failure, HttpError);
+// expect: number is incompatible with string
+export const statusIsNotAString: string = found == null ? "" : found.status;
+
+// A question, not a value: `is` answers a boolean and nothing wider.
+// expect: boolean is incompatible with
+export const isAnswersABoolean: string = is(failure, failure);
+
+// `join` answers an error or nothing, so a caller has to look before throwing.
+// expect: null
+export const joinCanBeNothing: Error = join(new Error("a"));
+
+// --- heap -------------------------------------------------------------------
+//
+// The comparator is the only place `T` appears in the constructor, so this is
+// the load-bearing inference: get it wrong and every heap in a program is a
+// heap of `any`.
+
+const numbers = new Heap((a: number, b: number) => a - b);
+
+// expect: number is incompatible with string
+export const heapPopsItsElement: string | void = numbers.pop();
+
+// The comparator's parameters are checked against what the heap holds, so a
+// method the element does not have is refused where it is written.
+// expect: toUpperCase is missing in Number
+export const comparatorSeesTheElement: mixed = new Heap<number>((a, b) => a.toUpperCase() - b);
+
+// `heapify` infers from the array as well as from the comparator.
+const words = heapify(["b", "a"], (a, b) => (a < b ? -1 : 1));
+// expect: string is incompatible with number
+export const heapifyKeepsTheElement: number | void = words.peek();
+
+// --- context ----------------------------------------------------------------
+//
+// A key carries the type of the value stored under it. If it did not, a context
+// would be a `Map<string, mixed>` with extra steps.
+
+const TRACE = key<string>("trace");
+const ATTEMPT = key<number>("attempt");
+const root = background();
+
+// expect: string is incompatible with number
+export const keyReadsAtItsType: number | void = withValue(root, TRACE, "abc").value(TRACE);
+
+// And the write is checked against the same type.
+// expect: 7 is incompatible with string
+export const keyWritesAtItsType: mixed = withValue(root, TRACE, 7);
+
+// Two keys of different types are not interchangeable at a read.
+// expect: number is incompatible with string
+export const keysDoNotUnify: string | void = withValue(root, ATTEMPT, 1).value(ATTEMPT);
+
+// The pair is a context and a cancel, in that order.
+const [scope, cancel] = withCancel(root);
+// expect: void is incompatible with number
+export const cancelIsNotTheContext: number = cancel(scope);
+
+// A deadline is milliseconds, not a Date.
+// expect: Date
+export const deadlineTakesMilliseconds: mixed = withTimeout(root, new Date());
+
+// --- sync -------------------------------------------------------------------
+//
+// Every one of these passes a value through a lock or a limit, and the type has
+// to survive the round trip.
+
+const limit = new Semaphore(2);
+// expect: 1 is incompatible with string
+export const permitReturnsTheTask: Promise<string> = limit.withPermit(() => 1);
+
+const mutex = new Mutex();
+// expect: 1 is incompatible with string
+export const lockReturnsTheBody: Promise<string> = mutex.withLock(async () => 1);
+
+const connect = once(() => ({ port: 5432 }));
+// expect: number is incompatible with string
+export const onceKeepsItsValue: string = connect().port;
+
+const rows = new Group<number>();
+// expect: "not a number" is incompatible with number
+export const groupTakesItsElement: mixed = rows.go(() => "not a number");
+
+// --- bytes and hex ----------------------------------------------------------
+
+const left = new Uint8Array(2);
+
+// expect: string
+export const equalTakesBytes: boolean = equal(left, "not bytes");
+
+// expect: is incompatible with number literal 2
+export const compareIsAnOrdering: 2 = compare(left, left);
+
+// A split gives views the caller may read and may not grow.
+// expect: push is missing in $ReadOnlyArray
+export const splitIsReadOnly: mixed = split(left, left).push(left);
+
+// expect: Uint8Array
+export const decodeGivesBytes: string = decode("dead");
+
+// expect: string, a primitive, cannot be used as a subtype of Uint8Array
+export const encodeGivesText: Uint8Array = encode(left);
+
+// A builder writes bytes; a string is the other method.
+// expect: string
+export const builderWritesBytes: mixed = new Builder().write("text");
+
+// --- what is *not* an error -------------------------------------------------
+//
+// Without these the fixture would pass just as happily on a package whose every
+// export was `any`.
+
+export const asNarrows: HttpError | null = as(failure, HttpError);
+export const isAsks: boolean = is(failure, failure);
+export const joinIsNullable: Error | null = join(new Error("a"));
+export const heapPops: number | void = numbers.pop();
+export const heapifyInfers: string | void = words.peek();
+export const drainYieldsElements: Array<number> = [...numbers.drain()];
+export const keyReads: string | void = withValue(root, TRACE, "abc").value(TRACE);
+export const attemptReads: number | void = withValue(root, ATTEMPT, 1).value(ATTEMPT);
+export const cancelTakesNothing: void = cancel();
+export const cancelTakesAReason: void = cancel(new Error("gone"));
+export const scopeHasASignal: AbortSignal = scope.signal();
+export const permitPasses: Promise<number> = limit.withPermit(() => 1);
+export const lockPasses: Promise<number> = mutex.withLock(async () => 1);
+export const onceKeeps: number = connect().port;
+export const groupWaits: Promise<$ReadOnlyArray<number>> = rows.wait();
+export const bytesCompare: -1 | 0 | 1 = compare(left, left);
+export const bytesSplit: $ReadOnlyArray<Uint8Array> = split(left, left);
+export const hexEncodes: string = encode(left);
+export const hexDecodes: Uint8Array = decode("dead");


### PR DESCRIPTION
The direction is that everything in Go's standard library that JavaScript does
not already have should exist in `@uniflowed/std`, runtime-agnostic. That is
far too large for one change, so this is the **first tranche**, and
ubugeeei-prod/uf#710 is the survey and the plan for the rest.

## What `@uniflowed/std` was

`packages/std/index.js` was 274 lines and ~74 exports, every one of which
called `nativeRuntimeRequired` and threw. `crates/uf_std`'s registry names 44
`@uniflowed/std/*` specifiers — `/vfs`, `/http`, `/sql`, `/lock`,
`/collections` — and **none of them had a file behind it**. `package.json`
exported one subpath.

Nothing in the package ran. That is the gap this closes a sixth of.

## What ships

Six modules, each on its own export subpath so a program pays only for what it
imports. `index.js` is untouched, so nothing that exists today changes.

| Import | Go | What was actually missing |
| --- | --- | --- |
| `@uniflowed/std/errors` | `errors` | `wrap`, `is`, `as`, `join`, `unwrap`, `chain`. `Error.cause` has existed since ES2022 with nothing that reads a chain — and the loop everyone writes hangs on a cycle, cannot see into an `AggregateError`, and is written once per predicate |
| `@uniflowed/std/sync` | `sync`, `errgroup` | `WaitGroup`, `Mutex`, `Semaphore`, `once`, `Group`. `Promise.all` answers one of the five questions |
| `@uniflowed/std/context` | `context` | Cancellation trees, deadlines that only ever shorten, typed request-scoped values — over `AbortSignal`, which has none of the three |
| `@uniflowed/std/bytes` | `bytes` | `equal`, `compare`, `indexOf`, `split`, `join`, `trimPrefix`, `Builder`… `String` has thirty of these; `Uint8Array` has three |
| `@uniflowed/std/heap` | `container/heap` | A binary heap with a comparator. There is no priority queue in JavaScript, and both things people write instead are `O(n² log n)` |
| `@uniflowed/std/hex` | `encoding/hex` | `encode`, `decode`, `isValid`, `dump`. `Uint8Array.prototype.toHex` reached **Node 25.0 in October 2025** — one major after the Node this repository runs on |

### Why these six and not the others

Each is (a) genuinely absent rather than merely Go-shaped, (b) reached for
constantly, and (c) pure enough to be runtime-agnostic. Two deliberate
omissions from the suggested list:

- **`io`.** `ReadableStream` is **not polymorphic** in the Flow libdefs uf's
  checker uses: `ReadableStream<Uint8Array>` is `Cannot instantiate
  ReadableStream because class ReadableStream is not a polymorphic type`. A
  typed `Reader`/`Writer` bridge to Web Streams cannot be written until that is
  fixed, and shipping an untyped one would undercut the whole point. Filed as
  the first item of #710.
- **`encoding/csv`.** No blocker, just next. It is the item after `io`/`bufio`
  because a CSV reader over an `io.Reader` is the right shape and a CSV reader
  over a `string` is the one that has to be rewritten later.

`sync.RWMutex` is absent on purpose: readers and writers cannot run at the same
time in one runtime, so it would buy a fairness policy and nothing else.

## The types

The stated direction is that uf is *"めちゃくちゃ型推論、型付けに強く"*, so
every generic here infers at the call site with nothing annotated:

```js
const queue = new Heap((a, b) => a.due - b.due);   // Heap<Job>, from the comparator
queue.pop();                                       // Job | void

const TRACE = key<string>("trace-id");
withValue(ctx, TRACE, 7);                          // refused: 7 is not a string
traced.value(TRACE);                               // string | void

as(failure, HttpError)?.status;                    // number, from the class alone
limit.withPermit(() => fetchRow(id));              // Promise<Row>
```

That is proved rather than asserted. `tests/type-tests/std-inference.js` holds
**22 deliberate misuses**, each with the diagnostic it must produce; the suite
fails if `uf check` stops reporting any of them *or* starts reporting anything
else, which is what says the fixture describes the types rather than merely
being broken. It runs through the existing `everyMisuseIsReported` harness.

Two design notes that only exist because the checker caught them:

- `Key<T>` is opaque and **invariant** — `T` sits in both an argument and a
  return position of the carrier — so a `Key<Dog>` cannot read a context that
  stored an `Animal`, nor the reverse. The scope stores the key as `mixed`
  internally, because `Key` being invariant means no single type a
  heterogeneous chain of scopes could share; identity is the whole comparison
  and the type comes back at the `return`.
- Three inline object casts in `errors.js` had to become `readonly`, because
  casting a `mixed` to a type with a writable property is a variance error.
  `uf check` was right.

## Native was measured, not assumed

The direction says native where it would be meaningfully faster. The comparison
is against **Node's own C++ implementations of the same operations** —
`Buffer#toString("hex")`, `Buffer#equals`, `Buffer#indexOf` — reached across
the same kind of JavaScript-to-native boundary a binding would use, so it is a
measurement of what native buys rather than an estimate of it. Node 24, M-series
laptop, nanoseconds per call:

| Operation | Size | This, in JS | Node, native | Native is |
| --- | --- | --- | --- | --- |
| `hex.encode` | 16 B | 83 ns | 40 ns | 2.1x faster |
| `hex.encode` | 1 MiB | 1.69 ms | 0.26 ms | 6.5x faster |
| `hex.decode` | 16 B | 80 ns | 72 ns | 1.1x faster |
| `hex.decode` | 1 MiB | 4.54 ms | 0.66 ms | 6.8x faster |
| `bytes.equal` | 16 B | 14 ns | 25 ns | **1.8x slower** |
| `bytes.equal` | 64 B | 59 ns | 30 ns | 2.0x faster |
| `bytes.equal` | 1 MiB | 0.89 ms | 0.02 ms | 42x faster |
| `bytes.indexOf` | 1 KiB | 324 ns | 69 ns | 4.7x faster |
| `bytes.indexOf` | 1 MiB | 332 µs | 21 µs | 16x faster |

**Nothing here should be native, and only the third reason is about speed:**

1. **Below a few dozen bytes the boundary is the whole bill.** `bytes.equal` on
   sixteen bytes is *faster* in JavaScript than the native call that does the
   same thing. Most calls to most of these functions are small — a 32-byte
   digest, a four-byte delimiter.
2. **There is no binding to cross.** No N-API crate, no `wasm-bindgen` anywhere
   in the workspace; `nativeRuntimeRequired` is a promise with no mechanism
   behind it. Native is not a build flag away, it is a layer that does not
   exist.
3. **A native module would not be runtime-agnostic.** N-API binds std to Node
   and Bun — red line 6. WebAssembly copies its arguments across the boundary,
   which for a function whose argument *is* a byte buffer is the cost native
   was supposed to save.

So the effort went where it was measurable. Each row is one JavaScript
implementation against another:

| Change | Effect |
| --- | --- |
| `hex.encode` writing ASCII bytes and decoding once, above 128 B | **43 MB/s → 620 MB/s** |
| `hex.encode` appending to a string, below 128 B | 520 ns → 150 ns on a 32 B digest |
| `hex.decode` reading a 128-entry table instead of comparing ranges | 111 MB/s → 231 MB/s |
| `bytes.indexOf` finding the first byte with the native `indexOf` | **8–10x** over the naive double loop |
| `bytes.Builder` against re-allocating per chunk | 11x at 100 chunks, **825x** at 10,000 |
| `heap` against sorting on every insert | 161x at 1,000 items, **507x** at 10,000 |

The last two are the difference between linear and quadratic. The 128-byte
split in `hex.encode` is a measured crossover, not a guess: `TextDecoder` costs
about 500 ns per call whatever the length, and the appending loop about 6 ns per
byte. A test walks across that boundary — 127, 128, 129 bytes — against a
reference implementation, because a fork chosen by length is a fork that can
disagree with itself.

## Verification

- `uf test#library` — **2796 passed, 0 failed, 1 skipped**, 81 files. 62 of
  those are new (`tests/library/std.test.js`), including the type-test fixture.
- `uf check packages/std` — 0 errors, 0 warnings.
- `uf lint` — 0 errors repo-wide; 14 warnings, all pre-existing and all in
  files this branch does not touch.
- `uf fmt --check` — clean.
- **Ran on Bun 1.3.13** as well as Node 24: all six modules, all eighteen smoke
  assertions green under `bun --preload @uniflowed/host/bun-preload`. Nothing
  here imports `node:` anything, touches `Buffer`, or reads `process`.
- `cargo test` was **not** run: the disk has 5 GiB free and the shared target
  directory is in use by other agents. The invariants
  `crates/uf_lib/tests/package_surface.rs` enforces were checked by hand
  instead — pragma, no `export *`, no import-time side effects, every subpath
  resolving, every module reachable, `sideEffects: false`, modern Flow
  spellings, no dangling relative imports. `the_registry_names_exactly_what_each_package_exports`
  reads only `index.js`, which is unchanged.

## Three things review found, in later commits

Each is its own commit, because each is a claim the first one got wrong.

- **`heap.pop` lost the root of a `Heap<T | void>`.** It took the item to sift
  down from `Array.prototype.pop`'s return value and skipped the sift when that
  was `undefined` — indistinguishable from a legitimately stored `undefined`.
  Reading the last item by index before shortening the array is right for every
  `T`.
- **`withValue` leaked a listener per call.** A value scope was built as a full
  scope: an `AbortController`, a promise, and an abort listener on its parent —
  none of which it needs, since it ends exactly when its parent does, and the
  listener had nothing to release it because `withValue` returns no `cancel`. A
  middleware chain adding four values to a long-lived context left four
  listeners on it per request. `signal`, `err` and `done` now delegate upwards
  and a value scope allocates nothing but itself, which is what Go's `valueCtx`
  does.
- **Two docs said something the code does not do.** `Group.wait` waits for the
  tasks that ignored their signal rather than rejecting before they finish, and
  the host table said "yes" for Deno and the edge, which nothing here starts.

## Deliberately not in this PR

- **`crates/uf_std`'s registry.** `StdModule::new` hardcodes
  `nativeBinding: true` and `wintertcAligned: true` for all 44 entries, so it
  cannot describe a shipped pure-JavaScript module without lying, and
  `uf inspect --json` prints it. Adding six honest modules to a list of 44
  aspirational ones makes it less informative, not more. Reconciling it — a
  status field, and a test that its specifiers agree with
  `package.json#exports` — is the first housekeeping item of #710.
- **Release manifests.** `@uniflowed/std` is in neither
  `published-packages.txt` nor `pending-packages.txt`; whether it moves is a
  decision, and it is filed rather than taken here.

## Found in passing

`uf transform` rejects top-level `await`, which `uf check` accepts. A `// @flow`
module with `const x = await Promise.resolve(1)` at the top level passes the
checker with zero errors and fails to load through
`@uniflowed/host/register` with `TransformError: Unexpected identifier`. Not
touched — `crates/uf_transform` belongs to another stream — but the checker and
the transform disagreeing about the grammar is worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
