### PR TITLE
fix(cli, deploy): the schedule an artefact declares and the entry that runs it, checked both ways

### DIFF
--- a/crates/uf_cli/src/commands/deploy.rs
+++ b/crates/uf_cli/src/commands/deploy.rs
@@ -322,6 +322,15 @@ pub(crate) fn deploy(
         copied.count(fs::metadata(directory.join(entry).as_std_path())?.len());
     }
 
+    // The last thing before this directory is reported as an artefact: what it
+    // says about its scheduled work, read back out of the files rather than
+    // assumed from the list they were written from. `entry_files` above asks
+    // whether the driver wrote the entry it promised; this asks whether the
+    // entry and the platform file beside it agree about what runs — which is
+    // the question #712 shipped the wrong answer to. See
+    // [`schedules::assert_wired`].
+    schedules::assert_wired(adapter, &directory, schedules)?;
+
     Ok(Deployed {
         adapter,
         directory,

--- a/crates/uf_cli/src/commands/deploy/schedules.rs
+++ b/crates/uf_cli/src/commands/deploy/schedules.rs
@@ -375,5 +375,301 @@ pub(crate) fn refuse_unrunnable(
     );
 }
 
+/// Check the finished artefact against the list it was built from.
+///
+/// # Why this is a check in the product and not only in a test
+///
+/// A deployment description that claims a capability the code beside it does
+/// not serve is the failure this whole area has had once already: #712 wrote
+/// `triggers.crons` into a `wrangler.json` beside a `worker.js` that exported
+/// no `scheduled()`, which Cloudflare accepts, deploys, and then fails on
+/// every invocation — a Worker that looks configured for work that never
+/// happens. #717 took it back and `assert_worker_shape` in
+/// `crates/uf_cli/tests/vite.rs` began asserting the pairing in both
+/// directions.
+///
+/// That assertion is worth having and was never once exercised in the
+/// direction that broke: no fixture in this repository declares a schedule, so
+/// every artefact those tests have ever built carried no `triggers` and no
+/// `scheduled`, and the comparison could only ever be `false == false`. A
+/// change that emitted one half again would have gone green.
+///
+/// So the check moved to where the artefact is: `uf build --adapter` reads
+/// back the files it just wrote and refuses to report a directory whose two
+/// halves disagree. It costs two file reads on a command that has just copied
+/// a build, it holds for a project this repository has no fixture for, and it
+/// is the same rule stated once rather than once per test.
+///
+/// # What is checked, and why it is only this
+///
+/// The two files this reads are *bundler output*. `@uniflowed/vite` writes an
+/// entry and Rolldown links it, so the identifiers, the whitespace and the
+/// statement shapes in the artefact belong to a third program and are none of
+/// uf's business — a check that matched `const routes = {` would be uf
+/// asserting how Rolldown formats an object, and would go red the day it
+/// formatted one differently. What no bundler alters is the *data*: a cron
+/// expression and a route path are string literals, and a property name an
+/// object is read by at runtime is preserved because dropping it would break
+/// the program. So that is the whole of what is matched here.
+///
+/// * `edge` — `wrangler.json`'s `triggers.crons` is exactly the declared list,
+///   `worker.js` exports a `scheduled` when and only when there is one to
+///   call, and for every declared schedule the worker carries its expression
+///   *followed by its route*, which is the routes map entry Cloudflare's
+///   invocation is looked up in. An expression the map does not hold is an
+///   invocation with nowhere to go, which the `scheduled` export alone would
+///   not catch.
+/// * `node`, `bun`, `container` — the process is its own scheduler, so there
+///   is no platform file to disagree with and what can disagree is the entry.
+///   `server.js` has to carry a `cron:` and a `path:` holding the strings of
+///   every declaration.
+/// * `serverless`, `static`, `deno` — run none, and [`refuse_unrunnable`] has
+///   already said so. Reaching here with a schedule means that refusal was
+///   bypassed rather than that this one is wrong, so it is reported as the
+///   internal fault it is.
+///
+/// The direction this cannot state is an *extra* schedule on a target with no
+/// platform file. Those entries carry the scheduler itself — `serve` reaches
+/// `@uniflowed/server/schedule` for every project — so a bare `cron:` in a
+/// linked `server.js` is `schedule.js`'s own code far more often than it is a
+/// schedule, and telling one from the other needs a JavaScript parser. A
+/// second one of those in `uf` is a worse trade than the gap. On `edge`, where
+/// the platform file is uf's own rather than a linker's, both directions are
+/// exact.
+///
+/// # Errors
+///
+/// When a file cannot be read, or when what the artefact declares and what it
+/// carries are not the same list.
+pub(crate) fn assert_wired(
+    adapter: DeployAdapter,
+    directory: &Utf8Path,
+    schedules: &[DeclaredSchedule],
+) -> Result<()> {
+    match adapter {
+        DeployAdapter::Node | DeployAdapter::Bun | DeployAdapter::Container => {
+            assert_process_entry(adapter, &directory.join("server.js"), schedules)
+        }
+        DeployAdapter::Edge => assert_worker(directory, schedules),
+        DeployAdapter::Serverless | DeployAdapter::Static | DeployAdapter::Deno => {
+            if schedules.is_empty() {
+                Ok(())
+            } else {
+                bail!(
+                    "the `{}` adapter runs no schedule and this build carried {} — \
+                     `refuse_unrunnable` should have refused it before anything was linked \
+                     (ubugeeei-prod/uf#531)",
+                    adapter.as_str(),
+                    schedules.len()
+                )
+            }
+        }
+    }
+}
+
+/// The three targets that keep a process, checked against their `server.js`.
+fn assert_process_entry(
+    adapter: DeployAdapter,
+    entry: &Utf8Path,
+    schedules: &[DeclaredSchedule],
+) -> Result<()> {
+    let source =
+        std::fs::read_to_string(entry.as_std_path()).with_context(|| format!("reading {entry}"))?;
+
+    // Deliberately no "and carries nothing else". `serve` reaches
+    // `@uniflowed/server/schedule` whether or not a project declared anything,
+    // so `schedule.js`'s own `cron: parseCron(options.cron)` is linked into
+    // every one of these entries — and a check that read a bare `cron:` as a
+    // schedule would refuse every `node` build there has ever been. What is
+    // unambiguous is a `cron:` whose value is *this* expression, so that is
+    // what is asked, once per declaration.
+    for schedule in schedules {
+        for (what, value) in [("path", schedule.path.as_str()), ("cron", &schedule.cron)] {
+            if !carries_property(&source, what, value) {
+                bail!(
+                    "{entry} runs no schedule with `{what}: {}` and this project declares one \
+                     on {} at `{}` — {}{}",
+                    json_string(value),
+                    schedule.path,
+                    schedule.cron,
+                    pairing_note(adapter),
+                    shown(entry, &source)
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Cloudflare's two halves: what it is told to fire, and what answers.
+fn assert_worker(directory: &Utf8Path, schedules: &[DeclaredSchedule]) -> Result<()> {
+    let worker_file = directory.join("worker.js");
+    let config_file = directory.join("wrangler.json");
+    let worker = std::fs::read_to_string(worker_file.as_std_path())
+        .with_context(|| format!("reading {worker_file}"))?;
+    let config: Value = serde_json::from_str(
+        &std::fs::read_to_string(config_file.as_std_path())
+            .with_context(|| format!("reading {config_file}"))?,
+    )
+    .with_context(|| format!("parsing {config_file}"))?;
+
+    // `wrangler.json` is uf's own file rather than a bundler's, so this half is
+    // an exact comparison and not a search.
+    let declared: Vec<&str> = schedules
+        .iter()
+        .map(|schedule| schedule.cron.as_str())
+        .collect();
+    let triggers: Vec<&str> = config
+        .pointer("/triggers/crons")
+        .and_then(Value::as_array)
+        .map(|crons| crons.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    if triggers != declared {
+        bail!(
+            "{config_file} tells Cloudflare to fire {triggers:?} and this project declares \
+             {declared:?} — {}",
+            pairing_note(DeployAdapter::Edge)
+        );
+    }
+
+    // The half #712 shipped without. A property name an object is read by
+    // survives linking, because dropping it would break the program.
+    let answers = property_value(&worker, "scheduled").is_some();
+    if answers != !schedules.is_empty() {
+        bail!(
+            "{config_file} carries {} cron trigger(s) and {worker_file} {} — {}{}",
+            declared.len(),
+            if answers {
+                "exports a `scheduled()` for Cloudflare to call"
+            } else {
+                "exports no `scheduled()` for Cloudflare to call"
+            },
+            pairing_note(DeployAdapter::Edge),
+            shown(&worker_file, &worker)
+        );
+    }
+
+    // And each expression reaches its route. Cloudflare fires the string, so
+    // an expression the map does not hold is an invocation with nowhere to go.
+    for schedule in schedules {
+        if !followed_by(
+            &worker,
+            &json_string(&schedule.cron),
+            &json_string(&schedule.path),
+        ) {
+            bail!(
+                "{config_file} tells Cloudflare to fire `{}` and {worker_file} does not route \
+                 it to {} — {}{}",
+                schedule.cron,
+                schedule.path,
+                pairing_note(DeployAdapter::Edge),
+                shown(&worker_file, &worker)
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Whether `text` carries `name: "value"`, whatever it was formatted like.
+///
+/// The property name and the string are the two halves a runtime reads, so
+/// they are the two halves that survive linking; the space between them is the
+/// linker's and is skipped rather than matched.
+fn carries_property(text: &str, name: &str, value: &str) -> bool {
+    let quoted = json_string(value);
+    let mut rest = text;
+    while let Some(found) = property_value(rest, name) {
+        if found.starts_with(&quoted) {
+            return true;
+        }
+        // Past this one, and on to the next property of the same name: an
+        // entry with several schedules carries several `cron:`. One character
+        // rather than one byte, because a value is a string a project wrote
+        // and this must not slice one down the middle of a character.
+        let at = rest.len() - found.len();
+        let step = rest[at..].chars().next().map_or(1, char::len_utf8);
+        rest = &rest[at + step..];
+    }
+    false
+}
+
+/// What follows the first `name:` in `text`, with the whitespace skipped.
+///
+/// [`None`] when there is no such property. A bare `contains(\"name:\")` would
+/// answer the same question and answer it wrong: `"scheduled:"` also matches
+/// the middle of a longer identifier, and a linker is free to produce one.
+fn property_value<'a>(text: &'a str, name: &str) -> Option<&'a str> {
+    let mut from = 0;
+    while let Some(at) = text[from..].find(name) {
+        let at = from + at;
+        let before_is_name = text[..at]
+            .chars()
+            .next_back()
+            .is_some_and(|character| character.is_alphanumeric() || character == '_');
+        let after = text[at + name.len()..].trim_start();
+        if !before_is_name && let Some(value) = after.strip_prefix(':') {
+            return Some(value.trim_start());
+        }
+        from = at + name.len();
+    }
+    None
+}
+
+/// Whether `first` appears somewhere with `second` right after it, past one
+/// `:` and whatever whitespace the linker left.
+///
+/// The shape of a routes map entry — `"*/15 * * * *": "/api/sweep"` — read
+/// without depending on how the object around it is written.
+fn followed_by(text: &str, first: &str, second: &str) -> bool {
+    let mut from = 0;
+    while let Some(at) = text[from..].find(first) {
+        let at = from + at;
+        let after = text[at + first.len()..].trim_start();
+        if after
+            .strip_prefix(':')
+            .is_some_and(|rest| rest.trim_start().starts_with(second))
+        {
+            return true;
+        }
+        from = at + first.len();
+    }
+    false
+}
+
+/// The file, appended to a message about it.
+///
+/// These entries are small — the application is `handler.js` beside them —
+/// and a fault that says "these two do not agree" without showing either is a
+/// fault somebody has to reproduce before they can read it. Capped, because
+/// "small" is a fact about today's generator and not a promise.
+fn shown(file: &Utf8Path, source: &str) -> String {
+    const MOST: usize = 4_000;
+    let (text, elided) = match source.char_indices().nth(MOST) {
+        Some((at, _)) => (&source[..at], "\n… (truncated)"),
+        None => (source, ""),
+    };
+    format!("\n\n{file}:\n{text}{elided}")
+}
+
+/// The sentence every one of these failures ends with.
+///
+/// One string rather than one per message, because the reader needs the same
+/// two things each time: what has gone wrong in general, and where to read
+/// about why it is refused rather than warned about.
+fn pairing_note(adapter: DeployAdapter) -> String {
+    format!(
+        "a schedule and the code that runs it must arrive together, and the `{}` artefact \
+         `uf build` just wrote has one without the other. This is a fault in uf rather than \
+         in the project: report it with the file(s) named above \
+         (ubugeeei-prod/uf#712, ubugeeei-prod/uf#531).",
+        adapter.as_str()
+    )
+}
+
+/// One string, quoted the way JavaScript quotes it.
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| format!("\"{value}\""))
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/uf_cli/src/commands/deploy/schedules/tests.rs
+++ b/crates/uf_cli/src/commands/deploy/schedules/tests.rs
@@ -271,3 +271,421 @@ fn the_handler_counts_in_any_spelling_a_module_may_use() {
 fn a_module_with_no_schedule_may_export_whatever_it_answers() {
     assert_eq!(read("export function POST() {}\n").expect("parses"), None);
 }
+
+/// The annotated spelling, which is the one a Flow project actually writes.
+///
+/// `export const schedule: string = "…"` puts a type annotation on the
+/// identifier, and this reads the declarator rather than the token after the
+/// name — so both spellings are one declaration. Asserted rather than assumed
+/// because the fixture in `crates/uf_cli/tests/vite.rs` is written this way,
+/// and a build that silently found no schedule there would assert nothing.
+#[test]
+fn a_type_annotation_does_not_hide_the_declaration() {
+    let found = read_with_handler("export const schedule: string = \"*/15 * * * *\";\n")
+        .expect("a module that parses");
+    assert_eq!(found.as_deref(), Some("*/15 * * * *"));
+}
+
+// # The artefact's own two halves
+//
+// Everything above is about reading a declaration out of a project. What
+// follows is about the other end: whether the directory `uf build --adapter`
+// just wrote says the same thing in both of the places it says it.
+//
+// The sources below are *linked* files rather than the entries
+// `@uniflowed/vite`'s `driver.js` writes, and that is the point of every shape
+// here: what lands in an artefact has been through Rolldown, so the
+// identifiers, the statement forms and the whitespace are a third program's
+// and the check must not depend on any of them. Two spellings of each shape
+// are driven — one the way a reader would write it, one renamed and reflowed
+// the way a linker may — because a check that only passed the readable one
+// would be a check that goes red the first time the linker changes its mind.
+
+/// A declaration, as [`discover_schedules`] would have returned it.
+fn declared(path: &str, cron: &str) -> DeclaredSchedule {
+    DeclaredSchedule {
+        path: path.into(),
+        file: Utf8PathBuf::from(format!("app{path}/_uf.route.js")),
+        cron: cron.to_owned(),
+    }
+}
+
+/// A directory holding `files`, as an artefact directory.
+fn artefact(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    for (name, source) in files {
+        std::fs::write(dir.path().join(name), source).expect("writing an artefact file");
+    }
+    dir
+}
+
+/// That directory's path, as the check takes it.
+fn at(dir: &tempfile::TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("a UTF-8 path")
+}
+
+/// `wrangler.json`, with `crons` when there are any and no `triggers` at all
+/// when there are none — which is what `wrangler_config` writes.
+fn wrangler(crons: &[&str]) -> String {
+    if crons.is_empty() {
+        return "{ \"main\": \"./worker.js\" }\n".to_owned();
+    }
+    let listed = crons
+        .iter()
+        .map(|cron| format!("\"{cron}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{{ \"main\": \"./worker.js\", \"triggers\": {{ \"crons\": [{listed}] }} }}\n")
+}
+
+/// A linked `worker.js`, as a reader would find it in the output.
+fn worker_entry(routes: &[(&str, &str)], scheduled: bool) -> String {
+    let mut source =
+        String::from("import { c as createWorkerFetch } from \"./chunks/edge.js\";\n\n");
+    if !routes.is_empty() {
+        let map = routes
+            .iter()
+            .map(|(cron, path)| format!("  \"{cron}\": \"{path}\""))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        source.push_str(&format!("const routes = {{\n{map}\n}};\n\n"));
+    }
+    source.push_str("export default {\n  fetch: createWorkerFetch({ handle, beginRequest }),\n");
+    if scheduled {
+        source.push_str("  scheduled: createWorkerScheduled({ handle, beginRequest, routes }),\n");
+    }
+    source.push_str("};\n");
+    source
+}
+
+/// The same worker after a linker that renames and reflows.
+///
+/// Nothing a runtime reads has changed: the property names are still there
+/// because the runtime reads them, and the strings are still there because
+/// they are data. Everything else has.
+fn worker_entry_linked(routes: &[(&str, &str)], scheduled: bool) -> String {
+    let map = routes
+        .iter()
+        .map(|(cron, path)| format!("\"{cron}\":\"{path}\""))
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut source = String::from("import{a as n$3,b as s$2}from\"./chunks/edge-a1b2.js\";");
+    if !routes.is_empty() {
+        source.push_str(&format!("var r$4={{{map}}};"));
+    }
+    source.push_str("var w$1={fetch:n$3({handle:h$2,beginRequest:b$1})");
+    if scheduled {
+        source.push_str(",scheduled:s$2({handle:h$2,beginRequest:b$1,routes:r$4})");
+    }
+    source.push_str("};export{w$1 as default};\n");
+    source
+}
+
+/// A linked `server.js`, as a reader would find it in the output.
+fn process_entry(wired: &[(&str, &str)]) -> String {
+    let mut source =
+        String::from("import { s as serve, r as routeSchedule } from \"./chunks/n.js\";\n");
+    if !wired.is_empty() {
+        source.push_str("\nconst schedules = [\n");
+        for (path, cron) in wired {
+            source.push_str(&format!(
+                "  routeSchedule({{ handle: fetch, beginRequest, path: \"{path}\", \
+                 cron: \"{cron}\" }}),\n"
+            ));
+        }
+        source.push_str("];\n");
+    }
+    source.push_str("\nserve({ handle: fetch, staticDir, beginRequest, schedules });\n");
+    source
+}
+
+/// The same after a linker that renames and reflows.
+fn process_entry_linked(wired: &[(&str, &str)]) -> String {
+    let mut source = String::from("import{s as v$2,r as q$3}from\"./chunks/n-c3d4.js\";");
+    if !wired.is_empty() {
+        let built = wired
+            .iter()
+            .map(|(path, cron)| {
+                format!("q$3({{handle:f$1,beginRequest:b$1,path:\"{path}\",cron:\"{cron}\"}})")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        source.push_str(&format!("var z$5=[{built}];"));
+    }
+    source.push_str("v$2({handle:f$1,staticDir:d$1,beginRequest:b$1,schedules:z$5});\n");
+    source
+}
+
+/// An artefact whose halves agree is an artefact this says nothing about.
+#[test]
+fn a_worker_that_declares_what_it_runs_is_accepted() {
+    for written in [worker_entry, worker_entry_linked] {
+        let dir = artefact(&[
+            (
+                "worker.js",
+                &written(&[("*/15 * * * *", "/api/sweep")], true),
+            ),
+            ("wrangler.json", &wrangler(&["*/15 * * * *"])),
+        ]);
+        assert_wired(
+            DeployAdapter::Edge,
+            &at(&dir),
+            &[declared("/api/sweep", "*/15 * * * *")],
+        )
+        .expect("both halves name the same expression, however it was linked");
+    }
+}
+
+/// The bug itself: ubugeeei-prod/uf#712, taken back by #717.
+///
+/// A `triggers.crons` beside a `worker.js` that exports no `scheduled()` is a
+/// Worker Cloudflare accepts, deploys, and then fails on every invocation of.
+#[test]
+fn a_trigger_with_no_handler_to_call_is_refused() {
+    let dir = artefact(&[
+        ("worker.js", &worker_entry(&[], false)),
+        ("wrangler.json", &wrangler(&["*/15 * * * *"])),
+    ]);
+    let message = assert_wired(
+        DeployAdapter::Edge,
+        &at(&dir),
+        &[declared("/api/sweep", "*/15 * * * *")],
+    )
+    .expect_err("a trigger with nothing to call is refused")
+    .to_string();
+    assert!(message.contains("exports no `scheduled()`"), "{message}");
+    assert!(message.contains("uf#712"), "{message}");
+    // And the file itself, so the fault can be read rather than reproduced.
+    assert!(message.contains("export default {"), "{message}");
+}
+
+/// And the other direction, which is the half a one-way check would miss: a
+/// `scheduled()` nothing will ever call.
+#[test]
+fn a_handler_no_trigger_would_call_is_refused() {
+    let dir = artefact(&[
+        (
+            "worker.js",
+            &worker_entry(&[("*/15 * * * *", "/api/sweep")], true),
+        ),
+        ("wrangler.json", &wrangler(&[])),
+    ]);
+    let message = assert_wired(DeployAdapter::Edge, &at(&dir), &[])
+        .expect_err("a scheduled export nothing fires is refused")
+        .to_string();
+    assert!(message.contains("exports a `scheduled()`"), "{message}");
+}
+
+/// A trigger and an export together are still not enough: Cloudflare fires the
+/// expression, so an expression the routes map does not hold is an invocation
+/// with nowhere to go.
+#[test]
+fn a_trigger_the_worker_routes_nowhere_is_refused() {
+    let dir = artefact(&[
+        (
+            "worker.js",
+            &worker_entry(&[("0 6 * * 1", "/api/digest")], true),
+        ),
+        ("wrangler.json", &wrangler(&["*/15 * * * *"])),
+    ]);
+    let message = assert_wired(
+        DeployAdapter::Edge,
+        &at(&dir),
+        &[declared("/api/sweep", "*/15 * * * *")],
+    )
+    .expect_err("an expression with no route is refused")
+    .to_string();
+    assert!(
+        message.contains("does not route it to /api/sweep"),
+        "{message}"
+    );
+}
+
+/// And one routed to a path the project never declared it on.
+#[test]
+fn a_schedule_routed_to_another_path_is_refused() {
+    for written in [worker_entry, worker_entry_linked] {
+        let dir = artefact(&[
+            (
+                "worker.js",
+                &written(&[("*/15 * * * *", "/api/digest")], true),
+            ),
+            ("wrangler.json", &wrangler(&["*/15 * * * *"])),
+        ]);
+        let message = assert_wired(
+            DeployAdapter::Edge,
+            &at(&dir),
+            &[declared("/api/sweep", "*/15 * * * *")],
+        )
+        .expect_err("a schedule on the wrong route is refused")
+        .to_string();
+        assert!(message.contains("/api/sweep"), "{message}");
+    }
+}
+
+/// A project with none gets the worker it has always had.
+#[test]
+fn a_worker_with_no_schedules_declares_and_runs_none() {
+    let dir = artefact(&[
+        ("worker.js", &worker_entry(&[], false)),
+        ("wrangler.json", &wrangler(&[])),
+    ]);
+    assert_wired(DeployAdapter::Edge, &at(&dir), &[]).expect("nothing declared and nothing run");
+}
+
+/// The three targets with no configuration file to make a disagreement
+/// visible: what has to be true is that the entry carries the declaration.
+#[test]
+fn a_process_entry_that_carries_what_was_declared_is_accepted() {
+    for adapter in [
+        DeployAdapter::Node,
+        DeployAdapter::Bun,
+        DeployAdapter::Container,
+    ] {
+        for written in [process_entry, process_entry_linked] {
+            let dir = artefact(&[("server.js", &written(&[("/api/sweep", "*/15 * * * *")]))]);
+            assert_wired(
+                adapter,
+                &at(&dir),
+                &[declared("/api/sweep", "*/15 * * * *")],
+            )
+            .unwrap_or_else(|error| panic!("`{}`: {error}", adapter.as_str()));
+        }
+    }
+}
+
+/// An entry that lost one. On these targets a schedule the entry does not
+/// carry is scheduled work that never happens, with nothing anywhere saying
+/// so — the same failure as #712 with no `wrangler.json` to make it visible.
+#[test]
+fn a_process_entry_that_lost_a_declaration_is_refused() {
+    for adapter in [
+        DeployAdapter::Node,
+        DeployAdapter::Bun,
+        DeployAdapter::Container,
+    ] {
+        let dir = artefact(&[("server.js", &process_entry(&[]))]);
+        let message = assert_wired(
+            adapter,
+            &at(&dir),
+            &[declared("/api/sweep", "*/15 * * * *")],
+        )
+        .expect_err("a declaration nothing carries is refused")
+        .to_string();
+        assert!(message.contains("runs no schedule with"), "{message}");
+        assert!(message.contains(adapter.as_str()), "{message}");
+    }
+}
+
+/// The expression, and not merely a schedule on that route.
+#[test]
+fn a_process_entry_that_carries_a_different_expression_is_refused() {
+    let dir = artefact(&[("server.js", &process_entry(&[("/api/sweep", "0 6 * * 1")]))]);
+    let message = assert_wired(
+        DeployAdapter::Node,
+        &at(&dir),
+        &[declared("/api/sweep", "*/15 * * * *")],
+    )
+    .expect_err("a schedule on a different expression is refused")
+    .to_string();
+    assert!(message.contains("*/15 * * * *"), "{message}");
+}
+
+/// And the route, and not merely the expression.
+#[test]
+fn a_process_entry_that_carries_a_different_route_is_refused() {
+    let dir = artefact(&[(
+        "server.js",
+        &process_entry(&[("/api/digest", "*/15 * * * *")]),
+    )]);
+    let message = assert_wired(
+        DeployAdapter::Node,
+        &at(&dir),
+        &[declared("/api/sweep", "*/15 * * * *")],
+    )
+    .expect_err("a schedule on a different route is refused")
+    .to_string();
+    assert!(message.contains("/api/sweep"), "{message}");
+}
+
+/// Several, each of which has to be found beside its own property name rather
+/// than anywhere in the file.
+#[test]
+fn every_declaration_is_matched_against_its_own_property() {
+    let dir = artefact(&[(
+        "server.js",
+        &process_entry(&[("/api/sweep", "*/15 * * * *"), ("/api/digest", "0 6 * * 1")]),
+    )]);
+    assert_wired(
+        DeployAdapter::Node,
+        &at(&dir),
+        &[
+            declared("/api/digest", "0 6 * * 1"),
+            declared("/api/sweep", "*/15 * * * *"),
+        ],
+    )
+    .expect("two declarations, both carried");
+}
+
+/// The scheduler's own code is not a schedule.
+///
+/// `serve` reaches `@uniflowed/server/schedule` for every project, so
+/// `schedule.js`'s `cron: parseCron(options.cron)` is linked into every one of
+/// these entries. A check that read a bare `cron:` as a declaration would
+/// refuse every `node` build there has ever been — which is why the reverse
+/// direction is not stated on these three, and why this test exists to hold
+/// that line.
+#[test]
+fn the_schedulers_own_cron_property_is_not_read_as_a_declaration() {
+    let dir = artefact(&[(
+        "server.js",
+        "import{p as parseCron}from\"./chunks/n.js\";\
+         function defineSchedule(o){return{name:o.name,cron:parseCron(o.cron),run:o.run}}\
+         v$2({handle:f$1,staticDir:d$1,beginRequest:b$1});\n",
+    )]);
+    assert_wired(DeployAdapter::Node, &at(&dir), &[])
+        .expect("a project that declared none, in an entry that links the scheduler");
+}
+
+#[test]
+fn a_process_entry_with_no_schedules_is_the_file_it_has_always_been() {
+    let dir = artefact(&[("server.js", &process_entry(&[]))]);
+    assert_wired(DeployAdapter::Node, &at(&dir), &[]).expect("nothing declared and nothing run");
+}
+
+/// The three that run none. Reaching here with one means [`refuse_unrunnable`]
+/// was bypassed, which is a fault in uf and is reported as one rather than
+/// quietly accepted.
+#[test]
+fn a_target_that_runs_no_schedule_never_carries_one() {
+    let dir = artefact(&[]);
+    for adapter in [
+        DeployAdapter::Serverless,
+        DeployAdapter::Static,
+        DeployAdapter::Deno,
+    ] {
+        assert_wired(adapter, &at(&dir), &[]).expect("a project that declared none");
+        let message = assert_wired(adapter, &at(&dir), &[declared("/api/sweep", "* * * * *")])
+            .expect_err("a schedule this target would not run")
+            .to_string();
+        assert!(message.contains("runs no schedule"), "{message}");
+        assert!(message.contains("refuse_unrunnable"), "{message}");
+    }
+}
+
+/// A property name is a whole name, not a substring of a longer one.
+///
+/// The reason [`property_value`] exists rather than a `contains("scheduled:")`:
+/// a linker is free to produce `unscheduled:` or `rescheduled:`, and a check
+/// that read one of those as the export would pass an artefact with no
+/// `scheduled()` in it at all.
+#[test]
+fn a_longer_identifier_ending_in_the_name_is_not_that_property() {
+    assert_eq!(property_value("{ unscheduled: 1 }", "scheduled"), None);
+    assert_eq!(property_value("{ scheduled: 1 }", "scheduled"), Some("1 }"));
+    // And the whitespace between the two is the linker's, so it is skipped.
+    assert_eq!(
+        property_value("{scheduled  :\n  2}", "scheduled"),
+        Some("2}")
+    );
+}

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -2560,6 +2560,14 @@ fn assert_worker_shape(deployed: &Path) {
     // work that never runs — and uf shipped exactly that for one commit
     // (ubugeeei-prod/uf#712, taken back by #717). Asserted in both directions
     // so neither can arrive alone, whichever way a future change breaks it.
+    //
+    // `served-app` declares no schedule, so what this compares here is
+    // `false == false`: the two halves are both absent and both have to be.
+    // The case where they are both present is
+    // `a_declared_schedule_reaches_both_halves_of_the_artefact`, which builds a
+    // project that has one — and `schedules::assert_wired` is the same rule
+    // inside `uf build` itself, for every project this repository has no
+    // fixture for.
     let worker = fs::read_to_string(deployed.join("worker.js")).unwrap();
     let triggers = wrangler.get("triggers").is_some();
     let scheduled = worker.contains("scheduled");
@@ -2828,6 +2836,168 @@ fn every_adapter_answers_exactly_what_the_node_adapter_answers() {
                 "a path the build wrote a file for is answered with the file:\n{prerendered}"
             );
         }
+    }
+}
+
+/// A project that declares a schedule, which no fixture in this repository did.
+///
+/// `served-app` deliberately does not grow one: it is the project every
+/// adapter's artefact is built from, and `--adapter serverless` refuses a
+/// declared schedule outright (ubugeeei-prod/uf#531), so adding one there
+/// would take that target out of the comparison every other assertion rests
+/// on. This is the smallest project that has one instead.
+fn scheduled_app() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "uf.config.js",
+            "// @flow\nimport { defineConfig } from \"@uniflowed/config\";\n\n\
+             export default defineConfig({\n  \
+             app: { router: { entry: \"app.js\", root: \"app\" } },\n  \
+             build: { entries: [\"app.js\"], outDir: \"dist\" },\n});\n",
+        ),
+        (
+            "app.js",
+            "// @flow\nimport { routerView } from \"@uniflowed/router\";\n\n\
+             export default routerView(\"./app\");\n",
+        ),
+        (
+            "app/_uf.layout.js",
+            "// @flow\nimport * as React from \"@uniflowed/react\";\n\n\
+             export component Layout(children: React.Node) {\n  return (\n    \
+             <html lang=\"en\">\n      <body>{children}</body>\n    </html>\n  );\n}\n",
+        ),
+        (
+            "app/_uf.page.js",
+            "// @flow\nimport * as React from \"@uniflowed/react\";\n\n\
+             export default component Home() {\n  return <h1>scheduled</h1>;\n}\n",
+        ),
+        // The declaration itself, and the `GET` a trigger calls. A string
+        // rather than a call, because `uf build` reads this without running
+        // the project.
+        (
+            "app/api/sweep/_uf.route.js",
+            "// @flow\n\nexport const schedule: string = \"*/15 * * * *\";\n\n\
+             export function GET(): Response {\n  \
+             return Response.json({ swept: true });\n}\n",
+        ),
+    ]
+}
+
+/// A declared schedule reaches both halves of every artefact that runs one.
+///
+/// The end-to-end half of `schedules::assert_wired`, and the reason that check
+/// exists at all: `assert_worker_shape` below has compared `triggers` against
+/// `scheduled` since ubugeeei-prod/uf#717, and had never once compared them in
+/// the direction that broke. No fixture declared a schedule, so every artefact
+/// this file has ever built carried neither half and the comparison was
+/// `false == false`. A change that emitted one half alone — which is exactly
+/// what #712 shipped — would have gone green.
+///
+/// So this builds a project that declares one, and asks the three shapes:
+///
+/// * `edge` — Cloudflare is told to fire an expression, `worker.js` exports
+///   the `scheduled()` it calls, and the routes map sends that expression at
+///   the route that declared it.
+/// * `node` — the process is its own scheduler, so what has to be true is that
+///   `server.js` wires the run *and hands the list to `serve`*; an entry that
+///   built the array and dropped the argument is #712 with no configuration
+///   file to make it visible.
+/// * `serverless` — refused, by name, before anything is linked. uf writes no
+///   configuration file for a zip, so there is nowhere to say when to call it.
+///
+/// Two builds and one refusal. The refusal costs nothing — it happens before
+/// the bundle — and the two builds are of the smallest project that can carry
+/// a route handler at all.
+#[test]
+fn a_declared_schedule_reaches_both_halves_of_the_artefact() {
+    if !fixture_ready() {
+        return;
+    }
+    let project = Project::new(&scheduled_app());
+    let root = project.path();
+
+    // Cloudflare's half: a trigger, an export, and a route for the expression.
+    let built = uf()
+        .arg("--cwd")
+        .arg(root)
+        .args(["build", "--adapter", "edge"])
+        .output()
+        .unwrap();
+    assert!(
+        built.status.success(),
+        "`uf build --adapter edge` failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+    let deployed = root.join(".uf/deploy/edge");
+    let wrangler: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(deployed.join("wrangler.json")).unwrap()).unwrap();
+    assert_eq!(
+        wrangler["triggers"]["crons"][0], "*/15 * * * *",
+        "{wrangler}"
+    );
+    let worker = fs::read_to_string(deployed.join("worker.js")).unwrap();
+    assert!(
+        worker.contains("scheduled:"),
+        "a trigger with nothing to call is the bug #712 shipped:\n{worker}"
+    );
+    assert!(
+        worker.contains("\"*/15 * * * *\": \"/api/sweep\""),
+        "Cloudflare fires the expression, so it has to reach a route:\n{worker}"
+    );
+
+    // The process targets' half, on `node`, which `bun` and `container` share:
+    // the run is wired *and* the list is handed to the server.
+    let built = uf()
+        .arg("--cwd")
+        .arg(root)
+        .args(["build", "--adapter", "node"])
+        .output()
+        .unwrap();
+    assert!(
+        built.status.success(),
+        "`uf build --adapter node` failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+    let server = fs::read_to_string(root.join(".uf/deploy/node/server.js")).unwrap();
+    for expected in ["routeSchedule(", "\"/api/sweep\"", "\"*/15 * * * *\""] {
+        assert!(server.contains(expected), "missing {expected}:\n{server}");
+    }
+    // The list reaches the server, asked without depending on how the linker
+    // laid the call out. `schedules` is the property `serve` reads, so it
+    // survives; what would not survive is a line, and an earlier version of
+    // this assertion looked for one and went red the moment the linker put
+    // `serve({` on its own. An entry that assembles the array and never
+    // passes it mentions the name once, where the array is declared — so the
+    // question is whether it is mentioned again *after* the last schedule
+    // went into it.
+    let built_at = server
+        .rfind("routeSchedule(")
+        .unwrap_or_else(|| panic!("no `routeSchedule(` in:\n{server}"));
+    assert!(
+        server[built_at..].contains("schedules"),
+        "an entry that assembles the list and never passes it runs nothing:\n{server}"
+    );
+
+    // And the target that would run none says so before it links anything.
+    let refused = uf()
+        .arg("--cwd")
+        .arg(root)
+        .args(["build", "--adapter", "serverless"])
+        .output()
+        .unwrap();
+    assert!(
+        !refused.status.success(),
+        "a schedule nothing runs is refused"
+    );
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&refused.stdout),
+        String::from_utf8_lossy(&refused.stderr)
+    );
+    for expected in ["serverless", "/api/sweep", "*/15 * * * *", "_uf.route.js"] {
+        assert!(said.contains(expected), "missing {expected} in:\n{said}");
     }
 }
 


### PR DESCRIPTION
## What this is

`uf build --adapter edge` writes `triggers.crons` into a `wrangler.json` and a `scheduled()` into the `worker.js` beside it, both from one list. #712 shipped the first without the second — a Worker Cloudflare accepts, deploys, and then fails on every invocation of — and #717 took it back, leaving an assertion in `assert_worker_shape` that compares the two halves **in both directions**.

**That assertion has never once run in the direction that broke.** No fixture in this repository declares a schedule, so every artefact the suite has ever built carried neither half, and the comparison could only ever be `false == false`. A change that emitted one half alone again would have gone green.

This moves the rule into the product, and gives the test suite a project that has one.

## The check

`uf build --adapter` now reads back the files it has just written, before it reports the directory as an artefact (`schedules::assert_wired`):

| target | what has to agree |
| --- | --- |
| `edge` | `triggers.crons` is exactly the declared list; `worker.js` exports a `scheduled` when and only when there is one to call; every declared expression is followed by the route it was declared on |
| `node`, `bun`, `container` | `server.js` carries a `cron:` and a `path:` holding the strings of every declaration |
| `serverless`, `static`, `deno` | run none — a schedule reaching here is the bypassed `refuse_unrunnable` it would be, reported as a fault in uf |

The expression-to-route check is the one a `scheduled` export alone would not catch: Cloudflare fires the *expression*, so one the routes map does not hold is an invocation with nowhere to go.

**Only the data is matched, and that is the design.** These files are Rolldown output — the identifiers, the statement forms and the whitespace belong to a third program. What no linker alters is a string literal, or a property name an object is read by at runtime, so that is the whole of what this looks for. Every unit-test fixture is driven in two spellings, one readable and one renamed-and-reflowed, to keep it that way.

The direction it therefore cannot state is an *extra* schedule on a target with no platform file. Those entries link the scheduler itself — `serve` reaches `@uniflowed/server/schedule` for every project — so a bare `cron:` in a linked `server.js` is `schedule.js`'s own `cron: parseCron(options.cron)` far more often than it is a declaration, and telling one from the other needs a second JavaScript parser in `uf`, which is a worse trade than the gap. `the_schedulers_own_cron_property_is_not_read_as_a_declaration` holds that line. On `edge`, where the platform file is uf's own rather than a linker's, both directions are exact.

## The fixture, and what it caught immediately

`a_declared_schedule_reaches_both_halves_of_the_artefact` builds the first project here that declares a schedule, and asks `edge`'s two files, `node`'s entry, and `serverless`'s refusal.

It is a project of its own rather than a route added to `served-app`: `--adapter serverless` refuses a declared schedule outright (#531), and `served-app` is the project every adapter's artefact is built from — adding one there would take that target out of the comparison the rest of those assertions rest on.

**It earned its keep twice before this PR went green.** The first version of the check matched `const routes = {` — the shape `workerEntrySource` generates — and CI failed, because the linker renames that binding. The next run got past the check and failed on the *test's* own assertion, which looked for `schedules` on the same line as `serve({` and met a `serve({` the linker had put on a line by itself. Both are exactly the over-fitting that a check written against generated source and never run against a linked artefact would have shipped, and between them they are why nothing here now depends on a line or on an identifier the linker owns.

## Tests fail without the change

17 new tests (16 unit, 1 end-to-end). Verified by making `assert_wired` return `Ok(())` unconditionally and re-running: **8 of them fail** — every refusal direction. The acceptance tests keep passing, which is what they are for.

```
failures:
    a_handler_no_trigger_would_call_is_refused
    a_process_entry_that_carries_a_different_expression_is_refused
    a_process_entry_that_carries_a_different_route_is_refused
    a_process_entry_that_lost_a_declaration_is_refused
    a_schedule_routed_to_another_path_is_refused
    a_target_that_runs_no_schedule_never_carries_one
    a_trigger_the_worker_routes_nowhere_is_refused
    a_trigger_with_no_handler_to_call_is_refused
test result: FAILED. 50 passed; 8 failed
```

The check was then restored and the suite re-run.

## What was run

* `cargo fmt --all` — exit 0.
* `cargo clippy -p uf_cli --all-targets -- -D warnings` — **exit 0**, no warnings from `uf_cli`.
* `cargo test -p uf_cli` (the whole crate, not `--lib`) — **733 passed, 1 failed**. The failure is `permissions::a_permission_node_cannot_enforce_stops_the_run`, and it **fails identically with this change stashed**: the machine this was written on has no `node_modules`, so that test's project cannot resolve `@uniflowed/host`. Pre-existing and environmental, verified by running it on the stashed tree rather than assumed.
* CI is where the end-to-end test actually runs: without `node_modules` every fixture-driven test in `vite.rs` skips locally, as `fixture_ready` describes ("CI sets nothing and so can never skip").

## What this is not

**No adapter is added, and #391 stays open.** Six of its seven are implemented (`node`, `bun`, `edge`, `serverless`, `static`, `container`); `deno` is the one left, and its gate is written into `DeployAdapter::unimplemented_because`, into `docs/app/reference/cli/_uf.page.mdx`, and into the issue: the `node` output already runs unchanged on Deno, so the adapter is worth writing only once a benchmark shows the native server beating `node:http` under the same handler. That benchmark has been run for Bun and not for Deno, and this machine has no Deno to run it with. Writing it anyway would have been the "directory with a different name on it" the issue refuses by name, and — unlike `bun`, which has `the_bun_adapter_writes_a_directory_bun_serves_from_an_empty_one` — nothing here could have bound its socket to disagree. See the issue comment for what else #391 still has open.

Refs #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)
