### PR TITLE
feat(rsc): whose `useState` it is, and which name an import bound

### DIFF
--- a/crates/uf_rsc/src/directive/function.rs
+++ b/crates/uf_rsc/src/directive/function.rs
@@ -2,14 +2,19 @@
 //!
 //! A directive at the top of a function body turns that one closure into a
 //! server action, so the pass has to decide which `{` opens a function body at
-//! all — the single place the scanner reasons about syntax rather than tokens
-//! — and then walk backwards to whatever names the function, falling back to a
-//! stable ordinal when nothing does.
+//! all, and then walk backwards to whatever names the function, falling back to
+//! a stable ordinal when nothing does.
+//!
+//! Both of those questions are asked elsewhere too — `scan::owner` needs the
+//! same two answers to say which body a `useState` call sits in — so they live
+//! in `crate::scan::owner` and this module reads them. There is one place that
+//! decides whether a `{` opens a function body, for the reason there is one
+//! lexer: a second opinion is a second set of edge cases to keep in step.
 
-use compact_str::CompactString;
 use uf_infra::LineIndex;
 
-use crate::scan::{Token, TokenKind, matching_open};
+use crate::scan::owner::{FunctionHead, function_head, function_name};
+use crate::scan::{Token, TokenKind};
 
 use super::{
     DirectiveIssue, DirectiveKind, DirectiveScan, FunctionDirective, FunctionOwner, line_column,
@@ -70,133 +75,22 @@ pub(crate) fn scan_function_directives(
     }
 }
 
-/// Where the head of a function whose body opens at `brace` sits.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FunctionHead {
-    /// Token index of the `=>` of an arrow function.
-    Arrow(usize),
-    /// Token index of the `)` closing the parameter list.
-    Params(usize),
-}
-
-/// Decide whether the `{` at `brace` opens a function body.
-///
-/// This is the one place the lexer has to reason about syntax. The walk goes
-/// backwards from the brace, skipping a Flow return-type annotation, and stops
-/// at the first token that decides the question:
-///
-/// * `=>` — an arrow function body;
-/// * `)`  — a parameter list, unless the token before its `(` is a control-flow
-///   keyword, which is what separates `function f() {` from `if (c) {`;
-/// * anything else — a block, an object literal, or a class body.
-fn function_head(source: &str, tokens: &[Token], brace: usize) -> Option<FunctionHead> {
-    const MAX_TYPE_TOKENS: usize = 128;
-
-    let mut at = brace.checked_sub(1)?;
-    for _ in 0..MAX_TYPE_TOKENS {
-        let token = tokens.get(at)?;
-        match token.kind {
-            TokenKind::Arrow => return Some(FunctionHead::Arrow(at)),
-            TokenKind::Punct(b')') => {
-                let open = matching_open(tokens, at, b'(', b')')?;
-                let previous = open.checked_sub(1)?;
-                let head = tokens.get(previous)?;
-                if head.kind == TokenKind::Ident
-                    && matches!(
-                        head.text(source),
-                        "if" | "for" | "while" | "switch" | "catch" | "with"
-                    )
-                {
-                    return None;
-                }
-                return Some(FunctionHead::Params(at));
-            }
-            // Tokens a Flow return-type annotation is made of.
-            TokenKind::Ident
-            | TokenKind::String
-            | TokenKind::Number
-            | TokenKind::Punct(
-                b':' | b'<' | b'>' | b'|' | b'&' | b'?' | b'.' | b'[' | b']' | b'+',
-            ) => {
-                if token.kind == TokenKind::Ident
-                    && matches!(token.text(source), "else" | "try" | "do" | "finally")
-                {
-                    return None;
-                }
-                at = at.checked_sub(1)?;
-            }
-            _ => return None,
-        }
-    }
-    None
-}
-
 /// Best-effort name for the function whose head is at `head`.
+///
+/// An inline closure has no name to give, and numbering it is what makes an
+/// anonymous action addressable at all: the ordinal is its position among the
+/// module's other anonymous actions, which is stable as long as the module is.
 fn function_owner(
     source: &str,
     tokens: &[Token],
     head: FunctionHead,
     anonymous: &mut u32,
 ) -> FunctionOwner {
-    let params_start = match head {
-        FunctionHead::Arrow(arrow) => arrow
-            .checked_sub(1)
-            .map(|before| {
-                if tokens[before].is_punct(b')') {
-                    matching_open(tokens, before, b'(', b')').unwrap_or(before)
-                } else {
-                    before
-                }
-            })
-            .unwrap_or(arrow),
-        FunctionHead::Params(close) => matching_open(tokens, close, b'(', b')').unwrap_or(close),
-    };
-
-    if let Some(name) = binding_name(source, tokens, params_start) {
+    if let Some(name) = function_name(source, tokens, head) {
         return FunctionOwner::Named(name);
     }
 
     let ordinal = *anonymous;
     *anonymous = anonymous.saturating_add(1);
     FunctionOwner::Anonymous { ordinal }
-}
-
-/// Walk backwards from the parameter list to whatever names the function.
-fn binding_name(source: &str, tokens: &[Token], params_start: usize) -> Option<CompactString> {
-    const MAX_HEAD_TOKENS: usize = 16;
-
-    let mut at = params_start;
-    for _ in 0..MAX_HEAD_TOKENS {
-        let previous = at.checked_sub(1)?;
-        let token = tokens.get(previous)?;
-        match token.kind {
-            TokenKind::Ident => {
-                let text = token.text(source);
-                if matches!(text, "function" | "async" | "hook" | "component") {
-                    at = previous;
-                    continue;
-                }
-                return Some(CompactString::from(text));
-            }
-            TokenKind::Punct(b'*') => {
-                at = previous;
-                continue;
-            }
-            // Generic parameter list of a method or function.
-            TokenKind::Punct(b'>') => {
-                at = matching_open(tokens, previous, b'<', b'>')?;
-                continue;
-            }
-            TokenKind::Punct(b'=' | b':') => {
-                let name = tokens.get(previous.checked_sub(1)?)?;
-                return match name.kind {
-                    TokenKind::Ident => Some(CompactString::from(name.text(source))),
-                    TokenKind::String => Some(CompactString::from(name.quoted_content(source))),
-                    _ => None,
-                };
-            }
-            _ => return None,
-        }
-    }
-    None
 }

--- a/crates/uf_rsc/src/graph.rs
+++ b/crates/uf_rsc/src/graph.rs
@@ -29,9 +29,9 @@ use crate::directive::{
     scan_directive_tokens,
 };
 use crate::scan::{
-    ClientApiUseList, ExportKind, ExportList, HookCallList, ImportKind, ImportList,
-    ImportSpecifier, ModuleExport, client_api_uses_from_tokens, exports_from_tokens,
-    hook_calls_from_tokens, imports_from_tokens, tokenize,
+    ClientApiUseList, ExportKind, ExportList, HookCallList, ImportBindingList, ImportKind,
+    ImportList, ImportSpecifier, ModuleExport, client_api_uses_from_tokens, exports_from_tokens,
+    hook_calls_from_tokens, imports_from_tokens, owner_spans, tokenize,
 };
 
 mod build;
@@ -102,13 +102,19 @@ fn is_client_only_hook_package(specifier: &str) -> bool {
 /// The package a called hook came from, when this crate can say.
 ///
 /// Attributed through the module's imports rather than through the binding the
-/// import introduced, because `ImportSpecifier` keeps the specifier and drops
-/// the names it bound. That makes this answer wrong in exactly one shape: a
+/// import introduced. That makes this answer wrong in exactly one shape: a
 /// module that imports `@uniflowed/hooks` *and* separately defines or imports
 /// its own `useMediaQuery`, and calls that one. It is the same imprecision the
 /// rest of this scanner already has — it matches identifiers against name
 /// lists — and it is narrower than the alternative of saying nothing, which is
 /// what this did before.
+///
+/// [`ImportSpecifier::bindings`] now carries what would narrow it: the
+/// `{ imported, local }` pairs say whether `useMediaQuery` is the name this
+/// module bound from that package or a different function that shares its
+/// spelling. Reading them here would change which calls are reported, so it
+/// belongs with the rest of the classification work rather than with the
+/// plumbing that made it possible — ubugeeei-prod/uf#388.
 ///
 /// [`None`] is the honest answer and stays reported as one: a hook from a
 /// package with no table, a hook the project wrote, a hook reached through a
@@ -276,6 +282,9 @@ impl RscModuleInput {
         let tokens = tokenize(source);
         let index = LineIndex::new(source);
         let directives = scan_directive_tokens(source, &tokens, &index);
+        // One span table for both use-site collectors, for the same reason
+        // there is one token vector for all five passes.
+        let owners = owner_spans(source, &tokens);
 
         Self {
             path: normalize_module_path(&path.into()),
@@ -283,8 +292,8 @@ impl RscModuleInput {
             imports: imports_from_tokens(source, &tokens, &index),
             exports: exports_from_tokens(source, &tokens, &index),
             function_actions: directives.function_directives,
-            client_api_uses: client_api_uses_from_tokens(source, &tokens, &index),
-            hook_calls: hook_calls_from_tokens(source, &tokens, &index),
+            client_api_uses: client_api_uses_from_tokens(source, &tokens, &index, &owners),
+            hook_calls: hook_calls_from_tokens(source, &tokens, &index, &owners),
             directive_issues: directives.issues,
         }
     }
@@ -295,6 +304,7 @@ impl RscModuleInput {
             specifier: specifier.into(),
             kind: ImportKind::Static,
             line: 1,
+            bindings: ImportBindingList::new(),
         });
         self
     }

--- a/crates/uf_rsc/src/lib.rs
+++ b/crates/uf_rsc/src/lib.rs
@@ -68,10 +68,10 @@ pub use project::{
     analyze_project,
 };
 pub use scan::{
-    CLIENT_ONLY_APIS, CLIENT_ONLY_GLOBALS, ClientApiUse, ExportKind, HookCall, ImportKind,
-    ImportSpecifier, MAX_SOURCE_BYTES, ModuleExport, Token, TokenKind, matching_close,
-    matching_open, scan_client_api_uses, scan_exports, scan_hook_calls, scan_imports,
-    starts_statement, tokenize,
+    CLIENT_ONLY_APIS, CLIENT_ONLY_GLOBALS, ClientApiUse, ExportKind, HookCall, ImportBinding,
+    ImportKind, ImportSpecifier, ImportedName, MAX_SOURCE_BYTES, ModuleExport, Token, TokenKind,
+    matching_close, matching_open, scan_client_api_uses, scan_exports, scan_hook_calls,
+    scan_imports, starts_statement, tokenize,
 };
 pub use types::{
     SERVER_ACTION_TYPES_FILE_NAME, SERVER_ACTION_TYPES_HEADER, ServerActionType,

--- a/crates/uf_rsc/src/scan.rs
+++ b/crates/uf_rsc/src/scan.rs
@@ -19,14 +19,19 @@ mod client_api;
 mod exports;
 mod imports;
 pub mod lexer;
+pub(crate) mod owner;
 
 pub(crate) use client_api::{client_api_uses_from_tokens, hook_calls_from_tokens};
 pub(crate) use exports::exports_from_tokens;
 pub(crate) use imports::imports_from_tokens;
 pub use lexer::{Token, TokenKind, matching_close, matching_open, starts_statement, tokenize};
+pub(crate) use owner::owner_spans;
 
 /// Inline list of import specifiers belonging to one module.
 pub type ImportList = InlineVec<ImportSpecifier, 8>;
+
+/// Inline list of the bindings one import clause introduces.
+pub type ImportBindingList = InlineVec<ImportBinding, 4>;
 
 /// Inline list of exported bindings belonging to one module.
 pub type ExportList = InlineVec<ModuleExport, 8>;
@@ -95,6 +100,60 @@ pub enum ImportKind {
     Require,
 }
 
+/// What an import specifier names in the module it points at.
+///
+/// Three shapes rather than one string, because `*` is not a name a module can
+/// export and `default` is: `import { default as x }` and `import x` bind the
+/// same export and are the same variant here, while a namespace import binds
+/// the module itself and has no exported name behind it at all.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ImportedName {
+    /// The default export: `import x from "m"`, `import { default as x } from "m"`.
+    Default,
+    /// The module itself: `import * as x from "m"`.
+    Namespace,
+    /// A named export: `import { imported as local } from "m"`.
+    Named(CompactString),
+}
+
+impl ImportedName {
+    /// The exported name behind the binding, when there is one.
+    ///
+    /// [`None`] for a namespace import, which binds no single export — a
+    /// caller asking "which export of `@uniflowed/hooks` is this" has to get
+    /// nothing rather than a name it can compare against a table.
+    pub fn as_export_name(&self) -> Option<&str> {
+        match self {
+            Self::Default => Some("default"),
+            Self::Namespace => None,
+            Self::Named(name) => Some(name.as_str()),
+        }
+    }
+}
+
+/// One `{ imported, local }` pair of an import clause.
+///
+/// The pair rather than either half alone. Collapsing them loses the aliased
+/// import — `import { useState as useS } from "react"` binds `useS` in this
+/// module and names `useState` in React's — so a scanner that keeps only the
+/// local name cannot look a hook up in a package's table, and one that keeps
+/// only the imported name cannot connect a call site to it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportBinding {
+    /// The name in the module the specifier points at.
+    pub imported: ImportedName,
+    /// The name this module binds it under.
+    ///
+    /// A module-scope binding for every [`ImportKind`] but
+    /// [`ImportKind::ReExport`], where `export { a as b } from "m"` introduces
+    /// no local binding at all and `b` is the name this module *exports* it
+    /// as. Both answer the same question — which name here is that name there
+    /// — so both are recorded, and the kind says which reading applies.
+    pub local: CompactString,
+}
+
 /// One import specifier as written in the source.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -105,6 +164,15 @@ pub struct ImportSpecifier {
     pub kind: ImportKind,
     /// 1-based line the specifier appeared on.
     pub line: u32,
+    /// The names the clause binds, in source order.
+    ///
+    /// Empty when the form binds nothing the scanner can name: a bare
+    /// `import "m"`, an `export * from "m"`, a dynamic `import("m")` or a
+    /// `require("m")` — the last two because what they bind is decided by the
+    /// expression around them and not by a clause. Flow's inline type
+    /// specifiers are dropped with the rest of the types: `import { type T, a }`
+    /// binds only `a` at runtime.
+    pub bindings: ImportBindingList,
 }
 
 /// Shape of an exported binding, as far as a lexer can tell.
@@ -158,6 +226,13 @@ pub struct HookCall {
     pub line: u32,
     /// 1-based column of the call.
     pub column: u32,
+    /// The module-level declaration whose body the call sits in.
+    ///
+    /// Same rule and same caveats as [`ClientApiUse::owner`]. It is the second
+    /// half of the fixpoint's edge set: a wrapper is client-only when it
+    /// reaches a client-only API *or* calls a hook that does, and without an
+    /// owner here the second clause has no left-hand side.
+    pub owner: Option<CompactString>,
 }
 
 /// One use of a client-only API inside a module.
@@ -170,6 +245,18 @@ pub struct ClientApiUse {
     pub line: u32,
     /// 1-based column of the use.
     pub column: u32,
+    /// The module-level declaration whose body the use sits in.
+    ///
+    /// A line and a column say where a `useState` is; this says whose it is,
+    /// which is what turns "this module reaches a client-only API" into "this
+    /// *export* does" — the edge an export-graph fixpoint propagates along.
+    /// See ubugeeei-prod/uf#388.
+    ///
+    /// [`None`] for a use no module-level body contains: module top-level
+    /// code, a method of a class or an object literal, and an anonymous body.
+    /// Not a fallback to the nearest enclosing name — an owner that might be
+    /// wrong is worse than none, because the fixpoint would propagate it.
+    pub owner: Option<CompactString>,
 }
 
 /// Collect the import specifiers of a module.
@@ -190,14 +277,16 @@ pub fn scan_exports(source: &str) -> ExportList {
 pub fn scan_client_api_uses(source: &str) -> ClientApiUseList {
     let tokens = tokenize(source);
     let index = LineIndex::new(source);
-    client_api_uses_from_tokens(source, &tokens, &index)
+    let owners = owner_spans(source, &tokens);
+    client_api_uses_from_tokens(source, &tokens, &index, &owners)
 }
 
 /// Collect calls to hooks that [`CLIENT_ONLY_APIS`] does not name.
 pub fn scan_hook_calls(source: &str) -> HookCallList {
     let tokens = tokenize(source);
     let index = LineIndex::new(source);
-    hook_calls_from_tokens(source, &tokens, &index)
+    let owners = owner_spans(source, &tokens);
+    hook_calls_from_tokens(source, &tokens, &index, &owners)
 }
 
 /// Clamp a `usize` position into the `u32` used by diagnostics.

--- a/crates/uf_rsc/src/scan/client_api.rs
+++ b/crates/uf_rsc/src/scan/client_api.rs
@@ -13,11 +13,18 @@
 //! silent in the other: `useRoute` is built on `useContext`, and a call to
 //! `useRoute` looks like a call to nothing at all. [`hook_calls_from_tokens`]
 //! is the second half of that sentence, said out loud.
+//!
+//! Both collectors record, beside the line and the column, the module-level
+//! declaration the use sits in — `super::owner` has the rule and what it
+//! declines to answer. That is what makes "this module reaches `useState`" into
+//! "`useTheme` does", which is the difference between a fact about a file and
+//! an edge an export graph can propagate along.
 
 use compact_str::CompactString;
 use uf_infra::LineIndex;
 
 use super::lexer::{Token, TokenKind, matching_close};
+use super::owner::{OwnerSpan, owner_at};
 use super::{
     CLIENT_ONLY_APIS, CLIENT_ONLY_GLOBALS, ClientApiUse, ClientApiUseList, HookCall, HookCallList,
     clamp_u32,
@@ -27,6 +34,7 @@ pub(crate) fn client_api_uses_from_tokens(
     source: &str,
     tokens: &[Token],
     index: &LineIndex,
+    owners: &[OwnerSpan],
 ) -> ClientApiUseList {
     let mut uses = ClientApiUseList::new();
     for (position, token) in tokens.iter().enumerate() {
@@ -64,11 +72,12 @@ pub(crate) fn client_api_uses_from_tokens(
         });
 
         if let Some(api) = matched {
-            let position = index.line_col(token.start);
+            let at = index.line_col(token.start);
             uses.push(ClientApiUse {
                 api,
-                line: clamp_u32(position.line),
-                column: clamp_u32(position.column),
+                line: clamp_u32(at.line),
+                column: clamp_u32(at.column),
+                owner: owner_at(owners, position),
             });
         }
     }
@@ -175,6 +184,7 @@ pub(crate) fn hook_calls_from_tokens(
     source: &str,
     tokens: &[Token],
     index: &LineIndex,
+    owners: &[OwnerSpan],
 ) -> HookCallList {
     let mut calls = HookCallList::new();
     for (position, token) in tokens.iter().enumerate() {
@@ -210,6 +220,7 @@ pub(crate) fn hook_calls_from_tokens(
             name: CompactString::new(text),
             line: clamp_u32(at.line),
             column: clamp_u32(at.column),
+            owner: owner_at(owners, position),
         });
     }
     calls

--- a/crates/uf_rsc/src/scan/imports.rs
+++ b/crates/uf_rsc/src/scan/imports.rs
@@ -13,12 +13,27 @@
 //! endpoints from who reaches whom, and a Client Component that imports a
 //! *type* from a server module used to make every action that module reaches
 //! dialable from the browser. A type annotation must not open an endpoint.
+//!
+//! The same rule one level down: `import { type T, useRoute } from "./m.js"` is
+//! an edge, and only `useRoute` is a binding of it.
+//!
+//! # The clause, and not only the specifier
+//!
+//! Each specifier carries the `{ imported, local }` pairs its clause
+//! introduced. A specifier alone says this module depends on `"react"`; the
+//! pairs say `useS` here is `useState` there, which is what connects a call
+//! site to a name a package's table can be looked up by. Keeping only one half
+//! loses the aliased import in one direction or the other — see
+//! [`ImportBinding`](super::ImportBinding).
 
 use compact_str::CompactString;
 use uf_infra::LineIndex;
 
-use super::lexer::{Token, TokenKind, starts_statement};
-use super::{ImportKind, ImportList, ImportSpecifier, clamp_u32};
+use super::lexer::{Token, TokenKind, matching_close, starts_statement};
+use super::{
+    ImportBinding, ImportBindingList, ImportKind, ImportList, ImportSpecifier, ImportedName,
+    clamp_u32,
+};
 
 pub(crate) fn imports_from_tokens(source: &str, tokens: &[Token], index: &LineIndex) -> ImportList {
     let mut imports = ImportList::new();
@@ -37,26 +52,45 @@ pub(crate) fn imports_from_tokens(source: &str, tokens: &[Token], index: &LineIn
                 }
                 if let Some(next) = tokens.get(position + 1) {
                     if next.kind == TokenKind::String {
-                        push_specifier(&mut imports, source, next, ImportKind::Static, index);
+                        // `import "m"`: a side effect and no bindings.
+                        push_specifier(
+                            &mut imports,
+                            source,
+                            next,
+                            ImportKind::Static,
+                            index,
+                            ImportBindingList::new(),
+                        );
                         continue;
                     }
                     if next.is_punct(b'(') {
                         if let Some(literal) = tokens.get(position + 2)
                             && literal.kind == TokenKind::String
                         {
+                            // What `import("m")` binds is decided by the
+                            // expression around it, not by a clause.
                             push_specifier(
                                 &mut imports,
                                 source,
                                 literal,
                                 ImportKind::Dynamic,
                                 index,
+                                ImportBindingList::new(),
                             );
                         }
                         continue;
                     }
                 }
-                if let Some(literal) = find_from_clause(source, tokens, position) {
-                    push_specifier(&mut imports, source, literal, ImportKind::Static, index);
+                if let Some(from) = find_from_clause(source, tokens, position) {
+                    let bindings = clause_bindings(source, tokens, position + 1, from);
+                    push_specifier(
+                        &mut imports,
+                        source,
+                        &tokens[from + 1],
+                        ImportKind::Static,
+                        index,
+                        bindings,
+                    );
                 }
             }
             "export" => {
@@ -70,8 +104,16 @@ pub(crate) fn imports_from_tokens(source: &str, tokens: &[Token], index: &LineIn
                 }) {
                     continue;
                 }
-                if let Some(literal) = find_from_clause(source, tokens, position) {
-                    push_specifier(&mut imports, source, literal, ImportKind::ReExport, index);
+                if let Some(from) = find_from_clause(source, tokens, position) {
+                    let bindings = clause_bindings(source, tokens, position + 1, from);
+                    push_specifier(
+                        &mut imports,
+                        source,
+                        &tokens[from + 1],
+                        ImportKind::ReExport,
+                        index,
+                        bindings,
+                    );
                 }
             }
             "require" => {
@@ -84,7 +126,14 @@ pub(crate) fn imports_from_tokens(source: &str, tokens: &[Token], index: &LineIn
                 if let Some(literal) = tokens.get(position + 2)
                     && literal.kind == TokenKind::String
                 {
-                    push_specifier(&mut imports, source, literal, ImportKind::Require, index);
+                    push_specifier(
+                        &mut imports,
+                        source,
+                        literal,
+                        ImportKind::Require,
+                        index,
+                        ImportBindingList::new(),
+                    );
                 }
             }
             _ => {}
@@ -123,21 +172,168 @@ fn push_specifier(
     literal: &Token,
     kind: ImportKind,
     index: &LineIndex,
+    bindings: ImportBindingList,
 ) {
     let position = index.line_col(literal.start);
     imports.push(ImportSpecifier {
         specifier: CompactString::from(literal.quoted_content(source)),
         kind,
         line: clamp_u32(position.line),
+        bindings,
     });
 }
 
-/// Find the string literal of a `from "..."` clause started at `position`.
-pub(crate) fn find_from_clause<'a>(
+/// The `{ imported, local }` pairs of the clause in `start..end`.
+///
+/// `end` is the index of the `from` keyword, so the range is exactly what was
+/// written between the `import` (or `export`) and the specifier: a default
+/// binding, a namespace binding, a braced list, or any comma-separated
+/// combination of them.
+fn clause_bindings(source: &str, tokens: &[Token], start: usize, end: usize) -> ImportBindingList {
+    let mut bindings = ImportBindingList::new();
+    let mut at = start;
+
+    while at < end {
+        let token = &tokens[at];
+
+        if token.is_punct(b'*') {
+            // `* as ns`, the one form whose local name binds no single export.
+            if let Some(local) = aliased_name(source, tokens, at, end) {
+                bindings.push(ImportBinding {
+                    imported: ImportedName::Namespace,
+                    local,
+                });
+                at += 3;
+                continue;
+            }
+            at += 1;
+            continue;
+        }
+
+        if token.is_punct(b'{') {
+            let close = matching_close(tokens, at, b'{', b'}')
+                .unwrap_or(end)
+                .min(end);
+            named_bindings(source, tokens, at + 1, close, &mut bindings);
+            at = close + 1;
+            continue;
+        }
+
+        if token.kind == TokenKind::Ident {
+            // A bare name in a clause is the default binding: `import d from`.
+            bindings.push(ImportBinding {
+                imported: ImportedName::Default,
+                local: CompactString::from(token.text(source)),
+            });
+            at += 1;
+            continue;
+        }
+
+        at += 1;
+    }
+
+    bindings
+}
+
+/// The `local` of an `as local` following the token at `at`, if there is one.
+fn aliased_name(source: &str, tokens: &[Token], at: usize, end: usize) -> Option<CompactString> {
+    if at + 2 >= end {
+        return None;
+    }
+    let keyword = tokens.get(at + 1)?;
+    if keyword.kind != TokenKind::Ident || keyword.text(source) != "as" {
+        return None;
+    }
+    let local = tokens.get(at + 2)?;
+    (local.kind == TokenKind::Ident).then(|| CompactString::from(local.text(source)))
+}
+
+/// Split a braced specifier list into its pairs.
+///
+/// Each comma-separated entry is one of `a`, `a as b`, `type T`, `type T as U`
+/// or `"a-b" as c` — the last being ES2022's arbitrary module namespace names,
+/// which are legal export names a lexer would otherwise drop.
+fn named_bindings(
     source: &str,
-    tokens: &'a [Token],
-    position: usize,
-) -> Option<&'a Token> {
+    tokens: &[Token],
+    start: usize,
+    end: usize,
+    bindings: &mut ImportBindingList,
+) {
+    let mut at = start;
+    while at < end {
+        let mut next = at;
+        while next < end && !tokens[next].is_punct(b',') {
+            next += 1;
+        }
+        push_named_binding(source, &tokens[at..next], bindings);
+        at = next + 1;
+    }
+}
+
+/// Read one entry of a braced specifier list.
+fn push_named_binding(source: &str, entry: &[Token], bindings: &mut ImportBindingList) {
+    let Some(first) = entry.first() else {
+        return;
+    };
+
+    // `{ type T }` and `{ typeof x }` are erased, and `{ type }` and
+    // `{ type as t }` are not: what separates them is whether a *name* follows
+    // the keyword, which is exactly the test the statement-level
+    // `is_type_only_import` makes one level up.
+    if first.kind == TokenKind::Ident
+        && matches!(first.text(source), "type" | "typeof")
+        && entry
+            .get(1)
+            .is_some_and(|next| next.kind == TokenKind::Ident && next.text(source) != "as")
+    {
+        return;
+    }
+
+    let Some(imported) = specifier_name(source, first) else {
+        return;
+    };
+    let local = match (entry.get(1), entry.get(2)) {
+        (Some(keyword), Some(local))
+            if keyword.kind == TokenKind::Ident
+                && keyword.text(source) == "as"
+                && local.kind == TokenKind::Ident =>
+        {
+            CompactString::from(local.text(source))
+        }
+        // Unaliased, so the two names are the same one. A string entry with no
+        // alias is not legal — `import { "a-b" } from "m"` binds nothing
+        // nameable — and falls out here as the imported name repeated, which
+        // no lookup can be wrong about.
+        _ => imported.clone(),
+    };
+
+    bindings.push(ImportBinding {
+        imported: if imported == "default" {
+            // `import { default as x }` and `import x` name the same export.
+            ImportedName::Default
+        } else {
+            ImportedName::Named(imported)
+        },
+        local,
+    });
+}
+
+/// The exported name an entry starts with, identifier or string literal.
+fn specifier_name(source: &str, token: &Token) -> Option<CompactString> {
+    match token.kind {
+        TokenKind::Ident => Some(CompactString::from(token.text(source))),
+        TokenKind::String => Some(CompactString::from(token.quoted_content(source))),
+        _ => None,
+    }
+}
+
+/// Find the `from` keyword of a `from "..."` clause started at `position`.
+///
+/// Returns the index of the keyword, so a caller that wants the specifier
+/// reads `tokens[index + 1]` — checked to be a string literal before this
+/// returns — and a caller that wants the clause has its end.
+pub(crate) fn find_from_clause(source: &str, tokens: &[Token], position: usize) -> Option<usize> {
     let mut at = position + 1;
     let limit = (position + 512).min(tokens.len());
     while at < limit {
@@ -147,7 +343,7 @@ pub(crate) fn find_from_clause<'a>(
         }
         if token.kind == TokenKind::Ident && token.text(source) == "from" {
             let literal = tokens.get(at + 1)?;
-            return (literal.kind == TokenKind::String).then_some(literal);
+            return (literal.kind == TokenKind::String).then_some(at);
         }
         at += 1;
     }

--- a/crates/uf_rsc/src/scan/owner.rs
+++ b/crates/uf_rsc/src/scan/owner.rs
@@ -1,0 +1,265 @@
+//! Which declaration's body a token sits inside.
+//!
+//! A line and a column say *where* a use of `useState` is. They do not say
+//! *whose* it is, and that is the fact an export-graph fixpoint needs: an
+//! exported function is a client hook when its body reaches a client-only API,
+//! so every use site has to be attributable to the body that contains it or
+//! there is nothing to propagate. See ubugeeei-prod/uf#388.
+//!
+//! # The rule
+//!
+//! The owner of a token is the **module-level declaration whose body contains
+//! it**, and there is at most one: a body opened by a `{` that no other
+//! bracket encloses runs to that brace's match, and two such spans are
+//! therefore disjoint. A token no such span contains — module top-level code,
+//! an import clause, the initializer of a plain `const` — has no owner, which
+//! is the honest answer and not a fallback to the nearest name.
+//!
+//! Nested bodies are deliberately not spans of their own. A `useEffect`
+//! callback inside `useTheme` belongs to `useTheme` for every question this
+//! crate asks, because `useTheme` is the name another module can import; the
+//! callback has no name at all. Skipping the body once its span is recorded is
+//! what implements that, and it is also what keeps the walk linear.
+//!
+//! # What it is wrong about
+//!
+//! * A method body — `class Store { read() { … } }`, or the same shape in an
+//!   object literal — is enclosed by the class or object brace, so it is not a
+//!   module-level body and its uses have no owner. Naming the method would be
+//!   worse: `read` is not a name any importer can reach, and it can collide
+//!   with an export that has nothing to do with it.
+//! * A declaration the lexer cannot name — `export default (() => { … })()`,
+//!   a body reached through a call — records no span, so its uses have no
+//!   owner rather than the wrong one.
+//! * A binding redefined mid-body. The span says which body a use is in; it
+//!   does not say that the `useState` inside it is React's.
+//!
+//! All three fail towards [`None`], which downstream reads as "uf cannot say"
+//! — the state this crate already reports rather than guesses at.
+
+use compact_str::CompactString;
+
+use super::lexer::{Token, TokenKind, matching_close, matching_open};
+
+/// One module-level declaration body, as a token range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OwnerSpan {
+    /// Name of the declaration the body belongs to.
+    pub(crate) name: CompactString,
+    /// Token index of the `{` opening the body.
+    pub(crate) open: usize,
+    /// Token index of the `}` closing it.
+    pub(crate) close: usize,
+}
+
+/// Where the head of a function whose body opens at a `{` sits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FunctionHead {
+    /// Token index of the `=>` of an arrow function.
+    Arrow(usize),
+    /// Token index of the `)` closing the parameter list.
+    Params(usize),
+}
+
+/// Decide whether the `{` at `brace` opens a function body.
+///
+/// This is the one place the lexer has to reason about syntax. The walk goes
+/// backwards from the brace, skipping a Flow return-type annotation, and stops
+/// at the first token that decides the question:
+///
+/// * `=>` — an arrow function body;
+/// * `)`  — a parameter list, unless the token before its `(` is a control-flow
+///   keyword, which is what separates `function f() {` from `if (c) {`;
+/// * anything else — a block, an object literal, or a class body.
+///
+/// # A return type is stepped over, not walked through
+///
+/// A `]` or a `>` jumps to its opener rather than being stepped past one token
+/// at a time, because a Flow return type can contain the very tokens this walk
+/// stops at. `hook useTheme(): [Theme, (next: Theme) => void] {` is not an
+/// arrow function, and a walk that meets that `=>` before the `)` of the
+/// parameter list says it is — which is how the hook the issue was filed about
+/// ended up unnameable. An unmatched closer steps back one token, which is what
+/// it did before.
+///
+/// A `}` is not jumped, and an object-type return annotation is the price. The
+/// group before a `{` is far more often the body of the *previous* declaration
+/// — `function setup() {}` and then a bare block — and walking behind it would
+/// hand that block the previous function's parameter list and its name. A
+/// wrong owner propagates; a missing one is the answer this crate already
+/// gives.
+pub(crate) fn function_head(source: &str, tokens: &[Token], brace: usize) -> Option<FunctionHead> {
+    const MAX_TYPE_TOKENS: usize = 128;
+
+    let mut at = brace.checked_sub(1)?;
+    for _ in 0..MAX_TYPE_TOKENS {
+        let token = tokens.get(at)?;
+        match token.kind {
+            TokenKind::Arrow => return Some(FunctionHead::Arrow(at)),
+            TokenKind::Punct(b')') => {
+                let open = matching_open(tokens, at, b'(', b')')?;
+                let previous = open.checked_sub(1)?;
+                let head = tokens.get(previous)?;
+                if head.kind == TokenKind::Ident
+                    && matches!(
+                        head.text(source),
+                        "if" | "for" | "while" | "switch" | "catch" | "with"
+                    )
+                {
+                    return None;
+                }
+                return Some(FunctionHead::Params(at));
+            }
+            // A group of the annotation: `[…]` or `<…>`. Behind it in one step,
+            // so nothing inside it can be mistaken for the head.
+            TokenKind::Punct(b']') => {
+                at = matching_open(tokens, at, b'[', b']').unwrap_or(at);
+                at = at.checked_sub(1)?;
+            }
+            TokenKind::Punct(b'>') => {
+                at = matching_open(tokens, at, b'<', b'>').unwrap_or(at);
+                at = at.checked_sub(1)?;
+            }
+            // Tokens a Flow return-type annotation is made of.
+            TokenKind::Ident
+            | TokenKind::String
+            | TokenKind::Number
+            | TokenKind::Punct(b':' | b'<' | b'|' | b'&' | b'?' | b'.' | b'[' | b'+') => {
+                if token.kind == TokenKind::Ident
+                    && matches!(token.text(source), "else" | "try" | "do" | "finally")
+                {
+                    return None;
+                }
+                at = at.checked_sub(1)?;
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Best-effort name of the function whose head is at `head`.
+///
+/// [`None`] for a genuine anonymous closure — a callback, an IIFE — which the
+/// two callers then say differently: a `"use server"` directive numbers it,
+/// and an owner span declines to exist.
+pub(crate) fn function_name(
+    source: &str,
+    tokens: &[Token],
+    head: FunctionHead,
+) -> Option<CompactString> {
+    let params_start = match head {
+        FunctionHead::Arrow(arrow) => arrow
+            .checked_sub(1)
+            .map(|before| {
+                if tokens[before].is_punct(b')') {
+                    matching_open(tokens, before, b'(', b')').unwrap_or(before)
+                } else {
+                    before
+                }
+            })
+            .unwrap_or(arrow),
+        FunctionHead::Params(close) => matching_open(tokens, close, b'(', b')').unwrap_or(close),
+    };
+    binding_name(source, tokens, params_start)
+}
+
+/// Walk backwards from the parameter list to whatever names the function.
+fn binding_name(source: &str, tokens: &[Token], params_start: usize) -> Option<CompactString> {
+    const MAX_HEAD_TOKENS: usize = 16;
+
+    let mut at = params_start;
+    for _ in 0..MAX_HEAD_TOKENS {
+        let previous = at.checked_sub(1)?;
+        let token = tokens.get(previous)?;
+        match token.kind {
+            TokenKind::Ident => {
+                let text = token.text(source);
+                if matches!(text, "function" | "async" | "hook" | "component") {
+                    at = previous;
+                    continue;
+                }
+                return Some(CompactString::from(text));
+            }
+            TokenKind::Punct(b'*') => {
+                at = previous;
+                continue;
+            }
+            // Generic parameter list of a method or function.
+            TokenKind::Punct(b'>') => {
+                at = matching_open(tokens, previous, b'<', b'>')?;
+                continue;
+            }
+            TokenKind::Punct(b'=' | b':') => {
+                let name = tokens.get(previous.checked_sub(1)?)?;
+                return match name.kind {
+                    TokenKind::Ident => Some(CompactString::from(name.text(source))),
+                    TokenKind::String => Some(CompactString::from(name.quoted_content(source))),
+                    _ => None,
+                };
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// The module-level declaration bodies of one module, in source order.
+///
+/// Linear in the token count: every token is visited once, and a body is
+/// skipped whole rather than descended into, so a deeply nested module costs
+/// no more than a flat one.
+pub(crate) fn owner_spans(source: &str, tokens: &[Token]) -> Vec<OwnerSpan> {
+    let mut spans: Vec<OwnerSpan> = Vec::new();
+    // Nesting of every bracket kind, not just braces: a `{` inside a call
+    // argument or an array is not a module-level declaration's body, and
+    // `foo({ bar() { … } })` would otherwise look like one.
+    let mut depth = 0usize;
+    let mut at = 0usize;
+
+    while at < tokens.len() {
+        let token = &tokens[at];
+        if token.is_punct(b'{') {
+            if depth == 0
+                && let Some(head) = function_head(source, tokens, at)
+                && let Some(name) = function_name(source, tokens, head)
+                && let Some(close) = matching_close(tokens, at, b'{', b'}')
+            {
+                spans.push(OwnerSpan {
+                    name,
+                    open: at,
+                    close,
+                });
+                at = close + 1;
+                continue;
+            }
+            depth += 1;
+        } else if token.is_punct(b'(') || token.is_punct(b'[') {
+            depth += 1;
+        } else if token.is_punct(b'}') || token.is_punct(b')') || token.is_punct(b']') {
+            // Saturating rather than panicking: an unbalanced source is a
+            // syntax error somebody else reports, and this walk still has to
+            // finish over it.
+            depth = depth.saturating_sub(1);
+        }
+        at += 1;
+    }
+
+    spans
+}
+
+/// The declaration whose body contains the token at `position`.
+///
+/// The spans are disjoint and in ascending order, so the first one that starts
+/// after `position` ends the search: no later span can reach back over it.
+pub(crate) fn owner_at(spans: &[OwnerSpan], position: usize) -> Option<CompactString> {
+    for span in spans {
+        if span.open > position {
+            break;
+        }
+        if position < span.close {
+            return Some(span.name.clone());
+        }
+    }
+    None
+}

--- a/crates/uf_rsc/src/scan/tests.rs
+++ b/crates/uf_rsc/src/scan/tests.rs
@@ -366,3 +366,330 @@ fn a_method_definition_is_not_a_client_api_use() {
     assert!(scan_client_api_uses("const o = { useEffect() {} };").is_empty());
     assert!(!scan_client_api_uses("function Page() { useState(1); }").is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// Import bindings: which local name an import binds, and to which export.
+// ---------------------------------------------------------------------------
+
+fn bindings(source: &str) -> Vec<(ImportedName, String)> {
+    scan_imports(source)
+        .iter()
+        .flat_map(|import| import.bindings.clone())
+        .map(|binding| (binding.imported, binding.local.to_string()))
+        .collect()
+}
+
+fn named(imported: &str, local: &str) -> (ImportedName, String) {
+    (
+        ImportedName::Named(CompactString::from(imported)),
+        local.to_string(),
+    )
+}
+
+/// The case the pair exists for. Collapsing `{ imported, local }` into either
+/// half loses an aliased import: the local name `useS` is what the call site
+/// two lines down says, and `useState` is what a package's table is keyed on.
+#[test]
+fn an_aliased_import_keeps_both_names() {
+    let source = "import { useState as useS } from \"react\";\n";
+    assert_eq!(bindings(source), vec![named("useState", "useS")]);
+
+    let import = &scan_imports(source)[0];
+    assert_eq!(import.specifier, "react");
+    assert_eq!(
+        import.bindings[0].imported.as_export_name(),
+        Some("useState"),
+        "the aliased name must still resolve to the export it renames"
+    );
+}
+
+/// An unaliased import binds the same name twice, which is what makes a lookup
+/// by either half agree.
+#[test]
+fn an_unaliased_import_binds_the_name_it_names() {
+    assert_eq!(
+        bindings("import { useRoute } from \"@uniflowed/router\";\n"),
+        vec![named("useRoute", "useRoute")]
+    );
+}
+
+#[test]
+fn every_clause_shape_records_what_it_binds() {
+    assert_eq!(
+        bindings("import Counter from \"./Counter.js\";\n"),
+        vec![(ImportedName::Default, "Counter".to_string())]
+    );
+    assert_eq!(
+        bindings("import * as hooks from \"@uniflowed/hooks\";\n"),
+        vec![(ImportedName::Namespace, "hooks".to_string())]
+    );
+    assert_eq!(
+        bindings("import React, { useState, useRef as ref } from \"react\";\n"),
+        vec![
+            (ImportedName::Default, "React".to_string()),
+            named("useState", "useState"),
+            named("useRef", "ref"),
+        ]
+    );
+    assert_eq!(
+        bindings("import Counter, * as all from \"./Counter.js\";\n"),
+        vec![
+            (ImportedName::Default, "Counter".to_string()),
+            (ImportedName::Namespace, "all".to_string()),
+        ]
+    );
+    // `import x` and `import { default as x }` name the same export, so they
+    // are the same variant here.
+    assert_eq!(
+        bindings("import { default as Counter } from \"./Counter.js\";\n"),
+        vec![(ImportedName::Default, "Counter".to_string())]
+    );
+    // ES2022 arbitrary module namespace names are legal export names.
+    assert_eq!(
+        bindings("import { \"use-route\" as useRoute } from \"./m.js\";\n"),
+        vec![named("use-route", "useRoute")]
+    );
+}
+
+/// A re-export binds no module-scope name; `useCurrentRoute` is what this
+/// module exports the other module's `useRoute` as, which answers the same
+/// question from the other side.
+#[test]
+fn a_re_export_records_the_name_it_publishes() {
+    let source = "export { useRoute as useCurrentRoute } from \"./router.js\";\n";
+    assert_eq!(scan_imports(source)[0].kind, ImportKind::ReExport);
+    assert_eq!(bindings(source), vec![named("useRoute", "useCurrentRoute")]);
+}
+
+/// The forms that are edges and bind nothing a clause can name.
+#[test]
+fn a_form_with_no_clause_binds_nothing() {
+    for source in [
+        "import \"./side-effect.js\";\n",
+        "export * from \"./barrel.js\";\n",
+        "const lazy = import(\"./lazy.js\");\n",
+        "const legacy = require(\"./legacy.js\");\n",
+    ] {
+        assert!(
+            scan_imports(source)[0].bindings.is_empty(),
+            "clause-less form bound something: {source}"
+        );
+    }
+}
+
+/// Inline type specifiers are erased with the rest of the types, exactly as the
+/// statement-level `import type` is — and by the same test, so `{ type }` and
+/// `{ type as t }`, which import a value called `type`, survive.
+#[test]
+fn inline_type_specifiers_are_not_bindings() {
+    assert_eq!(
+        bindings("import { type Theme, typeof Store, useTheme } from \"./theme.js\";\n"),
+        vec![named("useTheme", "useTheme")]
+    );
+    assert_eq!(
+        bindings("import { type } from \"./m.js\";\n"),
+        vec![named("type", "type")]
+    );
+    assert_eq!(
+        bindings("import { type as t } from \"./m.js\";\n"),
+        vec![named("type", "t")]
+    );
+    assert_eq!(
+        bindings("import { type Theme as T } from \"./theme.js\";\n"),
+        vec![],
+        "an aliased type specifier is still a type specifier"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Owners: which body a use site is in.
+// ---------------------------------------------------------------------------
+
+fn use_owners(source: &str) -> Vec<(&'static str, Option<String>)> {
+    scan_client_api_uses(source)
+        .iter()
+        .map(|use_site| {
+            (
+                use_site.api,
+                use_site.owner.as_ref().map(ToString::to_string),
+            )
+        })
+        .collect()
+}
+
+/// The nesting case. A `localStorage` inside a callback inside `useTheme`
+/// belongs to `useTheme`: the callback has no name any importer can reach, and
+/// `useTheme` is the binding an export-graph fixpoint propagates along.
+#[test]
+fn a_use_inside_a_nested_closure_belongs_to_the_declaration_that_holds_it() {
+    let source = r#"
+export hook useTheme() {
+  const [theme, setTheme] = useState("system");
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    subscribe(() => setTheme(stored));
+  }, []);
+  return theme;
+}
+"#;
+    assert_eq!(
+        use_owners(source),
+        vec![
+            ("useState", Some("useTheme".to_string())),
+            ("useEffect", Some("useTheme".to_string())),
+            ("localStorage", Some("useTheme".to_string())),
+        ]
+    );
+}
+
+/// And a use no declaration holds gets nothing rather than the nearest name.
+/// A wrong owner propagates through a fixpoint; a missing one is the answer
+/// this crate already gives for everything it cannot decide.
+#[test]
+fn a_use_at_module_top_level_has_no_owner() {
+    let source = r#"
+const theme = localStorage.getItem("theme");
+export hook useTheme() {
+  return useState(theme);
+}
+if (window.matchMedia) { track(); }
+"#;
+    assert_eq!(
+        use_owners(source),
+        vec![
+            ("localStorage", None),
+            ("useState", Some("useTheme".to_string())),
+            ("window", None),
+        ]
+    );
+}
+
+/// Every declaration shape a hook is written in, including the one the issue
+/// was filed about: a Flow return type holding a function type used to make
+/// the walk mistake its `=>` for the head of an arrow function, so `useTheme`
+/// had no name at all.
+#[test]
+fn a_declaration_is_named_however_it_is_written() {
+    for (source, owner) in [
+        ("function Page() { useState(1); }", "Page"),
+        ("export function Page() { useState(1); }", "Page"),
+        ("export async function load() { useState(1); }", "load"),
+        ("hook useTheme() { useState(1); }", "useTheme"),
+        ("component Card() { useState(1); }", "Card"),
+        ("const useTheme = () => { useState(1); };", "useTheme"),
+        (
+            "export const useTheme = function () { useState(1); };",
+            "useTheme",
+        ),
+        ("export default function Page() { useState(1); }", "Page"),
+        ("export default function () { useState(1); }", "default"),
+        ("export default () => { useState(1); };", "default"),
+        (
+            "export hook useTheme(): Promise<number> { useState(1); }",
+            "useTheme",
+        ),
+        (
+            "export hook useTheme(): [string, (next: string) => void] { useState(1); }",
+            "useTheme",
+        ),
+    ] {
+        assert_eq!(
+            use_owners(source),
+            vec![("useState", Some(owner.to_string()))],
+            "wrong owner for: {source}"
+        );
+    }
+}
+
+/// Two declarations in one module are two disjoint bodies, and neither borrows
+/// the other's uses.
+#[test]
+fn each_declaration_owns_only_its_own_body() {
+    let source = r#"
+export hook useA() { useState(1); }
+export hook useB() { useEffect(noop); }
+"#;
+    assert_eq!(
+        use_owners(source),
+        vec![
+            ("useState", Some("useA".to_string())),
+            ("useEffect", Some("useB".to_string())),
+        ]
+    );
+}
+
+/// A method body is not a module-level declaration, and naming it would be
+/// worse than naming nothing: `read` is not a name an importer can reach, and
+/// it can collide with an export that has nothing to do with it.
+#[test]
+fn a_use_inside_a_method_has_no_module_level_owner() {
+    for source in [
+        "class Store { read() { return localStorage.getItem(\"k\"); } }",
+        "const store = { read() { return localStorage.getItem(\"k\"); } };",
+        "register({ onMount() { useEffect(noop); } });",
+    ] {
+        let owners: Vec<_> = scan_client_api_uses(source)
+            .iter()
+            .map(|use_site| use_site.owner.clone())
+            .collect();
+        assert_eq!(owners, vec![None], "method body claimed an owner: {source}");
+    }
+}
+
+/// The other half of the fixpoint's edge set. A wrapper is client-only when it
+/// reaches a client-only API *or* calls a hook that does, and the second clause
+/// needs the calling body as much as the first.
+#[test]
+fn a_hook_call_records_the_body_that_makes_it() {
+    let source = r#"
+export hook useTheme() {
+  const { pathname } = useRoute();
+  useMediaQuery(() => track());
+}
+useRoute();
+"#;
+    let owners: Vec<_> = scan_hook_calls(source)
+        .iter()
+        .map(|call| {
+            (
+                call.name.to_string(),
+                call.owner.as_ref().map(ToString::to_string),
+            )
+        })
+        .collect();
+    assert_eq!(
+        owners,
+        vec![
+            ("useRoute".to_string(), Some("useTheme".to_string())),
+            ("useMediaQuery".to_string(), Some("useTheme".to_string())),
+            ("useRoute".to_string(), None),
+        ]
+    );
+}
+
+/// An anonymous body at module level names nobody, so nothing inside it is
+/// attributed — the walk declines rather than reaching for the next name up.
+#[test]
+fn an_anonymous_module_level_body_owns_nothing() {
+    let owners: Vec<_> = scan_client_api_uses("(() => { useState(1); })();")
+        .iter()
+        .map(|use_site| use_site.owner.clone())
+        .collect();
+    assert_eq!(owners, vec![None]);
+}
+
+/// An unbalanced source is a syntax error somebody else reports; the walk still
+/// has to finish over it rather than loop or panic.
+#[test]
+fn an_unbalanced_source_still_scans() {
+    for source in [
+        "export hook useTheme() { useState(1);",
+        "}}} useState(1);",
+        "function f( { useState(1); }",
+        "import { useState as from \"react\";",
+    ] {
+        let _ = scan_client_api_uses(source);
+        let _ = scan_hook_calls(source);
+        let _ = scan_imports(source);
+    }
+}


### PR DESCRIPTION
Section (1) of [#388](https://github.com/ubugeeei-prod/uf/issues/388), and only
section (1): the two facts the issue lists as missing, and nothing that reads
them yet. [#690](https://github.com/ubugeeei-prod/uf/pull/690) decided 57 of the
94 hooks from a table somebody had already checked; the other 37 need a body to
read, and a body is what this puts within reach.

Deliberately no new diagnostic. Nothing here changes a line of `uf build`,
`uf dev` or `uf lint` output on any input — the point is that the information is
now recorded, not that something fires on it.

## `ClientApiUse` and `HookCall` carry an owner

`ClientApiUse` recorded a line and a column and no owner, so `useEffect` at 38:3
could not be attributed to `useTheme`. Both use-site records now carry
`owner: Option<CompactString>`, and the rule is one sentence:

> The owner of a use site is the **module-level declaration whose body contains
> it** — the span from the `{` that opens the body to that brace's match.

A body opened by a `{` that no other bracket encloses runs to its match, so two
such spans are disjoint and there is at most one owner. That is the whole of
`crates/uf_rsc/src/scan/owner.rs`, and it is linear in the token count: a body
is skipped whole once its span is recorded rather than descended into.

**Nested closures resolve outward, to the name an importer can reach.** A
`localStorage` inside a callback inside `useTheme` is `useTheme`'s: the callback
has no name anything can import, and `useTheme` is what a fixpoint propagates
along.

**A use no module-level body contains gets `None`, not the nearest name.**
Module top-level code, a method of a class or an object literal, an anonymous
`(() => { … })()` — all `None`. Naming the method would be worse than naming
nothing: `read` is not a name any importer can reach, and it can collide with an
export that has nothing to do with it. A wrong owner propagates through a
fixpoint; a missing one is the answer this crate already gives for everything it
cannot decide.

`HookCall` gets the same field from the same table, because the fixpoint's rule
has two clauses — a wrapper is client-only when it reaches a client-only API
**or** calls a hook that does — and the second clause has no left-hand side
without it.

### One bug fell out of this, in shared machinery

`function_head` walked backwards from a `{` one token at a time, and a Flow
return type can contain the tokens it stops at:

```js
export hook useTheme(): [Theme, (next: Theme) => void] {
```

That `=>` is not this function's head, and the walk met it before the `)` of the
parameter list — so uf's own `docs/app/_design/theme.js`, the hook the issue
leads with, could not be named at all. A `]` or a `>` now jumps to its opener,
which puts the whole annotation behind one step.

A `}` deliberately does **not** jump. The group before a `{` is far more often
the body of the *previous* declaration — `function setup() {}` and then a bare
block — and walking behind it would hand that block the previous function's
parameter list and its name. An object-type return annotation is the price, and
it is paid in `None`.

`function_head`, `function_name` and `binding_name` moved from
`directive/function.rs` to `scan/owner.rs`, otherwise unchanged, because both
passes need the same two answers and a second opinion is a second set of edge
cases to keep in step. `directive/function.rs` keeps only the ordinal-numbering
that is its own.

## `ImportSpecifier` keeps `{ imported, local }` pairs

`ImportSpecifier` kept the specifier and dropped the bindings, so
`import { useRoute } from "…"` could not be connected to the `useRoute()` two
lines down. It now carries `bindings: ImportBindingList` of

```rust
pub struct ImportBinding {
    pub imported: ImportedName,   // Default | Namespace | Named(CompactString)
    pub local: CompactString,
}
```

Three variants rather than one string, because `*` is not a name a module can
export and `default` is: `import x from "m"` and `import { default as x }` bind
the same export and are the same variant, while a namespace import binds the
module itself and has no exported name behind it — `as_export_name()` returns
`None` for it, so a caller cannot compare it against a package's table by
accident.

The pair is the point. `import { useState as useS } from "react"` binds `useS`
here and names `useState` there; a scanner that keeps only the local name cannot
look the hook up in a package's table, and one that keeps only the imported name
cannot connect the call site to it.

What binds nothing stays empty: a bare `import "m"`, an `export * from "m"`, a
dynamic `import("m")` and a `require("m")` — the last two because what they bind
is decided by the expression around them and not by a clause. Flow's *inline*
type specifiers are dropped exactly as the statement-level `import type` already
is, and by the same test, so `{ type }` and `{ type as t }` — which import a
value called `type` — survive while `{ type T }` does not.

For an `ImportKind::ReExport`, `export { a as b } from "m"` introduces no local
binding and `b` is the name this module *exports* it as. Both answer the same
question — which name here is that name there — so both are recorded, and the
kind says which reading applies.

## Tests

Fourteen new tests in `crates/uf_rsc/src/scan/tests.rs`, including the two the
change lives or dies on:

* `an_aliased_import_keeps_both_names` — `import { useState as useS } from
  "react"` records `Named("useState")` / `useS`, and `as_export_name()` still
  resolves to `useState`.
* `a_use_inside_a_nested_closure_belongs_to_the_declaration_that_holds_it` —
  `useState`, `useEffect` and a `localStorage` two closures deep all belong to
  `useTheme`.
* `a_use_at_module_top_level_has_no_owner` — with a hook between the two
  ownerless uses, so the `None`s are not the walk giving up.
* `a_declaration_is_named_however_it_is_written` — twelve shapes, including
  `export hook useTheme(): [string, (next: string) => void]`, which pins the bug
  above.
* `a_use_inside_a_method_has_no_module_level_owner`,
  `an_anonymous_module_level_body_owns_nothing` — the documented `None`s.
* `an_unbalanced_source_still_scans` — a syntax error is somebody else's
  diagnostic, and these walks still have to finish over it.

## The issue's worked example, end to end

Not asserted — scanned, off this repository's own two files, with a throwaway
probe that is not part of the change:

`docs/app/_uf.layout.js`

```
122:24 useRoute -> Some("Masthead")
149:29 useTheme -> Some("ThemeToggle")
@uniflowed/router  [Named("useRoute") -> useRoute, Named("Link") -> Link]
./_design/theme.js [Named("useTheme") -> useTheme, …]
@uniflowed/react   [Namespace -> React]
```

`docs/app/_design/theme.js`

```
47:3  useEffect    -> Some("useTheme")
56:9  localStorage -> Some("useTheme")     ← inside `choose`, a nested arrow
58:9  localStorage -> Some("useTheme")     ← same
88:19 localStorage -> Some("stored")
99:16 document     -> Some("apply")
@uniflowed/react [Named("useEffect") -> useEffect, Named("useState") -> useState]
```

`useTheme` is `#348`'s example and `useRoute` is `#388`'s, and the chain that
was missing — *call site → owning export → the module and name the import
resolves to → that body's own uses* — is now readable in both directions.

### One thing that probe found and this does not fix

`useState<Theme>("system")` on line 45 of `theme.js` is **not** in that list.
`client_api_uses_from_tokens` requires a `(` immediately after the name, so a
call with explicit type arguments is invisible to it — and to
`hook_calls_from_tokens`, which makes the same test.

It is deliberately left alone. Recognising it would make
`rsc/client-only-api-in-server` fire on that line, which is an **error** on uf's
own documentation site for a module that works — the exact outcome this issue's
comments argue against until #252 lands. It is a real gap and section (2) will
walk into it, so it is written down here rather than fixed quietly.

## What section (2) can now decide that it could not before

Not done here, and named so the next change does not have to rediscover it:

1. **Derive the other ten packages' tables instead of asserting them.** The
   scanner in this issue's comments called `useGeolocation` and `useStorage`
   server-safe because it could not find where a name's body was once the
   definition and the barrel were different files. `{ imported, local }` is that
   link, and the owner span is the body at the end of it. 36 hand judgements
   become 36 derivations with a test behind them.
2. **The fixpoint over a project's own exports.** `owner` is the edge:
   `client_api_uses` gives *export → client-only API*, `hook_calls` gives
   *export → hook*, and `ImportSpecifier::bindings` resolves that hook to a
   module and a name. Monotone over a finite set, so it terminates and does not
   depend on module order.
3. **Narrow `client_only_hook_package`.** It attributes a call through the
   module's imports rather than the binding, so a module that imports
   `@uniflowed/hooks` *and* defines its own `useMediaQuery` is answered wrong.
   The pairs say which is which. Left alone here on purpose: reading them would
   change which calls are reported, which is classification and not plumbing.

And the thing the comments settled that this does not touch: `useRoute` reaching
`useContext` does **not** make it client-only while uf's provider is rendered on
the server too. Deciding that needs
[#252](https://github.com/ubugeeei-prod/uf/issues/252) /
[#519](https://github.com/ubugeeei-prod/uf/issues/519) first, not more scanner.

## Verification

* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo test -p uf_rsc -p uf_lib` — 226 + 32 + 14 + 1 doc-test, all green
* `uf test#library` — 2,765 passed, 0 failed, 1 skipped
* `uf lint` over this repository — 467 files, **0 errors**, the same 14 warnings
  as before, and no `rsc/` rule among them. That is the property this change
  claims: the information is recorded and nothing new fires on it.

`crates/uf_lib` is untouched, so the table test it carries is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
