### PR TITLE
docs(contributing): the exclusion this repository is waiting for does not exist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,11 @@
 #     --print-width 100 crates/uf_fmt/tests/fixtures/<name>.js
 #
 # Saying so collapses them in a diff, where the interesting half is the input
-# beside them, and keeps review tools from reading them as code somebody meant.
+# beside them.
+#
+# It does not keep a review tool out, which is what #158 hoped for when it
+# added this line. GitHub Code Quality does not read `linguist-generated`, and
+# #434 is the proof: it commented on `top_level_await.expected.js` on the 6th,
+# the day after this line landed on the 5th. CONTRIBUTING.md says what to do
+# with those comments; ubugeeei-prod/uf#157 is where the exclusion is argued.
 crates/uf_fmt/tests/fixtures/*.expected.js linguist-generated=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,25 +63,39 @@ Fuzzing, formal verification, benchmarks, scripts, and Nix support live under
 `tools/` so the root stays focused on the Rust workspace and project metadata.
 Use `nix develop ./tools/nix` for the pinned development environment.
 
-## Reviews On Formatter Fixtures
+## Reviews On Test Fixtures
 
-`crates/uf_fmt/tests/fixtures` holds input to a printer, not programs. Nothing
-declared in a fixture is meant to be used, half the constructs are deliberately
-awkward, and the `.expected.js` beside each one is Prettier's output for it
-byte for byte.
+The JavaScript under `crates/` is fixtures — input to the tool the Rust tests
+beside it are exercising, not programs anybody runs. `crates/uf_fmt` holds
+badly formatted input and, beside each file, the `.expected.js` that is
+Prettier's output for it byte for byte; `crates/uf_check` holds input that
+fails to check on purpose; `crates/uf_cli` holds small applications a test
+builds and serves. Nothing declared in any of them is meant to be used, which
+is why `uf.config.js` keeps the whole of `crates` out of `uf fmt`, `uf lint`,
+`uf check`, `uf test` and `uf doc`.
 
-GitHub's code-quality review reads them as code anyway, and reports every
-binding in them as an unused variable. A pull request that adds a fixture
-arrives with a dozen of those, and because `main` requires conversations to be
-resolved, they block the merge.
+GitHub Code Quality reads them as code anyway, and reports every binding in
+them as an unused variable. A pull request that adds a fixture arrives with a
+dozen of those: on #139 and on #154, every single review thread — 31 and 23
+of them — was one. Because `main` requires conversations to be resolved, they
+block the merge with every check green. Nor is it only the formatter's: a
+comment landed on `crates/uf_check/tests/fixtures` in #652.
 
 They are false positives and they are resolved as such — with a reply saying
-so, not silently. Do not "fix" one by using a variable in a fixture: the
-fixture is what Prettier was run on, and changing it changes what the
-expectation means.
+so, not silently. Do not "fix" one by using a variable in a fixture: a
+formatter fixture is what Prettier was run on, and a checker fixture is the
+program whose error is the expectation. Editing either changes what the test
+asserts.
 
-The exclusion belongs in the analysis rather than in the fixtures, and it is
-not configurable from this repository. See ubugeeei-prod/uf#157.
+The exclusion belongs in the analysis rather than in the fixtures, and there is
+nowhere to put it. Code Quality has no path filter at all — GitHub's answer to
+[the request for one][cq-paths] is that choosing the directories to scan is on
+the roadmap — and it does not read `linguist-generated`, so the
+`.gitattributes` entry that marks the expectations as generated does not keep
+them out either. Until it ships, the reply is the procedure. See
+ubugeeei-prod/uf#157.
+
+[cq-paths]: https://github.com/orgs/community/discussions/186446
 
 ## Verification
 


### PR DESCRIPTION
## What was wrong

Three things this repository says about GitHub Code Quality are not true, and
two of them are load-bearing in #157.

**`linguist-generated` was never keeping anything out.** `.gitattributes` said
that marking the expectations as generated "keeps review tools from reading
them as code somebody meant". Code Quality does not read the attribute. The
proof is here: #158 added the line on 2026-09-05, and on 2026-09-06 Code
Quality commented on `crates/uf_fmt/tests/fixtures/top_level_await.expected.js`
in #434 — a file the pattern matches. A mitigation that was never in effect is
worse than no mitigation, because the next person reads it and believes the
problem is handled.

**It is not only the formatter's fixtures.** `CONTRIBUTING.md` named
`crates/uf_fmt/tests/fixtures`. On 2026-09-08 #652 collected a finding on
`crates/uf_check/tests/fixtures/web_crypto.js`, and
`crates/uf_cli/tests/fixtures` holds 21 more `.js` files nothing has walked
into yet.

**"Not configurable from this repository" understates it.** It is not
configurable anywhere. Code Quality has no path filter at all:
[organization-level targeting](https://github.blog/changelog/2026-07-09-organization-level-targeting-for-github-code-quality/)
(2026-07-09) selects *repositories* — by custom property, manual selection,
visibility or fork status — and GitHub's answer in
[community#186446](https://github.com/orgs/community/discussions/186446) is
that choosing which directories and files to scan is on the roadmap and not
started. That distinction is the whole difference between a contributor
resolving ten threads as the procedure and a contributor hunting for a setting
that does not exist.

## What changed

- **`.gitattributes`** keeps the attribute — it still collapses the
  expectations in a diff, which is true and worth having — and stops claiming
  the other thing, with the dates that disprove it.
- **`CONTRIBUTING.md`**'s section is now "Reviews On Test Fixtures" and states
  a *rule* — the JavaScript under `crates/` — rather than a list of
  directories. The list is what drifted: it said `uf_fmt` while `uf_check` was
  already being commented on. It is also the rule `uf.config.js` already
  states, where it keeps the whole of `crates` out of `uf fmt`, `uf lint`,
  `uf check`, `uf test` and `uf doc` for exactly this reason.

## What this does not do

It does not fix #157, which stays open. Its three remedies are all settings:

1. Excluding the fixtures from Code Quality — **this cannot be configured
   today**, in the organization or anywhere else. It is a feature GitHub has
   not shipped, so the issue's first preference is not a setting somebody has
   to find.
2. Turning Code Quality off for this repository — available, via org-level
   targeting.
3. Dropping `required_conversation_resolution` — available, via branch
   protection.

2 and 3 are decisions for the repository owner rather than code, so I have not
touched either. The evidence, including a count of everything the bot has
actually found here, is in a comment on #157.

## Test plan

- [x] `cargo fmt --all` — exit 0, and `cargo fmt --all --check` exit 0 after
      it, so no Rust was reformatted.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0 in
      1m 25s. The 15 warnings in the log are all in the vendored
      `upstream/flow` crates and predate this branch.
- [x] `cargo test -p uf_fmt` — exit 0. 97 tests, 0 failed (59 + 6 + 26 + 4 + 2
      across the five binaries). This is the crate whose fixtures the issue is
      about; nothing else is touched.
- [x] `uf fmt --check` — "0 files of 428 need formatting". It exits 1 on this
      machine only because `uf.config.js` asks for Biome and Biome is not
      installed here, which is unrelated. `CONTRIBUTING.md` is not in uf's file
      set at all (`uf fmt --check CONTRIBUTING.md` answers "no file matched"),
      so nothing formats it.
- [x] Re-wrapped so no line begins with `#`. `#154` and `#652` at the start of
      a line would have rendered as Markdown headings.
- [ ] **No test accompanies this, and none can.** Nothing in the diff is
      compiled, linted or executed, so there is no behaviour to assert and no
      test that fails without it. What stands in its place is that every claim
      removed was checked against the GitHub API rather than reasoned about —
      and the dates are why #434 is cited as the proof for `linguist-generated`
      and #154, whose comments landed before the attribute existed, is not.

Refs #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791544577&installation_model_id=422833&pr_number=734&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F734&signature=19ebb2c8b357a81080f13ed44f221f6731a847a9e8d5d722e257da792324be8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->