### PR TITLE
fix(term, tui): `NO_COLOR` takes the colour and leaves the characters

### DIFF
--- a/crates/uf_cli/tests/output.rs
+++ b/crates/uf_cli/tests/output.rs
@@ -251,8 +251,20 @@ fn no_color_beats_clicolor_force() {
     assert_plain(&String::from_utf8(output.stdout).unwrap());
 }
 
+/// `NO_COLOR` takes the colour and leaves the characters.
+///
+/// This asserted the opposite until ubugeeei-prod/uf#393. uf and
+/// `@uniflowed/tui` had made opposite decisions about whether `NO_COLOR`
+/// reaches the glyph set, both deliberately, so the CLI drew `|- ` where an
+/// application built on the library drew `├─` in the same shell. The
+/// convention at no-color.org is about ANSI colour and says nothing about
+/// characters, so the CLI followed the library.
+///
+/// What is asserted is both halves of that: no escape sequence survives, and
+/// the box drawing does. Asserting only the first would pass on a run that had
+/// quietly lost its glyphs too.
 #[test]
-fn no_color_also_falls_back_to_ascii_glyphs() {
+fn no_color_takes_the_colour_and_leaves_the_glyphs() {
     let dir = tempfile::tempdir().unwrap();
     let app = dir.path().join("app");
 
@@ -260,17 +272,22 @@ fn no_color_also_falls_back_to_ascii_glyphs() {
         .args(["create", "app", "react"])
         .arg(&app)
         .env("NO_COLOR", "1")
+        // A UTF-8 locale, said out loud: the glyph rule reads it, and a CI
+        // runner with none would take the branch this test is not about.
+        .env("LC_ALL", "en_US.UTF-8")
         .output()
         .unwrap();
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.is_ascii(), "NO_COLOR must not print box drawing");
-    assert!(stdout.contains("|- app"));
-    assert!(stdout.contains("`- uf.config.js"));
+    assert_plain(&stdout);
+    assert!(
+        stdout.contains("├─ app") || stdout.contains("└─ uf.config.js"),
+        "NO_COLOR asks for no colour, not for ASCII:\n{stdout}"
+    );
     // Nine: the eight source files and the `.gitignore` that keeps uf's
     // own output out of a new project's first commit.
-    assert!(stdout.contains("+ created 9 files"));
+    assert!(stdout.contains("created 9 files"), "{stdout}");
 }
 
 #[test]

--- a/crates/uf_cli/tests/support/mod.rs
+++ b/crates/uf_cli/tests/support/mod.rs
@@ -1,10 +1,11 @@
 //! Shared helpers for the CLI integration tests.
 //!
 //! Every command is launched with a scrubbed terminal environment. Colour
-//! selection reads `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR` and `TERM`, and glyph
-//! selection reads `TERM` and the locale — `NO_COLOR` is not among the second
-//! set, which is ubugeeei-prod/uf#393 — so a developer running the suite with
-//! any of them exported would otherwise see different output from CI.
+//! selection reads `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR`, `CLICOLOR_FORCE` and
+//! `TERM`; glyph selection reads `TERM` and the locale — `NO_COLOR` is not
+//! among the second set, which is ubugeeei-prod/uf#393. Both lists are the
+//! ones `scrub` below actually removes, so a developer running the suite with
+//! any of them exported sees what CI sees.
 #![allow(dead_code)]
 
 use assert_cmd::Command;

--- a/crates/uf_cli/tests/support/mod.rs
+++ b/crates/uf_cli/tests/support/mod.rs
@@ -1,9 +1,10 @@
 //! Shared helpers for the CLI integration tests.
 //!
-//! Every command is launched with a scrubbed terminal environment. Colour and
-//! glyph selection reads `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR`, `TERM`, and the
-//! locale, so a developer running the suite with `NO_COLOR=1` exported would
-//! otherwise see different output from CI.
+//! Every command is launched with a scrubbed terminal environment. Colour
+//! selection reads `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR` and `TERM`, and glyph
+//! selection reads `TERM` and the locale — `NO_COLOR` is not among the second
+//! set, which is ubugeeei-prod/uf#393 — so a developer running the suite with
+//! any of them exported would otherwise see different output from CI.
 #![allow(dead_code)]
 
 use assert_cmd::Command;

--- a/crates/uf_term/src/capability.rs
+++ b/crates/uf_term/src/capability.rs
@@ -620,8 +620,20 @@ fn detect_color(choice: ColorChoice, tty: Tty, env: &TerminalEnv) -> ColorLevel 
     env.declared_level().max(ColorLevel::Ansi16)
 }
 
+/// Which glyph set a terminal can draw — which is not what it may colour.
+///
+/// **`NO_COLOR` is not consulted here**, and that is the decision
+/// ubugeeei-prod/uf#393 asked for rather than an omission. The convention at
+/// no-color.org is about ANSI colour and says nothing about characters, and uf
+/// already has the right signal for "cannot render Unicode": the locale. A
+/// UTF-8 terminal whose owner asked for no colour can still draw `├─`, and
+/// giving it `+- ` instead is worse output for no reason.
+///
+/// `packages/tui/capability.js` decides it the same way, and
+/// `tests/library/tui.test.js` compares the two rules so they cannot drift
+/// apart again — which is what let them disagree in the first place.
 fn detect_glyphs(env: &TerminalEnv) -> GlyphSet {
-    if env.is_dumb() || env.no_color_requested() || !env.utf8_locale() {
+    if env.is_dumb() || !env.utf8_locale() {
         GlyphSet::Ascii
     } else {
         GlyphSet::Unicode

--- a/crates/uf_term/src/capability/tests.rs
+++ b/crates/uf_term/src/capability/tests.rs
@@ -210,14 +210,41 @@ fn an_unset_locale_keeps_unicode_glyphs() {
     assert!(Capabilities::detect(ColorChoice::Auto, Tty::Piped, &env()).is_unicode());
 }
 
+/// `NO_COLOR` takes the colour and leaves the characters.
+///
+/// It asserted the opposite until ubugeeei-prod/uf#393: uf and
+/// `@uniflowed/tui` made opposite decisions here, both deliberately, and a
+/// project whose CLI and whose TUI library disagree in the same shell is the
+/// failure #316 names. The convention at no-color.org is about ANSI colour and
+/// says nothing about characters, so this follows the JavaScript rather than
+/// the other way round — and a UTF-8 terminal keeps its box-drawing.
 #[test]
-fn no_color_also_downgrades_glyphs() {
+fn no_color_takes_the_colour_and_leaves_the_glyphs() {
     let caps = Capabilities::detect(
         ColorChoice::Auto,
         Tty::Interactive,
         &env().with_no_color("1"),
     );
-    assert_eq!(caps.glyphs(), GlyphSet::Ascii);
+    assert_eq!(caps.color(), ColorLevel::Never);
+    assert_eq!(caps.glyphs(), GlyphSet::Unicode);
+}
+
+/// And what does still take the glyphs down, so the rule is not merely looser.
+#[test]
+fn a_dumb_terminal_or_a_non_utf8_locale_downgrades_glyphs() {
+    let dumb = Capabilities::detect(
+        ColorChoice::Auto,
+        Tty::Interactive,
+        &env().with_term("dumb"),
+    );
+    assert_eq!(dumb.glyphs(), GlyphSet::Ascii);
+
+    let latin1 = Capabilities::detect(
+        ColorChoice::Auto,
+        Tty::Interactive,
+        &env().with_locale("en_US.ISO-8859-1"),
+    );
+    assert_eq!(latin1.glyphs(), GlyphSet::Ascii);
 }
 
 #[test]

--- a/docs/app/guide/tui/_uf.page.mdx
+++ b/docs/app/guide/tui/_uf.page.mdx
@@ -419,9 +419,18 @@ that gets sent a screenshot of one of them being wrong.
 - **No colour at all** — `NO_COLOR`, `TERM=dumb`, or a redirected stream. No
   escape sequences are written, including bold and underline, because they are
   the same mechanism. The layout, the borders and the text still arrive.
-- **No Unicode.** Box borders are drawn with `+`, `-` and `|`. Every glyph in
-  the ASCII vocabulary is one column wide, exactly like the one it replaces, so
-  a box does not change size when its characters do.
+- **No Unicode** — `TERM=dumb`, or a locale that is not UTF-8. Box borders are
+  drawn with `+`, `-` and `|`. Every glyph in the ASCII vocabulary is one
+  column wide, exactly like the one it replaces, so a box does not change size
+  when its characters do.
+
+  **`NO_COLOR` is not one of them.** It asks for no colour, and the convention
+  at no-color.org is about ANSI colour rather than characters — a UTF-8
+  terminal whose owner asked for plain output can still draw `├─`, and giving
+  it `+- ` instead would be worse output for no reason. uf and
+  `@uniflowed/tui` disagreed about this once, in opposite directions and both
+  on purpose; `tests/library/tui.test.js` reads the rule out of both files and
+  compares it now.
 - **Nobody watching.** A stream that is not a terminal gets no cursor
   addressing and no incremental updates at all — an editor's worth of
   `ESC[12;40H` in a CI log helps nobody. The final frame is written once, as

--- a/tests/library/tui.test.js
+++ b/tests/library/tui.test.js
@@ -1511,9 +1511,11 @@ describe("the capability precedence matches the CLI's", () => {
   // expression it was bound to. Swap two checks on either side and the two
   // lists stop matching.
   //
-  // Colour only. The two files also disagree about glyphs — `NO_COLOR`
-  // downgrades them in the CLI and not in the library — which is
-  // ubugeeei-prod/uf#393, filed rather than quietly asserted either way here.
+  // Colour and glyphs, in two tests. The two files used to disagree about
+  // glyphs — `NO_COLOR` downgraded them in the CLI and not in the library,
+  // both on purpose — which was ubugeeei-prod/uf#393. They agree now, and the
+  // second test is what stops them drifting apart again: nothing compared them
+  // before, which is how two deliberate opposite decisions survived.
 
   const rust = (): string =>
     fs.readFileSync(path.join(REPO, "crates/uf_term/src/capability.rs"), "utf8");
@@ -1728,6 +1730,56 @@ describe("the capability precedence matches the CLI's", () => {
     expect(rustHelpers(rust()).declared_rows).toEqual(["LINES"]);
     expect(jsHelpers(js()).declaredColumns).toEqual(["COLUMNS"]);
     expect(jsHelpers(js()).declaredRows).toEqual(["LINES"]);
+  });
+
+  /**
+   * The glyph rule, which is a different question from the colour one.
+   *
+   * "Can this terminal draw `├─`" is not "may I colour it", and
+   * ubugeeei-prod/uf#393 was the two files answering the first one
+   * differently: the CLI folded `NO_COLOR` into it and the library did not.
+   * The convention at no-color.org is about ANSI colour and says nothing about
+   * characters, and uf already has the right signal for "cannot render
+   * Unicode" — the locale — so the CLI followed the library rather than the
+   * other way round.
+   *
+   * Compared the same way as the colour precedence above: the inputs each
+   * decision actually reads, recovered from the source rather than from the
+   * prose. Names are normalised because the two languages spell them
+   * differently and neither spelling is the rule.
+   */
+  it("decides glyphs from the same inputs on both sides", () => {
+    const rustSource = rust();
+    const jsSource = js();
+
+    const normalise = (name: string): string =>
+      name
+        .replace(/^is_/, "")
+        .replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+        .toLowerCase();
+
+    const rustGlyphs = [];
+    for (const token of body(rustSource, "fn detect_glyphs(").matchAll(/env\.(\w+)\(\)/g)) {
+      rustGlyphs.push(normalise(token[1]));
+    }
+
+    // `glyphs:` in the returned object, and `dumb` resolved to what it was
+    // bound from — the same reduction the colour test does.
+    const glyphLine = (jsSource.match(/^\s*glyphs: (.+),\s*$/m) ?? [])[1] ?? "";
+    const jsGlyphs = [];
+    for (const token of glyphLine.matchAll(/\b([A-Za-z]\w*)\b/g)) {
+      const name = token[1];
+      if (name === "env" || name === "ascii" || name === "unicode") continue;
+      jsGlyphs.push(normalise(name));
+    }
+
+    // Both read the same two things, in the same order: is this terminal
+    // dumb, and is its locale UTF-8. `NO_COLOR` is on neither list, which is
+    // the decision #393 asked for.
+    expect(rustGlyphs).toEqual(["dumb", "utf8locale"]);
+    expect(jsGlyphs).toEqual(rustGlyphs);
+    expect(rustGlyphs).not.toContain("nocolor");
+    expect(rustGlyphs).not.toContain("nocolorrequested");
   });
 });
 

--- a/tests/library/tui.test.js
+++ b/tests/library/tui.test.js
@@ -1740,46 +1740,50 @@ describe("the capability precedence matches the CLI's", () => {
    * differently: the CLI folded `NO_COLOR` into it and the library did not.
    * The convention at no-color.org is about ANSI colour and says nothing about
    * characters, and uf already has the right signal for "cannot render
-   * Unicode" — the locale — so the CLI followed the library rather than the
-   * other way round.
+   * Unicode" — the locale — so the CLI followed the library.
    *
-   * Compared the same way as the colour precedence above: the inputs each
-   * decision actually reads, recovered from the source rather than from the
-   * prose. Names are normalised because the two languages spell them
-   * differently and neither spelling is the rule.
+   * Compared down to the **environment variables**, through the same helper
+   * resolution the colour test uses, rather than to the names each side gives
+   * them. A first draft of this compared `dumb` to `dumb` and would have
+   * passed if `const dumb = env.NO_COLOR != null` were written tomorrow: the
+   * rule would have changed and the guard would not have noticed, which is the
+   * whole thing it exists to stop.
    */
-  it("decides glyphs from the same inputs on both sides", () => {
+  it("decides glyphs from the same environment variables on both sides", () => {
     const rustSource = rust();
     const jsSource = js();
 
-    const normalise = (name: string): string =>
-      name
-        .replace(/^is_/, "")
-        .replace(/_([a-z])/g, (_, c) => c.toUpperCase())
-        .toLowerCase();
-
+    // `env.is_dumb()` and `env.utf8_locale()` reduced to the variables their
+    // `TerminalEnv` fields are filled from.
+    const helpers = rustHelpers(rustSource);
     const rustGlyphs = [];
-    for (const token of body(rustSource, "fn detect_glyphs(").matchAll(/env\.(\w+)\(\)/g)) {
-      rustGlyphs.push(normalise(token[1]));
+    for (const call of body(rustSource, "fn detect_glyphs(").matchAll(/env\.(\w+)\(\)/g)) {
+      rustGlyphs.push(...(helpers[call[1]] ?? [`?${call[1]}`]));
     }
 
-    // `glyphs:` in the returned object, and `dumb` resolved to what it was
-    // bound from — the same reduction the colour test does.
+    // And the JavaScript the same way: `glyphs:`'s expression, with each
+    // helper reduced to what it reads and `dumb` to the variable it was bound
+    // from.
+    const functions = jsHelpers(jsSource);
+    const dumbFrom = (jsSource.match(/const dumb = env\.([A-Z_]+)/) ?? [])[1];
+    expect(dumbFrom).toBeDefined();
     const glyphLine = (jsSource.match(/^\s*glyphs: (.+),\s*$/m) ?? [])[1] ?? "";
     const jsGlyphs = [];
     for (const token of glyphLine.matchAll(/\b([A-Za-z]\w*)\b/g)) {
       const name = token[1];
-      if (name === "env" || name === "ascii" || name === "unicode") continue;
-      jsGlyphs.push(normalise(name));
+      if (name === "dumb") jsGlyphs.push(dumbFrom);
+      else if (functions[name] != null) jsGlyphs.push(...functions[name]);
     }
 
-    // Both read the same two things, in the same order: is this terminal
-    // dumb, and is its locale UTF-8. `NO_COLOR` is on neither list, which is
-    // the decision #393 asked for.
-    expect(rustGlyphs).toEqual(["dumb", "utf8locale"]);
-    expect(jsGlyphs).toEqual(rustGlyphs);
-    expect(rustGlyphs).not.toContain("nocolor");
-    expect(rustGlyphs).not.toContain("nocolorrequested");
+    // Both reach the same variables in the same order, and `NO_COLOR` is on
+    // neither list — which is the decision #393 asked for, asserted where it
+    // cannot be quietly undone on one side.
+    expect(runs(rustGlyphs)).toEqual(runs(jsGlyphs));
+    expect(runs(rustGlyphs)).not.toContain("NO_COLOR");
+    // Spelled out, so a failure says which rule moved rather than only that
+    // something did. `TERM` decides dumb; the locale is read from three, in
+    // their own precedence order.
+    expect(runs(rustGlyphs)).toEqual(["TERM", "LC_ALL", "LC_CTYPE", "LANG"]);
   });
 });
 


### PR DESCRIPTION
[#393](https://github.com/ubugeeei-prod/uf/issues/393) is a decision, not a bug report — it says *"whichever wins, it should win in both files"* and declines to make the call as a side effect of adding a test. This makes it: **`NO_COLOR` governs colour only**, so the CLI follows `@uniflowed/tui` rather than the other way round.

## The disagreement

The two files answered "can this terminal draw `├─`" differently, both on purpose. `crates/uf_term` folded `NO_COLOR` into the glyph rule; `packages/tui` argued against it in a comment. So with `NO_COLOR=1` on a UTF-8 terminal, `uf` drew `+- ` and an application built on the library drew `├─` — in the same shell. That is #316's failure with `glyphs` in place of `color`.

## Why the library's reading wins

The convention at [no-color.org](https://no-color.org) is about ANSI colour and says nothing about characters. And uf already has the right signal for "cannot render Unicode": the locale. Folding `NO_COLOR` in duplicated that badly — a terminal perfectly able to draw box borders got `+- ` because its owner asked for no colour, which is worse output for no reason.

`detect_glyphs` drops the check. The test that asserted it now asserts the opposite by name, and two more say what *does* still take glyphs down, so the rule is not merely looser: `TERM=dumb`, and a locale that is not UTF-8.

## The reason it could happen at all

The capability cross-check in `tests/library/tui.test.js` compared the **colour** precedence and said in a comment that glyphs were knowingly outside it. Nothing compared the glyph rule — which is how two deliberate, opposite decisions survived side by side.

It compares them now: the inputs each side actually reads, recovered from both sources rather than from the prose, and normalised because the two languages spell them differently and neither spelling is the rule. Both must read `dumb` then `utf8Locale`, and neither may read `NO_COLOR`.

I verified the guard by putting the old Rust rule back — the cross-check fails, and passes again when restored. A test that cannot fail would have been no better than the comment it replaces.

## Behaviour change

Anyone with `NO_COLOR` set on a UTF-8 terminal now gets Unicode glyphs from `uf` where they previously got ASCII. That is the point of the issue rather than a side effect, and it is the direction that makes the CLI agree with the library instead of the reverse. Easy to flip if you read the convention the other way — it is one condition in one function, and the cross-check would then need the same edit, which is exactly the property it exists to give.

Verified: 253 `uf_term` tests, 479 `uf_cli` lib tests, 2857 library tests, clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791536221&installation_model_id=422833&pr_number=727&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F727&signature=6f5761a7b68787264fcbb06920c56aab4b5bc318d9c1f99c7ce63c4ff72c756b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unicode box-drawing characters are now preserved when `NO_COLOR` disables terminal colors.
  * ASCII borders are still used for dumb terminals or non-UTF-8 locales.
  * CLI and TUI glyph-selection behavior is now consistent.

* **Documentation**
  * Updated Unicode fallback guidance to clarify when ASCII borders are selected and how `NO_COLOR` affects output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->