### PR TITLE
feat(tui): a scrolling box that costs its window, not its content

### DIFF
--- a/crates/uf_tui/src/lib.rs
+++ b/crates/uf_tui/src/lib.rs
@@ -208,6 +208,17 @@ pub enum TuiFeature {
     /// other mouse event — but the offset is still a prop, so scrolling
     /// remains something the application does rather than something the
     /// component does to itself.
+    ///
+    /// What this word does promise, and what ubugeeei-prod/uf#314 asked to be
+    /// proved rather than asserted, is that the *window* is what a scrolling
+    /// box costs. Moving one over a hundred thousand rows measures nothing,
+    /// lays out the rows on the screen, and walks into no others; a renderer
+    /// that laid all hundred thousand out and clipped them would draw the
+    /// same frames and is not this. It is counted rather than claimed —
+    /// `tests/library/tui.test.js` counts the calls layout makes into its
+    /// leaves — and the one pass still proportional to the content is the
+    /// first frame, which has to ask every row its height once because the
+    /// height of the content is what the offset gets clamped against.
     Scrollback,
     /// Key binding and command routing.
     Keymap,

--- a/docs/app/guide/tui/_uf.page.mdx
+++ b/docs/app/guide/tui/_uf.page.mdx
@@ -222,12 +222,59 @@ does not, a list moves a selection and lets the box follow *that*. A component
 that owned the offset would also have to own "how far is a page", which is the
 viewport's height, which nothing knows until layout has run.
 
-**What it costs.** Every child is measured, because the total height is what the
-offset is clamped against. Only the children that intersect the window are laid
-out, walked into, or painted — so ten thousand rows in a twenty-four row terminal
-is one measure per row and a screenful of everything else. `tests/library/tui.test.js`
-renders exactly that and asserts the first frame costs the terminal's 1,920 cells
-rather than the log's, and that changing one visible row afterwards costs one.
+### What a window costs
+
+The window, and not the content. Moving the offset over a hundred thousand rows
+measures none of them, lays out and paints the twenty-four that are on the
+screen, and never visits the rest; appending a line to that log measures the
+line. The one pass that does grow with the content is the **first** frame, and
+it has to: the height of the content is what `Number.MAX_SAFE_INTEGER` is
+clamped against, so every row is asked its height once. After that the answer is
+kept until something under that row changes.
+
+That is counted rather than claimed. `tests/library/tui.test.js` builds the
+layout tree by hand so that it can count the calls layout makes into its leaves,
+and asserts a hundred thousand measurements on the first frame and **zero** on
+every scroll after it — a renderer that laid all hundred thousand rows out and
+clipped them would draw the same frames and fail that. Beside it, the same suite
+renders ten thousand rows through the real renderer and asserts that the first
+frame costs the terminal's 1,920 cells rather than the log's, and that changing
+one visible row afterwards costs one.
+
+The clock agrees, which is `tools/bench/tui/window.js` — `uf run
+bench:tui:window`. Layout, paint and diff, at 80×24; each cell is the median of
+twenty keystrokes, and the range is across three whole runs on the machine in
+the provenance note above, while it was shared with other work:
+
+| rows | first frame | one row scrolled | one line appended |
+| --- | --- | --- | --- |
+| 30 | 0.33 ms | 0.16 – 0.29 ms | 0.17 – 0.32 ms |
+| 1,000 | 5.8 ms | 0.20 – 0.28 ms | 0.16 – 0.41 ms |
+| 10,000 | 65 ms | 0.21 – 0.25 ms | 0.23 – 0.28 ms |
+| 100,000 | 602 ms | 0.21 – 0.31 ms | 0.26 – 0.33 ms |
+
+Read the last two columns as one number: at every size a frame lands in the same
+fifth of a millisecond, and the thirty-row band and the hundred-thousand-row band
+overlap. Three thousand times the content, and the frame cannot tell.
+
+Before this was windowed the same scroll cost 0.23 ms, 3.64 ms, 59.64 ms and
+491.25 ms — a straight line through the origin, which is what a `ScrollBox` that
+measures every child on every frame looks like from the outside. The first-frame
+column is still that line, deliberately, and it is the noisy one: it allocates a
+row's worth of everything per row, so it is the step a garbage collection lands
+in, and across the three runs the hundred-thousand-row mount ranged from 602 ms
+to 1.3 s. It is reported as the fastest of three for the reason the start-up
+table below gives.
+
+The benchmark prints a second table that is **not** this component's, and it is
+there because reading only the first one would be reading half of it. React
+reconciling the tree costs about 0.2 ms at thirty rows and a few hundred at a
+hundred thousand, because a hundred thousand `<Text>` children are a hundred
+thousand fibers no matter who is scrolling them. That is the application's
+decision and not something a `ScrollBox` can undo — it cannot render children
+the caller did not create. An application with a log that long should hold its
+rows as elements it does not rebuild, which is what the benchmark does and what
+makes the first table the renderer's rather than `Array.from`'s.
 
 The wheel arrives as `onMouseScroll` and moves nothing on its own, which is
 the same rule one paragraph up: how far a notch goes is a question about the

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -197,8 +197,12 @@
 - [x] Implement terminal rendering, layout, input, and snapshots for `@uniflowed/tui`.
       Flow React on React's own reconciler rather than a native binding;
       `packages/tui/index.js` argues that out. Scrolling and the mouse — hit
-      testing, hover, drag capture, drop and the wheel — are in. Selection, key
-      release and rich content are ubugeeei-prod/uf#314.
+      testing, hover, drag capture, drop and the wheel — are in, and a
+      `ScrollBox` now costs its window rather than its content: moving one over
+      a hundred thousand rows measures none of them and lays out, paints and
+      diffs the twenty-four on the screen, counted in
+      `tests/library/tui.test.js` and timed by `tools/bench/tui/window.js`.
+      Selection, key release and rich content are ubugeeei-prod/uf#314.
 - [ ] Cover the shadcn-style component catalog with typed imports, preset styles, and no copy step.
 - [ ] Keep compound UI APIs cohesive, for example `Dialog.Body`.
 - [x] Add UI `renders` type utility declarations under `packages/ui`.

--- a/packages/tui/components.js
+++ b/packages/tui/components.js
@@ -299,6 +299,21 @@ export type ScrollBoxProps = {
  * There is still no horizontal scrolling: a terminal column is not a pixel,
  * and content wider than the window is nearly always content that should have
  * wrapped.
+ *
+ * # What it costs
+ *
+ * The window, and not the content. Moving the offset over a hundred thousand
+ * rows measures none of them, lays out and paints the ones on the screen, and
+ * never visits the rest; appending a line to that log measures the line. The
+ * first frame is the exception and has to be: the height of the content is
+ * what `Number.MAX_SAFE_INTEGER` is clamped against, so every row is asked its
+ * height once, and after that the answer is kept until something under the row
+ * changes.
+ *
+ * That is a property of `layout.js` rather than of this component, which is
+ * why this is a component at all — a caller cannot decide which of their
+ * children to render, because which ones are visible is not known until after
+ * layout has run.
  */
 export component ScrollBox(
   children?: React.Node,

--- a/packages/tui/internal/host.js
+++ b/packages/tui/internal/host.js
@@ -72,7 +72,7 @@ import type { HitGrid } from "./hits.js";
 import { createHitGrid, hitAt } from "./hits.js";
 import { measureText, paint, wrapModeOf } from "./paint.js";
 import type { TuiNode, TuiProps } from "./tree.js";
-import { applyProps, createNode } from "./tree.js";
+import { applyProps, createNode, invalidate } from "./tree.js";
 
 /** A global key handler, as `useKeyboard` registers one. */
 export type KeyHandler = (key: KeyEvent) => void;
@@ -520,6 +520,7 @@ const hostConfig = {
   },
   appendInitialChild: (parent: TuiNode, child: TuiNode): void => {
     child.parent = parent;
+    invalidate(parent, parent.children.length);
     parent.children.push(child);
   },
   finalizeInitialChildren: (): boolean => false,
@@ -528,19 +529,28 @@ const hostConfig = {
   // them into one string and lose the styles the nested ones carry.
   shouldSetTextContent: (): boolean => false,
   clearContainer: (renderer: Renderer): void => {
+    invalidate(renderer.root, 0);
     renderer.root.children = [];
   },
 
+  // An append is the one mutation whose position is known without looking for
+  // it, and it is the one a log makes: every child above the new one is where
+  // it was, so a scrolling parent has to re-measure exactly the child that
+  // arrived. Every other mutation moves a child that could be anywhere, so it
+  // invalidates the stack whole.
   appendChild: (parent: TuiNode, child: TuiNode): void => {
     child.parent = parent;
+    invalidate(parent, parent.children.length);
     parent.children.push(child);
   },
   appendChildToContainer: (renderer: Renderer, child: TuiNode): void => {
     child.parent = renderer.root;
+    invalidate(renderer.root, renderer.root.children.length);
     renderer.root.children.push(child);
   },
   insertBefore: (parent: TuiNode, child: TuiNode, before: TuiNode): void => {
     child.parent = parent;
+    invalidate(parent, 0);
     remove(parent.children, child);
     const at = parent.children.indexOf(before);
     parent.children.splice(at < 0 ? parent.children.length : at, 0, child);
@@ -549,10 +559,12 @@ const hostConfig = {
     hostConfig.insertBefore(renderer.root, child, before);
   },
   removeChild: (parent: TuiNode, child: TuiNode): void => {
+    invalidate(parent, 0);
     remove(parent.children, child);
     child.parent = null;
   },
   removeChildFromContainer: (renderer: Renderer, child: TuiNode): void => {
+    invalidate(renderer.root, 0);
     remove(renderer.root.children, child);
     child.parent = null;
   },
@@ -561,6 +573,7 @@ const hostConfig = {
   },
   commitTextUpdate: (node: TuiNode, _previous: string, next: string): void => {
     node.text = next;
+    invalidate(node);
   },
   resetTextContent: noop,
   commitMount: noop,
@@ -575,9 +588,11 @@ const hostConfig = {
   },
   hideTextInstance: (node: TuiNode): void => {
     node.text = "";
+    invalidate(node);
   },
   unhideTextInstance: (node: TuiNode, text: string): void => {
     node.text = text;
+    invalidate(node);
   },
   detachDeletedInstance: noop,
 

--- a/packages/tui/internal/paint.js
+++ b/packages/tui/internal/paint.js
@@ -164,12 +164,6 @@ export function paint(
   clip: Rect,
   hits: HitGrid | null = null,
 ): void {
-  // A scrolling ancestor decided this subtree is not on screen. Its geometry
-  // is deliberately not up to date, so walking into it would draw the last
-  // frame's positions on top of this one's.
-  if (node.hidden) {
-    return;
-  }
   switch (node.type) {
     case "root":
       for (const child of node.children) {
@@ -231,8 +225,22 @@ function paintBox(
       })
     : clip;
 
-  for (const child of node.children) {
-    paint(child, frame, capabilities, childClip, hits);
+  if (node.style.overflow === "scroll") {
+    // The children a scrolling box laid out, and only those. The rest were
+    // never given a position this frame, so their geometry is from whichever
+    // frame last showed them and drawing it would put those rows back on the
+    // screen. Reading the range rather than a flag per child is also what
+    // keeps the walk proportional to the window: a box holding ten thousand
+    // rows is not visited ten thousand times to be told nine thousand nine
+    // hundred and seventy-six of them are elsewhere.
+    const end = node.scrollFirst + node.scrollCount;
+    for (let index = node.scrollFirst; index < end; index += 1) {
+      paint(node.children[index], frame, capabilities, childClip, hits);
+    }
+  } else {
+    for (const child of node.children) {
+      paint(child, frame, capabilities, childClip, hits);
+    }
   }
 
   if (node.style.overflow === "scroll" && node.props.scrollbar === true) {

--- a/packages/tui/internal/paint.js
+++ b/packages/tui/internal/paint.js
@@ -164,6 +164,15 @@ export function paint(
   clip: Rect,
   hits: HitGrid | null = null,
 ): void {
+  // `hideInstance` — React's for a Suspense fallback and for `<Activity>` —
+  // sets `width: 0, height: 0, hidden: true`. The zero size is not enough on
+  // its own: `overflow` defaults to `"visible"`, so a child laid out inside a
+  // 0x0 box still draws over its edge, and the walk would also record hits for
+  // a subtree the reader cannot see. The flag is the thing that says the
+  // subtree is not here; read it before anything is drawn.
+  if (node.props.hidden === true) {
+    return;
+  }
   switch (node.type) {
     case "root":
       for (const child of node.children) {

--- a/packages/tui/internal/tree.js
+++ b/packages/tui/internal/tree.js
@@ -34,7 +34,7 @@
 // treats them as the same thing, so this does too. The direct prop wins when
 // both are present, which is the rule a reader guesses.
 
-import type { LayoutStyle } from "../layout.js";
+import type { LayoutStyle, ScrollIndex } from "../layout.js";
 import type { Color, Style } from "../cells.js";
 import { Attributes, INHERIT, PLAIN, parseColor } from "../cells.js";
 import type { BorderStyle } from "../capability.js";
@@ -76,8 +76,9 @@ export type TuiNode = {
   y: number,
   width: number,
   height: number,
-  /** Whether a scrolling ancestor put this node outside its window. */
-  hidden: boolean,
+  /** Which of its children a scrolling box laid out, as a range. */
+  scrollFirst: number,
+  scrollCount: number,
   /** Rows of content this node holds, when it scrolls. */
   scrollHeight: number,
   /** The first row it shows, after clamping, when it scrolls. */
@@ -86,6 +87,15 @@ export type TuiNode = {
   scrollViewTop: number,
   scrollViewRows: number,
   scrollBarColumn: number,
+  /** The intrinsic size this node last reported, and what it was offered. */
+  measuredForWidth: number,
+  measuredForHeight: number,
+  measuredWidth: number,
+  measuredHeight: number,
+  /** The first child of a scrolling box that changed, or `-1`. See {@link invalidate}. */
+  scrollDirtyFrom: number,
+  /** A scrolling box's stack of child heights; see `layout.js`. */
+  scrollIndex: ScrollIndex | null,
 };
 
 /** Read a prop, preferring the direct spelling over the one inside `style`. */
@@ -289,12 +299,19 @@ export function createNode(type: TuiNodeType, props: TuiProps): TuiNode {
     y: 0,
     width: 0,
     height: 0,
-    hidden: false,
+    scrollFirst: 0,
+    scrollCount: 0,
     scrollHeight: 0,
     scrollOffset: 0,
     scrollViewTop: 0,
     scrollViewRows: 0,
     scrollBarColumn: 0,
+    measuredForWidth: -1,
+    measuredForHeight: -1,
+    measuredWidth: 0,
+    measuredHeight: 0,
+    scrollDirtyFrom: 0,
+    scrollIndex: null,
   };
   applyProps(node, props);
   return node;
@@ -305,6 +322,51 @@ export function applyProps(node: TuiNode, props: TuiProps): void {
   node.props = props;
   node.style = styleFromProps(props);
   node.borderWidth = node.type === "box" && borderOf(props) != null ? 1 : 0;
+  invalidate(node);
+}
+
+/**
+ * Say that something under `node` changed, so layout may not reuse what it
+ * measured last time.
+ *
+ * Layout keeps two answers between frames: what a node's intrinsic size came
+ * out as, and — for a scrolling box — where each of its children sits in the
+ * stack. Both are only wrong when the tree changed, and React is the only
+ * participant that knows when it did; a layout that worked it out for itself
+ * would have to compare this frame's tree with the last one's, which is the
+ * walk over every child that the stack exists to avoid.
+ *
+ * The walk goes to the root because an intrinsic size is a fact about a
+ * subtree: a character added to a `"chars"` node can widen the `<Text>` above
+ * it, which can lengthen the box above that. It is bounded by the depth of the
+ * tree, and a terminal's tree is as deep as what fits on a screen.
+ *
+ * `from` is the first child index of `node` that changed. Appending a line to
+ * a log leaves every line above it where it was, which is what makes appending
+ * cost one measurement rather than the log; above `node` nothing is known that
+ * precisely, so every scrolling ancestor is invalidated whole.
+ *
+ * `null` — the default, and what a change to the node's *own* props or text
+ * means — leaves the node's own stack alone, because a scrolling box's props
+ * cannot move its children except through the width, the viewport height and
+ * the gap it gives them, and all three are part of what the stack is keyed on.
+ * That exemption is not a nicety: `scrollTop` is a prop on that box, so
+ * without it every scroll would invalidate the very thing that makes scrolling
+ * cheap, and a hundred thousand rows would rebuild their stack on each notch.
+ */
+export function invalidate(node: TuiNode, from: number | null = null): void {
+  let current: TuiNode | null = node;
+  let first = from;
+  while (current != null) {
+    current.measuredForWidth = -1;
+    current.measuredForHeight = -1;
+    if (first != null) {
+      current.scrollDirtyFrom =
+        current.scrollDirtyFrom < 0 ? first : Math.min(current.scrollDirtyFrom, first);
+    }
+    first = 0;
+    current = current.parent;
+  }
 }
 
 /** The style a text node's runs start from when nothing above it said otherwise. */

--- a/packages/tui/layout.js
+++ b/packages/tui/layout.js
@@ -141,14 +141,18 @@ export type LayoutNode = {
   width: number,
   height: number,
   /**
-   * Whether this node is outside a scrolling ancestor's window.
+   * The index of this node's first child that is inside a scrolling window,
+   * and how many of them are. Written by layout, read by the painter.
    *
-   * Written by layout and read by the painter. Zeroing the geometry would not
-   * be enough: a box zero cells wide draws nothing itself, and the painter
-   * would still walk into its children, whose geometry is whatever the last
-   * frame left there. A skipped subtree has to be skipped as a subtree.
+   * Zero and zero for everything that does not scroll, and for a scrolling box
+   * whose window has reached past the end of its content. The painter walks
+   * this range instead of the whole child list, which is the half of "only the
+   * visible window" that paint is responsible for: a child outside the range
+   * has geometry from whichever frame last showed it, and drawing that would
+   * put last frame's rows on top of this one's.
    */
-  hidden: boolean,
+  scrollFirst: number,
+  scrollCount: number,
   /** Rows of content a scrolling box holds. Written by layout. */
   scrollHeight: number,
   /** The first row it is actually showing, after clamping. Written by layout. */
@@ -165,7 +169,64 @@ export type LayoutNode = {
   scrollViewTop: number,
   scrollViewRows: number,
   scrollBarColumn: number,
+  /**
+   * The last intrinsic size this node reported, and what was offered for it.
+   *
+   * `measuredFor*` is `-1` when there is nothing cached, which is what
+   * `invalidate` in `internal/tree.js` writes when anything under the node
+   * changes. Layout never invalidates this itself: a cache that layout could
+   * clear would be cleared on the frame that most needs it.
+   */
+  measuredForWidth: number,
+  measuredForHeight: number,
+  measuredWidth: number,
+  measuredHeight: number,
+  /**
+   * The first child index whose height may have changed since the last frame,
+   * or `-1` when none has.
+   *
+   * Written by whoever changes the tree — `internal/tree.js`, which is to say
+   * React — and cleared by layout once it has acted on it. It is a number
+   * rather than a call into this module because the three participants named
+   * at the top of `internal/tree.js` do not import each other; a node's fields
+   * are the whole of what they say to one another.
+   */
+  scrollDirtyFrom: number,
+  /** A scrolling box's stack of child heights. Owned by {@link layout}. */
+  scrollIndex: ScrollIndex | null,
   ...
+};
+
+/**
+ * Where each child of a scrolling box sits in its content, kept between frames.
+ *
+ * This is what makes scrolling cost the window rather than the content. The
+ * stack of child heights does not change when the offset does, so rebuilding
+ * it on every frame would be recomputing the answer to a question nobody
+ * asked — and it is the only part of a scrolling box that is proportional to
+ * how many children it has.
+ *
+ * `from` is the first index that has to be rebuilt, and it is written from
+ * outside layout: `internal/tree.js` sets it when React mutates the tree, and
+ * sets it to the old child count when the mutation was an append, which is the
+ * shape a log has. A frame that changed nothing leaves it at the child count
+ * and rebuilds none of it.
+ *
+ * `tops[i]` is where child `i`'s border box starts, measured from the top of
+ * the content and including every margin and gap above it; `heights[i]` is how
+ * tall it is.
+ */
+export type ScrollIndex = {
+  /** The content width, viewport height and gap the stack was built for. */
+  width: number,
+  view: number,
+  gap: number,
+  /** The first index whose height is not known to be current. */
+  from: number,
+  tops: Array<number>,
+  heights: Array<number>,
+  /** Rows of content the whole stack adds up to. */
+  content: number,
 };
 
 /** A resolved size, in whole cells. */
@@ -272,6 +333,23 @@ export function intrinsicSize(
   availableWidth: number,
   availableHeight: number,
 ): Size {
+  // The same offer twice is the same answer twice, and the answer is only
+  // stale when something under the node changed — which is a fact React knows
+  // and layout does not, so `internal/tree.js` is what clears this. Without
+  // it, a scrolling box that has not changed re-measures every child on every
+  // frame, and measuring a line of text means walking it grapheme by grapheme.
+  if (node.measuredForWidth === availableWidth && node.measuredForHeight === availableHeight) {
+    return { width: node.measuredWidth, height: node.measuredHeight };
+  }
+  const size = measureIntrinsic(node, availableWidth, availableHeight);
+  node.measuredForWidth = availableWidth;
+  node.measuredForHeight = availableHeight;
+  node.measuredWidth = size.width;
+  node.measuredHeight = size.height;
+  return size;
+}
+
+function measureIntrinsic(node: LayoutNode, availableWidth: number, availableHeight: number): Size {
   const style = node.style;
   const [insetTop, insetRight, insetBottom, insetLeft] = insets(node);
   const innerAvailableWidth = Math.max(0, availableWidth - insetLeft - insetRight);
@@ -290,6 +368,22 @@ export function intrinsicSize(
     );
     contentWidth = measured.width;
     contentHeight = measured.height;
+  } else if (style.overflow === "scroll") {
+    // A scrolling box's height is its content's, which the stack already
+    // knows; and its width is whatever it was offered, because there is no
+    // horizontal scrolling and so nothing about a child can widen it. Asking
+    // the children for a width would also be asking ten thousand of them, and
+    // the answer would be the width of a row that may be nowhere near the
+    // window — which is the coupling this whole component exists to break.
+    contentWidth = innerAvailableWidth;
+    // A box that was given a height has already answered this, and the answer
+    // below is thrown away — so the stack is not consulted for it. That also
+    // avoids keying one on a viewport this pass can only guess at, which
+    // `layout` would then have to rebuild whole at the height it settles on.
+    contentHeight =
+      fixedHeight != null
+        ? 0
+        : scrollStack(node, innerAvailableWidth, innerAvailableHeight).content;
   } else {
     const row = isRow(direction(node.style));
     const gap = gapOf(style, row);
@@ -375,9 +469,18 @@ export function layout(
   node.y = y;
   node.width = width;
   node.height = height;
-  node.hidden = false;
+  // Cleared before the branch that may set it, so that a box which has run out
+  // of children does not leave the painter a range into a list that no longer
+  // has those rows in it.
+  node.scrollFirst = 0;
+  node.scrollCount = 0;
 
   if (node.children.length === 0) {
+    // A scrolling box that has lost its content has nothing to say about where
+    // in it the window is, and a bar drawn from what it said last frame is a
+    // control pointing into rows that are gone.
+    node.scrollHeight = 0;
+    node.scrollOffset = 0;
     return;
   }
 
@@ -548,45 +651,27 @@ export function layout(
  *
  * # What this costs, exactly
  *
- * Every child is **measured** — its height at this width — because the total
- * is what `scrollTop` is clamped against, and a box that guessed its own
- * content height would let `Number.MAX_SAFE_INTEGER` scroll into empty space.
- * Measuring one line of text is measuring one line of text.
+ * A child is **measured** once — its height at this width — and the height is
+ * kept on the child until something under it changes. The total is what
+ * `scrollTop` is clamped against, so a box that guessed at its own content
+ * height would let `Number.MAX_SAFE_INTEGER` scroll into empty space; keeping
+ * the answer is how that total stays exact without being recomputed.
  *
- * Only the children that intersect the window are **laid out**: the rest get
- * no position, no size, and no walk into their subtrees, and {@link
- * LayoutNode.hidden} keeps the painter out of them too. So a ten-thousand-line
- * log costs one measure per line and a screenful of everything else — which is
- * the property the whole component exists for, and the reason this is not
- * `overflow: "hidden"` with a margin on top.
+ * Only the children that intersect the window are **laid out**, and the
+ * painter is given their range rather than a flag per child, so the rest get
+ * no position, no size, no walk into their subtrees and no visit at all. What
+ * remains proportional to the number of children is the stack of heights, and
+ * {@link ScrollIndex} rebuilds only the part of it that changed.
+ *
+ * So moving the window over ten thousand rows touches the rows in the window
+ * and nothing else, whatever the other nine thousand nine hundred and
+ * seventy-six are — which is the property the whole component exists for, and
+ * the reason this is not `overflow: "hidden"` with a margin on top.
  */
 function layoutScroll(node: LayoutNode, x: number, y: number, width: number, height: number): void {
   const children = node.children;
-  // What a scrolling box offers a child that has not been given a height:
-  // nothing in particular. That is what scrolling means — a child is as tall as
-  // its content and the window decides how much is seen — and the only thing
-  // this basis is read for is a percentage `minHeight` or `maxHeight` on the
-  // child, which inside a scroll region is a question with no good answer.
-  const unbounded = Number.MAX_SAFE_INTEGER;
-  const gap = gapOf(node.style, false);
-
-  // Margins are part of the stack, exactly as they are in the flex path and
-  // in `intrinsicSize`: a child's outer height is what the next one starts
-  // after and what the scroll range is made of. Leaving them out of any one
-  // of those makes the content shorter than it is drawn, which is a bottom
-  // the offset clamps to too early and a last row nobody can scroll to.
-  const margins = children.map((child) => margin(child.style));
-
-  const heights = new Array<number>(children.length);
-  let content = 0;
-  for (let index = 0; index < children.length; index += 1) {
-    const child = children[index];
-    const [marginTop, marginRight, marginBottom, marginLeft] = margins[index];
-    const available = Math.max(0, width - marginLeft - marginRight);
-    const fixed = resolve(child.style.height, height);
-    heights[index] = fixed ?? intrinsicSize(child, available, unbounded).height;
-    content += heights[index] + marginTop + marginBottom + (index > 0 ? gap : 0);
-  }
+  const stack = scrollStack(node, width, height);
+  const content = stack.content;
 
   const offset = clamp(Math.floor(node.style.scrollTop ?? 0), 0, Math.max(0, content - height));
   node.scrollHeight = content;
@@ -597,30 +682,141 @@ function layoutScroll(node: LayoutNode, x: number, y: number, width: number, hei
   // reserved by adding one to its right padding.
   node.scrollBarColumn = x + width;
 
-  let cursor = 0;
-  for (let index = 0; index < children.length; index += 1) {
-    const child = children[index];
-    const [marginTop, marginRight, marginBottom, marginLeft] = margins[index];
-    const childHeight = heights[index];
-    const childY = y + cursor + marginTop - offset;
-    cursor += marginTop + childHeight + marginBottom + gap;
+  // The bottom of a child's border box only ever moves down the list, so the
+  // first child the window reaches can be found without looking at the ones
+  // above it. This is the step that would otherwise make the offset — the one
+  // thing about a scrolling box that changes every frame — cost the content.
+  const first = firstVisible(stack, offset);
+  let count = 0;
+  for (let index = first; index < children.length; index += 1) {
+    const top = stack.tops[index];
     // The border box, not the outer one: a margin draws nothing, so a child
     // whose own box has left the window has left it.
-    if (childY + childHeight <= y || childY >= y + height) {
-      hide(child);
-      continue;
+    if (top - offset >= height) {
+      break;
     }
+    const child = children[index];
+    const [, marginRight, , marginLeft] = margin(child.style);
     const available = Math.max(0, width - marginLeft - marginRight);
     const childWidth = Math.min(available, resolve(child.style.width, width) ?? available);
-    layout(child, x + marginLeft, childY, childWidth, childHeight);
+    layout(child, x + marginLeft, y + top - offset, childWidth, stack.heights[index]);
+    count += 1;
   }
+  node.scrollFirst = first;
+  node.scrollCount = count;
 }
 
-/** Take a node and everything under it out of this frame. */
-function hide(node: LayoutNode): void {
-  node.hidden = true;
-  node.width = 0;
-  node.height = 0;
+/**
+ * The first child whose border box has not finished above `offset`.
+ *
+ * A binary search rather than a scan, because a scan is the thing this is
+ * replacing. `tops[i] + heights[i]` never decreases as `i` grows — every term
+ * between two children is a height, a margin or a gap, and none of those is
+ * negative — which is exactly the ordering a binary search needs.
+ */
+function firstVisible(stack: ScrollIndex, offset: number): number {
+  let low = 0;
+  let high = stack.heights.length;
+  while (low < high) {
+    const middle = (low + high) >> 1;
+    if (stack.tops[middle] + stack.heights[middle] > offset) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
+}
+
+/**
+ * Where each child of a scrolling box sits, rebuilding only what moved.
+ *
+ * Margins are part of the stack, exactly as they are in the flex path and in
+ * {@link intrinsicSize}: a child's outer height is what the next one starts
+ * after and what the scroll range is made of. Leaving them out of any one of
+ * those makes the content shorter than it is drawn, which is a bottom the
+ * offset clamps to too early and a last row nobody can scroll to.
+ *
+ * The width, the viewport height and the gap are part of the key rather than
+ * inputs to a patch: all three change every height in the stack at once, so
+ * there is nothing to salvage. The viewport is in there because a child may
+ * give its height as a percentage, and the percentage is of the window.
+ */
+function scrollStack(node: LayoutNode, width: number, height: number): ScrollIndex {
+  const children = node.children;
+  const gap = gapOf(node.style, false);
+  let stack = node.scrollIndex;
+  if (stack == null || stack.width !== width || stack.view !== height || stack.gap !== gap) {
+    stack = {
+      width,
+      view: height,
+      gap,
+      from: 0,
+      tops: [],
+      heights: [],
+      content: 0,
+    };
+    node.scrollIndex = stack;
+  }
+
+  // What React changed since the last frame, taken rather than read: acting on
+  // it twice would be harmless and leaving it set would make every later frame
+  // rebuild from the same index forever.
+  if (node.scrollDirtyFrom >= 0) {
+    stack.from = Math.min(stack.from, node.scrollDirtyFrom);
+    node.scrollDirtyFrom = -1;
+  }
+
+  // Children the tree no longer has. `from` is clamped rather than reset: a
+  // removal has already put it at zero, and an unmount during a Suspense
+  // fallback must not be able to leave an index pointing past the end.
+  if (stack.heights.length > children.length) {
+    stack.heights.length = children.length;
+    stack.tops.length = children.length;
+    stack.from = Math.min(stack.from, children.length);
+  }
+
+  if (children.length === 0) {
+    stack.content = 0;
+    stack.from = 0;
+    return stack;
+  }
+
+  if (stack.from < children.length) {
+    // What a scrolling box offers a child that has not been given a height:
+    // nothing in particular. That is what scrolling means — a child is as tall
+    // as its content and the window decides how much is seen — and the only
+    // thing this basis is read for is a percentage `minHeight` or `maxHeight`
+    // on the child, which inside a scroll region is a question with no good
+    // answer.
+    const unbounded = Number.MAX_SAFE_INTEGER;
+    // Where the child before the first stale one ended. Read back out of the
+    // stack rather than carried, because a rebuild may start anywhere and only
+    // the entries below it are known to be current.
+    let cursor = 0;
+    if (stack.from > 0) {
+      const previous = children[stack.from - 1];
+      const [, , previousBottom] = margin(previous.style);
+      cursor = stack.tops[stack.from - 1] + stack.heights[stack.from - 1] + previousBottom + gap;
+    }
+    for (let index = stack.from; index < children.length; index += 1) {
+      const child = children[index];
+      const [marginTop, marginRight, marginBottom, marginLeft] = margin(child.style);
+      const available = Math.max(0, width - marginLeft - marginRight);
+      const fixed = resolve(child.style.height, height);
+      const own = fixed ?? intrinsicSize(child, available, unbounded).height;
+      stack.tops[index] = cursor + marginTop;
+      stack.heights[index] = own;
+      cursor += marginTop + own + marginBottom + gap;
+    }
+    // `cursor` counts a gap after the last child, which the content does not
+    // have. Subtracting it at the end rather than skipping the first one is
+    // what makes the running total patchable from any index.
+    stack.content = cursor - gap;
+    stack.from = children.length;
+  }
+
+  return stack;
 }
 
 // Not implemented here, on purpose, and tracked rather than discovered:

--- a/tests/library/tui.test.js
+++ b/tests/library/tui.test.js
@@ -47,6 +47,11 @@ import {
   useTerminalSize,
 } from "@uniflowed/tui";
 import type { Frame, MouseEvent } from "@uniflowed/tui";
+// The layout module directly, and not through the package root: what a
+// scrolling box costs is a number of calls into layout, and the only place a
+// call into layout can be counted is a tree whose leaves this file wrote.
+import { layout } from "@uniflowed/tui/layout";
+import type { LayoutNode, LayoutStyle } from "@uniflowed/tui/layout";
 
 import { HEIGHT, START, STEPS, WIDTH, lines } from "../../tools/bench/tui/workload.js";
 
@@ -532,6 +537,54 @@ describe("a window onto more than fits", () => {
     handle.stop();
   });
 
+  it("moves the window when a row above it grows", () => {
+    // Layout keeps what it measured, so the risk it takes is a row that
+    // changed and was not noticed. This one is *outside* the window — nothing
+    // about the frame would redraw it — and it still has to shift everything
+    // under it, because the offset counts rows and there is now one more.
+    component Grow() {
+      const [tall, setTall] = useState<boolean>(false);
+      useKeyboard(() => setTall(true));
+      return (
+        <ScrollBox height={2} width={6} scrollbar={false} scrollTop={2}>
+          <Text wrap="char">{tall ? "aaaaaaaaaaaa" : "a"}</Text>
+          <Text wrap="none">b</Text>
+          <Text wrap="none">c</Text>
+          <Text wrap="none">d</Text>
+        </ScrollBox>
+      );
+    }
+
+    const handle = testRender(<Grow />, { width: 6, height: 2 });
+    expect(rows(handle.frame())).toEqual(["c     ", "d     "]);
+
+    handle.press("x");
+    expect(rows(handle.frame())).toEqual(["b     ", "c     "]);
+    handle.stop();
+  });
+
+  it("moves it back when a row above it goes away", () => {
+    component Shrink() {
+      const [gone, setGone] = useState<boolean>(false);
+      useKeyboard(() => setGone(true));
+      return (
+        <ScrollBox height={2} width={6} scrollbar={false} scrollTop={0}>
+          {gone ? null : <Text wrap="none">a</Text>}
+          <Text wrap="none">b</Text>
+          <Text wrap="none">c</Text>
+          <Text wrap="none">d</Text>
+        </ScrollBox>
+      );
+    }
+
+    const handle = testRender(<Shrink />, { width: 6, height: 2 });
+    expect(rows(handle.frame())).toEqual(["a     ", "b     "]);
+
+    handle.press("x");
+    expect(rows(handle.frame())).toEqual(["b     ", "c     "]);
+    handle.stop();
+  });
+
   it("does not paint what the window does not reach", () => {
     // The other half of the same property, and the one a clipping renderer
     // would fail: a child outside the window is not merely invisible, it is
@@ -591,6 +644,192 @@ describe("a window onto more than fits", () => {
     );
     expect(rows(handle.frame())).toEqual(["two     ", "        "]);
     handle.stop();
+  });
+});
+
+describe("a window costs the window", () => {
+  // The claim `ScrollBox` exists for, counted rather than described. Every
+  // assertion below is a number of operations rather than a picture: a
+  // renderer that laid a hundred thousand rows out and clipped them would draw
+  // exactly the frames the section above asserts, and fail every one of these.
+  //
+  // These build `LayoutNode`s by hand instead of rendering. That is what
+  // `layout.js` is for — it imports neither the React binding nor the painter —
+  // and it is the only way to count measurements, because a measurement is a
+  // call layout makes into a leaf and nothing above layout can watch one
+  // happen.
+
+  /** How many times layout has asked a leaf how big it is. */
+  let measured = 0;
+
+  /** A leaf that reports `height` and says so. */
+  const leaf = (height: number) => () => {
+    measured += 1;
+    return { width: 6, height };
+  };
+
+  /**
+   * One node, with every field layout reads or writes.
+   *
+   * Written out rather than produced by the tree module, so that a field added
+   * to `LayoutNode` and not to layout's own bookkeeping fails here rather than
+   * being read as `undefined` somewhere further away. `y` starts at `-1`,
+   * which is not a position any layout produces, so {@link placed} can tell a
+   * child layout reached from one it skipped.
+   */
+  const node = (
+    style: LayoutStyle,
+    children: Array<LayoutNode>,
+    height: number | null = null,
+  ): LayoutNode => ({
+    style,
+    children,
+    borderWidth: 0,
+    measure: height == null ? null : leaf(height),
+    x: 0,
+    y: -1,
+    width: 0,
+    height: 0,
+    scrollFirst: 0,
+    scrollCount: 0,
+    scrollHeight: 0,
+    scrollOffset: 0,
+    scrollViewTop: 0,
+    scrollViewRows: 0,
+    scrollBarColumn: 0,
+    measuredForWidth: -1,
+    measuredForHeight: -1,
+    measuredWidth: 0,
+    measuredHeight: 0,
+    scrollDirtyFrom: 0,
+    scrollIndex: null,
+  });
+
+  /** A scrolling box of `count` one-row children, showing from `offset`. */
+  const scrolling = (count: number, offset: number): LayoutNode =>
+    node(
+      { overflow: "scroll", scrollTop: offset },
+      Array.from({ length: count }, () => node({}, [], 1)),
+    );
+
+  /** Move the window, which is the one thing about a scrolling box that is not a fact about its children. */
+  const scrollTo = (box: LayoutNode, offset: number) => {
+    box.style = { overflow: "scroll", scrollTop: offset };
+    for (const child of box.children) {
+      child.y = -1;
+    }
+  };
+
+  /** Which children layout gave a position to. */
+  const placed = (box: LayoutNode): Array<number> => {
+    const out = [];
+    for (let index = 0; index < box.children.length; index += 1) {
+      if (box.children[index].y !== -1) {
+        out.push(index);
+      }
+    }
+    return out;
+  };
+
+  it("lays out the window and not the content, at any size", () => {
+    // The property in one assertion: two boxes three orders of magnitude apart
+    // do the same work to show the same twenty-four rows.
+    const small = scrolling(30, 3);
+    const large = scrolling(100_000, 3);
+
+    layout(small, 0, 0, 20, 24);
+    layout(large, 0, 0, 20, 24);
+
+    expect(placed(small).length).toBe(24);
+    expect(placed(large)).toEqual(placed(small));
+    // And the large one still knows exactly how much content it has, which is
+    // what `Number.MAX_SAFE_INTEGER` gets clamped against.
+    expect(large.scrollHeight).toBe(100_000);
+    expect(large.scrollCount).toBe(24);
+  });
+
+  it("measures a row once and never again while it is unchanged", () => {
+    const box = scrolling(100_000, 0);
+
+    measured = 0;
+    layout(box, 0, 0, 20, 24);
+    // The first frame has to see the content, because the height of the
+    // content is what the offset is clamped against and nothing can know it
+    // without asking. This is the one pass that is proportional to the log,
+    // and it is the honest half of the claim.
+    expect(measured).toBe(100_000);
+
+    // Every frame after it is proportional to the window instead. Scrolling
+    // to the far end of a hundred thousand rows asks nothing of the ninety-nine
+    // thousand nine hundred and seventy-six that are not on the screen.
+    for (const offset of [1, 500, 50_000, 99_976]) {
+      measured = 0;
+      scrollTo(box, offset);
+      layout(box, 0, 0, 20, 24);
+      expect(measured).toBe(0);
+      expect(placed(box).length).toBe(24);
+    }
+    expect(placed(box)[0]).toBe(99_976);
+  });
+
+  it("costs one measurement to append a line to a hundred thousand", () => {
+    // A log grows at the end, which is the one mutation whose position is
+    // known without looking for it — `internal/tree.js` hands layout that
+    // index, and here the stack works out the same thing from the child count.
+    const box = scrolling(100_000, Number.MAX_SAFE_INTEGER);
+    layout(box, 0, 0, 20, 24);
+    expect(box.scrollOffset).toBe(99_976);
+
+    measured = 0;
+    box.children.push(node({}, [], 1));
+    layout(box, 0, 0, 20, 24);
+
+    expect(measured).toBe(1);
+    expect(box.scrollHeight).toBe(100_001);
+    // And it followed its tail, which is what asking for a row number no
+    // caller could know is for.
+    expect(box.scrollOffset).toBe(99_977);
+  });
+
+  it("finds the window without walking to it", () => {
+    // Rows that are not all the same height cannot be divided into, so the
+    // stack is searched. One row and three alternating puts row `2k` at `4k`
+    // and row `2k+1` at `4k+1`, which no arithmetic on the offset alone
+    // would find.
+    const children = Array.from({ length: 10_000 }, (_, index) =>
+      node({}, [], index % 2 === 0 ? 1 : 3),
+    );
+    const box = node({ overflow: "scroll", scrollTop: 5_000 }, children);
+    layout(box, 0, 0, 20, 4);
+
+    expect(box.scrollHeight).toBe(20_000);
+    expect(placed(box)).toEqual([2_500, 2_501]);
+  });
+
+  it("re-measures the row that changed, and moves the ones under it", () => {
+    // The half of a kept measurement that can go wrong. A cache nothing
+    // invalidated would leave this box the height it was and draw the rows
+    // below the changed one two lines too high.
+    const children = [node({}, [], 1), node({}, [], 1), node({}, [], 1)];
+    const box = node({ overflow: "scroll", scrollTop: 0 }, children);
+    layout(box, 0, 0, 20, 8);
+    expect(box.scrollHeight).toBe(3);
+
+    // Exactly what `invalidate` in `internal/tree.js` writes when React
+    // changes a node: the node's own measurement is forgotten, and the
+    // scrolling box is told from which child its stack is stale.
+    children[0].measure = leaf(3);
+    children[0].measuredForWidth = -1;
+    children[0].measuredForHeight = -1;
+    box.scrollDirtyFrom = 0;
+
+    measured = 0;
+    layout(box, 0, 0, 20, 8);
+    // One, not three: rebuilding the stack from the top re-reads three heights
+    // and re-measures only the row that stopped knowing its own.
+    expect(measured).toBe(1);
+    expect(box.scrollHeight).toBe(5);
+    expect(children[1].y).toBe(3);
   });
 });
 

--- a/tools/bench/tui/window.js
+++ b/tools/bench/tui/window.js
@@ -1,0 +1,283 @@
+// @flow
+//
+// What a `ScrollBox` costs as its content grows.
+//
+//   uf run bench:tui:window
+//
+// # The question
+//
+// `ScrollBox` claims that only the visible window is laid out, painted and
+// diffed — that moving the window over a hundred thousand rows costs what
+// moving it over thirty costs. `tests/library/tui.test.js` proves the shape of
+// that by counting the calls layout makes into its leaves, which is exact and
+// the same number on every machine and says nothing about how long anything
+// takes. This says how long.
+//
+// The two are deliberately different in kind and neither replaces the other. A
+// count cannot tell you that a constant is small; a clock cannot tell you that
+// a curve is flat, because a flat curve and a gently sloping one look alike on
+// a machine that is also doing something else. Together they can.
+//
+// # Two clocks, because there are two costs and only one of them is this one
+//
+// A keystroke here does two separate things, and lumping them together is how
+// this benchmark was wrong the first time it ran:
+//
+// * **commit** is React reconciling the tree. It is proportional to how many
+//   elements the *application* creates, which is the application's decision —
+//   a hundred thousand `<Text>` children are a hundred thousand fibers whoever
+//   is scrolling them. Nothing `ScrollBox` does can make that constant, and it
+//   is reported here so that nobody reads the other column as the whole story.
+// * **frame** is `layout` + `paint` + `diff`: everything between "the tree is
+//   what it is" and "here are the bytes". This is the column the claim is
+//   about, and the one that should not move when the content does.
+//
+// The row elements are built once and kept, which is what an application that
+// scrolls a long log would do anyway. Rebuilding a hundred thousand elements
+// on every keystroke is a cost a caller chooses, and charging it to the
+// renderer would be measuring `Array.from`.
+//
+// # Three steps
+//
+// * **first** — nothing to a first frame. The one step that is *supposed* to
+//   grow: the height of the content is what `scrollTop` is clamped against, so
+//   every row is measured once. It is here to be seen growing, because a table
+//   where every row is flat is a table nobody believes.
+// * **scroll** — the offset moves by one row and nothing else changes.
+// * **append** — one line is added at the end, which is what a log does. The
+//   rows above have not moved, so the stack of heights is extended rather than
+//   rebuilt.
+//
+// # Why this is not `bench.js`
+//
+// That one compares uf with React Ink on one frame and reports bytes as its
+// deterministic half. Ink has no `ScrollBox`, so there is nothing to compare;
+// and bytes are not the question either — the window sends the window whatever
+// it cost to work out which rows the window is.
+//
+// Wall clock is noisy, so every figure is a median with the spread beside it.
+
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+
+import * as React from "@uniflowed/react";
+import { useState } from "@uniflowed/react";
+import { ScrollBox, Text, testRender, useKeyboard } from "@uniflowed/tui";
+import type { TestHandle } from "@uniflowed/tui";
+
+/** The terminal every measurement here happens in. */
+const WIDTH = 80;
+const HEIGHT = 24;
+
+/** How many rows the content has, across the four runs. */
+const SIZES: $ReadOnlyArray<number> = [30, 1_000, 10_000, 100_000];
+
+/** How many keystrokes each step is measured over. */
+const SAMPLES = 20;
+
+/** What one step came out as, on one of the two clocks. */
+type Row = {
+  readonly medianMs: number,
+  readonly minMs: number,
+  readonly maxMs: number,
+};
+
+/** Both clocks for one step, plus the cells the step re-sent. */
+type Step = {
+  readonly commit: Row,
+  readonly frame: Row,
+  readonly cells: number,
+};
+
+/**
+ * The application, and the only two things a key does to it.
+ *
+ * `"s"` scrolls and `"a"` appends, which keeps both steps in one tree and one
+ * commit path. The offset and the row count are state so that a step is a
+ * React update rather than a fresh mount — the question is what an *existing*
+ * application pays to move its window.
+ */
+const line = (index: number) =>
+  React.createElement(Text, { key: String(index), wrap: "none" }, `line ${index}`);
+
+component Log(rows: number) {
+  const [top, setTop] = useState<number>(0);
+  const [down, setDown] = useState<boolean>(true);
+  // Whether the box is following its tail, which is what a log does while it is
+  // being appended to and what makes an append move the window. A scroll takes
+  // it back off the tail.
+  const [following, setFollowing] = useState<boolean>(false);
+  // The rows, kept as the elements themselves rather than as a count.
+  // Appending is `[...lines, line(n)]`, so every element already in the list is
+  // the *same object* as last render and React bails out of its subtree — which
+  // is what makes this measure a log that grew by a line rather than a log that
+  // was rebuilt. A benchmark that recreated all hundred thousand elements would
+  // be timing `Array.from`.
+  const [lines, setLines] = useState<Array<React.Node>>(() =>
+    Array.from({ length: rows }, (_, index) => line(index)),
+  );
+  useKeyboard((key) => {
+    if (key.name === "s") {
+      // A bounce rather than a run to the bottom: thirty rows in a twenty-four
+      // row window can only scroll six, and a step that stopped moving would be
+      // timing a frame in which nothing happened while the hundred-thousand-row
+      // one was timing a real scroll.
+      const limit = Math.max(0, lines.length - HEIGHT);
+      const next = down ? top + 1 : top - 1;
+      setFollowing(false);
+      if (next > limit) {
+        setDown(false);
+        setTop(Math.max(0, limit - 1));
+      } else if (next < 0) {
+        setDown(true);
+        setTop(Math.min(limit, 1));
+      } else {
+        setTop(next);
+      }
+    }
+    if (key.name === "a") {
+      setFollowing(true);
+      setLines((list) => [...list, line(list.length)]);
+    }
+  });
+  return React.createElement(
+    ScrollBox,
+    {
+      height: HEIGHT,
+      width: WIDTH,
+      scrollbar: false,
+      scrollTop: following ? Number.MAX_SAFE_INTEGER : top,
+    },
+    lines,
+  );
+}
+
+/** The median of a list this function may reorder. */
+function median(values: Array<number>): number {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const middle = sorted.length >> 1;
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+const summarise = (times: Array<number>): Row => ({
+  medianMs: median(times),
+  minMs: Math.min(...times),
+  maxMs: Math.max(...times),
+});
+
+/** Mount `rows` rows, and time the first frame — the pass that is allowed to grow. */
+function mount(rows: number): { handle: TestHandle, first: number } {
+  const handle = testRender(React.createElement(Log, { rows }), {
+    width: WIDTH,
+    height: HEIGHT,
+  });
+  const started = performance.now();
+  handle.update();
+  return { handle, first: performance.now() - started };
+}
+
+/**
+ * One step, measured `SAMPLES` times on one mounted application.
+ *
+ * The same application throughout rather than a fresh one per sample, because
+ * a fresh one would pay the first frame's measurement again and that is the
+ * cost this is trying to hold separate. The first keystroke is taken off the
+ * clock for the same reason every other benchmark here warms up.
+ */
+function step(handle: TestHandle, key: string): Step {
+  handle.press(key);
+  handle.update();
+
+  const commits = [];
+  const frames = [];
+  let cells = 0;
+  for (let sample = 0; sample < SAMPLES; sample += 1) {
+    const beforeCommit = performance.now();
+    handle.press(key);
+    const beforeFrame = performance.now();
+    const update = handle.update();
+    const after = performance.now();
+    commits.push(beforeFrame - beforeCommit);
+    frames.push(after - beforeFrame);
+    cells = update.cells;
+  }
+  return { commit: summarise(commits), frame: summarise(frames), cells };
+}
+
+const pad = (text: string, width: number) => text.padStart(width);
+const ms = (row: Row) => `${pad(row.medianMs.toFixed(2), 8)} ms`;
+const spread = (row: Row) => `${row.minMs.toFixed(2)}–${row.maxMs.toFixed(2)}`;
+
+function main() {
+  // A whole run that is thrown away. The first mount in a process pays for
+  // React's module initialisation and every shape V8 has not seen yet, and
+  // charging that to the first size measured would make the smallest content
+  // look like the most expensive one — which it did, the first time this was
+  // written.
+  const warm = mount(SIZES[0]).handle;
+  step(warm, "s");
+  step(warm, "a");
+  warm.stop();
+
+  const table = SIZES.map((rows) => {
+    // The first frame is reported as the fastest of three rather than as a
+    // median, for the reason `startup.js` gives about start-up: it allocates a
+    // row's worth of everything per row, so it is the one step a garbage
+    // collection can land in the middle of, and contention can only make it
+    // slower. The steps below it run on the last of the three.
+    let first = Number.POSITIVE_INFINITY;
+    let handle = null;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      if (handle != null) {
+        handle.stop();
+      }
+      const mounted = mount(rows);
+      first = Math.min(first, mounted.first);
+      handle = mounted.handle;
+    }
+    const live = handle;
+    if (live == null) {
+      throw new Error("unreachable: three mounts leave one handle");
+    }
+    const scroll = step(live, "s");
+    const append = step(live, "a");
+    live.stop();
+    return { rows, first, scroll, append };
+  });
+
+  const size = (rows: number) => pad(rows.toLocaleString("en-US"), 8);
+
+  process.stdout.write(`${WIDTH}×${HEIGHT}, median of ${SAMPLES}\n\n`);
+  process.stdout.write("layout, paint and diff — what this renderer costs\n");
+  process.stdout.write(
+    `${pad("rows", 8)} ${pad("first frame", 11)} ${pad("scroll", 11)} ${pad("append", 11)}\n`,
+  );
+  for (const row of table) {
+    process.stdout.write(
+      `${size(row.rows)} ${pad(`${row.first.toFixed(2)} ms`, 11)} ${ms(row.scroll.frame)} ${ms(row.append.frame)}\n`,
+    );
+  }
+
+  process.stdout.write("\nReact reconciling the tree — the application's cost, not this one's\n");
+  process.stdout.write(`${pad("rows", 8)} ${pad("scroll", 11)} ${pad("append", 11)}\n`);
+  for (const row of table) {
+    process.stdout.write(`${size(row.rows)} ${ms(row.scroll.commit)} ${ms(row.append.commit)}\n`);
+  }
+
+  process.stdout.write("\ncells re-sent, which is deterministic and is checked by tests\n");
+  process.stdout.write(`${pad("rows", 8)} ${pad("scroll", 11)} ${pad("append", 11)}\n`);
+  for (const row of table) {
+    process.stdout.write(
+      `${size(row.rows)} ${pad(String(row.scroll.cells), 11)} ${pad(String(row.append.cells), 11)}\n`,
+    );
+  }
+
+  process.stdout.write("\nspread of the frame column, low to high, in milliseconds\n");
+  for (const row of table) {
+    process.stdout.write(
+      `${size(row.rows)} ${pad(spread(row.scroll.frame), 16)} ${pad(spread(row.append.frame), 16)}\n`,
+    );
+  }
+}
+
+main();

--- a/uf.config.js
+++ b/uf.config.js
@@ -442,6 +442,17 @@ export default defineConfig({
         "UF_PROJECT_ROOT=. UF_BINARY=./target/release/uf node --import @uniflowed/host/register tools/bench/tui/startup.js",
       dependsOn: ["build"],
     },
+    // What a `ScrollBox` costs as its content grows, which is the wall-clock
+    // half of ubugeeei-prod/uf#314's "only the visible window is laid out and
+    // diffed". The exact half — how many times layout asks a row how tall it
+    // is — is counted in `tests/library/tui.test.js` and does run in CI,
+    // because a count is the same number on every machine and a millisecond
+    // is not. This needs no Ink, only the four sizes and a quiet machine.
+    "bench:tui:window": {
+      command:
+        "UF_PROJECT_ROOT=. UF_BINARY=./target/release/uf node --import @uniflowed/host/register tools/bench/tui/window.js",
+      dependsOn: ["build"],
+    },
 
     // What the route cache is worth in front of a slow loader: the same page
     // served twice, with and without the cache `rendering.cache.route` turns


### PR DESCRIPTION
The first slice of #314, which names `ScrollBox` as the one to do first and says
why: it is where *only the visible window is laid out and diffed* has to be
proved. A `ScrollBox` that lays out all its children and clips is not that
feature.

Half of it was already true. #449 stopped laying out and painting children
outside the window, and `TuiFeature::Scrollback` was claimed on that basis. The
other half was not: every frame still **measured** every child, called `hide()`
on every child it skipped, and walked past every child in the painter. A
hundred thousand rows cost a hundred thousand of each, three times per
keystroke.

## The measurement

Two of them, deliberately different in kind — a count cannot tell you a constant
is small, and a clock cannot tell you a curve is flat.

**Counted, in `tests/library/tui.test.js`.** The suite builds `LayoutNode`s by
hand, which is what `layout.js` is designed for, so it can count the calls
layout makes into its leaves. A measurement is a call *into* a leaf and nothing
above layout can watch one happen.

| | measure calls | children laid out |
| --- | --- | --- |
| 100,000 rows, first frame | 100,000 | 24 |
| ...then scrolled to row 1 / 500 / 50,000 / 99,976 | **0** each | 24 each |
| ...then one line appended | **1** | 24 |
| 30 rows, same window | — | 24, the same indices |

Four of the five new cases **fail against the renderer as it is on `main`**,
with `expected 100000 to be 0` and `expected 100001 to be 1`. They are not
descriptions of the change; they are the discriminator.

**Timed, in `tools/bench/tui/window.js`** (`uf run bench:tui:window`, new).
Layout + paint + diff only, 80×24, median of 20 keystrokes, range over three
whole runs:

| rows | first frame | one row scrolled | one line appended |
| --- | --- | --- | --- |
| 30 | 0.33 ms | 0.16 – 0.29 ms | 0.17 – 0.32 ms |
| 1,000 | 5.8 ms | 0.20 – 0.28 ms | 0.16 – 0.41 ms |
| 10,000 | 65 ms | 0.21 – 0.25 ms | 0.23 – 0.28 ms |
| 100,000 | 602 ms | 0.21 – 0.31 ms | 0.26 – 0.33 ms |

The thirty-row band and the hundred-thousand-row band overlap: three thousand
times the content, and the frame cannot tell. **Before**, the same scroll cost
0.23 ms, 3.64 ms, 59.64 ms, 491.25 ms — a straight line through the origin. At
a hundred thousand rows that is 491 ms → 0.24 ms.

The first-frame column is still that line, deliberately: the height of the
content is what `Number.MAX_SAFE_INTEGER` gets clamped against, so every row is
asked its height once. It is also the noisy column, and is reported as the
fastest of three for the reason `startup.js` gives.

The benchmark prints a second table that is **not** this component's, because
publishing only the flat one would be publishing half of it: React reconciling
the tree costs ~0.2 ms at thirty rows and a few hundred at a hundred thousand.
A hundred thousand `<Text>` children are a hundred thousand fibers whoever is
scrolling them, and a `ScrollBox` cannot render children the caller did not
create.

## Where the layout/diff boundary went, and why

**In JavaScript, in `packages/tui`.** Not a preference — `crates/uf_tui/src/lib.rs`
opens with *"This crate holds no renderer"*, and the argument against a Rust
core with a binding is written out in `packages/tui/index.js`. The Rust crate is
the contract `uf inspect` prints; putting the windowing behind it would need a
JS-to-native bridge uf does not have, and would have to cross that bridge on
every frame to answer a question about a tree React owns. Nothing in the Rust
half changes here except one doc comment.

The same reasoning settles the measurement's home. `crates/uf_profiler` counts
allocations in Rust and criterion benches Rust crates; neither can see a
JavaScript renderer. The repository already measures this package in
`tools/bench/tui/` (#315's Ink comparison, #316's start-up), so the new bench
went beside them, and the *exact* half went into the test suite where it runs in
CI on every machine — a count is the same number everywhere and a millisecond is
not.

Inside JS, the boundary that mattered was between **React and layout**. Layout
cannot know that a tree changed without comparing it with the one it saw last,
which is the walk the whole change exists to avoid; React knows exactly. So
`internal/tree.js` writes `scrollDirtyFrom` and layout reads it. It is a plain
number on the node rather than a call into `layout.js` because that file's own
header says the three participants do not import each other, and a node's fields
are the whole of what they say to one another.

## What changed

- `ScrollIndex` — a scrolling box keeps where each child sits, and rebuilds only
  the part that moved. An **append** dirties from the old child count, so a log
  that grew by a line re-measures a line.
- The first visible child is found by **binary search** over the stack.
- The painter is handed the **range** of children layout placed (`scrollFirst`,
  `scrollCount`) instead of a `hidden` flag per child, so the paint walk is the
  window too. `LayoutNode.hidden` is gone; it was only ever the mechanism for
  this.
- `intrinsicSize` keeps what it measured, keyed on what it was offered;
  `invalidate` clears it up the tree on every mutation React makes.
- A scrolling box's **own** props deliberately do not invalidate its stack: they
  cannot move its children except through the width, the viewport and the gap,
  and all three are in the stack's key. `scrollTop` is a prop on that box, so
  without that exemption every notch would invalidate the thing that makes
  scrolling cheap. The benchmark caught exactly that on its first run — 14 ms
  per scroll at a hundred thousand rows.
- Two renderer-level tests guard the kept measurement from the other side: a row
  **above** the window growing taller, and one going away, both move what is
  under them.

## The not-claimed list

**No line was deleted, and that is the finding.** The list in
`crates/uf_tui/src/tests.rs` is `Selection`, `Keymap`, `TerminalAutomation`,
`CodeHighlight`, `Markdown`, `Images`, `Audio`, `ThreeD`, `Ssh`, `QrCode`,
`EmbeddedTerminal`, `Clipboard`, `Notifications`, `Animations` — and
`Scrollback` left it in #449, before the property it names was true. This change
announces nothing new; it makes an existing claim honest. So the contract moved
the other way: `TuiFeature::Scrollback`'s doc comment now says which part is
proved, how it is counted, and which part — the first frame — is still
proportional to the content and why it has to be.

Selection is the next line to delete, and it is untouched here.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p uf_tui -p uf_term` — 5 + 252 pass, plus 2 doc-tests
- `uf run test:lib` — 2,772 pass, 0 fail (100 in `tui.test.js`, 21 of them
  `ScrollBox`)
- `uf fmt --check`, `uf lint` — clean, 0 errors

Docs: `docs/app/guide/tui/_uf.page.mdx` replaces "Every child is measured" with
what it costs now, both tables, the before numbers, and the part that is React's
rather than this renderer's. `docs/issue-roadmap.md` records the property beside
the scrolling entry.

Closes nothing — #314 is XL and this is one slice of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved `ScrollBox` performance for large content by limiting layout, painting, and updates to rows visible in the scroll window.
  - Added caching and incremental updates to reduce repeated measurement during scrolling and content changes.
  - Added support for efficiently handling row growth, removal, and appended content.

- **Documentation**
  - Expanded `ScrollBox` and Terminal UI performance guidance, including benchmark results and remaining application-side costs.

- **Tests**
  - Added coverage for visible-window layout, caching, scrolling, row changes, and measurement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->