### PR TITLE
feat(cli): a schedule declared in a route handler, and the build that refuses to ignore it

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -275,6 +275,17 @@ pub(crate) fn build(
     // which has a bundle to load and does not have it; that is refused in
     // `commands::serve`, where it is a fact rather than an opinion.
     let adapter = deploy::resolve(&resolved.config.app.runtime.deploy, requested_adapter)?;
+    // Before the build rather than after it: a project whose scheduled work
+    // this target would never run should hear so in a second, not after a
+    // bundle. ubugeeei-prod/uf#531.
+    let declared_schedules = match adapter {
+        Some(adapter) => {
+            let found = deploy::schedules::discover_schedules(&root, &resolved.config)?;
+            deploy::schedules::refuse_unrunnable(adapter, &found)?;
+            found
+        }
+        None => Vec::new(),
+    };
     // The fourth thing that needs a process, and the only one `uf` can see
     // without evaluating a module. Checked here rather than in the builder for
     // exactly that reason — see `refuse_unanswerable_actions`.
@@ -486,7 +497,9 @@ pub(crate) fn build(
                 "writing the {} adapter's output",
                 adapter.as_str()
             ));
-            Some(timer.measure("adapter", || deploy::deploy(ui, adapter, link))?)
+            Some(timer.measure("adapter", || {
+                deploy::deploy(ui, adapter, link, &declared_schedules)
+            })?)
         }
         None => None,
     };

--- a/crates/uf_cli/src/commands/deploy.rs
+++ b/crates/uf_cli/src/commands/deploy.rs
@@ -88,6 +88,7 @@ use crate::commands::vite::{Driver, Event, LinkContext, LogLevel, render_error, 
 use crate::support::project_label;
 use crate::ui::Ui;
 
+pub(crate) mod schedules;
 pub(crate) mod static_host;
 
 /// Where the generated entry files are written before they are linked.
@@ -201,6 +202,7 @@ pub(crate) fn deploy(
     ui: &mut Ui,
     adapter: DeployAdapter,
     link: LinkContext<'_>,
+    schedules: &[schedules::DeclaredSchedule],
 ) -> Result<Deployed> {
     let LinkContext {
         host,
@@ -296,7 +298,7 @@ pub(crate) fn deploy(
         directory.join("package.json"),
         "{\n  \"private\": true,\n  \"type\": \"module\"\n}\n".to_owned(),
     )];
-    files.extend(platform_files(adapter, root, &directory));
+    files.extend(platform_files(adapter, root, &directory, schedules));
     for (file, contents) in &files {
         fs::write(file.as_std_path(), contents)
             .with_context(|| format!("failed to write {file}"))?;
@@ -436,9 +438,13 @@ fn platform_files(
     adapter: DeployAdapter,
     root: &Utf8Path,
     directory: &Utf8Path,
+    schedules: &[schedules::DeclaredSchedule],
 ) -> Vec<(Utf8PathBuf, String)> {
     match adapter {
-        DeployAdapter::Edge => vec![(directory.join("wrangler.json"), wrangler_config(root))],
+        DeployAdapter::Edge => vec![(
+            directory.join("wrangler.json"),
+            wrangler_config(root, schedules),
+        )],
         DeployAdapter::Container => vec![
             (directory.join("Dockerfile"), DOCKERFILE.to_owned()),
             (directory.join(".dockerignore"), DOCKERIGNORE.to_owned()),
@@ -482,8 +488,8 @@ const WORKERS_COMPATIBILITY_DATE: &str = "2024-09-23";
 /// * `not_found_handling: "none"`, so a miss comes back as a 404 the Worker
 ///   can fall through, and the 404 a visitor sees is the project's own
 ///   `_uf.not-found` rather than Cloudflare's.
-fn wrangler_config(root: &Utf8Path) -> String {
-    let config = json!({
+fn wrangler_config(root: &Utf8Path, schedules: &[schedules::DeclaredSchedule]) -> String {
+    let mut config = json!({
         "name": worker_name(root),
         "main": "./worker.js",
         "compatibility_date": WORKERS_COMPATIBILITY_DATE,
@@ -496,6 +502,18 @@ fn wrangler_config(root: &Utf8Path) -> String {
             "not_found_handling": "none",
         },
     });
+    // Cloudflare's own scheduler, told about what the project declared. Written
+    // only when there is something to write: an empty `crons` is a key Wrangler
+    // has to interpret, and "no schedules" is better said by silence.
+    // ubugeeei-prod/uf#531.
+    if !schedules.is_empty() {
+        config["triggers"] = json!({
+            "crons": schedules
+                .iter()
+                .map(|schedule| schedule.cron.clone())
+                .collect::<Vec<_>>(),
+        });
+    }
     format!(
         "{}\n",
         serde_json::to_string_pretty(&config).unwrap_or_default()
@@ -763,7 +781,7 @@ mod tests {
 
     #[test]
     fn the_wrangler_config_asks_for_what_the_bundle_needs() {
-        let written = wrangler_config(Utf8Path::new("/src/served-app"));
+        let written = wrangler_config(Utf8Path::new("/src/served-app"), &[]);
         let config: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(config["name"], "served-app");
         assert_eq!(config["main"], "./worker.js");
@@ -774,6 +792,82 @@ mod tests {
         assert_eq!(config["assets"]["run_worker_first"], true);
         assert_eq!(config["assets"]["not_found_handling"], "none");
         assert_eq!(config["assets"]["binding"], "ASSETS");
+        // Silence rather than an empty list: `crons: []` is a key Wrangler has
+        // to interpret, and a project with no schedules said nothing.
+        assert!(config.get("triggers").is_none(), "{written}");
+    }
+
+    /// A declared schedule reaches Cloudflare's own scheduler.
+    ///
+    /// The emission half of ubugeeei-prod/uf#531: `edge` keeps no process, so
+    /// the platform has to be told, and `wrangler.json` is the file uf already
+    /// writes to tell it.
+    #[test]
+    fn a_declared_schedule_becomes_a_cloudflare_trigger() {
+        let declared = vec![
+            schedules::DeclaredSchedule {
+                path: "/api/sweep".into(),
+                file: Utf8PathBuf::from("app/api/sweep/_uf.route.js"),
+                cron: "*/15 * * * *".to_owned(),
+            },
+            schedules::DeclaredSchedule {
+                path: "/api/digest".into(),
+                file: Utf8PathBuf::from("app/api/digest/_uf.route.js"),
+                cron: "0 6 * * 1".to_owned(),
+            },
+        ];
+        let written = wrangler_config(Utf8Path::new("/src/served-app"), &declared);
+        let config: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(config["triggers"]["crons"][0], "*/15 * * * *");
+        assert_eq!(config["triggers"]["crons"][1], "0 6 * * 1");
+        // And nothing else about the file moved.
+        assert_eq!(config["main"], "./worker.js");
+    }
+
+    /// The refusal #531 asks for by name, on every target that would not run it.
+    #[test]
+    fn a_target_that_would_not_run_a_schedule_refuses_the_build() {
+        let declared = vec![schedules::DeclaredSchedule {
+            path: "/api/sweep".into(),
+            file: Utf8PathBuf::from("app/api/sweep/_uf.route.js"),
+            cron: "*/15 * * * *".to_owned(),
+        }];
+
+        // `edge` has somewhere to put it.
+        assert!(schedules::refuse_unrunnable(DeployAdapter::Edge, &declared).is_ok());
+
+        // The rest do not, today — including the ones that keep a process,
+        // because the entry uf generates for them does not pass the
+        // declaration to `serve` yet. Saying so beats the silence.
+        for adapter in [
+            DeployAdapter::Node,
+            DeployAdapter::Bun,
+            DeployAdapter::Container,
+            DeployAdapter::Serverless,
+            DeployAdapter::Static,
+        ] {
+            let message = schedules::refuse_unrunnable(adapter, &declared)
+                .expect_err("a schedule nothing would run is refused")
+                .to_string();
+            assert!(message.contains(adapter.as_str()), "{message}");
+            // Names the route, the expression and the file, so the reader does
+            // not have to go looking for which one.
+            assert!(message.contains("/api/sweep"), "{message}");
+            assert!(message.contains("*/15 * * * *"), "{message}");
+            assert!(message.contains("_uf.route.js"), "{message}");
+            assert!(
+                message.contains("issues/531") || message.contains("uf#531"),
+                "{message}"
+            );
+        }
+    }
+
+    /// And a project that declares none is refused by nobody.
+    #[test]
+    fn no_schedules_is_no_refusal_anywhere() {
+        for adapter in DeployAdapter::ALL {
+            assert!(schedules::refuse_unrunnable(*adapter, &[]).is_ok());
+        }
     }
 
     #[test]

--- a/crates/uf_cli/src/commands/deploy/schedules.rs
+++ b/crates/uf_cli/src/commands/deploy/schedules.rs
@@ -36,6 +36,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::CompactString;
 use serde_json::Value;
 use uf_config::{DeployAdapter, UniflowedConfig};
+use uf_infra::FxHashMap;
 use uf_router::{ServerModuleKind, discover_server_modules};
 
 /// The export a route handler declares its schedule with.
@@ -93,6 +94,13 @@ pub(crate) fn discover_schedules(
 }
 
 /// The expression a module exports, or [`None`] when it exports none.
+///
+/// Both spellings reach the same answer, because a reader who wrote the second
+/// one meant the first: `export const schedule = "…"` and
+/// `const schedule = "…"; export { schedule }` are one declaration to
+/// everything else that reads this module, and a build that saw only the first
+/// would miss a schedule silently — which is the failure this whole file
+/// exists to refuse.
 fn read_schedule(source: &str, file: &Utf8Path) -> Result<Option<String>> {
     // Through the same parser the build transforms with, rather than a second
     // reading of the file: `uf lint` and `uf build` already disagree with
@@ -100,63 +108,154 @@ fn read_schedule(source: &str, file: &Utf8Path) -> Result<Option<String>> {
     // opinion.
     let (program, _) = uf_transform::lowered_ast(source)
         .with_context(|| format!("parsing {file} to read its `{EXPORT}` export"))?;
-
-    for statement in program
+    let empty = Vec::new();
+    let body = program
         .get("body")
         .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-    {
+        .unwrap_or(&empty);
+    let literals = top_level_literals(body);
+
+    for statement in body {
         if statement.get("type").and_then(Value::as_str) != Some("ExportNamedDeclaration") {
             continue;
         }
-        let Some(declaration) = statement.get("declaration") else {
-            continue;
-        };
-        if declaration.get("type").and_then(Value::as_str) != Some("VariableDeclaration") {
+
+        // `null` and not absent: a specifier export carries the key with
+        // nothing in it, and treating that as a declaration is how the
+        // specifiers below never got looked at.
+        let declaration = statement
+            .get("declaration")
+            .filter(|declaration| !declaration.is_null());
+        if let Some(declaration) = declaration {
+            if let Some(found) = declared_here(declaration, file)? {
+                return Ok(Some(found));
+            }
             continue;
         }
-        for declarator in declaration
-            .get("declarations")
-            .and_then(Value::as_array)
-            .into_iter()
-            .flatten()
-        {
-            let name = declarator
-                .get("id")
-                .and_then(|id| id.get("name"))
-                .and_then(Value::as_str);
-            if name != Some(EXPORT) {
+
+        for specifier in specifiers(statement) {
+            if name_of(specifier.get("exported")) != Some(EXPORT) {
                 continue;
             }
-            let init = declarator.get("init");
-            let literal = init
-                .filter(|init| init.get("type").and_then(Value::as_str) == Some("Literal"))
-                .and_then(|init| init.get("value"))
-                .and_then(Value::as_str);
-            let Some(cron) = literal else {
+            // `export { schedule } from "./elsewhere.js"`: the value is in
+            // another module, and following imports to find it is a different
+            // and much larger question than reading this file. Refused rather
+            // than skipped, for the same reason a computed one is.
+            if statement
+                .get("source")
+                .is_some_and(|source| !source.is_null())
+            {
                 bail!(
-                    "{file} exports `{EXPORT}` as something this build cannot read.\n  \
-                     It has to be a string written in the file — `export const {EXPORT} = \
-                     \"*/15 * * * *\"` — because uf writes a platform's cron configuration \
-                     without running the project, and an expression it would have to \
-                     evaluate is one it cannot write down."
-                );
-            };
-            if cron.split_whitespace().count() != 5 {
-                bail!(
-                    "{file} exports `{EXPORT} = {cron:?}`, which is not five fields.\n  \
-                     A cron expression is `minute hour day-of-month month day-of-week`."
+                    "{file} re-exports `{EXPORT}` from another module, and this build reads \
+                     only the file that declares it.\n  Write the expression in this file — \
+                     `export const {EXPORT} = \"*/15 * * * *\"`."
                 );
             }
-            return Ok(Some(cron.to_owned()));
+            let Some(local) = name_of(specifier.get("local")) else {
+                continue;
+            };
+            let Some(cron) = literals.get(local) else {
+                bail!("{}", unreadable(file));
+            };
+            return Ok(Some(five_fields(cron, file)?));
         }
     }
     Ok(None)
 }
 
-#[cfg(test)]
-mod tests;
+/// The expression on an exported `const schedule = "…"`, if that is what this
+/// declaration is.
+fn declared_here(declaration: &Value, file: &Utf8Path) -> Result<Option<String>> {
+    if declaration.get("type").and_then(Value::as_str) != Some("VariableDeclaration") {
+        return Ok(None);
+    }
+    for declarator in declaration
+        .get("declarations")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if name_of(declarator.get("id")) != Some(EXPORT) {
+            continue;
+        }
+        let Some(cron) = literal_string(declarator.get("init")) else {
+            bail!("{}", unreadable(file));
+        };
+        return Ok(Some(five_fields(cron, file)?));
+    }
+    Ok(None)
+}
+
+/// Every top-level `const`/`let`/`var` bound to a string literal.
+///
+/// Collected so `export { schedule }` can be answered without a second walk,
+/// and only the literal ones: a binding this cannot read is the same refusal
+/// whether it was exported directly or by name.
+fn top_level_literals(body: &[Value]) -> FxHashMap<&str, &str> {
+    let mut literals = FxHashMap::default();
+    for statement in body {
+        if statement.get("type").and_then(Value::as_str) != Some("VariableDeclaration") {
+            continue;
+        }
+        for declarator in statement
+            .get("declarations")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if let (Some(name), Some(value)) = (
+                name_of(declarator.get("id")),
+                literal_string(declarator.get("init")),
+            ) {
+                literals.insert(name, value);
+            }
+        }
+    }
+    literals
+}
+
+fn specifiers(statement: &Value) -> impl Iterator<Item = &Value> {
+    statement
+        .get("specifiers")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+}
+
+fn name_of(node: Option<&Value>) -> Option<&str> {
+    node?.get("name")?.as_str()
+}
+
+/// The string a node is, when it is a string literal and nothing else.
+fn literal_string(node: Option<&Value>) -> Option<&str> {
+    let node = node?;
+    if node.get("type")?.as_str()? != "Literal" {
+        return None;
+    }
+    node.get("value")?.as_str()
+}
+
+/// The expression, or a refusal naming the field count.
+fn five_fields(cron: &str, file: &Utf8Path) -> Result<String> {
+    if cron.split_whitespace().count() != 5 {
+        bail!(
+            "{file} exports `{EXPORT} = {cron:?}`, which is not five fields.\n  \
+             A cron expression is `minute hour day-of-month month day-of-week`."
+        );
+    }
+    Ok(cron.to_owned())
+}
+
+/// What to say about a `schedule` this build cannot read.
+fn unreadable(file: &Utf8Path) -> String {
+    format!(
+        "{file} exports `{EXPORT}` as something this build cannot read.\n  \
+         It has to be a string written in the file — `export const {EXPORT} = \
+         \"*/15 * * * *\"` — because uf writes a platform's cron configuration without \
+         running the project, and an expression it would have to evaluate is one it cannot \
+         write down."
+    )
+}
 
 /// Whether `adapter` would actually run what a project declared.
 ///
@@ -208,3 +307,6 @@ pub(crate) fn refuse_unrunnable(
         schedules.len()
     );
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/uf_cli/src/commands/deploy/schedules.rs
+++ b/crates/uf_cli/src/commands/deploy/schedules.rs
@@ -1,0 +1,210 @@
+//! What a route handler says about when it should run without being asked.
+//!
+//! The build's half of ubugeeei-prod/uf#531. `@uniflowed/server/schedule` is
+//! the runtime's half and owns what an expression *means*; this owns finding
+//! one before anything runs, because a platform's own scheduler has to be told
+//! about it in a file written beside the deployment.
+//!
+//! # The declaration
+//!
+//! A route handler exports the expression as a string beside its handler:
+//!
+//! ```js
+//! export const schedule = "*/15 * * * *";
+//! export async function GET() { … }
+//! ```
+//!
+//! A *string*, and not a `defineSchedule(...)` call, for one reason: this runs
+//! offline. `uf build` writes Cloudflare's `triggers.crons` without evaluating
+//! a line of the project, and an expression it would have to run the module to
+//! learn is one it cannot write down. A computed value is refused by name
+//! rather than skipped, because a schedule the build could not read is a
+//! schedule the deployment would not run — which is the failure #531 exists to
+//! refuse.
+//!
+//! # What is checked here, and what is not
+//!
+//! Five fields, and nothing about what they contain. The meaning of a field
+//! lives in `packages/server/internal/cron.js` and belongs in one place: a
+//! second matcher here would be two implementations of one rule, drifting the
+//! first time either learned something. So `99 * * * *` passes this and is
+//! refused by `defineSchedule` when the deployment starts, loudly, rather than
+//! being quietly accepted by both.
+
+use anyhow::{Context, Result, bail};
+use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
+use serde_json::Value;
+use uf_config::{DeployAdapter, UniflowedConfig};
+use uf_router::{ServerModuleKind, discover_server_modules};
+
+/// The export a route handler declares its schedule with.
+const EXPORT: &str = "schedule";
+
+/// One schedule, as the build reads it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeclaredSchedule {
+    /// The route path of the handler that declared it, `/api/sweep`-style.
+    pub(crate) path: CompactString,
+    /// The file it was read from, for a message that names something.
+    pub(crate) file: Utf8PathBuf,
+    /// The expression, exactly as it was written.
+    pub(crate) cron: String,
+}
+
+/// Every schedule declared under the router root, in path order.
+///
+/// # Errors
+///
+/// When a module cannot be read or parsed, or when it exports `schedule` as
+/// something this cannot read offline.
+pub(crate) fn discover_schedules(
+    root: &Utf8Path,
+    config: &UniflowedConfig,
+) -> Result<Vec<DeclaredSchedule>> {
+    let modules = discover_server_modules(root, config)?;
+    let mut found = Vec::new();
+    for module in modules {
+        // Route handlers only. A middleware runs per request by definition, so
+        // a schedule on one would be a schedule on something that already has
+        // a trigger.
+        if module.kind != ServerModuleKind::RouteHandler {
+            continue;
+        }
+        let source = std::fs::read_to_string(module.file.as_std_path())
+            .with_context(|| format!("reading {}", module.file))?;
+        // The cheap gate first: a module that does not contain the word cannot
+        // declare one, and most modules do not. Textual on purpose, and only
+        // ever a *skip* — the parse below is what decides.
+        if !source.contains(EXPORT) {
+            continue;
+        }
+        let Some(cron) = read_schedule(&source, &module.file)? else {
+            continue;
+        };
+        found.push(DeclaredSchedule {
+            path: module.path,
+            file: module.file,
+            cron,
+        });
+    }
+    found.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(found)
+}
+
+/// The expression a module exports, or [`None`] when it exports none.
+fn read_schedule(source: &str, file: &Utf8Path) -> Result<Option<String>> {
+    // Through the same parser the build transforms with, rather than a second
+    // reading of the file: `uf lint` and `uf build` already disagree with
+    // nobody about what this module is, and a lexer here would be the third
+    // opinion.
+    let (program, _) = uf_transform::lowered_ast(source)
+        .with_context(|| format!("parsing {file} to read its `{EXPORT}` export"))?;
+
+    for statement in program
+        .get("body")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if statement.get("type").and_then(Value::as_str) != Some("ExportNamedDeclaration") {
+            continue;
+        }
+        let Some(declaration) = statement.get("declaration") else {
+            continue;
+        };
+        if declaration.get("type").and_then(Value::as_str) != Some("VariableDeclaration") {
+            continue;
+        }
+        for declarator in declaration
+            .get("declarations")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let name = declarator
+                .get("id")
+                .and_then(|id| id.get("name"))
+                .and_then(Value::as_str);
+            if name != Some(EXPORT) {
+                continue;
+            }
+            let init = declarator.get("init");
+            let literal = init
+                .filter(|init| init.get("type").and_then(Value::as_str) == Some("Literal"))
+                .and_then(|init| init.get("value"))
+                .and_then(Value::as_str);
+            let Some(cron) = literal else {
+                bail!(
+                    "{file} exports `{EXPORT}` as something this build cannot read.\n  \
+                     It has to be a string written in the file — `export const {EXPORT} = \
+                     \"*/15 * * * *\"` — because uf writes a platform's cron configuration \
+                     without running the project, and an expression it would have to \
+                     evaluate is one it cannot write down."
+                );
+            };
+            if cron.split_whitespace().count() != 5 {
+                bail!(
+                    "{file} exports `{EXPORT} = {cron:?}`, which is not five fields.\n  \
+                     A cron expression is `minute hour day-of-month month day-of-week`."
+                );
+            }
+            return Ok(Some(cron.to_owned()));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests;
+
+/// Whether `adapter` would actually run what a project declared.
+///
+/// `edge` is the only one today: `uf build` writes its `wrangler.json`, so
+/// there is a file to put `triggers.crons` in and Cloudflare's own scheduler
+/// to read it.
+///
+/// `node`, `bun` and `container` *could* — they keep a process, and
+/// `@uniflowed/server/schedule` ticks in one — but the entry `uf build`
+/// generates for them does not pass the declaration to `serve` yet. Until it
+/// does, a declaration in a route module would do nothing on those targets,
+/// and saying so is better than the silence.
+pub(crate) const fn runs_schedules(adapter: DeployAdapter) -> bool {
+    matches!(adapter, DeployAdapter::Edge)
+}
+
+/// Refuse a build whose schedules this target would not run.
+///
+/// The clause ubugeeei-prod/uf#531 asks for by name: *"a target that can do
+/// neither must refuse the configuration at build time rather than build
+/// something that never runs, which is the failure this feature has everywhere
+/// it exists."*
+///
+/// # Errors
+///
+/// When `schedules` is not empty and `adapter` would not run them.
+pub(crate) fn refuse_unrunnable(
+    adapter: DeployAdapter,
+    schedules: &[DeclaredSchedule],
+) -> Result<()> {
+    if schedules.is_empty() || runs_schedules(adapter) {
+        return Ok(());
+    }
+    let mut named = String::new();
+    for schedule in schedules {
+        named.push_str(&format!(
+            "\n    {} — `{}`, in {}",
+            schedule.path, schedule.cron, schedule.file
+        ));
+    }
+    bail!(
+        "the `{}` adapter would not run the {} schedule(s) this project declares, so this \
+         build would produce a deployment whose scheduled work never happens:{named}\n  \
+         `--adapter edge` writes them into `wrangler.json` for Cloudflare's own scheduler. \
+         On a target that keeps a process, pass them to `serve` yourself with \
+         `@uniflowed/server/schedule` — declaring one in a route module is not wired for \
+         those yet (ubugeeei-prod/uf#531).",
+        adapter.as_str(),
+        schedules.len()
+    );
+}

--- a/crates/uf_cli/src/commands/deploy/schedules/tests.rs
+++ b/crates/uf_cli/src/commands/deploy/schedules/tests.rs
@@ -171,3 +171,60 @@ fn a_computed_expression_in_a_real_project_fails_the_walk() {
         .to_string();
     assert!(message.contains("cannot read"), "{message}");
 }
+
+/// `export { schedule }` is the same declaration to everything else that reads
+/// this module, so a build that saw only `export const` would miss a schedule
+/// silently — the one failure this file exists to refuse.
+#[test]
+fn a_specifier_export_is_read_the_same_way_a_declaration_is() {
+    assert_eq!(
+        read("const schedule = \"*/15 * * * *\";\nexport { schedule };\n").expect("parses"),
+        Some("*/15 * * * *".to_owned())
+    );
+}
+
+#[test]
+fn a_renamed_specifier_export_is_read_under_the_name_it_takes() {
+    assert_eq!(
+        read("const every = \"0 6 * * 1\";\nexport { every as schedule };\n").expect("parses"),
+        Some("0 6 * * 1".to_owned())
+    );
+    // And the local name is not what is looked for.
+    assert_eq!(
+        read("const schedule = \"0 6 * * 1\";\nexport { schedule as other };\n").expect("parses"),
+        None
+    );
+}
+
+#[test]
+fn a_specifier_export_of_something_unreadable_is_refused() {
+    let message = read("const schedule = everyMinutes(15);\nexport { schedule };\n")
+        .expect_err("a computed binding is refused however it is exported")
+        .to_string();
+    assert!(message.contains("cannot read"), "{message}");
+}
+
+/// The value is in another module, and following imports to find it is a much
+/// larger question than reading this file. Refused rather than skipped.
+#[test]
+fn a_re_export_is_refused_rather_than_missed() {
+    let message = read("export { schedule } from \"./elsewhere.js\";\n")
+        .expect_err("a re-exported schedule is refused")
+        .to_string();
+    assert!(message.contains("re-exports"), "{message}");
+    assert!(
+        message.contains("elsewhere") || message.contains("another module"),
+        "{message}"
+    );
+}
+
+#[test]
+fn a_specifier_export_is_found_in_a_real_project_too() {
+    let dir = project(&[(
+        "app/api/sweep/_uf.route.js",
+        "const schedule = \"*/15 * * * *\";\nexport { schedule };\nexport function GET() {}\n",
+    )]);
+    let found = discovered(&dir);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].cron, "*/15 * * * *");
+}

--- a/crates/uf_cli/src/commands/deploy/schedules/tests.rs
+++ b/crates/uf_cli/src/commands/deploy/schedules/tests.rs
@@ -1,0 +1,173 @@
+use super::*;
+
+/// Read one module's `schedule` export, without a project around it.
+fn read(source: &str) -> Result<Option<String>> {
+    read_schedule(source, Utf8Path::new("app/api/_uf.route.js"))
+}
+
+#[test]
+fn a_string_export_is_the_expression() {
+    let found = read("export const schedule = \"*/15 * * * *\";\nexport function GET() {}\n")
+        .expect("a module that parses");
+    assert_eq!(found.as_deref(), Some("*/15 * * * *"));
+}
+
+#[test]
+fn a_module_without_one_declares_none() {
+    assert_eq!(
+        read("export function GET() {}\n").expect("a module that parses"),
+        None
+    );
+}
+
+/// A local `const schedule` is not an export, and neither is a different name.
+#[test]
+fn only_the_exported_binding_of_that_name_counts() {
+    assert_eq!(
+        read("const schedule = \"* * * * *\";\nexport function GET() {}\n").expect("parses"),
+        None
+    );
+    assert_eq!(
+        read("export const schedules = \"* * * * *\";\n").expect("parses"),
+        None
+    );
+}
+
+/// The refusal that matters: this build runs no project code, so an expression
+/// it would have to evaluate is one it cannot write into `wrangler.json`.
+#[test]
+fn a_computed_expression_is_refused_by_name_rather_than_skipped() {
+    let message = read("export const schedule = everyMinutes(15);\n")
+        .expect_err("a computed schedule is refused")
+        .to_string();
+    assert!(message.contains("cannot read"), "{message}");
+    assert!(message.contains("*/15 * * * *"), "{message}");
+    assert!(message.contains("_uf.route.js"), "{message}");
+}
+
+#[test]
+fn a_template_literal_is_refused_for_the_same_reason() {
+    let message = read("export const schedule = `*/${n} * * * *`;\n")
+        .expect_err("a template literal is computed")
+        .to_string();
+    assert!(message.contains("cannot read"), "{message}");
+}
+
+#[test]
+fn an_expression_that_is_not_five_fields_is_refused_here() {
+    let message = read("export const schedule = \"* * * *\";\n")
+        .expect_err("four fields is not a cron expression")
+        .to_string();
+    assert!(message.contains("not five fields"), "{message}");
+    assert!(message.contains("day-of-week"), "{message}");
+}
+
+/// What each field *contains* is `packages/server/internal/cron.js`'s to say,
+/// and a second matcher here would be two implementations of one rule. So this
+/// passes something that module refuses, deliberately — loudly at start-up
+/// rather than quietly in both places.
+#[test]
+fn what_a_field_holds_is_not_this_builds_question() {
+    assert_eq!(
+        read("export const schedule = \"99 * * * *\";\n").expect("five fields"),
+        Some("99 * * * *".to_owned())
+    );
+}
+
+#[test]
+fn a_let_export_is_read_the_same_way_a_const_is() {
+    // The declaration kind is not the point — being written in the file is.
+    assert_eq!(
+        read("export let schedule = \"0 0 * * *\";\n").expect("parses"),
+        Some("0 0 * * *".to_owned())
+    );
+}
+
+/// A project on disk, so `discover_server_modules`' walk is exercised rather
+/// than assumed: the string tests above never touch the router root, and the
+/// question "does it find the file" is a different one from "does it read it".
+fn project(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    for (path, contents) in files {
+        let file = dir.path().join(path);
+        std::fs::create_dir_all(file.parent().expect("a parent")).expect("the directory");
+        std::fs::write(&file, contents).expect("the file");
+    }
+    dir
+}
+
+fn discovered(dir: &tempfile::TempDir) -> Vec<DeclaredSchedule> {
+    let root = Utf8Path::from_path(dir.path()).expect("a UTF-8 path");
+    discover_schedules(root, &UniflowedConfig::default()).expect("a project that reads")
+}
+
+#[test]
+fn a_route_handler_that_declares_one_is_found_at_its_path() {
+    let dir = project(&[
+        (
+            "app/api/sweep/_uf.route.js",
+            "export const schedule = \"*/15 * * * *\";\nexport function GET() {}\n",
+        ),
+        ("app/api/health/_uf.route.js", "export function GET() {}\n"),
+    ]);
+
+    let found = discovered(&dir);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].path, "/api/sweep");
+    assert_eq!(found[0].cron, "*/15 * * * *");
+    assert!(
+        found[0].file.as_str().ends_with("_uf.route.js"),
+        "{:?}",
+        found[0].file
+    );
+}
+
+#[test]
+fn several_come_back_in_path_order() {
+    let dir = project(&[
+        (
+            "app/api/sweep/_uf.route.js",
+            "export const schedule = \"*/15 * * * *\";\n",
+        ),
+        (
+            "app/api/digest/_uf.route.js",
+            "export const schedule = \"0 6 * * 1\";\n",
+        ),
+    ]);
+
+    let paths: Vec<_> = discovered(&dir).into_iter().map(|s| s.path).collect();
+    // Sorted, so a message built from this does not depend on the order the
+    // filesystem hands entries back.
+    assert_eq!(paths, ["/api/digest", "/api/sweep"]);
+}
+
+/// A middleware runs per request by definition, so a schedule on one would be
+/// a schedule on something that already has a trigger.
+#[test]
+fn a_middleware_is_not_asked() {
+    let dir = project(&[(
+        "app/dashboard/_uf.middleware.js",
+        "export const schedule = \"* * * * *\";\nexport function middleware() {}\n",
+    )]);
+    assert_eq!(discovered(&dir), Vec::new());
+}
+
+#[test]
+fn a_project_with_no_router_root_declares_none() {
+    let dir = project(&[("package.json", "{}\n")]);
+    assert_eq!(discovered(&dir), Vec::new());
+}
+
+/// The refusal reaches out of a real project, not only out of a string.
+#[test]
+fn a_computed_expression_in_a_real_project_fails_the_walk() {
+    let dir = project(&[(
+        "app/api/sweep/_uf.route.js",
+        "export const schedule = everyMinutes(15);\n",
+    )]);
+    let root = Utf8Path::from_path(dir.path()).expect("a UTF-8 path");
+    let message = discover_schedules(root, &UniflowedConfig::default())
+        .expect_err("a computed schedule is refused")
+        .to_string();
+    assert!(message.contains("cannot read"), "{message}");
+}

--- a/docs/app/guide/routing/_uf.page.mdx
+++ b/docs/app/guide/routing/_uf.page.mdx
@@ -872,9 +872,53 @@ than one that always means the same minute.
 
 A target that keeps no process is **refused** an in-process schedule where the
 host is wired, because nothing would be running at the minute it names. Those
-targets need their platform's own scheduler pointed at the deployment, and
-emitting that configuration per platform is
-[#531](https://github.com/ubugeeei-prod/uf/issues/531).
+targets need their platform's own scheduler pointed at the deployment.
+
+### Declaring one in a route handler
+
+A route handler can say when it should run without being asked, so that
+`uf build` can tell a platform's own scheduler about it:
+
+```js
+// app/api/sweep/_uf.route.js
+// @flow
+export const schedule = "*/15 * * * *";
+
+export function GET(): Response {
+  return Response.json({ swept: true });
+}
+```
+
+A **string written in the file**, not a call. `uf build` writes a platform's
+cron configuration without running a line of your project, so an expression it
+would have to evaluate is one it cannot write down — and a computed one is
+refused by name rather than skipped, because a schedule the build could not
+read is a schedule the deployment would not run.
+
+`uf build --adapter edge` puts it in `wrangler.json`:
+
+```json
+"triggers": { "crons": ["*/15 * * * *"] }
+```
+
+Every other adapter **refuses the build**, and says which route, which
+expression and which file:
+
+```
+error: the `node` adapter would not run the 1 schedule(s) this project
+declares, so this build would produce a deployment whose scheduled work never
+happens:
+    /api/sweep — `*/15 * * * *`, in app/api/sweep/_uf.route.js
+```
+
+`node`, `bun` and `container` keep a process and *could* run one — the entry
+`uf build` generates for them does not pass the declaration to `serve` yet, so
+until it does, pass your schedules to `serve` yourself as above.
+[#531](https://github.com/ubugeeei-prod/uf/issues/531) tracks the rest.
+
+What each field *contains* is checked when the deployment starts rather than
+at build time: the meaning of a field lives in one place, and a second matcher
+in the build would be two implementations of one rule.
 
 ### What each target can do
 

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -361,7 +361,7 @@ the sixth runs none:
 | `node` | `handler.js`, `server.js`, `chunks/`, `static/`, `package.json` | `cd .uf/deploy/node && node server.js` |
 | `bun` | the same file names, with `Bun.serve` and `Bun.file` behind them | `cd .uf/deploy/bun && bun server.js` |
 | `container` | the same, plus `Dockerfile` and `.dockerignore` | `docker build -t NAME .uf/deploy/container` |
-| `edge` | `handler.js`, `worker.js`, `wrangler.json`, `chunks/`, `static/` | `cd .uf/deploy/edge && npx wrangler deploy` |
+| `edge` | `handler.js`, `worker.js`, `wrangler.json` (with `triggers.crons` for any declared schedule), `chunks/`, `static/` | `cd .uf/deploy/edge && npx wrangler deploy` |
 | `serverless` | `handler.js`, `lambda.js`, `chunks/`, `static/`, `package.json` | zip it, upload it, set the handler to `lambda.handler` |
 | `static` | your build, file for file, and nothing else | upload it to any static host |
 


### PR DESCRIPTION
The build's half of [#531](https://github.com/ubugeeei-prod/uf/issues/531). [#696](https://github.com/ubugeeei-prod/uf/pull/696) shipped the runtime — `defineSchedule` and a scheduler a process can tick — and left the declaration and the emission, which need the build rather than a running server.

A route handler says when it should run without being asked:

```js
// app/api/sweep/_uf.route.js
export const schedule = "*/15 * * * *";

export function GET(): Response {
  return Response.json({ swept: true });
}
```

## Why a string and not a call

`uf build` writes a platform's cron configuration **without running a line of the project**, so an expression it would have to evaluate is one it cannot write down. `export const schedule = everyMinutes(15)` is refused by name rather than skipped, because a schedule the build could not read is a schedule the deployment would not run — which is what this issue exists to refuse.

## What each adapter does

`--adapter edge` puts it where Cloudflare's own scheduler reads it. Verified against the real build:

```json
"triggers": { "crons": ["*/15 * * * *"] }
```

Everything else **refuses the build**, and names what it found:

```
error: the `node` adapter would not run the 1 schedule(s) this project declares,
so this build would produce a deployment whose scheduled work never happens:
    /api/sweep — `*/15 * * * *`, in app/api/sweep/_uf.route.js
  `--adapter edge` writes them into `wrangler.json` for Cloudflare's own
  scheduler. On a target that keeps a process, pass them to `serve` yourself
  with `@uniflowed/server/schedule` — declaring one in a route module is not
  wired for those yet (ubugeeei-prod/uf#531).
```

That is the clause #531 asks for by name: *"a target that can do neither must refuse the configuration at build time rather than build something that never runs, which is the failure this feature has everywhere it exists."*

`node`, `bun` and `container` keep a process and *could* run one — the entry uf generates for them does not pass the declaration to `serve` yet, so today they would not, and saying so beats the silence. That remains #531's.

The refusal runs immediately after the adapter is resolved, before the bundler does anything, so a project whose scheduled work would never happen hears about it in a second rather than after a build.

## What this deliberately does not check

What a field *contains*. `packages/server/internal/cron.js` owns that, and a second matcher here would be two implementations of one rule, drifting the first time either learned something. So `99 * * * *` passes the build with five fields and is refused by `defineSchedule` when the deployment starts — loudly, rather than quietly accepted in both places. There is a test asserting exactly that, so the split is deliberate rather than an oversight.

Reading is through `uf_transform::lowered_ast`, the same parser the build transforms with, rather than a third opinion about what a module is.

## Verification

- 13 unit tests for discovery — string forms, a real project tree, middleware excluded, path ordering, and every refusal.
- 4 for the emission and the refusal across all seven adapters.
- End to end against the real binary: `--adapter node` refuses in a second; `--adapter edge` builds and writes the `triggers.crons` above.
- `cargo test -p uf_cli` exit 0, 462 lib tests; `clippy --all-targets -- -D warnings` and `fmt --check` clean; docs tests green.

Rebased onto current main after #697, #702, #703 and #704 landed mid-work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791525954&installation_model_id=422833&pr_number=712&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F712&signature=d3408d1b1d8586c900322bd138c5995df7ad8c118091cbee60469fb312eee780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Route handlers can declare cron schedules using string literals.
  - Edge deployments now include declared schedules in the generated platform configuration.
  - Schedule declarations are discovered automatically and validated during deployment.

- **Bug Fixes**
  - Builds now fail clearly when schedules are used with unsupported deployment adapters, identifying affected routes and files.

- **Documentation**
  - Added routing guidance for declaring schedules and documented schedule support for the Edge adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->