### PR TITLE
fix(integrations, ci, docs): the install a `uf check` is worthless without, and the recipes read back against the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,16 @@ jobs:
       # and the failure surfaces as `uf: command not found` in a pipeline
       # belonging to somebody who cannot fix it.
       - run: ./target/release/uf run integrations
+      # And that the recipes inside those files still run. The step above
+      # checks the installation; this reads every `uf` command in the three
+      # integrations and in `/guide/ci` back against the binary this job
+      # downloaded, so a renamed command or a removed flag fails here rather
+      # than in somebody else's pipeline. It also holds the rule that costs the
+      # most to get wrong: a recipe must install the project before checking
+      # it, because `uf check` with no `node_modules` does not fail — it types
+      # every unresolved import as `any` and passes.
+      - run: ./target/release/uf run ci:recipes
+      - run: ./target/release/uf run ci:recipes:test
       # And that the set that goes to npm is closed under its own
       # dependencies. `@uniflowed/stylex` depends on `@uniflowed/core`, so a
       # release that sends one without the other publishes a package that

--- a/docs/app/_design/nav.js
+++ b/docs/app/_design/nav.js
@@ -199,7 +199,8 @@ export const sections: $ReadOnlyArray<Section> = [
       {
         href: "/guide/ci",
         title: "uf in CI",
-        blurb: "GitHub Actions, GitLab and CircleCI: one step each, and why they all pin.",
+        blurb:
+          "GitHub Actions, GitLab and CircleCI: one step each, why they all pin, and the install a check is worthless without.",
       },
     ],
   },

--- a/docs/app/guide/ci/_uf.page.mdx
+++ b/docs/app/guide/ci/_uf.page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "uf in CI · uf"
-description: "GitHub Actions, GitLab and CircleCI: one step each, and why they all pin."
+description: "GitHub Actions, GitLab and CircleCI: one step each, why they all pin, and the install a check is worthless without."
 ---
 
 <p className="eyebrow">The tools</p>
@@ -41,13 +41,18 @@ jobs:
       - uses: ubugeeei-prod/uf/integrations/github-actions@uf@0.0.0-alpha.10
         with:
           version: 0.0.0-alpha.10
-      - run: uf install
+      - run: uf install --frozen-lockfile
+      - run: uf fmt --check
       - run: uf check
       - run: uf test
 ```
 
-Inputs: `version`, `cache`, `setup-url`, `repository`. Outputs: `version`,
-`bin-dir`, `cache-hit`.
+Inputs: `version`, `cache`, `setup-url`, `repository`, `verify-origin`, `token`.
+Outputs: `version`, `bin-dir`, `cache-hit`.
+
+The action installs the *toolchain*. `uf install` is a separate line because it
+is a separate thing — see [Install before you check](#install-before-you-check),
+which is the one mistake in this page that does not announce itself.
 
 On a Windows runner it **fails** rather than skipping. uf publishes macOS and
 Linux binaries only, and a matrix leg that quietly does nothing still reports
@@ -66,20 +71,23 @@ variables:
 check:
   extends: .uf
   script:
-    - uf install
+    - uf install --frozen-lockfile
     - uf check
 ```
 
-The template also ships `uf:check`, `uf:test` and `uf:build` as ready-made jobs,
-so a project with nothing unusual about it writes no `script` at all. They are
-ordinary jobs: extend, override or delete them.
+The template also ships `uf:check`, `uf:fmt`, `uf:test` and `uf:build` as
+ready-made jobs, so a project with nothing unusual about it writes no `script`
+at all. They are ordinary jobs: extend, override or delete them.
 
-Two details are GitLab's rather than uf's. The toolchain installs into
+Three details are GitLab's rather than uf's. The toolchain installs into
 `$CI_PROJECT_DIR/.uf-toolchain`, because GitLab's cache only carries paths
 inside the project directory — install it in `$HOME` and every job of every
-pipeline downloads the release again. And the default image is Debian rather
-than Alpine: uf ships a `*-unknown-linux-gnu` binary, and a glibc binary does
-not start on musl.
+pipeline downloads the release again. The default image is glibc rather than
+Alpine, because uf ships a `*-unknown-linux-gnu` binary and a glibc binary does
+not start on musl. And it is `node:24-bookworm-slim` rather than a bare Debian,
+because `uf install` drives the project's own package manager and `uf test` and
+`uf build` run on a JavaScript host: `uf` itself needs nothing, and three of the
+four things a pipeline asks it to do need Node on the image.
 
 ## CircleCI
 
@@ -98,8 +106,65 @@ workflows:
 ```
 
 `uf/install` is the command on its own, for a job that does more than run one
-`uf` line. `uf/default` is a glibc executor with `curl` and `tar`, which is
-everything the installer needs.
+`uf` line — and a job that assembles its own steps runs `uf install` itself, the
+way the one above does. `uf/default` is a glibc executor with `curl`, `tar`,
+Node and npm: the first two are what the installer needs, the last two are what
+everything after it needs.
+
+`uf/run` runs `uf install --frozen-lockfile` before the command it was given.
+`install-dependencies: false` turns that off, for a job whose command reads no
+dependencies at all.
+
+## Install before you check
+
+The three files above install the toolchain. The toolchain is not the project,
+and the line that installs it is not optional:
+
+```yaml
+- run: uf install --frozen-lockfile
+```
+
+Leave it out and `uf test` and `uf build` fail, which is fine — a job that
+cannot run says so. `uf check` is the one to worry about, because it does not
+fail. It **passes**.
+
+`uf check` resolves an import to a file in the batch it is checking or to a
+package under `node_modules`, and a specifier that answers to neither is typed
+`any`. On a checkout with no dependencies installed, every `import type { … }
+from "@uniflowed/react"` is `any`, every annotation written against one is
+neither right nor wrong, and the job goes green having checked the parts of the
+program nobody was worried about. Against a fresh scaffold that looks like this:
+
+```console
+$ uf check                       # no node_modules
+✓ no problems
+
+  types checked  8
+  unchanged      8 of 8
+
+  › these imports are typed as any; uf resolved no module for them
+    - @uniflowed/config
+    - @uniflowed/react
+    - @uniflowed/router
+    - @uniflowed/test
+```
+
+A green tick with a footer nobody reads is the same failure the GitHub action
+refuses a Windows runner over: a job that quietly does nothing still reports the
+pipeline green.
+
+`uf fmt --check` is the quiet version of the same thing. The Flow half needs
+nothing, but JSON, CSS and TypeScript go to a formatter uf runs rather than
+links in, and it is looked for in `node_modules/.bin`. With none there those
+files are reported skipped — and deliberately do not reach the exit code, so a
+`uf fmt --check` job passes over files nothing formatted.
+
+`--frozen-lockfile` is what a pipeline wants rather than a plain install: it
+installs exactly what the lockfile pins and fails when the lockfile has drifted
+from the manifests, instead of resolving the drift away and testing something no
+reviewer approved. It is `npm ci`, `pnpm install --frozen-lockfile`, `yarn
+install --immutable` or `bun install --frozen-lockfile`, whichever manager the
+project brought.
 
 ## Pin the version
 
@@ -128,6 +193,93 @@ it. The GitHub action passes the workflow's own token through and is fine;
 GitLab and CircleCI hand you no GitHub token, so pin the version there. A
 pinned version builds the download URL directly and never reaches the API.
 
+## Reading the result from a job
+
+A pipeline reads two things: the exit code, and whatever the step wrote. Both
+are meant to be read by a program.
+
+The exit codes are uf's whole surface for "did this work", and there are three
+of them — `0`, `1` for a problem the command found, `2` for a command uf could
+not run at all. [The CLI reference](/reference/cli#exit-codes) has the table and
+the two cases that are `1` today and should be `2`.
+
+Nothing needs a terminal. uf draws no progress and no colour when stdout is not
+one, `--json` suppresses every human render there is, and a `uf` with no
+arguments prints the help and exits `2` rather than opening the menu it opens
+for a person. `TERM=dumb`, a closed stdin and a `CI` environment variable each
+say the same thing to it.
+
+For the report itself:
+
+| Command | Machine-readable form |
+| --- | --- |
+| `uf check` | `--json` |
+| `uf lint` | `--json` |
+| `uf test` | `--json`, and `--reporter junit --reporter-outfile <file>` |
+| `uf inspect`, `uf explain`, `uf doc` | `--json` |
+| `uf install` | the exit code, and the tree it wrote |
+| `uf build` | the exit code, and the build manifest under the output directory |
+| `uf fmt --check` | the exit code, and a list of files on stdout |
+
+`uf fmt --check` is the gap and is named as one: the other reports have a
+document and it has prose. A job that only needs the answer is fine — the exit
+code is `1` when a file needs formatting — and one that needs the list has to
+read the list.
+
+`uf check --json` carries the thing this page has been about, so a pipeline can
+fail on it rather than trust that somebody ran `uf install`:
+
+```bash
+uf check --json > check.json
+jq -e '.typeCheck.untypedModules | length == 0' check.json ||
+  { echo "uf resolved no module for some imports; are dependencies installed?"; exit 1; }
+```
+
+`typeCheck.untypedModules` is every specifier uf answered with `any`. It is
+empty on a project whose dependencies are installed and whose imports all
+resolve, and it is the difference between a check that found nothing and a check
+that saw nothing.
+
+## What to cache, and what the key has to say
+
+Two different things are worth carrying between runs, and they answer to
+different keys. One key for both is worse than one cache: it either re-downloads
+the release on every dependency bump or serves last week's dependencies after
+one.
+
+| What | Where | The key must include |
+| --- | --- | --- |
+| The toolchain | wherever `UF_INSTALL_ROOT` puts it | the uf version **and** the architecture |
+| The dependencies | `node_modules`, or the manager's store | the lockfile |
+| uf's own answers | `.uf/cache` | the uf version |
+
+The **architecture** is the one that gets left out, and it was left out of the
+GitLab template until recently. uf publishes one archive per target; a cache
+shared by a fleet with both amd64 and arm64 runners in it will restore one
+target's binary onto the other and report a hit. The GitHub action keys on
+`runner.os` and `runner.arch`, CircleCI on `{{ arch }}`, and GitLab on
+`CI_RUNNER_EXECUTABLE_ARCH`, which is the closest thing GitLab predefines.
+
+The **lockfile** is what `node_modules` answers to, and nothing else is. GitLab's
+`key: files:` hashes it and falls back to a shared key when there is none;
+GitHub's `actions/setup-node` has `cache: npm` for exactly this and is a better
+place for it than the uf action, which installs a toolchain and has no opinion
+about your package manager. pnpm is the exception in all three: its
+`node_modules` is a tree of symlinks into a store outside the project, so cache
+the store — with `store-dir` moved inside the workspace where the CI system
+requires that — rather than the links.
+
+`.uf/cache` holds transform and type-check answers, and each entry is already
+keyed by content — including the binary that produced it, so a stale entry is
+ignored rather than believed. It is safe to carry and safe to lose, which makes
+it the one of the three that is only ever an optimisation. Key it on the uf
+version anyway: entries a different uf wrote will never be read, and a cache
+that only grows is a cache that eventually costs more to restore than to miss.
+
+None of this is believed on the strength of a key. Every integration here runs
+`uf --version` out of a restored toolchain before trusting it, because a cache
+that lost a symlink is a hit that can run nothing.
+
 ## What is actually being run
 
 All three fetch and run
@@ -141,6 +293,8 @@ through the environment:
 | `UF_INSTALL_ROOT` | Where `runtimes/uf@<version>` is unpacked |
 | `UF_BIN_DIR` | Where `uf`, `ufr` and `ufx` are linked |
 | `UF_REPO` | The GitHub repository releases are downloaded from |
+| `UF_VERIFY_ORIGIN` | `auto`, `require` or `off`; see below |
+| `UF_CHECKSUM_BASE` | A second host serving `<version>/<asset>.sha256` |
 
 It resolves the version, downloads `uf-<target>.tar.gz`, **verifies its sha256
 against the checksum published beside it**, refuses an archive whose members
@@ -151,6 +305,44 @@ forget the checksum.
 
 If a pipeline must not depend on `setup.uniflowed.dev`, point `setup-url` (or
 `UF_CI_SETUP_URL` on GitLab) at a mirror, or at the raw file on a pinned tag.
+
+### Proving where the archive came from
+
+The sha256 above proves transit and nothing else: the checksum is published on
+the same host as the archive, so it says the bytes arrived intact, not who made
+them. Two things can say that, and a pipeline is the place to ask for one —
+because a pipeline can install a tool that a laptop usually has not.
+
+* **The signature.** Each release is signed with keyless Sigstore, and the
+  installer checks the bundle against the identity that signed it: the
+  repository and the release workflow inside it. It needs `cosign` on `PATH`,
+  which is a step before the setup one.
+* **A second opinion.** `UF_CHECKSUM_BASE` points at a mirror of the checksums
+  on a host that does not serve the archive. Weaker — it proves two operators
+  agree about the bytes rather than who built them — and an attacker has to hold
+  both hosts rather than one. The installer says so and ignores the setting when
+  the mirror turns out to be the same host.
+
+`verify-origin` (or `UF_VERIFY_ORIGIN`) decides what happens when neither is
+available. `auto`, the default, uses whatever evidence there is, refuses when a
+check *fails*, and says plainly when there was nothing to check. `require` turns
+"nothing to check" into a refusal as well, which is what uf's own release smoke
+test runs with:
+
+```yaml
+- run: |
+    curl -sSL "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64" \
+      -o /usr/local/bin/cosign && chmod +x /usr/local/bin/cosign
+- uses: ubugeeei-prod/uf/integrations/github-actions@uf@0.0.0-alpha.10
+  with:
+    version: 0.0.0-alpha.10
+    verify-origin: require
+```
+
+`off` is for an air-gapped mirror whose operator established the origin some
+other way. A value that is none of the three stops the installer before it
+downloads anything, because a typo in a security switch must not read as
+turning it off.
 
 ## Behind a proxy, or with no network at all
 
@@ -164,7 +356,21 @@ Flow submodule, and takes minutes rather than seconds.
 ## What is not here
 
 There is no Jenkins, Buildkite, Woodpecker or Drone file, and no Docker image
-that ships uf preinstalled. All of them are the same four lines — install,
-`PATH`, cache, run — and none of them is written here yet. `curl -fsSL
-https://setup.uniflowed.dev | sh` followed by adding `~/.local/bin` to `PATH`
-is the whole of what any of them would do.
+that ships uf preinstalled. All of them are the same five lines — install,
+`PATH`, cache, `uf install`, run — and none of them is written here yet.
+`curl -fsSL https://setup.uniflowed.dev | sh` followed by adding
+`~/.local/bin` to `PATH` is the whole of the first two, and everything on this
+page from [Install before you check](#install-before-you-check) onwards applies
+to a system with no file here exactly as it applies to the three that have one:
+they are properties of uf, not of the runner.
+
+There is also no `--json` on `uf fmt --check`, which is the one thing on this
+page a pipeline has to read as prose. It is a gap rather than a decision, and it
+is named in `tools/ci/recipes-are-runnable.sh` so that it stays one somebody
+chose to leave rather than one nobody noticed.
+
+What there *is*, for a system with no file here, is the same list of rules and a
+check that holds the three files to them. If you write a Jenkins or Buildkite
+recipe for uf, the four things to get right are on this page: pin the version,
+put the architecture in the cache key, run `uf install` before anything reads
+`node_modules`, and read the result out of `--json` rather than out of the log.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -30,17 +30,29 @@ archive whose members would land outside their own directory, unpacks it under
 times: an integration that fetched a tarball itself would be an integration that
 skipped the checksum.
 
-So each file here is the same four decisions in that system's own vocabulary:
+So each file here is the same six decisions in that system's own vocabulary:
 
 1. where to install (`UF_INSTALL_ROOT`, `UF_BIN_DIR`), chosen so that the
    system's own cache can carry it;
 2. how to get that directory onto `PATH` for the steps that follow;
 3. when the cache may be believed;
-4. what happens on a platform with no build.
+4. how hard to work at proving where the archive came from (`UF_VERIFY_ORIGIN`);
+5. what the project needs installed before a `uf` command means anything;
+6. what happens on a platform with no build.
 
-`tools/ci/integrations-agree.sh` checks the first of those against the installer
-itself: an integration may only set environment variables `install.sh` actually
-reads, so a renamed variable fails here rather than in somebody's pipeline.
+Two checks hold them to it, and they check different halves.
+
+`tools/ci/integrations-agree.sh` checks the *installation*: an integration may
+only set environment variables `install.sh` actually reads, so a renamed
+variable fails here rather than in somebody's pipeline.
+
+`tools/ci/recipes-are-runnable.sh` checks what the pipeline does next. It reads
+every `uf` command in these three files and in `/guide/ci` back against the
+binary — the subcommand exists, the flags exist, the result can be read by a
+machine — and holds the fifth decision above, which is the one that does not
+announce itself: `uf check` with no `node_modules` types every unresolved import
+as `any` and *passes*, so a recipe that forgets `uf install` reports a green
+pipeline over a program nothing checked.
 
 ## Pin the version
 
@@ -58,6 +70,12 @@ A restored cache is not believed on the strength of the key either. Each
 integration runs `uf --version` out of the restored directory first: a cache
 that lost a symlink, or one restored onto a different architecture under a key
 that did not distinguish it, looks like a hit and can run nothing.
+
+Every toolchain cache key names the version **and the architecture**, and
+`recipes-are-runnable.sh` checks that it does. uf publishes one archive per
+target, and a cache shared by a fleet with runners of both architectures in it
+will restore one target's binary onto the other and report a hit; the GitLab
+key did exactly that until it gained `CI_RUNNER_EXECUTABLE_ARCH`.
 
 ## Platforms
 

--- a/integrations/circleci/orb.yml
+++ b/integrations/circleci/orb.yml
@@ -15,15 +15,20 @@ display:
 executors:
   default:
     description: >
-      A glibc Linux image with curl and tar, which is everything the installer
-      needs. Alpine is deliberately not offered: uf ships a
-      `*-unknown-linux-gnu` binary and a glibc binary does not start on musl.
+      A glibc Linux image with curl, tar, Node and npm. Alpine is deliberately
+      not offered: uf ships a `*-unknown-linux-gnu` binary and a glibc binary
+      does not start on musl. Node is here because the installer is not the
+      only thing a job runs — `uf install` drives the project's own package
+      manager and `uf test` and `uf build` run on a Capability JS Host, and on
+      `cimg/base`, which is what this said until now, all three failed on a
+      missing `npm`. Pass your own executor to `uf/run` if the project needs
+      more than Node; it needs at least Node.
     parameters:
       tag:
         type: string
-        default: "24.04"
+        default: "22.11"
     docker:
-      - image: cimg/base:<< parameters.tag >>
+      - image: cimg/node:<< parameters.tag >>
 
 # --- Commands --------------------------------------------------------------
 
@@ -73,6 +78,23 @@ commands:
           useful for a fork or a rehearsal of the release process.
         type: string
         default: ubugeeei-prod/uf
+      verify-origin:
+        description: >
+          How hard the installer works at proving where the archive came from:
+          `auto` (the default) uses whatever evidence is available and refuses
+          when a check fails, `require` refuses unless one actually passed,
+          `off` skips it.
+
+          The sha256 the installer always checks proves transit and nothing
+          else — the checksum comes from the host that served the archive.
+          `require` is worth setting in a pipeline, because a pipeline can
+          arrange what a laptop usually cannot: install cosign in a step before
+          this one, and the Sigstore signature uf publishes with each release is
+          checked against the identity of the workflow that signed it. With no
+          cosign it needs `UF_CHECKSUM_BASE`, a mirror of the checksums on a
+          host that does not serve the archive, and fails when it has neither.
+        type: string
+        default: auto
     steps:
       # PATH first, and in its own step, because CircleCI reads $BASH_ENV at
       # the start of every *later* step and not during the one that wrote it.
@@ -100,6 +122,7 @@ commands:
           environment:
             UF_VERSION: << parameters.version >>
             UF_REPO: << parameters.repository >>
+            UF_VERIFY_ORIGIN: << parameters.verify-origin >>
           command: |
             set -eu
             install_dir="<< parameters.install-dir >>"
@@ -141,7 +164,8 @@ commands:
 jobs:
   run:
     description: >
-      Check out the repository, install uf, and run one uf command.
+      Check out the repository, install uf, install the project's dependencies,
+      and run one uf command.
     parameters:
       command:
         description: The uf command to run, for example `uf check`.
@@ -153,6 +177,27 @@ jobs:
       cache:
         type: boolean
         default: true
+      verify-origin:
+        description: Passed to `install`; see the command's own parameter.
+        type: string
+        default: auto
+      install-dependencies:
+        description: >
+          Run `uf install --frozen-lockfile` before the command. Leave it on.
+          The `install` command above installs the *toolchain*, which is not the
+          project: `uf check` resolves an import to a file in its batch or to a
+          package under `node_modules`, and a specifier that answers to neither
+          is typed `any`. With no dependencies installed a `uf check` job goes
+          green having typed the program against nothing — it does not fail, it
+          passes, which is the worse of the two. `uf fmt --check` is the quiet
+          version of the same thing: the formatter it runs over JSON, CSS and
+          TypeScript lives in `node_modules/.bin`, and with none there those
+          files are skipped without reaching the exit code.
+
+          Turn it off only for a job whose command reads no dependencies at all
+          — `uf lint`, say — or for one that installs them itself.
+        type: boolean
+        default: true
       executor:
         type: executor
         default: default
@@ -162,6 +207,16 @@ jobs:
       - install:
           version: << parameters.version >>
           cache: << parameters.cache >>
+          verify-origin: << parameters.verify-origin >>
+      # `--frozen-lockfile` rather than a plain install: it installs exactly
+      # what the lockfile pins and fails when the lockfile has drifted from the
+      # manifests, rather than resolving the drift away and testing something no
+      # reviewer approved. It is `npm ci` under whichever manager the project
+      # brought.
+      - when:
+          condition: << parameters.install-dependencies >>
+          steps:
+            - run: uf install --frozen-lockfile
       - run:
           name: << parameters.command >>
           command: << parameters.command >>
@@ -192,6 +247,10 @@ examples:
   install-in-your-own-job:
     description: >
       Use the command directly when a job does more than run one uf command.
+      `uf/install` installs the toolchain and nothing else, so a job that
+      assembles its own steps runs `uf install` itself — `uf build` has no
+      project to build without it, and `uf check` would type one against `any`
+      and pass.
     usage:
       version: 2.1
       orbs:
@@ -203,6 +262,7 @@ examples:
             - checkout
             - uf/install:
                 version: 0.0.0-alpha.10
+            - run: uf install --frozen-lockfile
             - run: uf build
             - store_artifacts:
                 path: dist

--- a/integrations/github-actions/action.yml
+++ b/integrations/github-actions/action.yml
@@ -2,6 +2,11 @@ name: Set up uf
 description: >-
   Install the uf toolchain and put uf, ufr and ufx on PATH, so a workflow can
   run uf check, uf test and uf build without building anything from source.
+  This installs the toolchain and not the project: run `uf install
+  --frozen-lockfile` in the job before checking, formatting, testing or
+  building. `uf check` with no node_modules does not fail, it passes — every
+  import that resolves to nothing is typed `any`, so the job goes green having
+  checked a program it could not see.
 author: ubugeeei
 
 branding:
@@ -38,6 +43,23 @@ inputs:
       useful for a fork or a rehearsal of the release process.
     required: false
     default: ubugeeei-prod/uf
+  verify-origin:
+    description: >-
+      How hard to work at proving where the archive came from: `auto` (the
+      default) uses whatever evidence is available and refuses when a check
+      fails, `require` refuses unless one actually passed, `off` skips it.
+
+      The installer always checks the archive's sha256 against the checksum
+      published beside it, and that proves transit and nothing else — it came
+      from the host that served the archive. `require` is the one worth setting
+      in a pipeline, because a pipeline can arrange what a laptop usually
+      cannot: install cosign in a step before this one, and the Sigstore
+      signature uf publishes with each release is checked against the identity
+      of the workflow that signed it. Without cosign on PATH, `require` needs
+      `UF_CHECKSUM_BASE` — a mirror of the checksums on a host that does not
+      serve the archive — and fails when it has neither, which is the point.
+    required: false
+    default: auto
   token:
     description: >-
       A GitHub token, used only to ask the API which release is newest — and
@@ -111,6 +133,7 @@ runs:
         UF_REPO: ${{ inputs.repository }}
         UF_INSTALL_ROOT: ${{ steps.paths.outputs.root }}
         UF_BIN_DIR: ${{ steps.paths.outputs.bin-dir }}
+        UF_VERIFY_ORIGIN: ${{ inputs.verify-origin }}
         SETUP_URL: ${{ inputs.setup-url }}
         CACHED: ${{ steps.restore.outputs.cache-hit }}
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/integrations/gitlab/uf.gitlab-ci.yml
+++ b/integrations/gitlab/uf.gitlab-ci.yml
@@ -11,15 +11,20 @@
 #     check:
 #       extends: .uf
 #       script:
+#         - uf install --frozen-lockfile
 #         - uf check
 #
 # Pin the `include` to a tag. A `remote:` include is fetched at pipeline
 # creation, so one on a branch changes what a pipeline runs without anything in
 # the project changing.
 #
-# The ready-made jobs at the bottom — `uf:check`, `uf:test`, `uf:build` — are
-# there so that a project with nothing unusual about it writes no script at all.
-# They are ordinary jobs: override, extend or delete them.
+# The ready-made jobs at the bottom — `uf:check`, `uf:fmt`, `uf:test`,
+# `uf:build` — are there so that a project with nothing unusual about it writes
+# no script at all. They are ordinary jobs: override, extend or delete them.
+#
+# `uf install` is in every one of them and in the example above, and the note
+# over the jobs says why it is not optional: `.uf` installs the toolchain, and
+# a `uf check` with no `node_modules` passes without having checked anything.
 #
 # ## Why the toolchain is installed inside the project directory
 #
@@ -51,6 +56,19 @@ variables:
   # setting the installer ignored. `tools/ci/integrations-agree.sh` holds the
   # line.
   UF_CI_SETUP_URL: "https://setup.uniflowed.dev"
+  # How hard the installer works at proving where the archive came from.
+  # `auto` uses whatever evidence is available and refuses when a check fails;
+  # `require` refuses unless one actually passed; `off` skips it.
+  #
+  # The sha256 the installer always checks proves transit and nothing else — the
+  # checksum comes from the host that served the archive. `require` is worth
+  # setting in a pipeline, because a pipeline can arrange what a laptop usually
+  # cannot: `apt-get install -y cosign` in `before_script`, and the Sigstore
+  # signature uf publishes with each release is checked against the identity of
+  # the workflow that signed it. With no cosign it needs `UF_CHECKSUM_BASE` — a
+  # mirror of the checksums on a host that does not serve the archive — and
+  # fails when it has neither, which is what asking for it means.
+  UF_VERIFY_ORIGIN: "auto"
   # Kept under the project directory so `cache:` can carry it. See above.
   UF_INSTALL_ROOT: "${CI_PROJECT_DIR}/.uf-toolchain"
   UF_BIN_DIR: "${CI_PROJECT_DIR}/.uf-toolchain/bin"
@@ -61,22 +79,72 @@ variables:
 # PATH` below reaches every line a job writes. A job that replaces
 # `before_script` replaces this too, and has to install the toolchain itself.
 #
-# `image` is Debian rather than Alpine on purpose: uf ships a
+# `image` is glibc rather than Alpine on purpose: uf ships a
 # `*-unknown-linux-gnu` binary, and Alpine is musl, where a glibc binary does
-# not start. Override `image` with any glibc distribution.
+# not start.
+#
+# It carries Node and npm on purpose too, and that is the newer half of the
+# reason. `uf` is one static binary and needs nothing to lint, format or type
+# check — but `uf install` drives the project's own package manager, and
+# `uf test` and `uf build` run on a Capability JS Host. On `debian:stable-slim`,
+# which is what this said until now, all three of those failed on a missing
+# `npm`, and `uf:check` ran with no `node_modules` at all: see the note over
+# the ready-made jobs for why that is worse than failing. Override `image` with
+# any glibc distribution that has a JavaScript runtime and a package manager on
+# `PATH`; `tools/ci/recipes-are-runnable.sh` in the uf repository holds the line
+# on the images this file itself may name.
 .uf:
-  image: debian:stable-slim
+  image: node:24-bookworm-slim
   cache:
+    # The toolchain, on the version *and the architecture*.
+    #
     # On the version, so a pipeline that pins one is never handed another.
     # `latest` is in the key too, and the `before_script` below deliberately
     # ignores what it restores: a cache keyed on the word `latest` answers with
     # whatever release was newest the first time the pipeline ran, and goes on
     # answering with it after a newer one ships. So on `latest` this cache is
     # inert, and a pipeline that wants it to do anything should pin a version.
-    key: "uf-${UF_VERSION}"
-    paths:
-      - .uf-toolchain/
-    policy: pull-push
+    #
+    # And on the architecture, which this key did not name until now. The
+    # archive under `.uf-toolchain/` is `uf-<target>.tar.gz` for one target, and
+    # a GitLab cache is shared by every runner attached to a project — a fleet
+    # with both amd64 and arm64 runners in it, which is the ordinary shape of a
+    # self-hosted fleet, restored one architecture's binary onto the other and
+    # got `Exec format error` from a cache that had "hit". The GitHub action and
+    # the CircleCI orb both had the architecture in their keys; this one did
+    # not. `CI_RUNNER_EXECUTABLE_ARCH` is the closest thing GitLab predefines —
+    # it describes the runner executable rather than the job's container, which
+    # is the same answer on every runner that is not cross-architecture with
+    # itself.
+    - key: "uf-${UF_VERSION}-${CI_RUNNER_EXECUTABLE_ARCH}"
+      paths:
+        - .uf-toolchain/
+      policy: pull-push
+    # The project's dependencies, on the lockfile. A different key from the one
+    # above, because they answer to different things: the toolchain changes when
+    # `UF_VERSION` does and the tree under `node_modules/` changes when the
+    # lockfile does, and one key for both would either re-download the release
+    # on every dependency bump or serve last week's tree after one.
+    #
+    # `key:files:` hashes the files it names and falls back to `default` when
+    # none of them is there, so a project that has not committed a lockfile
+    # gets a shared cache rather than a broken pipeline. `prefix` carries the
+    # architecture for the reason above: `node_modules` holds native addons.
+    #
+    # pnpm is the exception, and it is pnpm's own design rather than an
+    # oversight here: its `node_modules` is a tree of symlinks into a
+    # content-addressed store outside the project, and a cache that carries the
+    # links without the store restores a directory of dangling symlinks. A pnpm
+    # project should set `store-dir` inside `$CI_PROJECT_DIR` and cache that
+    # instead.
+    - key:
+        files:
+          - package-lock.json
+          - yarn.lock
+        prefix: "uf-deps-${CI_RUNNER_EXECUTABLE_ARCH}"
+      paths:
+        - node_modules/
+      policy: pull-push
   before_script:
     - |
       set -eu
@@ -104,23 +172,74 @@ variables:
 # Delete what a project does not want. `uf check` is both halves — the linter
 # and Flow's own inference — so a pipeline that runs it does not also need a
 # separate lint job.
+#
+# ## Every one of them installs the project's dependencies first
+#
+# `.uf` above installs the *toolchain*. That is `uf` itself, and it is not the
+# project: until `uf install` has run there is no `node_modules`, and three of
+# these four commands answer a different question without one.
+#
+# `uf check` is the one that matters, because it does not fail — it passes.
+# `uf check` resolves an import to a file in its batch or to a package under
+# `node_modules`, and a specifier that answers to neither is typed `any`. So on
+# a checkout with no dependencies installed every `import type { … } from
+# "@uniflowed/react"` is `any`, every annotation written against it is neither
+# right nor wrong, and the job goes green having checked the parts of the
+# program that were never in doubt. Run against a fresh scaffold that is what
+# it looks like:
+#
+#     $ uf check                 # no node_modules
+#     ✓ no problems
+#       › these imports are typed as any; uf resolved no module for them
+#         - @uniflowed/react …
+#
+# A green tick with a footer nobody reads is the same failure the GitHub action
+# refuses Windows over: a job that quietly does nothing still reports the
+# pipeline green.
+#
+# `uf fmt --check` is the quieter version of it. The Flow half needs nothing,
+# but JSON, CSS and TypeScript go to a formatter uf runs rather than links in,
+# and it is looked for in `node_modules/.bin` — with none there those files are
+# reported skipped and do not reach the exit code, so the job passes over files
+# nothing formatted. `uf test` and `uf build` do not have this problem: they
+# need a JavaScript host and they fail outright without one.
+#
+# `--frozen-lockfile` is what a pipeline wants rather than a plain install:
+# it installs exactly what the lockfile pins and fails when the lockfile has
+# drifted from the manifests, instead of resolving the drift away and building
+# something no reviewer approved. It is `npm ci`, `pnpm install
+# --frozen-lockfile`, `yarn install --immutable` and `bun install
+# --frozen-lockfile`, whichever manager the project brought.
 
 uf:check:
   extends: .uf
   stage: test
   script:
+    - uf install --frozen-lockfile
     - uf check
+
+# Formatting is not part of `uf check`: the checker answers whether the program
+# is right and this answers whether it is written the way the project writes
+# things. Both belong in a pipeline, and this is the cheaper of the two.
+uf:fmt:
+  extends: .uf
+  stage: test
+  script:
+    - uf install --frozen-lockfile
+    - uf fmt --check
 
 uf:test:
   extends: .uf
   stage: test
   script:
+    - uf install --frozen-lockfile
     - uf test
 
 uf:build:
   extends: .uf
   stage: build
   script:
+    - uf install --frozen-lockfile
     - uf build
   artifacts:
     paths:

--- a/tools/ci/recipes-are-runnable.sh
+++ b/tools/ci/recipes-are-runnable.sh
@@ -1,0 +1,416 @@
+#!/bin/sh
+# The CI recipes this repository ships run commands uf has, in an order and on
+# an image that can run them.
+#
+# `tools/ci/integrations-agree.sh` checks the *installation*: that the three
+# integrations configure `install.sh` with variables it reads, so `uf` ends up
+# on `PATH`. This checks what happens next — the recipes themselves. They are
+# YAML for three systems this repository has no runner for, and until this
+# existed nothing at all read them:
+#
+#   integrations/github-actions/action.yml
+#   integrations/gitlab/uf.gitlab-ci.yml
+#   integrations/circleci/orb.yml
+#   docs/app/guide/ci/_uf.page.mdx     (its fenced blocks, which are copied)
+#
+# That is the whole argument for this file. A shipped recipe is a copy of the
+# CLI's surface that ages on its own: rename a flag and three files go on
+# passing it, in pipelines belonging to people who cannot fix them. So the
+# recipes are read back against the binary rather than against a memory of it —
+# every command below is asked of `uf <command> --help` at the moment the check
+# runs, which is the only source that cannot be stale.
+#
+# Five rules. Three of them were failing when this was written, and the
+# integrations were fixed in the same commit; the failures are described where
+# each rule is.
+#
+#   1. Every `uf` command a recipe runs names a subcommand the binary has, and
+#      passes only flags that subcommand accepts.
+#   2. Every one of those commands can be read by a machine: it offers `--json`,
+#      or it is named in NO_MACHINE_READABLE_FORM below with the reason. A CI
+#      job should fail on a report, not on a grep of prose.
+#   3. A command that reads `node_modules` is preceded, in the same recipe, by
+#      `uf install`. This is the rule worth having: `uf check` with nothing
+#      installed does not fail, it *passes* — every import that resolves to
+#      nothing is typed `any` — so the job goes green having checked a program
+#      it could not see.
+#   4. A recipe that names its own image names one with a JavaScript runtime and
+#      a package manager on it, when it runs a command that needs one.
+#   5. A cache key for the toolchain names both the version and the
+#      architecture. A key missing either is a hit that can run nothing.
+#
+# It needs the binary. `UF_BIN` points at one — the `Metadata` job passes
+# `./target/release/uf`, which is the artefact `Toolchain` built — and the check
+# fails rather than guessing when there is none, because a rule that quietly
+# stops being applied is the failure mode every gate in this directory exists to
+# prevent.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+# --- The written lists -----------------------------------------------------
+
+# Recipes that ship, and the guide whose fenced blocks people copy.
+YAML_RECIPES="integrations/github-actions/action.yml
+integrations/gitlab/uf.gitlab-ci.yml
+integrations/circleci/orb.yml"
+GUIDE="docs/app/guide/ci/_uf.page.mdx"
+
+# Commands that read `node_modules`, and therefore need `uf install` to have run.
+#
+#   check   resolves an import to a file in its batch or to a package under
+#           `node_modules`; a specifier that answers to neither is typed `any`.
+#           With nothing installed it reports "no problems" over a program it
+#           could not see. It is the one that passes rather than failing, which
+#           is why this rule exists.
+#   fmt     prints Flow from the parser's tree and needs nothing for that, but
+#           JSON, CSS and TypeScript go to a formatter uf runs rather than links
+#           in, found in `node_modules/.bin`. With none there those files are
+#           reported skipped and deliberately do not reach the exit code, so the
+#           job passes over files nothing formatted.
+#   build   runs Vite, which is a dependency.
+#   test    runs the suite on a Capability JS Host against the project's own
+#           imports.
+NEEDS_DEPENDENCIES="build check fmt test"
+
+# Commands that need a JavaScript runtime or a package manager to exist on the
+# image at all — as opposed to needing the project installed. `install` is here
+# and not above: it *is* the install, and it drives npm, pnpm, yarn or bun.
+NEEDS_A_JS_HOST="build dev install preview start test"
+
+# Images that carry one, as prefixes. This list is short on purpose: it governs
+# the images *this repository* writes into its own recipes, not what a project
+# may pass to `uf/run`. Add to it when a recipe here needs another, and say what
+# the image provides.
+#
+#   node:       Debian with Node and npm, which is the whole requirement.
+#   cimg/node:  CircleCI's convenience image, Node and npm plus their caches.
+IMAGES_WITH_A_JS_HOST="node: cimg/node:"
+
+# Commands a recipe runs whose result a job reads without `--json`, with the
+# reason. Rule 2 requires `--json` of everything else.
+#
+#   install  answers with the tree it wrote and its exit code; `--frozen-lockfile`
+#            makes a drifted lockfile the failure, which is the outcome a
+#            pipeline is asking about.
+#   build    answers with its exit code, and writes a build manifest into the
+#            output directory — a file, which is machine-readable in the way
+#            that matters for a build.
+#   fmt      answers with its exit code and a list of files on stdout, and has
+#            no `--json` yet. This is a gap rather than a design: `uf check`,
+#            `uf lint` and `uf test` all have one, and a job that wants to know
+#            *which* files need formatting has to read prose. Named here so the
+#            exemption is a decision somebody made rather than one nobody
+#            noticed.
+NO_MACHINE_READABLE_FORM="build fmt install"
+
+# --- The binary ------------------------------------------------------------
+
+uf="${UF_BIN:-}"
+if [ -z "$uf" ]; then
+  for candidate in target/release/uf target/debug/uf; do
+    if [ -x "$candidate" ]; then
+      uf="$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$uf" ] || [ ! -x "$uf" ]; then
+  echo "recipes: FAIL: no uf binary to ask." >&2
+  echo "  This check reads the recipes back against the CLI rather than against" >&2
+  echo "  a copy of it, so it cannot run without one. Build it, or point at it:" >&2
+  echo "    cargo build --release --bin uf" >&2
+  echo "    UF_BIN=/path/to/uf tools/ci/recipes-are-runnable.sh" >&2
+  exit 1
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-recipes.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+status=0
+
+fail() {
+  echo "recipes: FAIL: $*" >&2
+  status=1
+}
+
+# `uf <name> --help`, cached, or empty when there is no such command.
+help_for() {
+  cached="$work/help.$1"
+  if [ ! -f "$cached" ]; then
+    if "$uf" "$1" --help >"$cached" 2>/dev/null; then
+      :
+    else
+      : >"$cached"
+    fi
+  fi
+  cat "$cached"
+}
+
+in_list() {
+  in_list_needle="$1"
+  for in_list_item in $2; do
+    [ "$in_list_item" = "$in_list_needle" ] && return 0
+  done
+  return 1
+}
+
+# --- Reading the recipes ---------------------------------------------------
+#
+# One record per `uf` command, as `file|line|unit|kind|command`.
+#
+# A *unit* is one recipe: a top-level key in a YAML file (`uf:check:`, `jobs:`)
+# and a fenced block in the guide. Rule 3 is about order within a unit, and a
+# `uf install` three jobs away is not an install this one ran.
+#
+# A *step* is a line a shell will run — `- uf check`, `- run: uf build` — and a
+# *declaration* is a command written as a value, which is what a CircleCI
+# parameter default and an orb invocation's `command:` are. Both are checked for
+# being real commands; only steps are ordered, because a default is not a thing
+# that runs before or after anything.
+#
+# Line-oriented, and it knows the shape these four files are written in, for the
+# same reason `gate-covers-every-job.sh` is: this runs in the `Metadata` job,
+# which installs nothing. Prose is deliberately out of reach — every `uf` here
+# has to sit in a command position, so the sentence "uf publishes macOS and
+# Linux binaries only" in an action's description is not read as a subcommand
+# called `publishes`.
+extract() {
+  awk -v MODE="$2" '
+    BEGIN { unit = "(top)"; fence = 0; infence = 0 }
+    MODE == "mdx" {
+      if ($0 ~ /^[ \t]*```/) {
+        infence = 1 - infence
+        if (infence) { fence++; unit = "block " fence }
+        next
+      }
+      if (!infence) next
+    }
+    {
+      raw = $0
+      if (MODE == "yaml" && raw ~ /^[^ \t#]/) {
+        u = raw
+        if (sub(/:[ \t]*$/, "", u)) unit = u
+      }
+      if (raw ~ /^[ \t]*#/) next
+      line = raw
+      sub(/[ \t]+#.*$/, "", line)
+      kind = ""
+      if (sub(/^[ \t]*-[ \t]+run:[ \t]*/, "", line)) kind = "step"
+      else if (sub(/^[ \t]*-[ \t]+/, "", line)) kind = "step"
+      else if (sub(/^[ \t]*run:[ \t]*/, "", line)) kind = "step"
+      else if (sub(/^[ \t]*command:[ \t]*/, "", line)) kind = "decl"
+      else if (sub(/^[ \t]*default:[ \t]*/, "", line)) kind = "decl"
+      else next
+      if (line !~ /^uf[ \t]+[a-z]/) next
+      gsub(/^[ \t]+|[ \t]+$/, "", line)
+      printf "%s|%d|%s|%s|%s\n", FILENAME, NR, unit, kind, line
+    }
+  ' "$1"
+}
+
+for file in $YAML_RECIPES $GUIDE; do
+  [ -f "$file" ] || {
+    fail "$file is missing"
+    continue
+  }
+done
+[ "$status" -eq 0 ] || exit 1
+
+: >"$work/records"
+for file in $YAML_RECIPES; do
+  extract "$file" yaml >>"$work/records"
+done
+extract "$GUIDE" mdx >>"$work/records"
+
+if [ ! -s "$work/records" ]; then
+  fail "found no uf command in any recipe — have they been rewritten?"
+  exit 1
+fi
+
+# --- Rules 1, 2 and 3 ------------------------------------------------------
+
+subcommands=""
+# The last `uf install` seen, per unit. Reset when the unit changes: the records
+# are in file order, and a unit's lines are contiguous.
+current_unit=""
+installed_at=""
+
+while IFS='|' read -r file line unit kind command; do
+  [ -n "$command" ] || continue
+  if [ "$file|$unit" != "$current_unit" ]; then
+    current_unit="$file|$unit"
+    installed_at=""
+  fi
+
+  # shellcheck disable=SC2086
+  set -- $command
+  shift # `uf`
+  name="$1"
+  shift
+
+  # 1. The command exists.
+  help="$(help_for "$name")"
+  if [ -z "$help" ]; then
+    fail "$file:$line runs \`uf $name\`, which this uf has no command for"
+    continue
+  fi
+
+  # 1. And so does every flag it passes.
+  flag_trouble=""
+  for word in "$@"; do
+    case "$word" in
+      --*)
+        # `--flag=value` names the flag before the `=`.
+        flag="${word%%=*}"
+        if ! printf '%s\n' "$help" |
+          grep -qE -- "(^|[^A-Za-z0-9_-])$flag([^A-Za-z0-9_-]|$)"; then
+          fail "$file:$line passes $flag to \`uf $name\`, which does not accept it"
+          flag_trouble="yes"
+        fi
+        ;;
+      *) ;;
+    esac
+  done
+  [ -z "$flag_trouble" ] || continue
+
+  case " $subcommands " in
+    *" $name "*) ;;
+    *) subcommands="$subcommands $name" ;;
+  esac
+
+  # 3. Order, for the commands that read `node_modules`.
+  if [ "$kind" = "step" ]; then
+    if [ "$name" = "install" ]; then
+      installed_at="$line"
+    elif in_list "$name" "$NEEDS_DEPENDENCIES"; then
+      if [ -z "$installed_at" ]; then
+        fail "$file:$line runs \`uf $name\` with no \`uf install\` before it in \`$unit\`"
+        echo "        \`uf $name\` reads node_modules, and installing the toolchain is" >&2
+        echo "        not installing the project. The two that do not simply fail are" >&2
+        echo "        the reason this is checked: \`uf check\` types every unresolved" >&2
+        echo "        import as \`any\` and reports no problems, and \`uf fmt --check\`" >&2
+        echo "        skips the files whose formatter lives in node_modules/.bin" >&2
+        echo "        without letting them reach the exit code. Both go green." >&2
+      fi
+    fi
+  fi
+done <"$work/records"
+
+echo "commands the recipes run:$subcommands"
+
+# 2. Each of them can be read by a machine.
+for name in $subcommands; do
+  if in_list "$name" "$NO_MACHINE_READABLE_FORM"; then
+    echo "  --  uf $name answers with its exit code (see NO_MACHINE_READABLE_FORM)"
+    continue
+  fi
+  if help_for "$name" | grep -qE -- '(^|[^A-Za-z0-9_-])--json([^A-Za-z0-9_-]|$)'; then
+    echo "  ok  uf $name --json"
+  else
+    fail "a recipe runs \`uf $name\`, which offers no --json"
+    echo "        A CI job has to read this command's result by grepping prose." >&2
+    echo "        Give it --json, or name it in NO_MACHINE_READABLE_FORM with the" >&2
+    echo "        reason a job does not need one." >&2
+  fi
+done
+
+# --- Rule 4: the image can run what the recipe runs -------------------------
+
+for file in $YAML_RECIPES; do
+  needs_host=""
+  while IFS='|' read -r record_file _ _ _ command; do
+    [ "$record_file" = "$file" ] || continue
+    # shellcheck disable=SC2086
+    set -- $command
+    if in_list "$2" "$NEEDS_A_JS_HOST"; then
+      needs_host="yes"
+    fi
+  done <"$work/records"
+  [ -n "$needs_host" ] || continue
+
+  # A whole line at a time: an image is one value, and `cimg/node:<< parameters.tag >>`
+  # is three words.
+  grep -v '^[[:space:]]*#' "$file" |
+    sed -n 's/^[[:space:]]*-\{0,1\}[[:space:]]*image:[[:space:]]*//p' >"$work/images"
+  while IFS= read -r image; do
+    [ -n "$image" ] || continue
+    known=""
+    for prefix in $IMAGES_WITH_A_JS_HOST; do
+      case "$image" in
+        "$prefix"*) known="yes" ;;
+      esac
+    done
+    if [ -n "$known" ]; then
+      echo "  ok  $file runs on $image"
+    else
+      fail "$file runs a command needing a JavaScript host on \`$image\`"
+      echo "        \`uf install\`, \`uf test\` and \`uf build\` need a runtime and a" >&2
+      echo "        package manager on the image. Name one of:" >&2
+      echo "        $IMAGES_WITH_A_JS_HOST" >&2
+    fi
+  done <"$work/images"
+done
+
+# --- Rule 5: a toolchain cache key names the version and the architecture ---
+#
+# A key that names neither is the worst of the three, and all three have been
+# wrong at least once. Without the version a pipeline that pins one is handed
+# another; without the architecture a fleet with amd64 and arm64 runners in it
+# restores one target's binary onto the other and gets `Exec format error` out
+# of a cache that reported a hit. Both are keys that "hit" and can run nothing,
+# which is the failure each integration already guards against at run time by
+# making the restored binary answer `uf --version` before believing it — this is
+# the same rule, one step earlier.
+VERSION_TOKENS="UF_VERSION inputs.version parameters.version"
+ARCH_TOKENS="runner.arch runner.os CI_RUNNER_EXECUTABLE_ARCH {{ arch }}"
+
+for file in $YAML_RECIPES; do
+  keys="$(
+    grep -v '^[[:space:]]*#' "$file" |
+      grep -E '^[[:space:]]*-?[[:space:]]*keys?:' |
+      grep -- 'uf-' || true
+  )"
+  [ -n "$keys" ] || continue
+  printf '%s\n' "$keys" | while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    # A dependency cache answers to the lockfile rather than to the toolchain,
+    # and GitLab spells that as `key: files:` on the lines below rather than
+    # inside the key. Only the toolchain's own key is this rule's business.
+    case "$key" in
+      *deps*) continue ;;
+    esac
+    has_version=""
+    for token in $VERSION_TOKENS; do
+      case "$key" in
+        *"$token"*) has_version="yes" ;;
+      esac
+    done
+    has_arch=""
+    for token in $ARCH_TOKENS; do
+      case "$key" in
+        *"$token"*) has_arch="yes" ;;
+      esac
+    done
+    if [ -z "$has_version" ]; then
+      echo "recipes: FAIL: $file caches the toolchain under a key naming no version:" >&2
+      echo "       $key" >&2
+      exit 1
+    fi
+    if [ -z "$has_arch" ]; then
+      echo "recipes: FAIL: $file caches the toolchain under a key naming no architecture:" >&2
+      echo "       $key" >&2
+      echo "        uf ships one archive per target. A cache shared by runners of" >&2
+      echo "        more than one architecture will restore the wrong binary and" >&2
+      echo "        report a hit. Name one of: $ARCH_TOKENS" >&2
+      exit 1
+    fi
+    echo "  ok  $file caches the toolchain on the version and the architecture"
+  done || status=1
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "recipes-are-runnable: ok"
+fi
+exit "$status"

--- a/tools/ci/test-recipes-are-runnable.sh
+++ b/tools/ci/test-recipes-are-runnable.sh
@@ -1,0 +1,283 @@
+#!/bin/sh
+# `recipes-are-runnable.sh` against recipes it can safely make wrong.
+#
+# The check reads four files nothing else in this repository reads, so what is
+# worth testing is that it *notices*. Each case below is one of the five rules,
+# planted in a scratch tree in the shape the real recipes are written in, and
+# each is a mistake that was in this repository or is one edit away from being
+# in it:
+#
+#   * `uf check` with no `uf install` before it — which is what the GitLab and
+#     CircleCI recipes shipped, and which passes rather than failing.
+#   * A renamed command and a removed flag, which is what a shipped recipe
+#     turns into on its own when the CLI moves under it.
+#   * An image with no JavaScript runtime on it, which is what both of those
+#     recipes named.
+#   * A toolchain cache key with no architecture in it, which is what the
+#     GitLab one used.
+#   * A command a job cannot read the result of, and no written reason.
+#
+# And one case for the guard itself: with no binary to ask, it fails rather
+# than passing, because a check that quietly stops applying is what every gate
+# in this directory exists to prevent.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+script="$repo_root/tools/ci/recipes-are-runnable.sh"
+
+# The binary the check asks. Resolved to an absolute path here: every case runs
+# from a scratch tree somewhere else, and a relative `target/release/uf` would
+# resolve to nothing there and be indistinguishable from a broken rule.
+uf="${UF_BIN:-}"
+if [ -z "$uf" ]; then
+  for candidate in "$repo_root/target/release/uf" "$repo_root/target/debug/uf"; do
+    if [ -x "$candidate" ]; then
+      uf="$candidate"
+      break
+    fi
+  done
+fi
+case "$uf" in
+  /*) ;;
+  *) uf="$repo_root/$uf" ;;
+esac
+if [ ! -x "$uf" ]; then
+  echo "test-recipes: FAIL: no uf binary at '$uf'." >&2
+  echo "  Build one, or set UF_BIN to an absolute path." >&2
+  exit 1
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-recipes.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+fail() {
+  echo "test-recipes: FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+# A tree with the check in it and one recipe of each shape beside it. The
+# shapes matter more than the contents: the check is line-oriented and knows
+# how these four files are written.
+scratch() {
+  root="$work/$1"
+  rm -rf "$root"
+  mkdir -p "$root/tools/ci" \
+    "$root/integrations/github-actions" \
+    "$root/integrations/gitlab" \
+    "$root/integrations/circleci" \
+    "$root/docs/app/guide/ci"
+  cp "$script" "$root/tools/ci/recipes-are-runnable.sh"
+
+  # The action installs the toolchain and runs no uf command of its own, and
+  # its description is prose that names commands — which is exactly the text a
+  # reader of these files must not mistake for a recipe.
+  cat > "$root/integrations/github-actions/action.yml" <<'ACTION'
+name: Set up uf
+description: >-
+  Install the uf toolchain so a workflow can run uf check and uf test.
+  uf publishes macOS and Linux binaries only.
+runs:
+  using: composite
+  steps:
+    - name: Restore
+      uses: actions/cache/restore@v4
+      with:
+        key: uf-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+ACTION
+
+  cat > "$root/integrations/gitlab/uf.gitlab-ci.yml" <<'GITLAB'
+variables:
+  UF_VERSION: "latest"
+
+.uf:
+  image: node:24-bookworm-slim
+  cache:
+    - key: "uf-${UF_VERSION}-${CI_RUNNER_EXECUTABLE_ARCH}"
+      paths:
+        - .uf-toolchain/
+
+uf:check:
+  extends: .uf
+  script:
+    - uf install --frozen-lockfile
+    - uf check
+GITLAB
+
+  cat > "$root/integrations/circleci/orb.yml" <<'ORB'
+executors:
+  default:
+    docker:
+      - image: cimg/node:22.11
+
+jobs:
+  run:
+    parameters:
+      command:
+        type: string
+        default: uf check
+    steps:
+      - restore_cache:
+          keys:
+            - uf-v1-{{ arch }}-<< parameters.version >>
+      - run: uf install --frozen-lockfile
+      - run:
+          command: << parameters.command >>
+ORB
+
+  cat > "$root/docs/app/guide/ci/_uf.page.mdx" <<'GUIDE'
+---
+title: "uf in CI"
+---
+
+Run uf check in a pipeline.
+
+```yaml
+jobs:
+  check:
+    steps:
+      - run: uf install
+      - run: uf check
+```
+GUIDE
+
+  echo "$root"
+}
+
+check() {
+  ( cd "$1" && UF_BIN="$uf" sh tools/ci/recipes-are-runnable.sh ) >"$work/out" 2>&1
+}
+
+# 1. A tree in which every rule holds.
+root="$(scratch clean)"
+check "$root" || {
+  cat "$work/out" >&2
+  fail "rejected a tree in which every rule holds"
+}
+pass "passes when the recipes are runnable"
+
+# 2. And the prose in the action's description was not read as a recipe. If it
+#    had been, `uf publishes` would have been rule 1's problem above.
+if grep -q 'publishes' "$work/out"; then
+  fail "read an action description as a command"
+fi
+pass "prose that names commands is not read as one"
+
+# 3. Rule 3: the mistake the GitLab and CircleCI recipes shipped.
+root="$(scratch no-install)"
+sed '/uf install/d' "$root/integrations/gitlab/uf.gitlab-ci.yml" > "$work/edited"
+cp "$work/edited" "$root/integrations/gitlab/uf.gitlab-ci.yml"
+if check "$root"; then
+  fail "accepted a \`uf check\` with no \`uf install\` before it"
+fi
+grep -q 'no `uf install` before it' "$work/out" ||
+  fail "failed for some other reason than the missing install"
+pass "rejects a command that reads node_modules with nothing installed"
+
+# 4. And it is the *order* it objects to, not the presence of the word: an
+#    install after the check is not an install the check ran with.
+root="$(scratch install-after)"
+cat > "$root/integrations/gitlab/uf.gitlab-ci.yml" <<'GITLAB'
+.uf:
+  image: node:24-bookworm-slim
+
+uf:check:
+  extends: .uf
+  script:
+    - uf check
+    - uf install --frozen-lockfile
+GITLAB
+if check "$root"; then
+  fail "accepted an install that runs after the command it is for"
+fi
+pass "rejects an install that comes after the command"
+
+# 5. And an install in a different job is a different job's install.
+root="$(scratch install-elsewhere)"
+cat > "$root/integrations/gitlab/uf.gitlab-ci.yml" <<'GITLAB'
+.uf:
+  image: node:24-bookworm-slim
+
+uf:install:
+  extends: .uf
+  script:
+    - uf install --frozen-lockfile
+
+uf:check:
+  extends: .uf
+  script:
+    - uf check
+GITLAB
+if check "$root"; then
+  fail "accepted an install from another job as this one's"
+fi
+pass "rejects an install that belongs to another job"
+
+# 6. Rule 1: a command the binary does not have. This is the staleness the
+#    whole file is for — a recipe outliving the name it was written against.
+root="$(scratch renamed)"
+sed 's/- uf check$/- uf typecheck/' "$root/integrations/gitlab/uf.gitlab-ci.yml" > "$work/edited"
+cp "$work/edited" "$root/integrations/gitlab/uf.gitlab-ci.yml"
+if check "$root"; then
+  fail "accepted a command this uf has no name for"
+fi
+grep -q 'no command for' "$work/out" || fail "failed for some other reason than the name"
+pass "rejects a command the binary does not have"
+
+# 7. Rule 1 again, for a flag. Same failure, one level down, and the more
+#    likely of the two.
+root="$(scratch unknown-flag)"
+sed 's/- uf check$/- uf check --format json/' "$root/integrations/gitlab/uf.gitlab-ci.yml" > "$work/edited"
+cp "$work/edited" "$root/integrations/gitlab/uf.gitlab-ci.yml"
+if check "$root"; then
+  fail "accepted a flag \`uf check\` does not take"
+fi
+grep -q 'does not accept it' "$work/out" || fail "failed for some other reason than the flag"
+pass "rejects a flag the command does not accept"
+
+# 8. Rule 4: an image that cannot run what the recipe runs.
+root="$(scratch no-host)"
+sed 's|image: node:24-bookworm-slim|image: debian:stable-slim|' \
+  "$root/integrations/gitlab/uf.gitlab-ci.yml" > "$work/edited"
+cp "$work/edited" "$root/integrations/gitlab/uf.gitlab-ci.yml"
+if check "$root"; then
+  fail "accepted an image with no JavaScript runtime on it"
+fi
+grep -q 'needing a JavaScript host' "$work/out" || fail "failed for some other reason than the image"
+pass "rejects an image that cannot run what the recipe runs"
+
+# 9. Rule 5: a toolchain cache key with no architecture in it.
+root="$(scratch key-without-arch)"
+sed 's/uf-${UF_VERSION}-${CI_RUNNER_EXECUTABLE_ARCH}/uf-${UF_VERSION}/' \
+  "$root/integrations/gitlab/uf.gitlab-ci.yml" > "$work/edited"
+cp "$work/edited" "$root/integrations/gitlab/uf.gitlab-ci.yml"
+if check "$root"; then
+  fail "accepted a toolchain cache key naming no architecture"
+fi
+grep -q 'naming no architecture' "$work/out" || fail "failed for some other reason than the key"
+pass "rejects a toolchain cache key with no architecture"
+
+# 10. Rule 2: a command whose result a job cannot read, with no written reason.
+root="$(scratch unreadable)"
+sed 's/- uf check$/- uf clean/' "$root/integrations/gitlab/uf.gitlab-ci.yml" > "$work/edited"
+cp "$work/edited" "$root/integrations/gitlab/uf.gitlab-ci.yml"
+if check "$root"; then
+  fail "accepted a command with no --json and no written exemption"
+fi
+grep -q 'offers no --json' "$work/out" || fail "failed for some other reason than the missing --json"
+pass "rejects a command a job would have to grep prose to read"
+
+# 11. The guard on the guard. With no binary to ask, this check cannot apply
+#     rules 1 and 2 at all, and the answer to that is to fail rather than to
+#     report the three it can still apply as a pass.
+root="$(scratch no-binary)"
+if ( cd "$root" && UF_BIN=/nonexistent/uf sh tools/ci/recipes-are-runnable.sh ) >"$work/out" 2>&1; then
+  fail "passed with no uf binary to ask"
+fi
+grep -q 'no uf binary to ask' "$work/out" || fail "failed for some other reason than the missing binary"
+pass "fails rather than passing when there is no binary to ask"
+
+echo "test-recipes-are-runnable: ok"

--- a/uf.config.js
+++ b/uf.config.js
@@ -633,6 +633,37 @@ export default defineConfig({
         "tools/ci/integrations-agree.sh",
       ],
     },
+    // And that the recipes inside those files still run. `integrations` above
+    // checks the installation — that `uf` reaches `PATH`; this checks what the
+    // pipeline does next, by reading every `uf` command in the three
+    // integrations and in `/guide/ci` back against the binary. A shipped recipe
+    // is a copy of the CLI's surface that ages on its own, and it also has to
+    // install the project before checking it: `uf check` with no `node_modules`
+    // does not fail, it passes, because every import that resolves to nothing
+    // is typed `any`.
+    //
+    // No `dependsOn: ["build"]`, unlike the other tasks that run
+    // `./target/release/uf`. This one runs in `Metadata`, which downloads the
+    // binary `Toolchain` built rather than building one, and has no Rust cache
+    // to build with — a dependency on `build` would spend a release build there
+    // to reproduce the artefact already in the directory. The script says how
+    // to point `UF_BIN` at a binary when there is none.
+    "ci:recipes": {
+      command: "UF_BIN=./target/release/uf tools/ci/recipes-are-runnable.sh",
+      // The recipes, the guide whose blocks people copy, and the script. Not
+      // `crates/**`: this asks the *binary* what commands it has, and the
+      // binary's own freshness is `Toolchain`'s question rather than this
+      // task's.
+      inputs: [
+        "integrations/**",
+        "docs/app/guide/ci/_uf.page.mdx",
+        "tools/ci/recipes-are-runnable.sh",
+      ],
+    },
+    "ci:recipes:test": {
+      command: "UF_BIN=./target/release/uf tools/ci/test-recipes-are-runnable.sh",
+      inputs: ["tools/ci/recipes-are-runnable.sh", "tools/ci/test-recipes-are-runnable.sh"],
+    },
     lockfile: {
       command: "tools/ci/lockfile-in-sync.sh",
       // The lock, the root manifest, and every workspace manifest the root's
@@ -755,6 +786,8 @@ export default defineConfig({
         "scripts:parse",
         "scripts:parse:test",
         "integrations",
+        "ci:recipes",
+        "ci:recipes:test",
         "release:closure",
         "publishable",
         "publishable:test",


### PR DESCRIPTION
## What "supported" has to mean

A CI runner is *mentioned* when a page shows YAML somebody can copy. It is
**supported** when what we ship is executed against the CLI it claims to drive,
and when the facts a pipeline needs are stated by uf rather than guessed by the
reader.

`integrations/` already had the first half of that: three files that install uf
through the same checksum-verifying installer a human runs, and
`tools/ci/integrations-agree.sh` holding them to the variables the installer
reads. Nothing read the other half — what the pipeline does *after* `uf` is on
`PATH`. That was YAML for three systems this repository has no runner for, and
it was wrong.

## What was wrong, and why it was green

**`uf check` with no `node_modules` does not fail. It passes.** An import that
resolves to nothing is typed `any` — #403's design, and correct — so a check on
an uninstalled checkout reports "no problems" over a program it could not see.
Run here, against a fresh scaffold, with the binary from this tree:

```console
$ uf check                 # no node_modules
✓ no problems

  types checked  8
  › these imports are typed as any; uf resolved no module for them
    - @uniflowed/config
    - @uniflowed/react
    - @uniflowed/router
    - @uniflowed/test
```

`uf:check`, `uf:test` and `uf:build` in the GitLab template ran no `uf install`.
Neither did the CircleCI `uf/run` job, nor the orb's `install-in-your-own-job`
example. `uf test` and `uf build` fail there, which is honest. `uf check` went
green — the same failure mode the GitHub action refuses a Windows runner over,
shipped as the default recipe for two systems.

`uf fmt --check` is the quiet version. Its non-Flow formatter lives in
`node_modules/.bin`, and files it cannot format are skipped without reaching the
exit code. Run here:

```console
! biome is not installed, so 2 non-Flow files were skipped
! 1 file of 8 needs formatting         ← the Flow file, and only it
```

**The images could not have installed anything anyway.** `debian:stable-slim`
and `cimg/base` carry no Node and no package manager, so `uf install`,
`uf test` and `uf build` had nothing to run on. `uf` itself needs neither, which
is exactly why this was easy to miss.

**And the GitLab cache key named no architecture.** `uf-${UF_VERSION}`, for a
cache a whole fleet shares. uf publishes one archive per target; a fleet with
amd64 and arm64 runners restores one onto the other and reports a hit. The
action keys on `runner.os`/`runner.arch` and the orb on `{{ arch }}` — GitLab
had version alone.

## The change

| | |
| --- | --- |
| Install first | `uf install --frozen-lockfile` in every ready-made recipe, plus a `uf:fmt` job on GitLab and an `install-dependencies` parameter on the orb |
| Images | `node:24-bookworm-slim`, `cimg/node:22.11` |
| Cache keys | `uf-${UF_VERSION}-${CI_RUNNER_EXECUTABLE_ARCH}`, and a second GitLab entry for `node_modules` keyed on the lockfile with `key: files:` — different things answer to different keys |
| Verification | `UF_VERIFY_ORIGIN` reaches all three, as a `verify-origin` input/parameter. The installer has had keyless Sigstore verification and a second-opinion checksum host for a while and no integration exposed either; a pipeline is the one place that can install `cosign` and ask for `require` |
| Documentation | `/guide/ci` gains the install rule, exit codes and the machine-readable table, the two cache keys, the origin section, and the `jq` that fails a job when `uf check` resolved nothing |

## What checks it

**`tools/ci/recipes-are-runnable.sh`**, wired into `Metadata` as `ci:recipes`.

It reads every `uf` command out of the three integrations and out of
`/guide/ci`'s fenced blocks and asks the **binary** about each one — a shipped
recipe is a copy of the CLI's surface that ages on its own, and the binary is
the only source that cannot be stale. Five rules:

1. the subcommand exists;
2. every flag it passes exists;
3. its result can be read by a machine (`--json`), or it is named in
   `NO_MACHINE_READABLE_FORM` with the reason;
4. a command that reads `node_modules` is preceded by `uf install` **in the same
   recipe** — a unit is a top-level YAML key or one fenced block, so an install
   three jobs away is not this job's install;
5. the image can run what the recipe runs, and a toolchain cache key names the
   version *and* the architecture.

**Three of the five were failing before this change.** Verified by restoring the
three integrations to `HEAD` and running the gate — six findings, and then green
again once restored:

```
recipes: FAIL: integrations/gitlab/uf.gitlab-ci.yml:112 runs `uf check` with no `uf install` before it in `uf:check`
recipes: FAIL: integrations/gitlab/uf.gitlab-ci.yml:118 runs `uf test` …
recipes: FAIL: integrations/gitlab/uf.gitlab-ci.yml:124 runs `uf build` …
recipes: FAIL: integrations/circleci/orb.yml:206 runs `uf build` … in `examples`
recipes: FAIL: integrations/gitlab/uf.gitlab-ci.yml runs a command needing a JavaScript host on `debian:stable-slim`
recipes: FAIL: integrations/circleci/orb.yml runs a command needing a JavaScript host on `cimg/base:<< parameters.tag >>`
recipes: FAIL: integrations/gitlab/uf.gitlab-ci.yml caches the toolchain under a key naming no architecture
```

Two more were checked the same way and also fail as they should: a renamed
command (`uf check` → `uf typecheck`) and a flag uf does not have
(`uf fmt --dry-run`) — which is the staleness the whole file exists for.

**`tools/ci/test-recipes-are-runnable.sh`** is the check against a repository it
can safely make wrong, in the shape of `test-scripts-parse.sh`. Eleven cases:
one per rule, the two orderings that must not count (an install *after* the
command, an install in another job), that prose naming commands is not read as a
recipe, and that with no binary to ask it **fails** rather than reporting the
three rules it could still apply as a pass.

```
  ok  passes when the recipes are runnable
  ok  prose that names commands is not read as one
  ok  rejects a command that reads node_modules with nothing installed
  ok  rejects an install that comes after the command
  ok  rejects an install that belongs to another job
  ok  rejects a command the binary does not have
  ok  rejects a flag the command does not accept
  ok  rejects an image that cannot run what the recipe runs
  ok  rejects a toolchain cache key with no architecture
  ok  rejects a command a job would have to grep prose to read
  ok  fails rather than passing when there is no binary to ask
```

### `ci.yml`

**Two steps added to the existing `Metadata` job. No job added, removed or
reordered**, and no `needs:` touched, so the `CI` gate's list is unchanged.
`ci:gate` and `ci:gate:test` both pass (16/16 cases). The steps are
`./target/release/uf run ci:recipes` and `ci:recipes:test`, which is the form
every other step in that job takes; the tasks deliberately carry no
`dependsOn: ["build"]`, because `Metadata` downloads the `Toolchain` artefact
and has no Rust cache — a dependency on `build` would spend a release build
there to reproduce the binary already in the directory.

## Run versus read

**Run** (a real `uf` binary, on a scaffold outside this repository, because the
workspace makes every package resolve inside it):

* `uf check` and `uf check --json` with and without dependencies — the
  vacuous pass, and `typeCheck.untypedModules` as the field a job can fail on.
* `uf fmt --check` with an unformatted CSS, JSON and Flow file and no
  `node_modules` — the skipped non-Flow files and the exit code that ignores
  them.
* Non-interactive behaviour, with **stdin closed and `TERM=dumb`**: `uf` with no
  arguments prints the help on stderr and exits `2` rather than opening the
  menu; `uf nonsuch` exits `2`; `uf lint --json` exits `1` with pure JSON on
  stdout and the error line on stderr; `uf fmt --check` exits `0` clean and `1`
  dirty. Exit codes and the "no TTY" rule are correct today and needed no
  change — this is the part of the brief that turned out already to be true.
* `--json` coverage across the CI surface: `check`, `lint`, `test`, `inspect`,
  `explain`, `doc` have it. `uf fmt --check` and `uf build` do not.
* The new gate, its test, and every gate this change is near:
  `integrations-agree`, `install-banner-fits`, `gate-covers-every-job` and its
  test, `scripts-parse` (42 scripts) and its test. All green.
* `sh -n` under dash on both new scripts.

**Read**: the CircleCI and GitLab YAML dialects. I have no runner for either, so
`when:` steps, `key: files:`, `CI_RUNNER_EXECUTABLE_ARCH` and the `cimg/node`
and `node:*-slim` tags are read from their documentation and reviewed by eye —
no YAML parser is installed on this machine either, so the files were not even
parsed here. `.github/workflows/ci.yml` is parsed by GitHub and by `zizmor` on
this PR. The `Integrations` workflow, which is the one that installs a real
release on a real runner, is deliberately untouched: an assertion there about
`--json` fields would run against a *published* release rather than this branch
and could fail for reasons this PR is not about.

## What remains

* **`uf fmt --check --json`.** It is the one command in the CI surface a job has
  to read as prose, and it is a gap rather than a design — `check`, `lint` and
  `test` all have a document. It is a Rust change in `uf_cli` (`Fmt` gains
  `json`, `wants_json()` gains a case, and `fmt.rs` grows a payload beside its
  render), and I could not build it here: the shared cargo target directory has
  had its `deps/` removed, so any cargo invocation is a full rebuild of the
  graph, and the machine had 4 GB free with eleven agents on it. Until it
  exists, `NO_MACHINE_READABLE_FORM` in the new gate is where it is written
  down, so it is an exemption somebody chose rather than one nobody noticed. No
  cargo ran, so there is no `cargo fmt`/`clippy`/`cargo test` output to report;
  no crate was touched.
* **uf stating its own cache paths.** `/guide/ci` now says what to cache and
  what each key must include, and the gate holds the integrations to the
  architecture rule — but the source of those facts is a table in a document,
  not the binary. A `uf cache --json` (or a `caches` section in a `uf info
  --json`) would let a runner ask instead of copy, and would let rule 5 check
  the paths as well as the keys.
* **`uf build --json`.** Exempted here because the build manifest it writes is
  the machine-readable artefact, which is true but is not the same as a report.
* **Runners with no file here.** Jenkins, Buildkite, Woodpecker, Drone. The
  guide now ends with the four rules rather than an apology, because they are
  properties of uf rather than of the runner — but nothing checks a recipe this
  repository does not ship, and I have not claimed support for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791545832&installation_model_id=422833&pr_number=739&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F739&signature=20bcb57bf7565b5c89142adf8a7dc2edc0e3fec77fd0fbf6de712599d527e320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->