### PR TITLE
docs: the server half is a BFF, and "full-stack" is not what uf is aiming at

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,11 @@ argument is worth nothing to you and most of the other rows are a downgrade.
 
 The Flow packages ship as `@uniflowed/*` modules — the router, the server, typed
 HTTP and query caching, effects, state, validation, forms, headless UI
-primitives, StyleX styling, the test runner and the rest. They are plain Flow
+primitives, StyleX styling, the test runner and the rest. "The server" there
+means a **BFF** — route handlers, server actions and rendering, the backend
+*for this frontend*. It is deliberately not an application backend, and
+[architecture red lines](docs/red-lines.md) says why that is a boundary rather
+than a gap. They are plain Flow
 with no native bindings, so what runs in the browser is what you can read, and
 `uf_lib` in this repository is the registry they are all declared in.
 

--- a/docs/red-lines.md
+++ b/docs/red-lines.md
@@ -209,6 +209,20 @@ plausible-sounding step toward the thing this document is about.
 - **Vendoring a provider to make it fit.** If uf needs behaviour Vite does not
   have, the fix is upstream or a plugin, never a fork — red line 1, and the
   reason it is first.
+- **An application backend.** uf's server half is a **BFF**: the backend *for
+  this frontend*. Route handlers, server actions, and rendering — the server a
+  UI needs in order to be a UI, and no more. What it is not is the place a
+  team's domain lives: no ORM as a first-class concern, no migrations, no job
+  queue, no service framework. Those belong to services uf talks to.
+
+  This is a red line and not a roadmap gap, because the pull is constant and
+  each step is individually reasonable. A framework that can render on the
+  server can obviously fetch; one that can fetch can obviously cache; one that
+  caches wants a schema; and a schema wants migrations. The end of that path
+  is a second place for the domain to live, owned by the frontend toolchain,
+  which is how a build tool becomes a platform nobody can leave. The word for
+  the far-away view of this is "full-stack", and it is not what uf is aiming
+  at.
 
 ## The failure this does not prevent
 

--- a/ubugeeei-redundancy.md
+++ b/ubugeeei-redundancy.md
@@ -262,7 +262,7 @@ minimal runtime overhead.
 
 | Domain | Required scope |
 | --- | --- |
-| Application framework | A full-stack React framework with RSC, Server Actions, SSR, ISR, SSG, and routing. Target Next.js-class completeness with portable deployment and optional provider integrations. |
+| Application framework | A React framework with RSC, Server Actions, SSR, ISR, SSG, and routing. Target Next.js-class completeness with portable deployment and optional provider integrations. The server half is a **BFF** — the backend *for this frontend*: route handlers, server actions and rendering, sized to what the UI needs. Not an application backend. A team's domain services, their database and their business logic stay where they are, and uf talks to them. "Full-stack" is what this looks like from far away, and the wrong thing to build toward: a framework that grows a backend grows a second place for the domain to live. |
 | Data and correctness | GraphQL, state management, validation, and an effect system designed together around end-to-end Flow types. |
 | Immutable updates | An Immer-class immutable-update library implemented in Flow, with ergonomic draft-based updates, structural sharing, and strong inference. |
 | Forms | A React Hook Form-class form library implemented in Flow, with strict React semantics, excellent inference, validation integration, and production-grade performance. |


### PR DESCRIPTION
## What

`ubugeeei-redundancy.md` described the application framework as **"a full-stack
React framework"** — the only place in the repository that word appeared — and
nothing anywhere said what uf's server half is actually *for*. From outside,
that reads as a promise to grow a backend.

Three changes, all copy:

* **The requirements table row** now says the server half is a BFF, and says
  plainly that "full-stack" is what this looks like from far away and the wrong
  thing to build toward.
* **`docs/red-lines.md`** gains "An application backend" under *What is not on
  the table*, beside `eject` and vendoring a provider.
* **`README.md`** — where the packages are first listed, "the server" now says
  which kind of server it is, and links to the red line.

## Why in red-lines rather than the roadmap

Because it is a boundary and not a gap. The pull toward the other thing is
constant and every step is individually reasonable: a framework that renders on
the server can obviously fetch; one that fetches can obviously cache; one that
caches wants a schema; and a schema wants migrations. The end of that path is a
second place for a team's domain to live, owned by the frontend toolchain —
which is the failure `docs/red-lines.md` exists to name, in the same voice it
already uses about `create-react-app`.

Stating it as a red line means a future PR that adds an ORM has to argue with a
document instead of with a reviewer's memory.

## Test plan

- [x] Documentation only — no code, no behaviour change.
- [x] `grep -rin "full.stack"` over the repository (excluding `target/`,
      `upstream/`, `node_modules/`) now returns only the sentence that
      explicitly rejects the framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791543739&installation_model_id=422833&pr_number=733&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F733&signature=a229352231ae91a9d5c759c8e0aac167bbdb5b3997d15ab927e77b5d236a60cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->