### PR TITLE
feat(lib, rsc): the ui subpaths that are client modules, and the guard that reads the files

### DIFF
--- a/crates/uf_lib/src/lib.rs
+++ b/crates/uf_lib/src/lib.rs
@@ -14,7 +14,8 @@ pub use descriptor::{
     Stability, UiComponent, UiReadiness, UiRuntime, ValidationStep,
 };
 pub use registry::{
-    builtin_modules, hook_descriptors, module_by_specifier, std_module_descriptors, tui_contract,
+    CLIENT_MODULE_PACKAGE, CLIENT_MODULE_SUBPATHS, builtin_modules, hook_descriptors,
+    is_client_module, module_by_specifier, std_module_descriptors, tui_contract,
 };
 pub use ui::ui_components;
 

--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -1055,3 +1055,92 @@ pub fn module_by_specifier(specifier: &str) -> Option<NativeModule> {
         .into_iter()
         .find(|module| module.specifier == specifier)
 }
+
+/// The package whose subpaths [`CLIENT_MODULE_SUBPATHS`] lists.
+pub const CLIENT_MODULE_PACKAGE: &str = "@uniflowed/ui";
+
+/// The exported subpaths of [`CLIENT_MODULE_PACKAGE`] that are client modules.
+///
+/// uf's RSC scan walks a project and skips `node_modules`, which is the right
+/// default — a dependency tree is enormous and almost none of it is in the
+/// application graph. The cost is that in a project that *installs*
+/// `@uniflowed/ui` rather than being this repository, uf's own components are
+/// invisible to the analysis that exists to find exactly them: every one of
+/// these carries `"use client"` and is a client bundle root, and the scan never
+/// opens the file to see it. See ubugeeei-prod/uf#718.
+///
+/// A list rather than a walk, and here rather than in `uf_rsc`, for the reason
+/// [`hook_descriptors`] is here: a fact about a package uf ships belongs beside
+/// the registry of packages uf ships, and a walk of an installed tree is the
+/// expense this exists to avoid. `the_client_module_list_names_exactly_the_ui_
+/// subpaths_that_are_client_modules` in `uf_rsc` holds the list to the files —
+/// with the parser that decides the question in production, not a second
+/// answer to it — which is the whole value of writing the names down.
+///
+/// Exported subpaths only, so this says what a project can *import*.
+/// `internal/form-value` and `internal/menu-tree` are client modules too and
+/// are deliberately absent: `package.json` does not export them, so no
+/// specifier reaches them and the ones that do are already here.
+///
+/// Not the whole package, which is the reason this is a list and not a rule.
+/// `alert`, `breadcrumb`, `pagination`, `progress` and `separator` are markup
+/// with no state and each says so in a section headed "No `use client`" — they
+/// are Server Components, and shipping them to the browser because they came
+/// out of the same package would be exactly the mistake RSC exists to stop.
+///
+/// uf's own package only. A third party needs a way to *declare* a client root
+/// — a manifest field, or the `react-server` export condition — which is the
+/// other half of #718 and waits on whether a manifest may name a specifier
+/// rather than a path.
+pub const CLIENT_MODULE_SUBPATHS: &[&str] = &[
+    "accordion",
+    "alert-dialog",
+    "avatar",
+    "calendar",
+    "carousel",
+    "checkbox",
+    "collapsible",
+    "combobox",
+    "context-menu",
+    "date-picker",
+    "dialog",
+    "drawer",
+    "field",
+    "hover-card",
+    "input-otp",
+    "menu",
+    "menubar",
+    "navigation-menu",
+    "popover",
+    "radio-group",
+    "resizable",
+    "scroll-area",
+    "select",
+    "sheet",
+    "sidebar",
+    "skeleton",
+    "slider",
+    "switch",
+    "table",
+    "tabs",
+    "toast",
+    "toggle",
+    "toggle-group",
+    "tooltip",
+];
+
+/// Whether a bare specifier resolves to a module uf knows carries `"use client"`.
+///
+/// Takes the specifier as written in the source — `@uniflowed/ui/dialog` — and
+/// answers for the package's exported subpaths only. The barrel,
+/// `@uniflowed/ui`, is a server module: it re-exports the client ones, which
+/// makes it a module that *imports* client modules rather than one that is
+/// one, and that distinction is the difference between a bundle root and an
+/// edge leading to one.
+#[must_use]
+pub fn is_client_module(specifier: &str) -> bool {
+    specifier
+        .strip_prefix(CLIENT_MODULE_PACKAGE)
+        .and_then(|rest| rest.strip_prefix('/'))
+        .is_some_and(|subpath| CLIENT_MODULE_SUBPATHS.contains(&subpath))
+}

--- a/crates/uf_rsc/src/tests.rs
+++ b/crates/uf_rsc/src/tests.rs
@@ -40,3 +40,87 @@ fn a_full_analysis_flows_from_sources_to_a_manifest() {
     assert_eq!(manifest.server_actions.len(), 1);
     assert!(manifest.diagnostics.is_empty());
 }
+
+/// The guard on `uf_lib::CLIENT_MODULE_SUBPATHS`, and the reason writing the
+/// names down is defensible at all.
+///
+/// The list exists because the scan skips `node_modules` (#718), so in an
+/// installed tree uf cannot see its own components' directives. A list that
+/// nothing checks is a list that is wrong by the second component added, so
+/// this holds it to the files — and to the exports map, since the list claims
+/// to say what a project can *import*, not what is on disk.
+///
+/// Deliberately in `uf_rsc` and deliberately through [`module_environment`]:
+/// the question "is this a client module" already has an answer in this
+/// repository, and a test that re-answered it with a different rule would
+/// check that two rules agree rather than that the list is right. `uf_lib`
+/// holds the data; the crate that owns the rule holds the guard.
+#[test]
+fn the_client_module_list_names_exactly_the_ui_subpaths_that_are_client_modules() {
+    let package = repository_root().join("packages").join("ui");
+    let manifest = std::fs::read_to_string(package.join("package.json"))
+        .expect("packages/ui/package.json cannot be read");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&manifest).expect("packages/ui/package.json does not parse");
+    let exports = manifest["exports"]
+        .as_object()
+        .expect("packages/ui/package.json has no exports map");
+
+    let mut client: Vec<String> = Vec::new();
+    for (specifier, target) in exports {
+        // The barrel is `.`; every other key is `./name`, and the subpath is
+        // what a project writes after the package name.
+        let Some(subpath) = specifier.strip_prefix("./") else {
+            continue;
+        };
+        let target = target
+            .as_str()
+            .unwrap_or_else(|| panic!("the export {specifier} is a conditions object, not a file"));
+        let file = package.join(target.trim_start_matches("./"));
+        let source = std::fs::read_to_string(&file)
+            .unwrap_or_else(|error| panic!("{} cannot be read: {error}", file.display()));
+        if module_environment(&source).runs_on_client() {
+            client.push(subpath.to_string());
+        }
+    }
+    client.sort();
+
+    let listed: Vec<String> = uf_lib::CLIENT_MODULE_SUBPATHS
+        .iter()
+        .map(|subpath| (*subpath).to_string())
+        .collect();
+    let missing: Vec<&String> = client.iter().filter(|s| !listed.contains(s)).collect();
+    let absent: Vec<&String> = listed.iter().filter(|s| !client.contains(s)).collect();
+    assert!(
+        missing.is_empty() && absent.is_empty(),
+        "CLIENT_MODULE_SUBPATHS and @uniflowed/ui disagree\n  \
+         declares `use client` and the list omits: {missing:?}\n  \
+         the list names and the module does not declare: {absent:?}"
+    );
+    // A floor as well as an equality: an exports map that stopped parsing into
+    // anything would otherwise make two empty lists agree.
+    assert!(
+        client.len() > 20,
+        "almost nothing came back as a client module, so this is checking nothing: {}",
+        client.len()
+    );
+    // The list is what `is_client_module` answers from, so check the specifier
+    // form once here rather than trusting that a caller assembles it the same
+    // way. The barrel re-exports client modules without being one.
+    assert!(uf_lib::is_client_module(&format!(
+        "{}/{}",
+        uf_lib::CLIENT_MODULE_PACKAGE,
+        client.first().expect("a client module")
+    )));
+    assert!(!uf_lib::is_client_module(uf_lib::CLIENT_MODULE_PACKAGE));
+    assert!(!uf_lib::is_client_module("@uniflowed/ui/does-not-exist"));
+}
+
+/// The repository, from this crate's manifest directory.
+fn repository_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("crates/uf_rsc has a grandparent")
+        .to_path_buf()
+}


### PR DESCRIPTION
## What

`@uniflowed/ui` ships 34 exported components that carry `"use client"`. uf's RSC
scan skips `node_modules` — correctly, since a dependency tree is enormous and
almost none of it is in the application graph — so in a project that *installs*
the package rather than being this repository, every one of them is invisible to
the analysis that exists to find exactly them.

This adds the recognition half of #718:

* `uf_lib::CLIENT_MODULE_SUBPATHS` — the 34 exported subpaths, beside
  `hook_descriptors()` and for the same reason: a fact about a package uf ships
  belongs with the registry of packages uf ships, and a walk of an installed
  tree is the expense the list exists to avoid.
* `uf_lib::is_client_module(specifier)` — mirrors the existing
  `is_client_only_hook_package`, with one deliberate difference: the bare
  `@uniflowed/ui` is **not** a client module. The barrel re-exports the client
  ones, which makes it a module that *imports* client modules rather than one
  that is one, and that is the difference between a bundle root and an edge
  leading to one.
* `the_client_module_list_names_exactly_the_ui_subpaths_that_are_client_modules`
  — the guard, in `uf_rsc` because that is where the rule lives.

## Why the guard is written this way

Through `module_environment`, the function that decides the question in
production. A test that re-answered "is this a client module" with its own rule
would check that two rules agree, not that the list is right. Writing it here
rather than in `uf_lib` keeps the dependency pointing the way it already does —
`uf_rsc` depends on `uf_lib`, not the reverse.

It walks the **exports map**, not the directory, because the list claims to say
what a project can *import*. `internal/form-value` and `internal/menu-tree` are
client modules that no specifier reaches, and they are absent on purpose.

A naive `grep '"use client"'` over the package returns 42 files. The parser
returns 34 exported ones. The eight-file difference is not a subtlety to be
clever about — `alert`, `breadcrumb`, `pagination`, `progress` and `separator`
are Server Components that each document the fact under a heading reading
"No `use client`", and the grep matched the heading. Shipping those to the
browser because they came out of the same package is the mistake RSC exists to
prevent, and it is why this is a list rather than a rule about a package name.

The equality is checked in both directions, plus a floor, so an exports map
that stopped parsing into anything cannot make two empty lists agree.

## What this does not do

Nothing consults the table yet. Making the graph act on it means deciding
whether a client boundary in the manifest is a path or a specifier —
`client_bundle_roots: Vec<Utf8PathBuf>` cannot name `@uniflowed/ui/dialog`, and
resolving it to `node_modules/@uniflowed/ui/dialog.js` puts installed paths in a
published manifest and needs a resolver the graph does not have. That is a
published-contract question and the other half of #718; it is left to whoever
owns the manifest's contract.

Refs #718

## Test plan

- [x] `cargo test -p uf_rsc` — 228 pass, including the new guard
- [x] `cargo test -p uf_lib` — 48 pass
- [x] `cargo clippy -p uf_lib -p uf_rsc --all-targets -- -D warnings` clean
- [x] Guard verified to actually fail: run first with an empty table, it named
      all 34 missing subpaths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791541079&installation_model_id=422833&pr_number=731&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F731&signature=56e95b42d2cbc0b8cc131ca82f1b776c21cf2606a6a507e6b3cf503ce69afb09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a registry of supported client-side UI module paths.
  * Added validation to identify whether a module specifier refers to a supported client module.

* **Tests**
  * Added coverage verifying the client-module registry matches the UI package exports and correctly handles valid, root-package, and unknown paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->