### PR TITLE
fix(check, lint): a library definition is merged, not linted

### DIFF
--- a/crates/uf_cli/src/commands/check.rs
+++ b/crates/uf_cli/src/commands/check.rs
@@ -684,8 +684,10 @@ fn untyped_module_list(report: &CheckReport) -> Vec<String> {
 
 #[cfg(feature = "upstream-typecheck")]
 mod dependencies;
+// `pub(crate)` rather than private: `uf lint` asks it which files are library
+// definitions, in order not to report on them.
 #[cfg(feature = "upstream-typecheck")]
-mod libdefs;
+pub(crate) mod libdefs;
 
 #[cfg(test)]
 mod tests;

--- a/crates/uf_cli/src/commands/check/libdefs.rs
+++ b/crates/uf_cli/src/commands/check/libdefs.rs
@@ -2,8 +2,12 @@
 //! not ship.
 //!
 //! A libdef is not a source file the project owns in `uf_project`'s sense:
-//! `uf fmt` does not rewrite it, `uf lint` does not report on it, and a
-//! diagnostic never points inside it. It is *declaration* — the
+//! `uf lint` does not report on it and a diagnostic never points inside it —
+//! [`declared_paths`] is what makes that true, and #699 is what it was not
+//! true of. `uf fmt` *does* rewrite one, and deliberately: a libdef is Flow
+//! source in a repository uf formats, and reformatting it invents no opinion
+//! about the project, where a lint rule about avoiding `any` does. It is
+//! *declaration* — the
 //! `declare module` block that says what `@xyflow/react` exports, the
 //! `declare type` that says what a project-wide global is — and it belongs to
 //! the type environment rather than to the batch. So it is read here, beside
@@ -48,6 +52,34 @@ use walkdir::WalkDir;
 /// project whose libdefs went missing reports one error per declared type and
 /// no explanation.
 const MAX_LIBDEF_FILES: usize = 2_000;
+
+/// Every library definition the project's configuration names, as paths
+/// relative to the project root.
+///
+/// The set [`super::super::lint::run_lint`] takes a file *out* of the lint with.
+/// This module's first line says a libdef is not a source file the project
+/// owns — `uf lint` does not report on it, and a diagnostic never points
+/// inside it — and until this existed that was true of the type check and
+/// false of the lint: the scan collects `flow-typed/` like any other
+/// directory, so `declare type FoldingRangeProvider = any` in a hand-written
+/// libdef was reported as `flow/unclear-type` and failed the build. An `any`
+/// is what a libdef for an untyped package is *made of*; a lint rule about
+/// avoiding it has nothing to say there. See ubugeeei-prod/uf#699.
+///
+/// Shares [`files_under`] with [`load`] rather than restating the rule, so the
+/// files uf declines to lint are exactly the files it merges.
+pub(crate) fn declared_paths(root: &Utf8Path, paths: &LibPaths) -> FxHashSet<String> {
+    let mut declared = FxHashSet::default();
+    for entry in paths.paths() {
+        for path in files_under(root, entry) {
+            if declared.len() == MAX_LIBDEF_FILES {
+                return declared;
+            }
+            declared.insert(path.into_string());
+        }
+    }
+    declared
+}
 
 /// Every library definition the project's configuration names, in merge order.
 pub(super) fn load(root: &Utf8Path, paths: &LibPaths) -> Vec<SourceFile> {

--- a/crates/uf_cli/src/commands/lint.rs
+++ b/crates/uf_cli/src/commands/lint.rs
@@ -31,12 +31,15 @@ use anyhow::{Result, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde_json::json;
 use uf_config::load_config;
+use uf_infra::FxHashSet;
 use uf_lint::{Diagnostic, LintReport, Severity, SourceFile, lint_sources};
 use uf_project::{SourceKind, scan_selected_source_files};
 use uf_term::{
     Cell, CodeFrame, Column, DiagnosticLevel, KeyValue, Status, Table, Tone, push_spaces,
 };
 
+#[cfg(feature = "upstream-typecheck")]
+use crate::commands::check::libdefs;
 use crate::fix::files::{FixMode, FixSummary, fix_project};
 use crate::support::{
     ignore_deprecation, plural, problem_summary, quoted_list, render_ignore_deprecation, selects,
@@ -173,10 +176,31 @@ pub(crate) fn run_lint(cwd: &Utf8Path, paths: &[String]) -> Result<LintRun> {
     scan.unreadable
         .retain(|failure| selects(paths, &failure.relative_path));
     let unreadable = unreadable_lines(&scan.unreadable);
+    // A library definition is not a source file the project owns. It declares
+    // the environment the sources are checked in — `declare module` and a
+    // top-level `declare type` are library syntax — so `uf check` merges it and
+    // takes it out of the batch, and the lint must leave it alone for the same
+    // reason. The scan collects `flow-typed/` like any other directory, so
+    // until this filter existed a hand-written libdef was linted as a source:
+    // `declare type Provider = any` came back as `flow/unclear-type` and failed
+    // the run, over an `any` that is what a libdef for an untyped dependency is
+    // made of. ubugeeei-prod/uf#699.
+    //
+    // Empty when the checker is not compiled in, since `lib_paths` is Flow's
+    // own `.flowconfig` parser and comes with it; a build without it merges no
+    // libdefs either, so nothing is being both merged and linted.
+    #[cfg(feature = "upstream-typecheck")]
+    let declared: FxHashSet<String> = match uf_check::lib_paths(resolved.root.as_std_path()) {
+        Ok(paths) => libdefs::declared_paths(&resolved.root, &paths),
+        Err(_) => FxHashSet::default(),
+    };
+    #[cfg(not(feature = "upstream-typecheck"))]
+    let declared: FxHashSet<String> = FxHashSet::default();
     let collected = scan
         .files
         .into_iter()
         .filter(|file| file.kind.is_flow() || file.kind == SourceKind::PackageManifest)
+        .filter(|file| !declared.contains(file.relative_path.as_str()))
         .map(|file| SourceFile {
             path: file.relative_path,
             source: file.source,
@@ -195,6 +219,11 @@ pub(crate) fn run_lint(cwd: &Utf8Path, paths: &[String]) -> Result<LintRun> {
         (selected, collected)
     };
     if sources.is_empty() && !paths.is_empty() && unreadable.is_empty() {
+        // "no file matched" is true and unhelpful when the file is right
+        // there and uf declined to lint it, so say which it was instead.
+        if let Some(libdef) = declared.iter().find(|path| selects(paths, path)) {
+            bail!("{libdef} is a library definition, not a source file uf lints");
+        }
         bail!("no file matched {}", quoted_list(paths));
     }
     let report = lint_sources(&sources, &resolved.config)?;

--- a/crates/uf_cli/tests/typecheck.rs
+++ b/crates/uf_cli/tests/typecheck.rs
@@ -321,3 +321,90 @@ fn imports_that_uf_cannot_type_yet_are_named_rather_than_hidden() {
         "{untyped:?}"
     );
 }
+
+/// A hand-written library definition is full of `any`, and that is what one is
+/// *for*: the point of `declare module "editor-pkg"` is to describe a package
+/// that ships no types, and every member uf cannot transcribe is an `any` on
+/// purpose. `flow/unclear-type` fired on each of them, because the scan
+/// collects `flow-typed/` like any other directory and the libdef was handed
+/// to the linter as well as to the type environment.
+///
+/// So `files checked` counted a file `flow check` would never lint, and a
+/// project whose types were right failed its build over the shape its
+/// declarations have to have. ubugeeei-prod/uf#699.
+#[test]
+fn a_library_definition_is_merged_rather_than_linted() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join(".flowconfig"), "[libs]\nflow-typed\n").unwrap();
+    let libs = root.join("flow-typed");
+    fs::create_dir_all(&libs).unwrap();
+    fs::write(
+        libs.join("editor.js"),
+        "// @flow\ndeclare module \"editor-pkg\" {\n  declare export namespace languages {\n    declare type FoldingRangeProvider = any;\n  }\n}\n",
+    )
+    .unwrap();
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("probe.js"),
+        "// @flow\nimport * as Editor from \"editor-pkg\";\n\nexport const provider: Editor.languages.FoldingRangeProvider = null;\n",
+    )
+    .unwrap();
+
+    let value = check_json(root);
+
+    let rules: Vec<&str> = value["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|diagnostic| diagnostic["rule"].as_str().unwrap())
+        .collect();
+    assert!(rules.is_empty(), "the libdef was linted: {rules:?}");
+    // The other half of the same fact, and the one a reader sees: a libdef is
+    // not among the files the run says it checked. Without it the assertion
+    // above could pass because the rule stopped firing rather than because the
+    // file stopped being linted.
+    assert_eq!(value["filesChecked"], serde_json::json!(1), "{value}");
+    // And it is still *merged*, which is the difference between not linting a
+    // libdef and not reading one: the annotation resolves, so nothing about
+    // `Editor.languages.FoldingRangeProvider` is reported.
+    let types: Vec<&str> = value["typeCheck"]["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|diagnostic| diagnostic["code"].as_str().unwrap_or("<none>"))
+        .collect();
+    assert!(types.is_empty(), "{types:?}");
+    assert_eq!(
+        value["typeCheck"]["libdefs"],
+        serde_json::json!(1),
+        "{value}"
+    );
+}
+
+/// Naming one says what it is, rather than "no file matched" about a file the
+/// reader is looking at.
+#[test]
+fn asking_to_lint_a_library_definition_says_that_is_what_it_is() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join(".flowconfig"), "[libs]\nflow-typed\n").unwrap();
+    let libs = root.join("flow-typed");
+    fs::create_dir_all(&libs).unwrap();
+    fs::write(libs.join("globals.js"), "declare type Kind = string;\n").unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(root)
+        .args(["check", "flow-typed/globals.js"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("flow-typed/globals.js is a library definition"),
+        "{stderr}"
+    );
+}


### PR DESCRIPTION
## What

`crates/uf_cli/src/commands/check/libdefs.rs` opens by stating the invariant:

> A libdef is not a source file the project owns in `uf_project`'s sense: `uf lint` does not report on it, and a diagnostic never points inside it.

That was true of the type check — `type_check` merges the `[libs]` files and
then filters them out of the batch — and **false of the lint**. `uf_project`'s
scan collects `flow-typed/` like any other directory, so the same file was both
the environment and a file reported against it.

What it produced, on a project whose only libdef is four lines:

```
flow-typed/editor.js  1 error

  error[flow/unclear-type]: avoid `any`; use `mixed`, opaque types, or generated router/action types
   --> flow-typed/editor.js:4:41
    │
  4 │     declare type FoldingRangeProvider = any;

  files checked  4
✗ 1 error
```

An `any` is what a libdef for an untyped dependency is *made of*. The point of
`declare module "editor-pkg"` is to describe a package that ships no types, and
every member uf cannot transcribe is an `any` on purpose — so a rule about
avoiding `any` has nothing to say there, and saying it fails the build.

## The change

`declared_paths` shares `files_under` with `load`, so the files uf declines to
lint are exactly the files it merges rather than a second list that could
disagree with the first.

Naming one explicitly now says what it is:

```
$ uf check flow-typed/editor.js
error: flow-typed/editor.js is a library definition, not a source file uf lints
```

which replaces `no file matched "flow-typed/editor.js"` — true, and unhelpful
about a file the reader is looking at.

`uf fmt` still rewrites a libdef, and the module doc now says so rather than
claiming otherwise. That asymmetry is deliberate: reformatting invents no
opinion about the project, where a lint rule does.

The exclusion is gated on `upstream-typecheck` because `lib_paths` is Flow's own
`.flowconfig` parser and arrives with it. A build without the checker merges no
libdefs either, so nothing there is both merged and linted.

## On #699

Found while trying to reproduce it, and it is the double role
[that issue's comment](https://github.com/ubugeeei-prod/uf/issues/699#issuecomment-5599876869)
suspected. It is **not** that issue's `value-as-type`: the type check already
excludes libdefs from the batch, and the reported shape checks clean here —
whole-project and path-scoped, warm cache and cold. #699 stays open; a fuller
account of what I could and could not reproduce is in a comment there.

## Test plan

- [x] `a_library_definition_is_merged_rather_than_linted` — asserts no lint
      diagnostic, `filesChecked == 1` (so it cannot pass by the rule merely
      going quiet), no type diagnostic, and `libdefs == 1` (so it cannot pass
      by the libdef going unread).
- [x] `asking_to_lint_a_library_definition_says_that_is_what_it_is`
- [x] Both verified to **fail** without the fix: `the libdef was linted:
      ["flow/unclear-type"]`.
- [x] `cargo test -p uf_cli` — 30/30 binaries green
- [x] `cargo clippy -p uf_cli --all-targets -- -D warnings` clean
- [x] `cargo check -p uf_cli --no-default-features` clean
- [x] Verified end to end on a project outside the repository: `files checked`
      4 → 2, the `flow/unclear-type` gone, the annotation still resolving.

Refs #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791543418&installation_model_id=422833&pr_number=732&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F732&signature=fc2e9eaef5f898ca91e970a22636f31d2f83e69abf2e1125544384ae568b7c8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->