### PR TITLE
fix(cli): no cron trigger without a handler to receive it

### DIFF
--- a/crates/uf_cli/src/commands/deploy.rs
+++ b/crates/uf_cli/src/commands/deploy.rs
@@ -489,7 +489,7 @@ const WORKERS_COMPATIBILITY_DATE: &str = "2024-09-23";
 ///   can fall through, and the 404 a visitor sees is the project's own
 ///   `_uf.not-found` rather than Cloudflare's.
 fn wrangler_config(root: &Utf8Path, schedules: &[schedules::DeclaredSchedule]) -> String {
-    let mut config = json!({
+    let config = json!({
         "name": worker_name(root),
         "main": "./worker.js",
         "compatibility_date": WORKERS_COMPATIBILITY_DATE,
@@ -502,18 +502,14 @@ fn wrangler_config(root: &Utf8Path, schedules: &[schedules::DeclaredSchedule]) -
             "not_found_handling": "none",
         },
     });
-    // Cloudflare's own scheduler, told about what the project declared. Written
-    // only when there is something to write: an empty `crons` is a key Wrangler
-    // has to interpret, and "no schedules" is better said by silence.
-    // ubugeeei-prod/uf#531.
-    if !schedules.is_empty() {
-        config["triggers"] = json!({
-            "crons": schedules
-                .iter()
-                .map(|schedule| schedule.cron.clone())
-                .collect::<Vec<_>>(),
-        });
-    }
+    // No `triggers.crons`, deliberately, and this is the second thought rather
+    // than the first: it was emitted for one commit. A Cloudflare Worker with a
+    // cron trigger and no exported `scheduled()` fails the invocation, and the
+    // `worker.js` uf generates exports `{ fetch }` and nothing else — so the
+    // configuration would have looked right and the work would never have run,
+    // which is the failure ubugeeei-prod/uf#531 exists to refuse. The trigger
+    // goes back in beside the handler, not before it.
+    let _ = schedules;
     format!(
         "{}\n",
         serde_json::to_string_pretty(&config).unwrap_or_default()
@@ -797,30 +793,25 @@ mod tests {
         assert!(config.get("triggers").is_none(), "{written}");
     }
 
-    /// A declared schedule reaches Cloudflare's own scheduler.
+    /// No cron trigger without a handler for it.
     ///
-    /// The emission half of ubugeeei-prod/uf#531: `edge` keeps no process, so
-    /// the platform has to be told, and `wrangler.json` is the file uf already
-    /// writes to tell it.
+    /// This asserted the opposite for one commit. A Cloudflare Worker with a
+    /// cron trigger and no exported `scheduled()` fails the invocation, and
+    /// the `worker.js` uf generates exports `{ fetch }` — so the trigger made
+    /// `wrangler.json` look configured for work that could never run, which is
+    /// exactly what ubugeeei-prod/uf#531 refuses. It goes back beside the
+    /// handler.
     #[test]
-    fn a_declared_schedule_becomes_a_cloudflare_trigger() {
-        let declared = vec![
-            schedules::DeclaredSchedule {
-                path: "/api/sweep".into(),
-                file: Utf8PathBuf::from("app/api/sweep/_uf.route.js"),
-                cron: "*/15 * * * *".to_owned(),
-            },
-            schedules::DeclaredSchedule {
-                path: "/api/digest".into(),
-                file: Utf8PathBuf::from("app/api/digest/_uf.route.js"),
-                cron: "0 6 * * 1".to_owned(),
-            },
-        ];
+    fn a_declared_schedule_is_not_written_as_a_trigger_yet() {
+        let declared = vec![schedules::DeclaredSchedule {
+            path: "/api/sweep".into(),
+            file: Utf8PathBuf::from("app/api/sweep/_uf.route.js"),
+            cron: "*/15 * * * *".to_owned(),
+        }];
         let written = wrangler_config(Utf8Path::new("/src/served-app"), &declared);
         let config: serde_json::Value = serde_json::from_str(&written).unwrap();
-        assert_eq!(config["triggers"]["crons"][0], "*/15 * * * *");
-        assert_eq!(config["triggers"]["crons"][1], "0 6 * * 1");
-        // And nothing else about the file moved.
+        assert!(config.get("triggers").is_none(), "{written}");
+        // And the rest of the file is what it was.
         assert_eq!(config["main"], "./worker.js");
     }
 
@@ -833,19 +824,10 @@ mod tests {
             cron: "*/15 * * * *".to_owned(),
         }];
 
-        // `edge` has somewhere to put it.
-        assert!(schedules::refuse_unrunnable(DeployAdapter::Edge, &declared).is_ok());
-
-        // The rest do not, today — including the ones that keep a process,
-        // because the entry uf generates for them does not pass the
-        // declaration to `serve` yet. Saying so beats the silence.
-        for adapter in [
-            DeployAdapter::Node,
-            DeployAdapter::Bun,
-            DeployAdapter::Container,
-            DeployAdapter::Serverless,
-            DeployAdapter::Static,
-        ] {
+        // Every one of them, `edge` included: each is one piece of wiring away
+        // and none of the pieces is written. Saying so beats the silence, and
+        // beats a `wrangler.json` that looks configured.
+        for adapter in DeployAdapter::ALL.iter().copied() {
             let message = schedules::refuse_unrunnable(adapter, &declared)
                 .expect_err("a schedule nothing would run is refused")
                 .to_string();

--- a/crates/uf_cli/src/commands/deploy/schedules.rs
+++ b/crates/uf_cli/src/commands/deploy/schedules.rs
@@ -259,17 +259,26 @@ fn unreadable(file: &Utf8Path) -> String {
 
 /// Whether `adapter` would actually run what a project declared.
 ///
-/// `edge` is the only one today: `uf build` writes its `wrangler.json`, so
-/// there is a file to put `triggers.crons` in and Cloudflare's own scheduler
-/// to read it.
+/// **None of them yet**, and that is the honest answer rather than a
+/// placeholder. Each target is one piece of wiring away and none of the pieces
+/// is written:
 ///
-/// `node`, `bun` and `container` *could* — they keep a process, and
-/// `@uniflowed/server/schedule` ticks in one — but the entry `uf build`
-/// generates for them does not pass the declaration to `serve` yet. Until it
-/// does, a declaration in a route module would do nothing on those targets,
-/// and saying so is better than the silence.
-pub(crate) const fn runs_schedules(adapter: DeployAdapter) -> bool {
-    matches!(adapter, DeployAdapter::Edge)
+/// * `node`, `bun` and `container` keep a process and
+///   `@uniflowed/server/schedule` ticks in one — but the entry `uf build`
+///   generates for them does not pass the declaration to `serve`.
+/// * `edge` has Cloudflare's own scheduler and a `wrangler.json` uf already
+///   writes, so `triggers.crons` is a two-line emission — but the `worker.js`
+///   uf generates exports `{ fetch }` and no `scheduled()`, and a Worker with
+///   a cron trigger and no scheduled handler fails the invocation. Emitting
+///   the trigger without the handler is the "deployment whose scheduled work
+///   never runs" this file exists to refuse, wearing a configuration file that
+///   looks right. It was emitted for one commit; this is that taken back.
+/// * `serverless` has no configuration file uf writes at all.
+///
+/// So every declaration is refused, and `refuse_unrunnable` says which wiring
+/// is missing. See ubugeeei-prod/uf#531.
+pub(crate) const fn runs_schedules(_adapter: DeployAdapter) -> bool {
+    false
 }
 
 /// Refuse a build whose schedules this target would not run.
@@ -299,10 +308,11 @@ pub(crate) fn refuse_unrunnable(
     bail!(
         "the `{}` adapter would not run the {} schedule(s) this project declares, so this \
          build would produce a deployment whose scheduled work never happens:{named}\n  \
-         `--adapter edge` writes them into `wrangler.json` for Cloudflare's own scheduler. \
-         On a target that keeps a process, pass them to `serve` yourself with \
-         `@uniflowed/server/schedule` — declaring one in a route module is not wired for \
-         those yet (ubugeeei-prod/uf#531).",
+         No adapter runs a declared schedule yet: the targets that keep a process are not \
+         handed it by the entry uf generates, and the Worker uf writes exports no \
+         `scheduled()` for Cloudflare's cron to call. Pass your schedules to `serve` \
+         yourself with `@uniflowed/server/schedule`, which does run them \
+         (ubugeeei-prod/uf#531).",
         adapter.as_str(),
         schedules.len()
     );

--- a/docs/app/guide/routing/_uf.page.mdx
+++ b/docs/app/guide/routing/_uf.page.mdx
@@ -895,13 +895,7 @@ would have to evaluate is one it cannot write down — and a computed one is
 refused by name rather than skipped, because a schedule the build could not
 read is a schedule the deployment would not run.
 
-`uf build --adapter edge` puts it in `wrangler.json`:
-
-```json
-"triggers": { "crons": ["*/15 * * * *"] }
-```
-
-Every other adapter **refuses the build**, and says which route, which
+**Every adapter refuses the build today**, and says which route, which
 expression and which file:
 
 ```
@@ -911,9 +905,17 @@ happens:
     /api/sweep — `*/15 * * * *`, in app/api/sweep/_uf.route.js
 ```
 
-`node`, `bun` and `container` keep a process and *could* run one — the entry
-`uf build` generates for them does not pass the declaration to `serve` yet, so
-until it does, pass your schedules to `serve` yourself as above.
+Each target is one piece of wiring away and none of the pieces is written.
+`node`, `bun` and `container` keep a process and `@uniflowed/server/schedule`
+ticks in one, but the entry `uf build` generates for them does not pass the
+declaration to `serve`. `edge` has Cloudflare's own scheduler and a
+`wrangler.json` uf already writes, but the `worker.js` uf generates exports
+`{ fetch }` and no `scheduled()` — and a Worker with a cron trigger and no
+scheduled handler fails the invocation, so writing the trigger first would be
+a configuration file that looks right for work that never runs.
+
+So the declaration is read and refused, and until the wiring lands, **pass your
+schedules to `serve` yourself** as above — that path works today.
 [#531](https://github.com/ubugeeei-prod/uf/issues/531) tracks the rest.
 
 What each field *contains* is checked when the deployment starts rather than

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -361,7 +361,7 @@ the sixth runs none:
 | `node` | `handler.js`, `server.js`, `chunks/`, `static/`, `package.json` | `cd .uf/deploy/node && node server.js` |
 | `bun` | the same file names, with `Bun.serve` and `Bun.file` behind them | `cd .uf/deploy/bun && bun server.js` |
 | `container` | the same, plus `Dockerfile` and `.dockerignore` | `docker build -t NAME .uf/deploy/container` |
-| `edge` | `handler.js`, `worker.js`, `wrangler.json` (with `triggers.crons` for any declared schedule), `chunks/`, `static/` | `cd .uf/deploy/edge && npx wrangler deploy` |
+| `edge` | `handler.js`, `worker.js`, `wrangler.json`, `chunks/`, `static/` | `cd .uf/deploy/edge && npx wrangler deploy` |
 | `serverless` | `handler.js`, `lambda.js`, `chunks/`, `static/`, `package.json` | zip it, upload it, set the handler to `lambda.handler` |
 | `static` | your build, file for file, and nothing else | upload it to any static host |
 


### PR DESCRIPTION
**I shipped a bug in [#712](https://github.com/ubugeeei-prod/uf/pull/712) and this takes it back.**

That PR wrote `triggers.crons` into the `wrangler.json` it emits for `--adapter edge`. The `worker.js` it emits beside it exports `{ fetch }` and **no `scheduled()`** — and a Cloudflare Worker with a cron trigger and no scheduled handler fails the invocation.

So the build produced a deployment carrying a configuration file that *looks* configured for scheduled work that could never run. That is precisely the failure [#531](https://github.com/ubugeeei-prod/uf/issues/531) exists to refuse, and I shipped it wearing the fix's clothes.

## What changes

`runs_schedules` is false for every adapter, and the refusal names the missing wiring instead of pointing at `--adapter edge` as an answer:

- `node`, `bun`, `container` — keep a process, and `@uniflowed/server/schedule` ticks in one, but the entry uf generates does not hand them the declaration.
- `edge` — has Cloudflare's scheduler and a `wrangler.json` uf already writes, but no `scheduled()` for it to call. **The trigger goes back beside the handler, not before it.**
- `serverless` — has no configuration file uf writes at all.

The test that asserted the trigger *was* emitted now asserts it is not, and says why, so the next person to add it reads the reason rather than rediscovering it.

## What #712 leaves standing

Everything that was actually right: the build reads a declared `export const schedule = "…"`, handles both export spellings, refuses what it cannot read offline, and refuses any target that would not run it. That is #531's clause by name — *"a target that can do neither must refuse the configuration at build time rather than build something that never runs."* What it must not do is emit configuration for a target that cannot honour it.

## Docs

Two places promised the emission. They now say what is true, and name the path that does work today — passing schedules to `serve` yourself, which #696 shipped and which runs them.

Verified: 467 lib tests, `clippy --all-targets -- -D warnings` and `fmt --check` clean, docs and schedule library tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791529140&installation_model_id=422833&pr_number=717&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F717&signature=a034c3b6bb63d75295d5c2122f5f2ef77e600ffd22fe3406df4964a6201a661c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->