### PR TITLE
test(server): the fifth front door, inside the comparison that keeps them one

### DIFF
--- a/packages/server/standalone.js
+++ b/packages/server/standalone.js
@@ -446,9 +446,19 @@ export function createHandler(
         // route handler, and for a path under it that matches neither — but an
         // embedded asset and a prerendered document are answered before it, which
         // is exactly what `uf preview` does, because Vite's file middleware runs
-        // before anything mounted behind it. The three front doors have to give
-        // one answer; that a prerendered page under a guard ships unguarded is
-        // true of all of them and is ubugeeei-prod/uf#342.
+        // before anything mounted behind it. The front doors have to give one
+        // answer, and `tests/library/deploy.test.js` is where they are asked
+        // the same questions and compared — this one included, since
+        // ubugeeei-prod/uf#391.
+        //
+        // That a prerendered page under a guard ships unguarded is true of all
+        // of them, and is no longer an open question about what to do: since
+        // ubugeeei-prod/uf#342 `uf build` names every route it wrote a document
+        // for that a middleware guards (`crates/uf_cli/src/commands/build/
+        // guards.rs`), `--adapter static` refuses such a project outright, and
+        // `build.staticBuild` makes it an error rather than a warning. What is
+        // left here is the fact itself, which is inherent to prerendering: the
+        // document is bytes, and bytes do not run a guard.
         const guarded = await app.runMiddleware(asRequest);
         if (guarded != null) {
           await sendUnlessHead(response, method, guarded);

--- a/tests/library/deploy.test.js
+++ b/tests/library/deploy.test.js
@@ -44,9 +44,17 @@
 // middleware before anything uf mounts behind it, so the file wins there and
 // therefore has to win everywhere.
 //
-// `the front doors give one answer` below drives all four of them over one
-// fixture and compares. It is the test that fails if a future adapter decides
-// to be cleverer than `uf preview` is allowed to be.
+// `the front doors give one answer` below drives all of them over one fixture
+// and compares. It is the test that fails if a future adapter decides to be
+// cleverer than `uf preview` is allowed to be.
+//
+// **Five doors, not four.** The fifth is `@uniflowed/server/standalone`, which
+// `uf build --compile` links into a single file. It is the one copy of the
+// order whose code genuinely cannot be shared — a binary has no `dist/` to
+// read, so its "a file the build already wrote" is a lookup in an embedded map
+// rather than a `stat` — and that is exactly why its *answer* has to be
+// checked here rather than only against itself in `standalone.test.js`. It was
+// outside this comparison until ubugeeei-prod/uf#391 said so.
 //
 // # What these tests do not establish
 //
@@ -59,6 +67,7 @@
 // that is what a Lambda Function URL sends. A passing test here is a statement
 // about uf, not about a deployment.
 
+import { Buffer } from "node:buffer";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -84,6 +93,7 @@ import { createFetchHandler } from "@uniflowed/server/fetch";
 import { beginRequest } from "@uniflowed/server/host";
 import { createLambdaHandler } from "@uniflowed/server/lambda";
 import { createServeHandler, createStaticHandler } from "@uniflowed/server/node";
+import { createHandler as createStandaloneHandler } from "@uniflowed/server/standalone";
 
 // The other front door, for the comparison. Reached by path rather than by
 // specifier because `@uniflowed/vite` deliberately does not export it: it is
@@ -533,14 +543,15 @@ describe("the AWS front door an adapter's lambda.js runs", () => {
 
 describe("the front doors", () => {
   it("give one answer, including where a file and a handler collide", async () => {
-    const distDir = directoryWith({
+    const built = {
       "index.html": "<!doctype html><p>home</p>",
       // A path that is *both* a prerendered document and a route handler. The
       // router allows a handler beside a page in one directory, so this is a
       // project somebody can write, and it is the only request whose answer
       // depends on which implementation is running.
       "api/health/index.html": "<!doctype html><p>prerendered health</p>",
-    });
+    };
+    const distDir = directoryWith(built);
     const app = appWith({
       handler: (request: Request) =>
         new URL(request.url).pathname.startsWith("/api/health")
@@ -553,13 +564,21 @@ describe("the front doors", () => {
     const deployed = createServeHandler({ staticDir: distDir, handle });
     const worker = createWorkerFetch({ handle, beginRequest });
     const invoked = createLambdaHandler({ handle, beginRequest, staticDir: distDir });
+    // The fifth door, and the only one that is not `createFetchHandler` behind
+    // a socket. A compiled binary has no `dist/` to read, so
+    // `@uniflowed/server/standalone` carries its own copy of the order — over
+    // an embedded map instead of a directory, which is why the code cannot be
+    // shared and why the *answer* has to be checked instead. ubugeeei-prod/uf#391
+    // named it as the copy that was outside this comparison.
+    const compiled = createStandaloneHandler({ app, assets: embedded(built), document: assets });
 
-    // Four front doors, one question each. `uf start` is the reference,
+    // Five front doors, one question each. `uf start` is the reference,
     // because it is the one a person checks a build with; each of the other
-    // three is a deployment, and a deployment that answered differently from
+    // four is a deployment, and a deployment that answered differently from
     // the command it was checked with is the whole failure this file exists to
     // catch. The Worker's static half is the platform's, standing in as an
-    // `ASSETS` binding; the Lambda's is the package's own copy.
+    // `ASSETS` binding; the Lambda's is the package's own copy; the binary's is
+    // the bytes inside it.
     const doors = {
       "uf start": async (url: string, init?: mixed) => {
         const response = await started(request(url, init));
@@ -581,6 +600,32 @@ describe("the front doors", () => {
         const result = await invoked(await eventFor(request(url, init)));
         return `${String(result.statusCode)} ${result.body}`;
       },
+      "uf build --compile": async (url: string, init?: mixed) => {
+        const response = nodeResponse();
+        const method = String(init?.method ?? "GET");
+        const body = String(init?.body ?? "");
+        await compiled(
+          {
+            method,
+            url,
+            headers: { host: "localhost" },
+            // The handler hands a non-`GET` body straight to `Request`, so what
+            // stands in for the socket has to be async-iterable the way an
+            // `IncomingMessage` is. A `GET` carries none, and passing one would
+            // be rejected before the comparison could ask anything.
+            ...(method === "GET" || method === "HEAD"
+              ? {}
+              : {
+                  // eslint-disable-next-line
+                  [Symbol.asyncIterator]: async function* iterate() {
+                    yield new TextEncoder().encode(body);
+                  },
+                }),
+          },
+          response,
+        );
+        return `${String(response.statusCode)} ${response.body()}`;
+      },
     };
 
     for (const [url, init] of [
@@ -593,10 +638,80 @@ describe("the front doors", () => {
     ]) {
       const said = `${String(init?.method ?? "GET")} ${String(url)}`;
       const reference = await doors["uf start"](String(url), init);
-      for (const name of ["adapter node", "adapter edge", "adapter serverless"]) {
+      for (const name of [
+        "adapter node",
+        "adapter edge",
+        "adapter serverless",
+        "uf build --compile",
+      ]) {
         const answered = await doors[name](String(url), init);
         expect(`${name} ${said}: ${answered}`).toBe(`${name} ${said}: ${reference}`);
       }
     }
   });
 });
+
+/**
+ * The same files, as `uf build --compile` embeds them.
+ *
+ * Built from the fixture's own literal rather than by reading back the
+ * directory the other doors serve, so the comparison is about the *order* and
+ * not about the fixture — and so that "the same bytes" is something a reader
+ * can see rather than something a walk has to be trusted to have done.
+ */
+function embedded(files: { [string]: string }): {
+  [string]: { readonly type: string, readonly body: string },
+} {
+  const out: { [string]: { readonly type: string, readonly body: string } } = {};
+  for (const key of Object.keys(files)) {
+    out[key] = {
+      type: key.endsWith(".html") ? "text/html; charset=utf-8" : "application/octet-stream",
+      body: Buffer.from(files[key], "utf8").toString("base64"),
+    };
+  }
+  return out;
+}
+
+/**
+ * The `ServerResponse` members `@uniflowed/server/standalone` touches.
+ *
+ * Only what this comparison needs — a status and a body. The pacing and
+ * cancellation halves of that contract are `standalone.test.js`'s subject and
+ * have their own, fuller, recorder there; a second copy of it here would be a
+ * second thing to keep in step for a question this file does not ask.
+ */
+function nodeResponse() {
+  const chunks = [];
+  const headers: { [string]: string } = {};
+  const collect = (chunk: Uint8Array | string) => {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk, "utf8") : Buffer.from(chunk));
+  };
+  return {
+    statusCode: 0,
+    headers,
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+    },
+    // The handler attaches `drain` and `close` listeners to pace a body. This
+    // comparison never fills a socket, so there is nothing to pace and nothing
+    // to fire; `standalone.test.js` is where those are driven. Returning
+    // `undefined` rather than the response is what keeps this a plain object
+    // literal rather than one that refers to itself.
+    on() {},
+    once() {},
+    off() {},
+    write(chunk: Uint8Array | string) {
+      collect(chunk);
+      return true;
+    },
+    end(chunk?: Uint8Array | string) {
+      if (chunk != null) {
+        collect(chunk);
+      }
+    },
+    destroy() {},
+    body(): string {
+      return Buffer.concat(chunks).toString("utf8");
+    },
+  };
+}


### PR DESCRIPTION
Closes the two "also found and not fixed" items #391 lists. **Not** the `deno`
adapter — that is still waiting on the benchmark `bun` was, and this machine has
no Deno to take it with.

## The fifth front door

`tests/library/deploy.test.js`'s `the front doors give one answer` drove four
implementations of one resolution order over one fixture and compared them.
There were five. `@uniflowed/server/standalone` — what `uf build --compile`
links into a single file — was outside it.

It is the copy whose code genuinely cannot be shared, which is exactly why it
is the one that most needed to be in there. The other four answer "a file the
build already wrote" by opening `dist/`; a binary has no `dist/`, so its answer
is a lookup in a map embedded in the executable. `standalone.js`'s header has
always said the order is written twice on purpose and that what holds the two
together is the *answer* — this is that sentence as a test.

**Checked by mutation, not by construction.** Replacing the prerendered lookup
in `createHandler` with `null` — the exact drift this exists for, the handler
winning a collision the file has to win — turns the comparison red:

```
expected "uf build --compile GET /: 200 <!doctype html><p>/</p>"
      to be "uf build --compile GET /: 200 <!doctype html><p>home</p>"
```

Two smaller decisions worth naming:

- the embedded map is built from the fixture's **own literal**, not by reading
  the directory back, so "the same bytes" is something a reader can see rather
  than something a walk has to be trusted to have done;
- the response recorder here has only what this question needs — a status and a
  body. The pacing and cancellation halves of the `ServerResponse` contract are
  `standalone.test.js`'s subject and keep their fuller recorder there; a second
  copy would be a second thing to hold in step for a question this file does not
  ask.

## The stale `#342`

`standalone.js` pointed at #342 as open work. It was closed by #394. The *fact*
it records is still true and inherent — a prerendered document is bytes, and
bytes do not run a guard — so the comment now says that, and points at where the
fact is now reported instead of at an issue: `uf build` names every route it
prerendered under a middleware (`crates/uf_cli/src/commands/build/guards.rs`),
`--adapter static` refuses such a project outright, and `build.staticBuild`
makes it an error rather than a warning.

## Verification

All local, all run:

- `uf test#library` — **2856 passed, 0 failed, 1 skipped** (82 files).
- the mutation above, to confirm the new door actually bites.
- `uf fmt --check` and `uf lint` clean on both changed files.
- `uf check` is not in `uf run ci` and is not gated; for the record, the added
  code contributes 5 diagnostics to `deploy.test.js`, every one the same
  `incompatible-variance` on an `appWith(...)` literal that the file already
  produces fourteen times. `standalone.js`'s own count is unchanged at 25.

## Still open on #391

`bun` and `deno` are the two adapters #391 tracks, and `bun` landed in #689.
`deno` keeps `tracking_issue() == Some(391)` and the same
`unimplemented_because`: the `node` output already runs unchanged there, so the
adapter is worth writing only once a benchmark shows the native server beating
`node:http` under the same handler. Nobody has run that one — there is no Deno
on this machine — and inventing a number for it would be the thing the sentence
exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791533989&installation_model_id=422833&pr_number=723&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F723&signature=0be8b1134a9cc0167b2af4d82b7f86af60c56dd1896d951641951edf7482951a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->