### PR TITLE
fix(release): a package that is never published says so in its manifest

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/browser",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/cli",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/hmr",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/jsx-runtime",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/lib",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/lint",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/loader",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/markdown",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/motion",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/orm",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/pm",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/prepare",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/pwa",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/react-compiler",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/react-native",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/react-native, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/rm",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/runtime",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/std",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/temporal",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/temporal, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniflowed/vrt",
   "version": "0.0.0-alpha.18",
+  "private": true,
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/tools/ci/publishable.sh
+++ b/tools/ci/publishable.sh
@@ -96,6 +96,34 @@ for (const name of directories) {
   );
 }
 
+// The third rule, and the one a reader hits from outside rather than inside.
+// A declaration module that is in neither list is never published — but nothing
+// on it *says* so. It carries a version, it is bumped by every release, its
+// description and source are on GitHub, and the only thing that ever refuses is
+// `npm install`, with `ETARGET` and no explanation. `private: true` is npm's own
+// way of saying "this is not for the registry", and saying it here means the
+// answer is in the package rather than in this script.
+//
+// Only for a package in neither list. Two directories look like declarations to
+// `isDeclaration` and are published on purpose: `core` *defines*
+// `nativeRuntimeRequired`, and `stylex`'s exports are compile-time — `uf
+// transform` replaces the call, so reaching the body means uf was bypassed and
+// throwing is the right answer. Marking either private would stop a release
+// that is correct today, which is why membership of a list wins over the scan.
+for (const name of directories) {
+  if (!isDeclaration(name)) continue;
+  if (published.includes(name) || pending.includes(name)) continue;
+  const manifest = JSON.parse(fs.readFileSync(`packages/${name}/package.json`, "utf8"));
+  if (manifest.private === true) continue;
+  problems.push(
+    `packages/${name} is a declaration module in neither release list, so it is ` +
+      'never published — but its manifest does not say so. Add `"private": true` ' +
+      "to packages/" +
+      name +
+      "/package.json, so `npm install` is not the only thing that refuses.",
+  );
+}
+
 for (const name of pending) {
   if (published.includes(name)) {
     problems.push(`${name} is in both lists; it is published, so take it out of the pending one.`);

--- a/tools/ci/test-publishable.sh
+++ b/tools/ci/test-publishable.sh
@@ -43,9 +43,13 @@ scratch() {
     > "$root/packages/orm/index.js"
   printf '// @flow\nexport const atom = <T>(value: T): { value: T } => ({ value });\n' \
     > "$root/packages/state/index.js"
-  for name in core orm state; do
+  for name in core state; do
     printf '{ "name": "@uniflowed/%s", "version": "0.0.0" }\n' "$name" > "$root/packages/$name/package.json"
   done
+  # `orm` is the declaration in neither list, so a correct tree says so in the
+  # manifest — that is the third rule this script now checks, and this fixture is
+  # what a repository looks like once it holds.
+  printf '{ "name": "@uniflowed/orm", "version": "0.0.0", "private": true }\n' > "$root/packages/orm/package.json"
   printf '# published\ncore\n' > "$root/tools/release/published-packages.txt"
   printf '# pending\nstate\n' > "$root/tools/release/pending-packages.txt"
 }
@@ -81,6 +85,27 @@ scratch forgotten
 printf '# published\ncore\n' > "$work/forgotten/tools/release/pending-packages.txt"
 run forgotten
 refuses "an implemented package in neither list" "packages/state"
+
+# --- and it has to say it is not for the registry ---------------------------
+# The rule the third check adds. A declaration in neither list is never
+# published, and until the manifest says `private` the only thing that ever
+# refuses is `npm install`, with `ETARGET` and no explanation. Taking the field
+# back out is exactly the state all twenty of these packages were in.
+scratch unmarked
+printf '{ "name": "@uniflowed/orm", "version": "0.0.0" }\n' > "$work/unmarked/packages/orm/package.json"
+run unmarked
+refuses "a declaration in neither list with no private" "packages/orm"
+
+# --- unless a list claims it -------------------------------------------------
+# Membership outranks the scan, which is what keeps `core` and `stylex`
+# publishable: both look like declarations to `isDeclaration` and both are
+# published on purpose. A package a list names is never asked to be private.
+scratch claimed
+printf '{ "name": "@uniflowed/orm", "version": "0.0.0" }\n' > "$work/claimed/packages/orm/package.json"
+printf '# pending\nstate\norm\n' > "$work/claimed/tools/release/pending-packages.txt"
+run claimed
+[ "$status" -eq 0 ] || fail "a declaration a list claims was refused: $out"
+pass "a list claiming a declaration outranks the scan"
 
 # --- a declaration is not required to be anywhere ---------------------------
 # The other direction of the same judgement: `packages/orm` is in no list and


### PR DESCRIPTION
Half of ubugeeei-prod/uf#700.

## The state it describes

Twenty directories under `packages/` are declaration modules — every exported function calls `nativeRuntimeRequired`, `tools/ci/publishable.sh` classifies them as such, and neither release manifest names them. No release has ever published one, and no release ever will.

Nothing said so. Each carries a `version`, `bump-version.sh` moves it every release, the description and the source are on GitHub, and the only thing that ever refuses is `npm install`, with `ETARGET` and no explanation. That is the state #700 says costs a reader time:

> the source, the version and the description are all discoverable, and only `pnpm add` says no.

`"private": true` is npm's own way of saying "not for the registry". Saying it in the manifest puts the answer where the reader already is.

## The rule, and why it is keyed the way it is

`publishable.sh` gains a third rule, for the reason its own header gives for the first two — *"a list somebody adds to is a list somebody forgets."*

**Membership of a release list wins over the scan, and it has to.** Two directories look like declarations to `isDeclaration` and are published on purpose:

| | why it matches | why it is right |
| --- | --- | --- |
| `core` | it **defines** `export function nativeRuntimeRequired(…)` | the regex cannot tell a definition from a call |
| `stylex` | three exports call it | they are **compile-time** — `uf transform` replaces the call with the object it computed, so reaching the body means uf was bypassed, and throwing is the correct answer |

Both are on npm today (`200` from the registry for each). A rule keyed on the scan alone would have marked them private and stopped a release that is correct. I very nearly shipped exactly that; the check is what caught it, which is the argument for keying on the list.

## Verification

- `sh tools/ci/publishable.sh` — passes: `27 implemented packages: 15 published, 12 waiting on npm trust`
- **Mutation-checked.** Removing `"private": true` from `packages/motion/package.json` makes it fail, naming the package:
  ```
  packages/motion is a declaration module in neither release list, so it is never
  published — but its manifest does not say so. Add `"private": true` …
  ```
- `uf test#library` — 2864 passed, 0 failed, 1 skipped
- `npm pack --dry-run` in `packages/ui` still packs its 52 files, so nothing about publishing a real package moved.

## What this does not do

The other half of #700 — `cell`, `state`, `effect` and `immer` are implemented, listed in `pending-packages.txt`, and blocked on the one step a checkout cannot take (`npm login`, `bootstrap-publish.sh`, `trust-npm.sh`). That is #210 and nothing here touches it.

It also does not decide `temporal`. It is private here because it is a declaration module **today**; #560 is the question of whether it should stop being one.

Refs ubugeeei-prod/uf#700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791540709&installation_model_id=422833&pr_number=730&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F730&signature=9d02dfe9350f13f182d498ca45cbabc07468d3fcae2e7454f2010a265e06f24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Marked internal packages as private to prevent accidental publication.
  * Added validation to ensure unpublished declaration packages are explicitly marked private.
* **Bug Fixes**
  * Updated release checks to allow packages listed as pending publication.
  * Added coverage for rejecting unmarked private packages and accepting pending packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->