### PR TITLE
perf(check): where the checker's two million allocations go

### DIFF
--- a/crates/uf_check/Cargo.toml
+++ b/crates/uf_check/Cargo.toml
@@ -73,10 +73,11 @@ flow_utils_concurrency = { workspace = true, optional = true }
 # The parse boundary, for the one question the port cannot be asked: whether
 # it is reading a module. See `uf_flow::module`.
 uf_flow = { path = "../uf_flow", optional = true }
+# `profile_span!` in the checker's own phases, and the counting allocator
+# behind the figures in ubugeeei-prod/uf#678. A dependency rather than a
+# dev-dependency because the spans are compiled into the library: with the gate
+# shut each is a relaxed atomic load and a `bool`. See `uf_profiler`'s header.
+uf_profiler = { path = "../uf_profiler" }
 
 [dev-dependencies]
 tempfile.workspace = true
-# For `examples/alloc_report.rs`: the counting allocator behind the figures in
-# ubugeeei-prod/uf#678, so the next person to touch the checker can take them
-# again rather than trust them.
-uf_profiler = { path = "../uf_profiler" }

--- a/crates/uf_check/examples/alloc_report.rs
+++ b/crates/uf_check/examples/alloc_report.rs
@@ -20,6 +20,13 @@
 //!   the second: a record's key is over the file's own text, so a keystroke
 //!   makes a key nothing has been filed under.
 //!
+//! `--phases` adds the table #678 asks for and could not take: one row per
+//! `profile_span!` in the checker, so the fixed cost of forcing a builtin
+//! environment is separated from what a module costs to infer. The spans are
+//! uf's own — the vendored port is a submodule and carries none — so the row
+//! that ends up largest is the boundary uf hands work across, not a line
+//! inside inference.
+//!
 //! Debug and release give identical allocation counts — the counter is in the
 //! allocator, not in the optimiser — so this can be run without a release
 //! build. Release is worth it for the wall clock and nothing else.
@@ -27,13 +34,20 @@
 use std::path::Path;
 
 use uf_check::{CheckCache, CheckLimits, Source, check_sources, check_sources_cached};
-use uf_profiler::{AllocDelta, AllocSnapshot, CountingAllocator, Window};
+use uf_profiler::{
+    AllocDelta, AllocSnapshot, CountingAllocator, Recorder, ReportConfig, SortBy, Window, scope,
+};
 
 #[global_allocator]
 static GLOBAL: CountingAllocator = CountingAllocator::new();
 
 fn main() {
-    let Arguments { path, batch, cache } = Arguments::parse(std::env::args().skip(1));
+    let Arguments {
+        path,
+        batch,
+        cache,
+        phases,
+    } = Arguments::parse(std::env::args().skip(1));
     let source = std::fs::read_to_string(&path).expect("read the module");
 
     if !uf_check::is_available() {
@@ -80,6 +94,32 @@ fn main() {
         std::hint::black_box(&report);
     });
     print_delta(&delta, runs);
+
+    if phases {
+        // A second pass rather than the one above: a span reads the
+        // allocator's counters as it opens and closes, and the headline should
+        // not be made to carry that.
+        // `measure` turns the allocator off when it is done, and a span with
+        // nothing counting reads four zeroes — so it goes back on around this
+        // pass or the table has a time column and nothing else.
+        CountingAllocator::enable();
+        scope::enable();
+        let mut recorder = Recorder::new("check_sources").with_config(ReportConfig {
+            sort_by: SortBy::Allocations,
+            ..ReportConfig::default()
+        });
+        for _ in 0..runs {
+            recorder.record(|| {
+                let report = check_sources(&sources, &[], &CheckLimits::default()).expect("checks");
+                std::hint::black_box(report)
+            });
+        }
+        let report = recorder.finish();
+        scope::disable();
+        CountingAllocator::disable();
+        println!();
+        println!("{}", report.render_table());
+    }
 }
 
 /// The three calls the cache question is actually about.
@@ -185,6 +225,8 @@ struct Arguments {
     batch: usize,
     /// Whether to run the three cached calls instead of the plain report.
     cache: bool,
+    /// Whether to print the per-phase table as well as the headline.
+    phases: bool,
 }
 
 impl Arguments {
@@ -198,10 +240,12 @@ impl Arguments {
         let mut path = None;
         let mut batch = 1;
         let mut cache = false;
+        let mut phases = false;
         let mut arguments = arguments.peekable();
         while let Some(argument) = arguments.next() {
             match argument.as_str() {
                 "--cache" => cache = true,
+                "--phases" => phases = true,
                 "--batch" => {
                     // Taken whatever it says, so a mistyped count is not
                     // silently a path as well as silently a batch of one.
@@ -222,6 +266,7 @@ impl Arguments {
             path: path.unwrap_or_else(|| String::from("packages/router/internal/runtime.js")),
             batch,
             cache,
+            phases,
         }
     }
 }

--- a/crates/uf_check/src/upstream/builtins.rs
+++ b/crates/uf_check/src/upstream/builtins.rs
@@ -27,6 +27,7 @@ use std::sync::Once;
 use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::Instant;
+use uf_profiler::profile_span;
 
 use compact_str::ToCompactString;
 use flow_common::type_strictness::TypeStrictnessKind;
@@ -113,6 +114,7 @@ pub(super) fn digest(libs: &[Source<'_>]) -> Digest {
 
 /// Build the environment `libs` makes, or return the shared one.
 pub(crate) fn prepare(libs: &[Source<'_>]) -> Result<BuiltinsTiming, CheckError> {
+    profile_span!("check::builtins_prepare");
     let started = Instant::now();
     let (builtins, cold) = environment(libs)?;
     Ok(BuiltinsTiming {
@@ -124,6 +126,7 @@ pub(crate) fn prepare(libs: &[Source<'_>]) -> Result<BuiltinsTiming, CheckError>
 
 /// The shared master context for `libs`, building it on first use.
 pub(super) fn master_context(libs: &[Source<'_>]) -> Result<Arc<MasterContext>, CheckError> {
+    profile_span!("check::master_context");
     Ok(environment(libs)?.0.master_cx)
 }
 

--- a/crates/uf_check/src/upstream/graph.rs
+++ b/crates/uf_check/src/upstream/graph.rs
@@ -34,6 +34,7 @@
 //! publishing a name.
 
 use compact_str::CompactString;
+use uf_profiler::profile_span;
 
 use super::project::ProjectModules;
 use crate::cache::{CachedRequire, Digest, Fields, hex};
@@ -97,6 +98,7 @@ impl<'a> Graph<'a> {
         facts: &'a [ModuleFacts],
         modules: &ProjectModules,
     ) -> Self {
+        profile_span!("check::graph");
         let resolutions: Vec<Vec<Resolution>> = paths
             .iter()
             .zip(facts)

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -42,6 +42,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
+use uf_profiler::profile_span;
 
 use compact_str::{CompactString, ToCompactString};
 use dupe::{Dupe, OptionDupedExt};
@@ -153,7 +154,15 @@ where
         let worker = std::thread::Builder::new()
             .name("uf-typecheck".to_owned())
             .stack_size(CHECK_STACK_BYTES)
-            .spawn_scoped(scope, work)
+            .spawn_scoped(scope, || {
+                let checked = work();
+                // Spans opened here are thread-local and die with the thread;
+                // this is the hand-over `scope::flush_thread_spans` documents.
+                // Every phase of the check runs on this thread, so without it
+                // the profiler would see none of them.
+                uf_profiler::scope::flush_thread_spans();
+                checked
+            })
             .map_err(|error| CheckError::Worker {
                 path: path.to_compact_string(),
                 detail: error.to_compact_string(),
@@ -184,6 +193,7 @@ fn check_batch(
     limits: &CheckLimits,
     cache: Option<&CheckCache>,
 ) -> Result<CheckReport, CheckError> {
+    profile_span!("check::batch");
     // Before anything reads a source, including the pass that only wants its
     // signature: the AST alone is several times the size of the text, so an
     // unbounded file is an unbounded allocation and no phase of this function
@@ -202,15 +212,29 @@ fn check_batch(
 
     let builtins = builtins::prepare(libs)?;
     let master_cx = builtins::master_context(libs)?;
-    let options = options::options(limits);
+    let options = {
+        profile_span!("check::options");
+        options::options(limits)
+    };
     // One builtin environment for the batch, made from the metadata a file has
     // before its own docblock is applied — `mk_check_file` keeps exactly this
     // one and hands it to every file it checks. Per file it would be both
     // wasted work and wrong: a type crossing a module boundary is compared
     // against the importer's builtins, and two independent merges of `core.js`
     // do not agree on `Array`.
-    let base_metadata = flow_typing_context::mk_context_metadata(&options, Arc::default());
-    let mk_builtins = merge::mk_builtins(&base_metadata, &master_cx);
+    // Spanned together because they are one thing: the builtin environment this
+    // call will check against. `builtins::prepare` and `master_context` are
+    // memoized per process and read as zero after a warm-up, so this is where
+    // the per-*call* fixed cost ubugeeei-prod/uf#678 measured actually lands.
+    // `_base_metadata` is bound rather than dropped: `mk_builtins` is built
+    // from it, and the original code kept it alive for the rest of the
+    // function. Keeping that exactly, so the span is the only change here.
+    let (_base_metadata, mk_builtins) = {
+        profile_span!("check::environment");
+        let base_metadata = flow_typing_context::mk_context_metadata(&options, Arc::default());
+        let mk_builtins = merge::mk_builtins(&base_metadata, &master_cx);
+        (base_metadata, mk_builtins)
+    };
     let modules = Rc::new(ProjectModules::new(
         sources,
         options.clone(),
@@ -433,6 +457,7 @@ fn check_one(
     source: &Source<'_>,
     modules: &Rc<ProjectModules>,
 ) -> Result<Vec<TypeDiagnostic>, CheckError> {
+    profile_span!("check::infer_one");
     let file_key = FileKey::new(FileKeyInner::SourceFile(source.path.to_owned()));
     let parsed = parse::parse_file(file_key.dupe(), source.source, options, false);
     if !parsed.is_parseable() {

--- a/crates/uf_check/src/upstream/project.rs
+++ b/crates/uf_check/src/upstream/project.rs
@@ -76,6 +76,7 @@ use std::cell::{LazyCell, OnceCell, RefCell};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
+use uf_profiler::profile_span;
 
 use compact_str::{CompactString, ToCompactString};
 use dupe::Dupe;
@@ -199,6 +200,7 @@ impl ProjectModules {
         mk_builtins: MkBuiltins,
         limits: &CheckLimits,
     ) -> Self {
+        profile_span!("check::project_modules");
         Self {
             index: ModuleIndex::new(sources.iter().map(|source| source.path)),
             packages: WorkspacePackages::new(sources, &options),
@@ -264,6 +266,7 @@ impl ProjectModules {
     /// types mention, while inference resolves every import the file has, and
     /// it is inference whose answer is being cached.
     pub(super) fn facts(&self, index: usize) -> ModuleFacts {
+        profile_span!("check::module_facts");
         let (path, source) = &self.sources[index];
         let file_key = FileKey::new(FileKeyInner::SourceFile(path.to_string()));
         let parsed = parse::parse_file(file_key, source, &self.options, false);


### PR DESCRIPTION
Answers the question ubugeeei-prod/uf#678 left open twice.

## The question

> It does **not** say where inside the checker, and I have not found out: the type checker is the vendored Flow port, so the per-phase table #668 has for the transform pipeline would need `profile_span!` inside `upstream/flow/rust_port`, which is a different kind of change from instrumenting uf's own crates.

That is true of the port — it is a submodule pinned to `facebook/flow`, and #709 is what makes patching it possible at all. But it is **not** true of `crates/uf_check/src/upstream`, which is uf's own driver for the port, and its boundaries turn out to be enough.

## The table

Eight spans at the phases `check_batch` already has. `packages/router/internal/runtime.js`, 123,056 bytes, three runs:

| phase | allocations / run | share |
| --- | ---: | ---: |
| `check::infer_one` | 1,940,972 | **91.6%** |
| `check::environment` | 136,236 | 6.4% |
| `check::module_facts` | 42,069 | 2.0% |
| `check::graph` | 43 | — |
| `check::options` | 18 | — |
| `check::project_modules` | 9 | — |
| `check::builtins_prepare` | 0 | — |
| `check::master_context` | 0 | — |

## Two things the totals could not say

**The fixed per-call cost is two lines, not "the environment".** #678 measured it as 136,906 allocations for a batch of one trivial file, and its later comment says memoizing it inside `CheckCache` would be worth 6.9% — but not *what* to memoize. It is these two:

```rust
let base_metadata = flow_typing_context::mk_context_metadata(&options, Arc::default());
let mk_builtins = merge::mk_builtins(&base_metadata, &master_cx);
```

136,236 allocations, rebuilt on every call — **within half a percent of #678's figure, reached by a completely different route**, which is the check that the instrumentation is measuring the thing it names.

And it says which parts are *not* it: `builtins::prepare` and `master_context` read **zero**. They are memoized per process and the warm-up has already forced them, so the obvious candidates were never the ones to memoize.

**Everything else uf owns is already free.** The graph, the project modules and the options are **70 allocations between them**. Nothing outside inference and the environment is worth looking at — a result rather than an absence of one.

## What this does not change

`check::infer_one` is one call into the port per module, so 91.6% is still the port's, and getting inside it still needs a patch — which #709 has now made a supported operation. This narrows the target from "two million allocations somewhere in `uf check`" to "1.94 million inside inference, and 136 thousand in two lines uf wrote".

Note the 6.9% has no consumer today, as #678's own correction records: `uf check --watch` does not exist and the language server does not type check. This PR does not build the memoization — it says exactly what to memoize when something needs it.

## Also

`uf_profiler` moves from a dev-dependency to a dependency of `uf_check`, as it did for `uf_lint` and `uf_transform` in #697 and for the same reason. `on_check_thread` gains `flush_thread_spans` — every phase of a check runs on that thread, so without it the profiler would see none of them.

`alloc_report --phases` prints the table, alongside the plain, `--batch` and `--cache` modes the example already had.

## Verification

- `cargo clippy -p uf_check --all-targets -- -D warnings` — clean
- `cargo test -p uf_check` — 174 + 24 + 7 + 3 + 2 + 2 + 2 passed, 0 failed
- The headline (2,119,370 allocations) is unchanged from `main`: with the gate shut a span is one relaxed atomic load.

Refs ubugeeei-prod/uf#678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791526458&installation_model_id=422833&pr_number=713&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F713&signature=2ded88a5a7652a54fa32a953e697d3bb8b03837f1cacf1d6ca0d49fb94fd5c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->