### PR TITLE
test(packages): close the allowlists that would publish a co-located test file

### DIFF
--- a/crates/uf_lib/tests/package_surface.rs
+++ b/crates/uf_lib/tests/package_surface.rs
@@ -8,6 +8,7 @@
 //! - no module runs anything when it is imported,
 //! - every module opens with the `// @flow` pragma,
 //! - every `exports` subpath resolves and every shipped module is reachable,
+//! - no test file is published, by the allowlist or through `exports`,
 //! - every shipped `package.json` declares `"sideEffects": false`,
 //! - the Rust registry in `uf_lib` and the shipped subpaths agree,
 //! - every `@uniflowed/*` a package imports is declared in its manifest.
@@ -829,6 +830,87 @@ fn shipped_packages_never_publish_flow_declaration_files() {
             assert!(
                 !entry.contains(".flow"),
                 "{relative} publishes {entry}; the product has no `.flow` files"
+            );
+        }
+    }
+}
+
+/// A published package must not ship a test file.
+///
+/// This is a rule about the *allowlist*, not about the files that happen to be
+/// on disk today, and it has to be: there are no test files under `packages/`
+/// yet, so a test that only walked the tree would pass while every manifest
+/// was wide open. What is checked is whether a test file placed beside the
+/// module it tests — which is where this repository wants them, and where
+/// `crates/*/src/tests.rs` already puts the Rust half — would reach npm.
+///
+/// Twenty-two of the forty-nine manifests would have published one. Ten
+/// allowlist `*.js`, which matches `alert.test.js` as readily as `alert.js`;
+/// the other twelve name `internal` as a bare directory, and a directory entry
+/// takes everything under it. Neither is visible by reading the entry.
+///
+/// The negation must be the **last** entry, and that is the whole reason this
+/// is enforced rather than written down. npm applies `files` in order, so
+///
+/// ```json
+/// "files": ["!*.test.js", "*.js", "internal"]
+/// ```
+///
+/// publishes every test file — the negation subtracts from nothing, because
+/// nothing has been added yet — while the same three entries in the other
+/// order do not. Both read as if they exclude tests. `npm pack --dry-run` is
+/// the only way to tell them apart, and nobody runs it on a manifest they did
+/// not think they had changed: sorting the array alphabetically is enough to
+/// move the negation to the front and start publishing tests silently.
+#[test]
+fn a_shipped_package_never_publishes_a_test_file() {
+    /// The entry that subtracts test files from whatever precedes it.
+    ///
+    /// No `/`, so npm reads it the way `.gitignore` does — matching at any
+    /// depth, which is what closes the bare-`internal` hole as well as the
+    /// top-level `*.js` one.
+    const NEGATION: &str = "!*.test.js";
+
+    for relative in shipped_manifests() {
+        let manifest = manifest(&relative);
+        let files = manifest
+            .get("files")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("{relative} must list published files"));
+
+        let entries = files
+            .iter()
+            .map(|entry| entry.as_str().unwrap_or_default())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            entries.last(),
+            Some(&NEGATION),
+            "{relative} must end its `files` with {NEGATION:?} so a test file \
+             beside the module it tests is not published; found {entries:?}"
+        );
+    }
+}
+
+/// And that no test file is reachable through an `exports` subpath either.
+///
+/// The allowlist is what npm packs, but `exports` is what a consumer can
+/// `import`. A package that named a test file as a subpath would be asking for
+/// it back even with the allowlist closed, so the two halves are checked
+/// separately — this one is cheap and it is the half a reviewer would assume
+/// was covered by the other.
+#[test]
+fn no_exports_subpath_names_a_test_file() {
+    for relative in shipped_manifests() {
+        let manifest = manifest(&relative);
+        let exports = manifest
+            .get("exports")
+            .unwrap_or_else(|| panic!("{relative} must declare exports"));
+
+        for (subpath, target) in exports_targets(exports) {
+            assert!(
+                !target.ends_with(".test.js"),
+                "{relative} exports {subpath} as {target}, which is a test file"
             );
         }
     }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -14,6 +14,7 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ]
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "index.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "index.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,8 @@
     "index.js",
     "internal/*.js",
     "random.js",
-    "temporal.js"
+    "temporal.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/config": "0.0.0-alpha.18",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -18,7 +18,8 @@
   "files": [
     "index.js",
     "schedule.js",
-    "stream.js"
+    "stream.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "index.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ],
   "dependencies": {}
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "*.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/react": "0.0.0-alpha.18",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/fetch": "0.0.0-alpha.18"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "index.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,7 +24,8 @@
     "./timing": "./timing.js"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -29,6 +29,7 @@
     "module-mocks.js",
     "transform.js",
     "write-atomically.js",
-    "internal/*.js"
+    "internal/*.js",
+    "!*.test.js"
   ]
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,6 +22,7 @@
     "format.js",
     "index.js",
     "negotiate.js",
-    "syntax.js"
+    "syntax.js",
+    "!*.test.js"
   ]
 }

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -21,6 +21,7 @@
     "draft.js",
     "freeze.js",
     "index.js",
-    "patches.js"
+    "patches.js",
+    "!*.test.js"
   ]
 }

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "*.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/config": "0.0.0-alpha.18",

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -25,7 +25,8 @@
     "./structural": "./structural.js"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/hooks": "0.0.0-alpha.18",

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "index.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,7 +15,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "peerDependencies": {
     "react": ">=19"

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "peerDependencies": {
     "react": ">=19",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/config": "0.0.0-alpha.18",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -26,7 +26,8 @@
     "index.js",
     "internal",
     "middleware.js",
-    "server.js"
+    "server.js",
+    "!*.test.js"
   ],
   "peerDependencies": {
     "react": ">=19",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,8 @@
     "schedule.js",
     "socket.js",
     "standalone.js",
-    "internal/*.js"
+    "internal/*.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "index.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/cell": "0.0.0-alpha.18",

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -27,7 +27,8 @@
     "heap.js",
     "hex.js",
     "index.js",
-    "sync.js"
+    "sync.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -19,7 +19,8 @@
     "./story": "./story.js"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/mock": "0.0.0-alpha.18",

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -18,7 +18,8 @@
     "./tokens.stylex.js": "./tokens.stylex.js"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -20,7 +20,8 @@
     "in-source.js",
     "index.js",
     "internal",
-    "worker.js"
+    "worker.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/host": "0.0.0-alpha.18"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/react-testing": "0.0.0-alpha.18",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -25,7 +25,8 @@
   },
   "files": [
     "*.js",
-    "internal/*.js"
+    "internal/*.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/react": "0.0.0-alpha.18",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,7 +54,8 @@
   },
   "files": [
     "*.js",
-    "internal"
+    "internal",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -29,6 +29,7 @@
     "./union": "./union.js"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "!*.test.js"
   ]
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -28,7 +28,8 @@
     "driver.js",
     "index.js",
     "internal",
-    "merge.js"
+    "merge.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -14,7 +14,8 @@
     ".": "./index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/browser": "0.0.0-alpha.18",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,7 +20,8 @@
     "./vitals": "./vitals.js"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "!*.test.js"
   ],
   "dependencies": {
     "@uniflowed/core": "0.0.0-alpha.18",


### PR DESCRIPTION
## What this is, and what it is not

The ask was to co-locate the JavaScript suite: move `tests/library/ui.test.js` to
`packages/ui/ui.test.js`, beside the module it tests, the way `crates/*/src/tests.rs`
already sits beside its own.

**I did not move the 81 test files, and I think the move should not happen until a
design question is settled.** What this PR does is the prerequisite the brief called
"solve it or the change is unshippable" — the npm allowlists, and the invariant that
keeps them solved. That part is correct and worth having whether or not the move
happens, and it is what a co-location PR would otherwise have to carry anyway.

The blocker is below, with the evidence.

---

## The blocker: `uf test#library` cannot see `packages/`

A uf workspace member is any directory with its own `uf.config.js`
(`crates/uf_project/src/workspace.rs`). `tests/library` has one, so `uf test#library`
enters that directory and **that becomes the project root**. Test discovery walks from
the root down. `packages/` is a sibling of `tests/`, so it is never walked.

This repository's own config already says so, at `uf.config.js:160`:

> `uf test#library` cannot do it: its project root is `tests/library`, and coverage is
> about the project's own files, so every package the suite exercises would be outside it.

Checked rather than assumed. I put one file at `packages/cell/probe-xyz.test.js` and ran
the suite:

```
$ uf test#library
  passed    2851
  files     82        # unchanged — the probe is invisible

$ uf test packages/cell
  ✓ 1 passed, 0 failed in 341ms   # the same file, found by path
```

So the two requirements in the brief are mutually exclusive:

- *"Move the JS suite next to the code it tests"*, and
- *"`uf test#library` must still find and run every test. The count must not drop."*

Every file moved out of `tests/library` leaves `uf test#library`. There is no config key
to bring it back: `TestConfig` is `module`, `runner`, `reactTestingLibraryNative` and
`coverage` — no `include`, no `roots`. The guide states the design deliberately
(`docs/app/guide/testing/_uf.page.mdx:64`): *"there is no separate 'include' pattern: a
file that declares a test is a test file."* Adding such a key would mean changing
`crates/uf_config`, which this stream was told not to touch.

### The two routes, for whoever picks this up

**(a) Run the suite from the repository root.** `uf test` at the root already discovers
`packages/**` and `tests/library/**` together, and it is green today:

```
$ uf test                    # repository root, no selector
  ✓ 2851 passed, 0 failed, 1 skipped, 39 unexpandable in 14.69s
  files     98
```

Same 2851. The 16 extra files and the 39 "unexpandable" entries are shipped modules that
mention `describe`/`it` in a way discovery cannot expand — `packages/story/runner.js`
registers stories dynamically, and `packages/validator/*.js` has the words in prose. They
contribute no cases. This is the route `test:lib:coverage` already uses.

The cost: `uf test#library` stops being the command a contributor types, the suite starts
running under the root `uf.config.js` instead of `tests/library`'s `defineConfig({})`, and
CI's entry point changes. That is a decision about the repository's shape, not a
consequence of moving files.

**(b) `packages/uf.config.js`, selected as `uf test#packages`.** Works, but note
`workspace.rs` stops descending once it finds a member, so per-package members would then
be undiscoverable — and `#library` still shrinks to whatever stays behind.

### The second blocker, which route (a) does not fix

`crates/uf_lib/tests/package_surface.rs` defines `shipped_modules()` as *every `.js` under
`packages/`*. Co-located tests would immediately fall under invariants written for shipped
modules and violate several:

- `shipped_modules_have_no_import_time_side_effects` — a test file's top-level
  `describe(...)` is exactly the import-time side effect this forbids.
- `every_shipped_module_is_reachable_through_exports` — would demand an `exports` subpath
  for `alert.test.js`, which is the opposite of what we want.
- `every_uniflowed_import_is_declared` — would demand `@uniflowed/test` as a dependency of
  `@uniflowed/ui`.

So before one test file can move, that file has to learn that a `.js` under `packages/` may
not be shipped at all — threading a "test file" concept through `shipped_files()` and
several invariants. That is a real refactor of the file, and the opposite of "add an
invariant to it". It should be its own PR, ahead of the move.

---

## What is in this PR

### 1. The allowlists

The brief said every package declares `files: ["*.js", "internal"]` or similar. That is not
what is there — and the real exposure is both narrower and broader than described:

| allowlist shape | packages | would publish a co-located test? |
|---|---|---|
| `["index.js"]` and other explicit lists | 27 | no |
| `["*.js"]`, `["*.js", "internal"]`, `["*.js", "internal/*.js"]` | 10 | yes, at the top level |
| explicit list + bare `internal` or `internal/*.js` | 12 | yes, but only inside `internal/` |

**22 of 49**, measured rather than eyeballed: I packed all 49 with a probe test file at the
top level and inside `internal/`, and counted. The twelve `internal` ones are the
interesting half — `["index.js", "internal"]` looks like a closed list, but a bare
directory entry takes everything under it, so `packages/cell/internal/foo.test.js` ships.

Every manifest now ends its `files` with `"!*.test.js"`. One line, uniform across all 49
rather than only the 22, because the shape of an allowlist changes over time and the
negation should not depend on which shape a package currently has.

### 2. `npm pack --dry-run`, on the real packages

One package per allowlist shape, four of the six with an `internal/`. Probe test files
dropped in, packed as committed, then packed again with the negation stripped:

```
@uniflowed/ui      files: ['*.js', 'internal', '!*.test.js']
  AFTER  (as committed):      0 test files in tarball
  BEFORE (negation removed):  2   internal/probe-colocated.test.js, probe-colocated.test.js

@uniflowed/hooks   files: ['*.js', '!*.test.js']
  AFTER   0        BEFORE  1   probe-colocated.test.js

@uniflowed/cell    files: ['index.js', 'internal', '!*.test.js']
  AFTER   0        BEFORE  1   internal/probe-colocated.test.js

@uniflowed/server  files: [... 16 explicit ..., 'internal/*.js', '!*.test.js']
  AFTER   0        BEFORE  1   internal/probe-colocated.test.js

@uniflowed/tui     files: ['*.js', 'internal/*.js', '!*.test.js']
  AFTER   0        BEFORE  2   internal/probe-colocated.test.js, probe-colocated.test.js

@uniflowed/core    files: ['clock.js', 'index.js', 'internal/*.js', 'random.js', 'temporal.js', '!*.test.js']
  AFTER   0        BEFORE  1   internal/probe-colocated.test.js
```

Two things this proved that I would otherwise have assumed wrongly:

- **A bare `!*.test.js` matches at any depth.** No `/` in the pattern, so npm applies
  `.gitignore` semantics. One entry closes both the top-level and the `internal/` hole;
  `!**/*.test.js` is not needed.
- **Order is load-bearing, and getting it wrong is silent.** npm applies `files` in
  sequence, so a negation before the pattern it subtracts from does nothing:

  ```
  files: ["!*.test.js", "*.js", "internal"]   → 3 test files packed
  files: ["*.js", "internal", "!*.test.js"]   → 0
  ```

  Both read as if they exclude tests. Sorting the array alphabetically — which is how 30
  of these arrays are already written — moves the negation to the front and silently
  starts publishing tests again.

### 3. The invariant

That last point is why the new test asserts the negation is the **last** entry rather than
merely present:

```rust
#[test]
fn a_shipped_package_never_publishes_a_test_file() {
    const NEGATION: &str = "!*.test.js";
    for relative in shipped_manifests() {
        ...
        assert_eq!(
            entries.last(), Some(&NEGATION),
            "{relative} must end its `files` with {NEGATION:?} so a test file \
             beside the module it tests is not published; found {entries:?}"
        );
    }
}
```

It is a rule about the allowlist, not about the files on disk — deliberately. There are no
test files under `packages/` yet, so a test that only walked the tree would pass while every
manifest was wide open. This one is non-vacuous today.

Confirmed it goes red on the exact silent case, by re-sorting `ui`'s array:

```
assertion `left == right` failed: ui/package.json must end its `files` with "!*.test.js"
so a test file beside the module it tests is not published;
found ["!*.test.js", "*.js", "internal"]
  left: Some("internal")
 right: Some("!*.test.js")
```

`no_exports_subpath_names_a_test_file` covers the other route in — a package naming a test
file as an `exports` subpath would hand it back even with the allowlist closed.

---

## In-source tests

Worth saying because someone will ask: uf already supports in-source tests (#518) — a block
inside the module gated on `import.meta.uf.test`, folded to `void 0` in a production build,
with `tests/library/in-source-subject.js` as the worked example. That is the other half of
"co-located", and it interacts with this: an in-source test is *inside* a shipped module, so
no allowlist can exclude it, and the folding is what keeps it out of the tarball. Nothing
here converts anything to in-source — that is a per-function judgement, not a move.

## Verification

| check | result |
|---|---|
| `uf test#library` | **2851 passed, 0 failed, 1 skipped, 82 files** — identical to baseline |
| `cargo test -p uf_lib` | 34 passed (was 32; +2 new invariants) |
| `cargo clippy -p uf_lib --all-targets` | clean |
| `uf fmt --check` | every file already formatted |
| `uf lint` | 0 errors, 14 warnings — the documented steady state |

Baseline was measured on this branch point before any edit. Note it is **2851**, not the
~2796 in the brief; the suite has grown since that number was taken. No test moved, so the
count is unchanged by construction rather than by luck.

`tests/library` is untouched: 81 `.test.js` files plus `in-source-subject.js` — the 82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791533555&installation_model_id=422833&pr_number=722&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F722&signature=a1da52184f8a170134138e348ede22560b0655d4f744f46cc506784d65ceadbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->