### PR TITLE
fix(config): the refusal names the expression it refused, and its line

### DIFF
--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -1683,10 +1683,26 @@ pub enum ConfigError {
     },
     #[error("failed to parse {path}: {message}")]
     Parse { path: Utf8PathBuf, message: String },
-    #[error(
-        "unsupported config expression in {path}; use `export default defineConfig({{ ... }})`"
-    )]
-    UnsupportedExpression { path: Utf8PathBuf },
+    /// The config file is read without being run, and something in it is not a
+    /// literal.
+    ///
+    /// The message names the expression and its line, because the export shape
+    /// is nearly always already right and saying so sends the reader looking in
+    /// the wrong place. See ubugeeei-prod/uf#698, where the reported fix was
+    /// the thing the file already did.
+    #[error("{path}:{line}: {reason}\n  found: {snippet}")]
+    UnsupportedExpression {
+        path: Utf8PathBuf,
+        /// 1-based line of the expression that was refused.
+        line: usize,
+        /// The refused text, trimmed and bounded.
+        snippet: String,
+        reason: &'static str,
+    },
+    /// A config file uf has no reader for, which is not the same problem as a
+    /// config file it cannot evaluate — and used to share its message.
+    #[error("cannot read {path}: uf reads `.js`, `.mjs`, `.cjs` and `.flow` config files")]
+    UnreadableConfigFile { path: Utf8PathBuf },
     /// A cache switch that is `true` and means nothing.
     ///
     /// `rendering.cache` has four keys and uf implements two of them. Reading
@@ -1829,11 +1845,18 @@ pub fn load_config_file(path: &Utf8Path) -> Result<UniflowedConfig, ConfigError>
 
     match path.extension() {
         Some("js" | "mjs" | "cjs" | "flow") => {
-            let json5 = extract_config_object(&source).ok_or_else(|| {
-                ConfigError::UnsupportedExpression {
-                    path: path.to_path_buf(),
+            let json5 = match extract_config_object(&source) {
+                Some(json5) => json5,
+                None => {
+                    let refusal = diagnose_config_expression(&source);
+                    return Err(ConfigError::UnsupportedExpression {
+                        path: path.to_path_buf(),
+                        line: refusal.line,
+                        snippet: refusal.snippet,
+                        reason: refusal.reason,
+                    });
                 }
-            })?;
+            };
             let config: UniflowedConfig =
                 json5::from_str(&json5).map_err(|source| ConfigError::Parse {
                     path: path.to_path_buf(),
@@ -1853,7 +1876,7 @@ pub fn load_config_file(path: &Utf8Path) -> Result<UniflowedConfig, ConfigError>
             library::check(path, &config)?;
             Ok(config)
         }
-        _ => Err(ConfigError::UnsupportedExpression {
+        _ => Err(ConfigError::UnreadableConfigFile {
             path: path.to_path_buf(),
         }),
     }
@@ -1908,6 +1931,130 @@ pub fn extract_config_object(source: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Why [`extract_config_object`] refused, with somewhere to look.
+///
+/// `uf.config.js` is read rather than run, so only literals survive. That is a
+/// real constraint and this type does not argue with it — it says *which*
+/// expression fell outside it and on what line, which is what the single
+/// message it replaces did not. See ubugeeei-prod/uf#698: the old message
+/// named `export default defineConfig({ ... })` as the fix, and the file it
+/// was reporting on already did exactly that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedConfig {
+    /// 1-based line of the refused expression.
+    pub line: usize,
+    /// The refused text, trimmed and bounded so a minified file cannot make
+    /// the diagnostic unreadable.
+    pub snippet: String,
+    pub reason: &'static str,
+}
+
+/// Longest refused expression the message will quote.
+const SNIPPET_BYTES: usize = 120;
+
+/// Explain a refusal, for the file [`extract_config_object`] returned [`None`]
+/// for.
+///
+/// Separate from the extractor rather than folded into it: the extractor runs
+/// on every successful load too, and it should not carry the cost of
+/// describing a failure that is not going to happen.
+#[must_use]
+pub fn diagnose_config_expression(source: &str) -> UnsupportedConfig {
+    let mut in_block_comment = false;
+    for (index, raw) in source.lines().enumerate() {
+        let line = index + 1;
+        let mut text = raw.trim();
+
+        if in_block_comment {
+            match text.find("*/") {
+                Some(end) => {
+                    in_block_comment = false;
+                    text = text[end + 2..].trim();
+                }
+                None => continue,
+            }
+        }
+        while let Some(rest) = text.strip_prefix("/*") {
+            match rest.find("*/") {
+                Some(end) => text = rest[end + 2..].trim(),
+                None => {
+                    in_block_comment = true;
+                    text = "";
+                    break;
+                }
+            }
+        }
+
+        if text.is_empty() || text.starts_with("//") || text.starts_with("import ") {
+            continue;
+        }
+
+        // The first thing that is neither an import nor a comment. Whatever is
+        // wrong with this file, this is where a reader should start.
+        let Some(exported) = text.strip_prefix("export default") else {
+            return UnsupportedConfig {
+                line,
+                snippet: snippet(text),
+                reason: "uf reads this file without running it, so a statement before the \
+                         default export is not evaluated — inline the value at its use",
+            };
+        };
+
+        let exported = exported.trim();
+        if let Some(call) = exported.strip_prefix("defineConfig") {
+            let argument = call.trim_start().strip_prefix('(').unwrap_or(call).trim();
+            if !argument.starts_with('{') {
+                return UnsupportedConfig {
+                    line,
+                    snippet: snippet(argument),
+                    reason: "the argument to `defineConfig` has to be an object literal, \
+                             because uf reads this file without running it",
+                };
+            }
+            return UnsupportedConfig {
+                line,
+                snippet: snippet(text),
+                reason: "the object passed to `defineConfig` is not closed",
+            };
+        }
+
+        if exported.starts_with('{') {
+            return UnsupportedConfig {
+                line,
+                snippet: snippet(text),
+                reason: "the exported object literal is not closed",
+            };
+        }
+
+        return UnsupportedConfig {
+            line,
+            snippet: snippet(exported),
+            reason: "the default export has to be an object literal or \
+                     `defineConfig({ ... })`, because uf reads this file without running it",
+        };
+    }
+
+    UnsupportedConfig {
+        line: 1,
+        snippet: String::new(),
+        reason: "this file has no default export",
+    }
+}
+
+/// The refused text, on one line and bounded.
+fn snippet(text: &str) -> String {
+    let text = text.trim();
+    let mut cut = text.len().min(SNIPPET_BYTES);
+    while cut < text.len() && !text.is_char_boundary(cut) {
+        cut += 1;
+    }
+    let mut shown = text[..cut].replace(['\n', '\r'], " ");
+    if cut < text.len() {
+        shown.push('…');
+    }
+    shown
 }
 
 fn strip_leading_comments(mut source: &str) -> &str {

--- a/crates/uf_config/src/tests.rs
+++ b/crates/uf_config/src/tests.rs
@@ -1348,3 +1348,109 @@ fn the_documented_highlight_key_path_is_the_one_uf_serializes() {
         );
     }
 }
+
+// --- ubugeeei-prod/uf#698: the refusal says which expression, and where -----
+
+/// The case #698 filed: a `const` before the export.
+///
+/// The old message named `export default defineConfig({ ... })` as the fix,
+/// and the file already did exactly that — so it pointed away from the line
+/// that was actually refused. This pins the line and the text instead.
+#[test]
+fn a_statement_before_the_export_is_named_with_its_line() {
+    let source = "// @flow\n\
+                  import { defineConfig } from \"@uniflowed/config\";\n\
+                  \n\
+                  const tasks = { hello: { command: \"echo hi\" } };\n\
+                  \n\
+                  export default defineConfig({ tasks });\n";
+
+    assert!(extract_config_object(source).is_none());
+    let refusal = diagnose_config_expression(source);
+
+    assert_eq!(refusal.line, 4);
+    assert_eq!(
+        refusal.snippet,
+        "const tasks = { hello: { command: \"echo hi\" } };"
+    );
+    assert!(
+        refusal.reason.contains("without running it"),
+        "the reason has to say why a statement is not evaluated: {}",
+        refusal.reason
+    );
+    // The old message's advice, which was already what the file did.
+    assert!(
+        !refusal.reason.contains("export default defineConfig"),
+        "naming the export shape sends the reader to the one thing that is right"
+    );
+}
+
+/// A `defineConfig` handed something that is not an object literal.
+#[test]
+fn a_non_literal_argument_to_define_config_is_named() {
+    let source = "// @flow\nexport default defineConfig(aggregate(\"a\", \"b\"));\n";
+
+    assert!(extract_config_object(source).is_none());
+    let refusal = diagnose_config_expression(source);
+
+    assert_eq!(refusal.line, 2);
+    assert!(
+        refusal.snippet.starts_with("aggregate("),
+        "the argument is what was refused, not the whole line: {}",
+        refusal.snippet
+    );
+}
+
+/// A default export that is neither a literal nor `defineConfig`.
+#[test]
+fn a_default_export_that_is_a_call_is_named() {
+    let source = "// @flow\nexport default buildConfig();\n";
+    let refusal = diagnose_config_expression(source);
+
+    assert_eq!(refusal.line, 2);
+    assert_eq!(refusal.snippet, "buildConfig();");
+}
+
+/// Comments and imports are not the answer, however many of them there are.
+#[test]
+fn leading_comments_and_imports_do_not_become_the_reported_line() {
+    let source = "// @flow\n\
+                  /* a block\n\
+                     comment */\n\
+                  import a from \"a\";\n\
+                  \n\
+                  // and a line comment\n\
+                  let x = 1;\n\
+                  export default {};\n";
+    let refusal = diagnose_config_expression(source);
+
+    assert_eq!(refusal.line, 7, "the first line that is neither");
+    assert_eq!(refusal.snippet, "let x = 1;");
+}
+
+/// A file with nothing in it says so rather than pointing at a line.
+#[test]
+fn a_file_with_no_default_export_says_that() {
+    let refusal = diagnose_config_expression("// @flow\nimport a from \"a\";\n");
+    assert!(
+        refusal.reason.contains("no default export"),
+        "{}",
+        refusal.reason
+    );
+}
+
+/// The snippet is bounded, so a minified config cannot make the error
+/// unreadable.
+#[test]
+fn a_very_long_expression_is_cut() {
+    let long = "x".repeat(500);
+    let source = format!("// @flow\nconst a = \"{long}\";\nexport default {{}};\n");
+    let refusal = diagnose_config_expression(&source);
+
+    assert!(
+        refusal.snippet.len() <= SNIPPET_BYTES + 4,
+        "{}",
+        refusal.snippet.len()
+    );
+    assert!(refusal.snippet.ends_with('…'));
+}


### PR DESCRIPTION
The message half of ubugeeei-prod/uf#698.

## Before

The issue's own file:

```js
// @flow
import { defineConfig } from "@uniflowed/config";

const tasks = { hello: { command: "echo hi" } };

export default defineConfig({ tasks });
```

```
error: unsupported config expression in …/uf.config.js; use `export default defineConfig({ ... })`
```

**The advice is the one thing the file already does.** Nothing in it points at the `const`, so finding it is a bisect — which the issue says is exactly what it cost:

> The message is the part that costs the most time: it names the export shape, and the export shape is already exactly `export default defineConfig({ ... })`. […] Naming the expression and its line would have made this a ten-second fix rather than a bisect.

## After

```
error: uf.config.js:4: uf reads this file without running it, so a statement
       before the default export is not evaluated — inline the value at its use
  found: const tasks = { hello: { command: "echo hi" } };
```

`diagnose_config_expression` walks the file, skips comments and imports, and reports the first thing that is neither. Four refusals with their own words:

| what was found | what it says |
| --- | --- |
| a statement before the export | it is not evaluated, inline the value |
| `defineConfig(notALiteral)` | the argument has to be an object literal |
| a default export that is neither | it has to be a literal or `defineConfig({ … })` |
| no default export at all | says so, rather than pointing at a line |

The snippet is bounded at 120 bytes so a minified config cannot make the diagnostic unreadable.

## One thing deliberately not said

The reason line does **not** offer `uf.config.json`. The issue suggests one as a possibility —

> If it must stay static, then a literal-only `uf.config.json` alongside would at least not look like code.

— but `CONFIG_FILES` is `["uf.config.js"]` and nothing else. Naming it in an error message would repeat this issue's own complaint: sending the reader to something that is not there. Whether to add one is a separate decision.

## Also

`UnreadableConfigFile` is split out. A file with an extension uf has no reader for is a different problem from a file it cannot evaluate, and the two shared a message that fitted neither of them.

## What this does not fix

The limit itself. The config is still read rather than run, so a constant, a template literal and a helper call are still refused, and #698's larger point stands:

> A file that cannot name a value it uses twice is a data format, and if that is the intent then Flow's syntax is a promise it does not keep.

That is an architecture decision — evaluating user code at config time is what every other JS config does, and `defineConfig` existing at all suggests it was the intent — and it wants its own change. **The issue stays open for it.** This one makes the current limit findable in ten seconds instead of by bisect.

## Verification

- `cargo test -p uf_config` — 107 passed (6 new, pinning the line and the text for each refusal)
- `cargo test -p uf_cli` — 446 + the integration suites, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- The before/after above is a real `uf run` against a real file, not a rendering of the format string.

Refs ubugeeei-prod/uf#698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791527869&installation_model_id=422833&pr_number=715&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F715&signature=aa14e212b2e70e23945ac9260e12709ce400423fe7f35db35b395da37245ead2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->