### PR TITLE
feat(ui): the escape hatch a copy step is for, on ten components rather than one

### DIFF
--- a/docs/app/guide/ui/_uf.page.mdx
+++ b/docs/app/guide/ui/_uf.page.mdx
@@ -39,6 +39,32 @@ One part renders no element and so forwards nothing: `Field.Control` takes a
 nowhere; it belongs on whatever `render` returns, beside the four attributes
 that function is handed.
 
+## Changing the element a part renders
+
+`render` is not only `Field.Control`'s. It is how you say "this one has to be an
+`<a>`", and it is what replaces the copy step a library that writes its source
+into your repository is reached for:
+
+```js
+<Menu.Item render={(props) => <a href="/settings" {...props} />}>Settings</Menu.Item>
+```
+
+The part computes every attribute, every id, every composed handler and every
+ref exactly as it would have, and hands them over for you to put on your own
+element; the children are in there too, so spreading and self-closing still
+renders what you wrote between the tags. The part is still the part — a
+`Menu.Item` rendered as an `<a>` is what `Menu.Body`'s `renders*` constraint
+accepts, and that constraint is the thing a copied source cannot keep.
+
+`Dialog`, `AlertDialog`, `Sheet`, `Drawer`, `Menu`, `ContextMenu`, `Menubar`,
+`Tabs`, `Switch` and `Checkbox` take it on every part that renders an element,
+along with `Field.Control`, `Tooltip.Trigger`, `HoverCard.Trigger` and
+`Sidebar.Item`. The rest of the package does not have it yet; the table in
+`tests/library/ui.test.js` names every part and which of the three states it is
+in, and the suite fails if that table stops matching the files.
+[#303](https://github.com/ubugeeei-prod/uf/issues/303) is the argument, and
+`packages/ui/index.js`'s header is where the decision is recorded.
+
 Import from the package root, where each family is a namespace:
 
 ```js

--- a/packages/ui/alert-dialog.js
+++ b/packages/ui/alert-dialog.js
@@ -46,7 +46,7 @@
 import * as React from "@uniflowed/react";
 import { createContext, useContext, useEffect, useMemo, useRef } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
 import { composeRefs, forwarded, withoutComposed } from "./internal/merge-props.js";
 import {
   DialogBody,
@@ -118,13 +118,17 @@ export component AlertDialogRoot(
 }
 
 /** What opens it, and what focus comes back to when it closes. */
-export component AlertDialogTrigger(children: React.Node, ...rest: Rest) {
-  return <DialogTrigger {...forwarded(rest)}>{children}</DialogTrigger>;
+export component AlertDialogTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogTrigger {...forwarded(rest)} render={render}>
+      {children}
+    </DialogTrigger>
+  );
 }
 
 /** The backdrop. See `Dialog.Overlay`: it is decoration and says so. */
-export component AlertDialogOverlay(...rest: Rest) {
-  return <DialogOverlay {...forwarded(rest)} />;
+export component AlertDialogOverlay(render?: RenderProp, ...rest: Rest) {
+  return <DialogOverlay {...forwarded(rest)} render={render} />;
 }
 
 /**
@@ -136,7 +140,7 @@ export component AlertDialogOverlay(...rest: Rest) {
  * who set two of them would have an alert dialog that is wrong in the third
  * without anything saying so.
  */
-export component AlertDialogBody(children: React.Node, ...rest: Rest) {
+export component AlertDialogBody(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const alert = useAlertDialog("AlertDialog.Body");
 
   return (
@@ -144,6 +148,7 @@ export component AlertDialogBody(children: React.Node, ...rest: Rest) {
       {...forwarded(rest)}
       dismissOnOutsidePress={false}
       initialFocus={alert.cancelRef}
+      render={render}
       role="alertdialog"
     >
       {children}
@@ -184,18 +189,30 @@ component RequireDescription() {
 }
 
 /** The top of the alert dialog. See `Dialog.Header` for why it is a `div`. */
-export component AlertDialogHeader(children: React.Node, ...rest: Rest) {
-  return <DialogHeader {...forwarded(rest)}>{children}</DialogHeader>;
+export component AlertDialogHeader(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogHeader {...forwarded(rest)} render={render}>
+      {children}
+    </DialogHeader>
+  );
 }
 
 /** The bottom, where `Action` and `Cancel` go. */
-export component AlertDialogFooter(children: React.Node, ...rest: Rest) {
-  return <DialogFooter {...forwarded(rest)}>{children}</DialogFooter>;
+export component AlertDialogFooter(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogFooter {...forwarded(rest)} render={render}>
+      {children}
+    </DialogFooter>
+  );
 }
 
 /** The question, which is the alert dialog's accessible name. */
-export component AlertDialogTitle(children: React.Node, ...rest: Rest) {
-  return <DialogTitle {...forwarded(rest)}>{children}</DialogTitle>;
+export component AlertDialogTitle(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogTitle {...forwarded(rest)} render={render}>
+      {children}
+    </DialogTitle>
+  );
 }
 
 /**
@@ -205,7 +222,7 @@ export component AlertDialogTitle(children: React.Node, ...rest: Rest) {
  * exists to deliver, and the only moment the reader has to decide whether they
  * care is before they have pressed anything.
  */
-export component AlertDialogDescription(children: React.Node, ...rest: Rest) {
+export component AlertDialogDescription(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const alert = useAlertDialog("AlertDialog.Description");
   const describedBy = alert.describedBy;
 
@@ -216,7 +233,11 @@ export component AlertDialogDescription(children: React.Node, ...rest: Rest) {
     };
   }, [describedBy]);
 
-  return <DialogDescription {...forwarded(rest)}>{children}</DialogDescription>;
+  return (
+    <DialogDescription {...forwarded(rest)} render={render}>
+      {children}
+    </DialogDescription>
+  );
 }
 
 /**
@@ -227,8 +248,12 @@ export component AlertDialogDescription(children: React.Node, ...rest: Rest) {
  * are made of, so the composition rule about a caller's `onClick` has one
  * implementation rather than a second copy here.
  */
-export component AlertDialogAction(children: React.Node, ...rest: Rest) {
-  return <DialogClose {...forwarded(rest)}>{children}</DialogClose>;
+export component AlertDialogAction(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogClose {...forwarded(rest)} render={render}>
+      {children}
+    </DialogClose>
+  );
 }
 
 /**
@@ -238,7 +263,7 @@ export component AlertDialogAction(children: React.Node, ...rest: Rest) {
  * without the caller wiring a ref: the least destructive action is a fact about
  * which part this is, not a decision to be repeated at every call.
  */
-export component AlertDialogCancel(children: React.Node, ...rest: Rest) {
+export component AlertDialogCancel(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const alert = useAlertDialog("AlertDialog.Cancel");
   const cancelRef = alert.cancelRef;
   const passed = withoutComposed(rest, ["ref"]);
@@ -249,6 +274,7 @@ export component AlertDialogCancel(children: React.Node, ...rest: Rest) {
       ref={composeRefs(rest.ref, (element: HTMLElement | null) => {
         cancelRef.current = element;
       })}
+      render={render}
     >
       {children}
     </DialogClose>

--- a/packages/ui/checkbox.js
+++ b/packages/ui/checkbox.js
@@ -68,8 +68,8 @@
 
 import * as React from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import { composeHandlers, withProps, withoutComposed } from "./internal/merge-props.js";
 import { useControlled } from "./internal/controlled-state.js";
 
 /**
@@ -203,7 +203,14 @@ function submitImplicitly(control: HTMLElement): void {
   form.requestSubmit(submitter);
 }
 
-/** A checkbox, which may also be mixed. */
+/**
+ * A checkbox, which may also be mixed.
+ *
+ * `render` is the escape hatch, and the implicit submission above is the reason
+ * it hands over `onKeyDown` rather than attaching it: whatever element a caller
+ * renders is the one `Enter` arrives on, and it is that element's `form` the
+ * key walks up to.
+ */
 export component Checkbox(
   checked?: boolean,
   defaultChecked?: boolean = false,
@@ -211,6 +218,7 @@ export component Checkbox(
   onCheckedChange?: (checked: boolean) => void,
   disabled?: boolean = false,
   children?: React.Node,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const [on, setOn] = useControlled(checked, defaultChecked, onCheckedChange);
@@ -218,41 +226,39 @@ export component Checkbox(
   // underneath it": a half-selected "select all" that clears itself on the
   // first click is the behaviour every table in every application gets wrong.
   const next = indeterminate ? true : !on;
-  const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);
+  const props = withProps(withoutComposed(rest, ["onClick", "onKeyDown"]), {
+    "aria-checked": indeterminate ? "mixed" : on ? "true" : "false",
+    children,
+    disabled,
+    onClick: composeHandlers(rest.onClick, () => {
+      if (!disabled) {
+        setOn(next);
+      }
+    }),
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      if (disabled) {
+        return;
+      }
+      if (event.key === " ") {
+        // Stops `Space` scrolling the page, and stops the browser's own click
+        // arriving afterwards and toggling this a second time.
+        event.preventDefault();
+        setOn(next);
+        return;
+      }
+      if (event.key === "Enter") {
+        // Claimed, and *not* to make the key inert: the default action here
+        // is a click on this button, and a click on this button toggles. See
+        // the module header for the whole of it.
+        event.preventDefault();
+        submitImplicitly(event.currentTarget as $FlowFixMe);
+      }
+    }),
+    role: "checkbox",
+  });
 
-  return (
-    <button
-      {...passed}
-      aria-checked={indeterminate ? "mixed" : on ? "true" : "false"}
-      disabled={disabled}
-      onClick={composeHandlers(rest.onClick, () => {
-        if (!disabled) {
-          setOn(next);
-        }
-      })}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        if (disabled) {
-          return;
-        }
-        if (event.key === " ") {
-          // Stops `Space` scrolling the page, and stops the browser's own click
-          // arriving afterwards and toggling this a second time.
-          event.preventDefault();
-          setOn(next);
-          return;
-        }
-        if (event.key === "Enter") {
-          // Claimed, and *not* to make the key inert: the default action here
-          // is a click on this button, and a click on this button toggles. See
-          // the module header for the whole of it.
-          event.preventDefault();
-          submitImplicitly(event.currentTarget as $FlowFixMe);
-        }
-      })}
-      role="checkbox"
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }

--- a/packages/ui/context-menu.js
+++ b/packages/ui/context-menu.js
@@ -58,8 +58,13 @@ import { useCallback, useContext, useMemo, useRef, useState } from "@uniflowed/r
 import { useLongPress } from "@uniflowed/hooks/dom";
 
 import type { Rect } from "./internal/anchor.js";
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 import { MenuAnchorContext, MenuContext, MenuLevel, useMenu } from "./internal/menu-tree.js";
 
 /**
@@ -126,7 +131,7 @@ hook usePoint(part: string): PointState {
  * region of the page. The module header says why it is in the tab order and
  * when a caller should take it out again.
  */
-export component ContextMenuTrigger(children: React.Node, ...rest: Rest) {
+export component ContextMenuTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const menu = useMenu("ContextMenu.Trigger");
   const { openAt } = usePoint("ContextMenu.Trigger");
   const triggerRef = useRef<HTMLElement | null>(null);
@@ -149,19 +154,19 @@ export component ContextMenuTrigger(children: React.Node, ...rest: Rest) {
     menu.setOpen(true);
   });
 
-  return (
-    <div
-      // Above the spread, alone, because it is the one attribute here a caller
-      // is invited to overrule: the module header promises `tabIndex={-1}` to a
-      // caller whose trigger already contains something focusable, and a prop
-      // written *after* `{...passed}` wins over the caller's silently — which
-      // is a documented escape hatch that does nothing. Everything below the
-      // spread is this component's own and stays there.
-      tabIndex={0}
-      {...passed}
-      aria-haspopup="menu"
-      id={`${menu.base}-trigger`}
-      onContextMenu={composeHandlers(rest.onContextMenu, (event) => {
+  const props = withProps(
+    // The `tabIndex` goes *underneath* the caller's props, alone, because it is
+    // the one attribute here a caller is invited to overrule: the module header
+    // promises `tabIndex={-1}` to a caller whose trigger already contains
+    // something focusable, and a value that won over the caller's would be a
+    // documented escape hatch that does nothing. Everything in the second
+    // argument is this component's own and stays on top.
+    withProps({ tabIndex: 0 }, passed),
+    {
+      "aria-haspopup": "menu",
+      children,
+      id: `${menu.base}-trigger`,
+      onContextMenu: composeHandlers(rest.onContextMenu, (event: PartEvent) => {
         const press: $FlowFixMe = event;
         // The browser's own menu would otherwise cover this one, and the reader
         // would be looking at the platform's Back/Reload rather than at the
@@ -170,8 +175,8 @@ export component ContextMenuTrigger(children: React.Node, ...rest: Rest) {
         openAt(pointAt(press.clientX ?? 0, press.clientY ?? 0));
         menu.pendingFocus.current = "first";
         menu.setOpen(true);
-      })}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
+      }),
+      onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
         // Both spellings. `ContextMenu` is the dedicated key on a PC keyboard;
         // `Shift+F10` is the one every platform has, and is what a laptop
         // without that key leaves a reader with.
@@ -182,17 +187,20 @@ export component ContextMenuTrigger(children: React.Node, ...rest: Rest) {
         }
         event.preventDefault();
         openHere();
-      })}
-      ref={composeRefs(rest.ref, (element) => {
+      }),
+      ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
         triggerRef.current = element;
         // What focus goes back to when the menu closes. It is deliberately not
         // registered as the menu's *name*; see the module header.
         menu.triggerRef.current = element;
-      })}
-    >
-      {children}
-    </div>
+      }),
+    },
   );
+
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 export type { MenuSelect } from "./menu.js";

--- a/packages/ui/dialog.js
+++ b/packages/ui/dialog.js
@@ -78,8 +78,13 @@ import {
 import { useScrollLock } from "@uniflowed/hooks/browser";
 import { useStableCallback } from "@uniflowed/hooks/lifecycle";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 import { focusable } from "./internal/focus.js";
 import { useControlled } from "./internal/controlled-state.js";
 
@@ -155,29 +160,34 @@ export component DialogRoot(
   return <DialogContext.Provider value={state}>{children}</DialogContext.Provider>;
 }
 
-/** What opens the dialog, and what focus comes back to when it closes. */
-export component DialogTrigger(children: React.Node, ...rest: Rest) {
+/**
+ * What opens the dialog, and what focus comes back to when it closes.
+ *
+ * `render` for a trigger that is not a `<button>` — a card, a table row, an
+ * icon in somebody else's `<Pressable>`. The ref goes across with everything
+ * else, which is what keeps "focus comes back here" true of whatever the
+ * caller rendered.
+ */
+export component DialogTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const dialog = useDialog("Dialog.Trigger");
-  const passed = withoutComposed(rest, ["onClick", "ref"]);
+  const props = withProps(withoutComposed(rest, ["onClick", "ref"]), {
+    // Only while it is open. An `aria-controls` naming an element that is not
+    // in the document is worse than no `aria-controls`: a reader is told
+    // there is somewhere to go and there is not.
+    "aria-controls": dialog.open ? `${dialog.base}-body` : undefined,
+    "aria-expanded": dialog.open ? "true" : "false",
+    "aria-haspopup": "dialog",
+    children,
+    onClick: composeHandlers(rest.onClick, () => dialog.setOpen(true)),
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      dialog.triggerRef.current = element;
+    }),
+  });
 
-  return (
-    <button
-      {...passed}
-      // Only while it is open. An `aria-controls` naming an element that is not
-      // in the document is worse than no `aria-controls`: a reader is told
-      // there is somewhere to go and there is not.
-      aria-controls={dialog.open ? `${dialog.base}-body` : undefined}
-      aria-expanded={dialog.open ? "true" : "false"}
-      aria-haspopup="dialog"
-      onClick={composeHandlers(rest.onClick, () => dialog.setOpen(true))}
-      ref={composeRefs(rest.ref, (element) => {
-        dialog.triggerRef.current = element;
-      })}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -189,12 +199,16 @@ export component DialogTrigger(children: React.Node, ...rest: Rest) {
  * their own backdrop or omits one entirely must still get it. That lives on
  * `Dialog.Body`, which is the part that knows where "outside" is.
  */
-export component DialogOverlay(...rest: Rest) {
+export component DialogOverlay(render?: RenderProp, ...rest: Rest) {
   const dialog = useDialog("Dialog.Overlay");
   if (!dialog.open) {
     return null;
   }
-  return <div {...rest} aria-hidden="true" data-state="open" />;
+  const props = withProps(rest, { "aria-hidden": "true", "data-state": "open" });
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /**
@@ -209,6 +223,7 @@ export component DialogBody(
   dismissOnOutsidePress?: boolean = true,
   initialFocus?: { current: HTMLElement | null },
   role?: DialogRole = "dialog",
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const dialog = useDialog("Dialog.Body");
@@ -295,72 +310,71 @@ export component DialogBody(
     return null;
   }
 
-  const passed = withoutComposed(rest, ["onKeyDown", "ref"]);
-
-  return (
-    <div
-      // `passed` first. A caller `ref` used to replace `bodyRef`, which left it
-      // null, made the Tab branch below return early, and turned the focus trap
-      // off while the dialog still announced `aria-modal="true"`. A caller
-      // `onKeyDown` used to replace this one, and Escape stopped closing it.
-      {...passed}
-      // Only ids that are in the document: an `aria-labelledby` naming a
-      // missing element makes a screen reader announce nothing at all, so a
-      // dialog without a `Dialog.Title` falls through to whatever `aria-label`
-      // the caller passed instead.
-      aria-describedby={dialog.described ? `${dialog.base}-description` : undefined}
-      aria-labelledby={dialog.titled ? `${dialog.base}-title` : undefined}
-      aria-modal="true"
-      id={`${dialog.base}-body`}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        if (event.key === "Escape") {
-          event.preventDefault();
-          // The dialog behind this one must not also close. Two stacked
-          // dialogs nest in the DOM, so without this the event bubbled to the
-          // outer dialog's handler and one Escape closed both.
-          event.stopPropagation();
-          close();
-          return;
-        }
-        if (event.key !== "Tab") {
-          return;
-        }
-        const body = bodyRef.current;
-        if (body == null) {
-          return;
-        }
-        const stops = focusable(body);
-        // An outer dialog must not also run its trap on this key.
+  // The caller's props first. A caller `ref` used to replace `bodyRef`, which
+  // left it null, made the Tab branch below return early, and turned the focus
+  // trap off while the dialog still announced `aria-modal="true"`. A caller
+  // `onKeyDown` used to replace this one, and Escape stopped closing it.
+  const props = withProps(withoutComposed(rest, ["onKeyDown", "ref"]), {
+    // Only ids that are in the document: an `aria-labelledby` naming a
+    // missing element makes a screen reader announce nothing at all, so a
+    // dialog without a `Dialog.Title` falls through to whatever `aria-label`
+    // the caller passed instead.
+    "aria-describedby": dialog.described ? `${dialog.base}-description` : undefined,
+    "aria-labelledby": dialog.titled ? `${dialog.base}-title` : undefined,
+    "aria-modal": "true",
+    children,
+    id: `${dialog.base}-body`,
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        // The dialog behind this one must not also close. Two stacked
+        // dialogs nest in the DOM, so without this the event bubbled to the
+        // outer dialog's handler and one Escape closed both.
         event.stopPropagation();
-        if (stops.length === 0) {
-          // Nothing to move to, so Tab must not leave either.
-          event.preventDefault();
-          return;
-        }
-        const first = stops[0];
-        const last = stops[stops.length - 1];
-        const active = body.ownerDocument?.activeElement;
-        // Wrap at the ends. This is the whole of "focus cannot leave"; every
-        // other Tab press is the browser's own business.
-        if (event.shiftKey && (active === first || active === body)) {
-          event.preventDefault();
-          last.focus();
-        } else if (!event.shiftKey && active === last) {
-          event.preventDefault();
-          first.focus();
-        }
-      })}
-      ref={composeRefs(rest.ref, (element) => {
-        bodyRef.current = element;
-      })}
-      role={role}
-      // So the dialog can hold focus itself when it contains nothing focusable,
-      // and so the trap has somewhere to put focus that is still inside.
-      tabIndex={-1}
-    >
-      {children}
-    </div>
-  );
+        close();
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const body = bodyRef.current;
+      if (body == null) {
+        return;
+      }
+      const stops = focusable(body);
+      // An outer dialog must not also run its trap on this key.
+      event.stopPropagation();
+      if (stops.length === 0) {
+        // Nothing to move to, so Tab must not leave either.
+        event.preventDefault();
+        return;
+      }
+      const first = stops[0];
+      const last = stops[stops.length - 1];
+      const active = body.ownerDocument?.activeElement;
+      // Wrap at the ends. This is the whole of "focus cannot leave"; every
+      // other Tab press is the browser's own business.
+      if (event.shiftKey && (active === first || active === body)) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }),
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      bodyRef.current = element;
+    }),
+    role,
+    // So the dialog can hold focus itself when it contains nothing focusable,
+    // and so the trap has somewhere to put focus that is still inside.
+    tabIndex: -1,
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /**
@@ -370,7 +384,7 @@ export component DialogBody(
  * rendered — a conditional title that is absent used to leave the dialog
  * pointing at an id nothing had.
  */
-export component DialogTitle(children: React.Node, ...rest: Rest) {
+export component DialogTitle(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const dialog = useDialog("Dialog.Title");
   const register = dialog.registerTitle;
   useEffect(() => {
@@ -378,11 +392,15 @@ export component DialogTitle(children: React.Node, ...rest: Rest) {
     return () => register(false);
   }, [register]);
 
-  return (
-    <h2 {...rest} id={`${dialog.base}-title`}>
-      {children}
-    </h2>
-  );
+  const props = withProps(rest, { children, id: `${dialog.base}-title` });
+  // `<h2>` is a default rather than a decision. Which heading level a dialog's
+  // name is depends on what is around it — ubugeeei-prod/uf#276 is the same
+  // observation about an accordion — and `render` is how a caller says so
+  // without losing the id `aria-labelledby` points at.
+  if (render != null) {
+    return render(props);
+  }
+  return <h2 {...props} />;
 }
 
 /**
@@ -392,7 +410,7 @@ export component DialogTitle(children: React.Node, ...rest: Rest) {
  * the one moment the reader has to decide whether they care — so this is where
  * "this cannot be undone" belongs, not in body text further down.
  */
-export component DialogDescription(children: React.Node, ...rest: Rest) {
+export component DialogDescription(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const dialog = useDialog("Dialog.Description");
   const register = dialog.registerDescription;
   useEffect(() => {
@@ -400,11 +418,11 @@ export component DialogDescription(children: React.Node, ...rest: Rest) {
     return () => register(false);
   }, [register]);
 
-  return (
-    <p {...rest} id={`${dialog.base}-description`}>
-      {children}
-    </p>
-  );
+  const props = withProps(rest, { children, id: `${dialog.base}-description` });
+  if (render != null) {
+    return render(props);
+  }
+  return <p {...props} />;
 }
 
 /**
@@ -416,29 +434,35 @@ export component DialogDescription(children: React.Node, ...rest: Rest) {
  * styling layer has a name to attach to, and contributes no semantics because
  * it has none to contribute.
  */
-export component DialogHeader(children: React.Node, ...rest: Rest) {
-  return <div {...rest}>{children}</div>;
+export component DialogHeader(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /** The bottom of the dialog, where the actions go. See `Dialog.Header`. */
-export component DialogFooter(children: React.Node, ...rest: Rest) {
-  return <div {...rest}>{children}</div>;
+export component DialogFooter(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /** A button that closes the dialog. */
-export component DialogClose(children: React.Node, ...rest: Rest) {
+export component DialogClose(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const dialog = useDialog("Dialog.Close");
-  const passed = withoutComposed(rest, ["onClick"]);
+  const props = withProps(withoutComposed(rest, ["onClick"]), {
+    children,
+    onClick: composeHandlers(rest.onClick, () => dialog.setOpen(false)),
+  });
 
-  return (
-    <button
-      {...passed}
-      onClick={composeHandlers(rest.onClick, () => dialog.setOpen(false))}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**

--- a/packages/ui/drawer.js
+++ b/packages/ui/drawer.js
@@ -53,11 +53,12 @@ import { createContext, useContext, useEffect, useMemo, useRef, useState } from 
 import { usePrefersReducedMotion } from "@uniflowed/hooks/browser";
 
 import type { Edge } from "./sheet.js";
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
 import {
   composeHandlers,
   composeRefs,
   forwarded,
+  withProps,
   withoutComposed,
 } from "./internal/merge-props.js";
 import {
@@ -172,13 +173,17 @@ export component DrawerRoot(
 }
 
 /** What opens it, and what focus comes back to when it closes. */
-export component DrawerTrigger(children: React.Node, ...rest: Rest) {
-  return <SheetTrigger {...forwarded(rest)}>{children}</SheetTrigger>;
+export component DrawerTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <SheetTrigger {...forwarded(rest)} render={render}>
+      {children}
+    </SheetTrigger>
+  );
 }
 
 /** The backdrop. It carries the edge, the same as a sheet's. */
-export component DrawerOverlay(...rest: Rest) {
-  return <SheetOverlay {...forwarded(rest)} />;
+export component DrawerOverlay(render?: RenderProp, ...rest: Rest) {
+  return <SheetOverlay {...forwarded(rest)} render={render} />;
 }
 
 /**
@@ -189,7 +194,7 @@ export component DrawerOverlay(...rest: Rest) {
  * no drag to provide an alternative to — and a drawer with a handle and no
  * `Drawer.Close` has a gesture that is the only way out.
  */
-export component DrawerBody(children: React.Node, ...rest: Rest) {
+export component DrawerBody(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const drawer = useDrawer("Drawer.Body");
   const { bodyRef, snapIndex, snapPoints } = drawer;
   const reducedMotion = usePrefersReducedMotion();
@@ -215,6 +220,7 @@ export component DrawerBody(children: React.Node, ...rest: Rest) {
       ref={composeRefs(rest.ref, (element: HTMLElement | null) => {
         bodyRef.current = element;
       })}
+      render={render}
     >
       {children}
       <RequireCloseForTheDrag />
@@ -254,23 +260,39 @@ component RequireCloseForTheDrag() {
 }
 
 /** The top of the drawer, where the handle usually goes. */
-export component DrawerHeader(children: React.Node, ...rest: Rest) {
-  return <SheetHeader {...forwarded(rest)}>{children}</SheetHeader>;
+export component DrawerHeader(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <SheetHeader {...forwarded(rest)} render={render}>
+      {children}
+    </SheetHeader>
+  );
 }
 
 /** The bottom of the drawer, where the actions go. */
-export component DrawerFooter(children: React.Node, ...rest: Rest) {
-  return <SheetFooter {...forwarded(rest)}>{children}</SheetFooter>;
+export component DrawerFooter(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <SheetFooter {...forwarded(rest)} render={render}>
+      {children}
+    </SheetFooter>
+  );
 }
 
 /** The drawer's accessible name. */
-export component DrawerTitle(children: React.Node, ...rest: Rest) {
-  return <SheetTitle {...forwarded(rest)}>{children}</SheetTitle>;
+export component DrawerTitle(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <SheetTitle {...forwarded(rest)} render={render}>
+      {children}
+    </SheetTitle>
+  );
 }
 
 /** What the drawer is for, announced after its name. */
-export component DrawerDescription(children: React.Node, ...rest: Rest) {
-  return <SheetDescription {...forwarded(rest)}>{children}</SheetDescription>;
+export component DrawerDescription(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <SheetDescription {...forwarded(rest)} render={render}>
+      {children}
+    </SheetDescription>
+  );
 }
 
 /**
@@ -279,7 +301,7 @@ export component DrawerDescription(children: React.Node, ...rest: Rest) {
  *
  * It registers itself so `Drawer.Body` can tell whether the gesture has one.
  */
-export component DrawerClose(children: React.Node, ...rest: Rest) {
+export component DrawerClose(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const drawer = useDrawer("Drawer.Close");
   const closes = drawer.closes;
 
@@ -290,7 +312,11 @@ export component DrawerClose(children: React.Node, ...rest: Rest) {
     };
   }, [closes]);
 
-  return <SheetClose {...forwarded(rest)}>{children}</SheetClose>;
+  return (
+    <SheetClose {...forwarded(rest)} render={render}>
+      {children}
+    </SheetClose>
+  );
 }
 
 /**
@@ -305,7 +331,11 @@ export component DrawerClose(children: React.Node, ...rest: Rest) {
  * `label` because a slider with no accessible name is announced as "slider",
  * which is the same failure `Resizable.Handle` names.
  */
-export component DrawerHandle(label?: string = "Resize the drawer", ...rest: Rest) {
+export component DrawerHandle(
+  label?: string = "Resize the drawer",
+  render?: RenderProp,
+  ...rest: Rest
+) {
   const drawer = useDrawer("Drawer.Handle");
   const { bodyRef, close, handles, setSnapIndex, side, snapIndex, snapPoints } = drawer;
   const passed = withoutComposed(rest, [
@@ -360,78 +390,80 @@ export component DrawerHandle(label?: string = "Resize the drawer", ...rest: Res
     return side === "top" || side === "left" ? from - now : now - from;
   };
 
-  return (
-    <div
-      {...passed}
-      aria-label={label}
-      // The axis the drag runs along, which is the axis the snap points are
-      // measured on: a bottom sheet grows upwards, so its slider is vertical.
-      aria-orientation={vertical ? "vertical" : "horizontal"}
-      aria-valuemax={last}
-      aria-valuemin={0}
-      aria-valuenow={snapIndex}
-      // The number a reader can act on. `aria-valuenow` is an index into a list
-      // nobody outside this component has seen, and "2" says nothing.
-      aria-valuetext={`${String(Math.round((snapPoints[snapIndex] ?? 1) * 100))}%`}
-      data-dragging={dragging ? "true" : undefined}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event: $FlowFixMe) => {
-        if (event.key === "Home" || event.key === "End") {
-          event.preventDefault();
-          setSnapIndex(event.key === "Home" ? 0 : last);
-          return;
-        }
-        const towardsOpen = OPENS_WITH[side];
-        const towardsClosed = CLOSES_WITH[side];
-        if (event.key === towardsOpen) {
-          event.preventDefault();
-          step(true);
-          return;
-        }
-        if (event.key === towardsClosed) {
-          event.preventDefault();
-          step(false);
-        }
-      })}
-      onPointerDown={composeHandlers(rest.onPointerDown, (event: $FlowFixMe) => {
-        dragFrom.current = vertical ? event.clientY : event.clientX;
-        setDragging(true);
-        // So the drag survives the pointer leaving the handle, which it does
-        // immediately: the handle moves with the drawer.
-        event.currentTarget?.setPointerCapture?.(event.pointerId);
-      })}
-      onPointerMove={composeHandlers(rest.onPointerMove, (event: $FlowFixMe) => {
-        const body = bodyRef.current;
-        if (dragFrom.current == null || body == null) {
-          return;
-        }
-        // Only away from the edge: dragging a drawer *past* fully open would
-        // otherwise lift it off the edge it is attached to.
-        body.style.setProperty("--uf-drawer-drag", `${String(Math.max(0, travelled(event)))}px`);
-      })}
-      onPointerUp={composeHandlers(rest.onPointerUp, (event: $FlowFixMe) => {
-        const body = bodyRef.current;
-        const moved = travelled(event);
-        dragFrom.current = null;
-        setDragging(false);
-        body?.style.setProperty("--uf-drawer-drag", "0px");
-        if (body == null) {
-          return;
-        }
-        const box = body.getBoundingClientRect();
-        const size = vertical ? box.height : box.width;
-        // A zero-sized box — a document that computes no layout — must not turn
-        // every release into a dismissal.
-        if (size <= 0 || Math.abs(moved) < size * DRAG_THRESHOLD) {
-          return;
-        }
-        step(moved < 0);
-      })}
-      role="slider"
-      // A drag handle that is not in the tab sequence is the WCAG 2.1.1
-      // failure this part exists to avoid.
-      tabIndex={0}
-    />
-  );
+  const props = withProps(passed, {
+    "aria-label": label,
+    // The axis the drag runs along, which is the axis the snap points are
+    // measured on: a bottom sheet grows upwards, so its slider is vertical.
+    "aria-orientation": vertical ? "vertical" : "horizontal",
+    "aria-valuemax": last,
+    "aria-valuemin": 0,
+    "aria-valuenow": snapIndex,
+    // The number a reader can act on. `aria-valuenow` is an index into a list
+    // nobody outside this component has seen, and "2" says nothing.
+    "aria-valuetext": `${String(Math.round((snapPoints[snapIndex] ?? 1) * 100))}%`,
+    "data-dragging": dragging ? "true" : undefined,
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: $FlowFixMe) => {
+      if (event.key === "Home" || event.key === "End") {
+        event.preventDefault();
+        setSnapIndex(event.key === "Home" ? 0 : last);
+        return;
+      }
+      const towardsOpen = OPENS_WITH[side];
+      const towardsClosed = CLOSES_WITH[side];
+      if (event.key === towardsOpen) {
+        event.preventDefault();
+        step(true);
+        return;
+      }
+      if (event.key === towardsClosed) {
+        event.preventDefault();
+        step(false);
+      }
+    }),
+    onPointerDown: composeHandlers(rest.onPointerDown, (event: $FlowFixMe) => {
+      dragFrom.current = vertical ? event.clientY : event.clientX;
+      setDragging(true);
+      // So the drag survives the pointer leaving the handle, which it does
+      // immediately: the handle moves with the drawer.
+      event.currentTarget?.setPointerCapture?.(event.pointerId);
+    }),
+    onPointerMove: composeHandlers(rest.onPointerMove, (event: $FlowFixMe) => {
+      const body = bodyRef.current;
+      if (dragFrom.current == null || body == null) {
+        return;
+      }
+      // Only away from the edge: dragging a drawer *past* fully open would
+      // otherwise lift it off the edge it is attached to.
+      body.style.setProperty("--uf-drawer-drag", `${String(Math.max(0, travelled(event)))}px`);
+    }),
+    onPointerUp: composeHandlers(rest.onPointerUp, (event: $FlowFixMe) => {
+      const body = bodyRef.current;
+      const moved = travelled(event);
+      dragFrom.current = null;
+      setDragging(false);
+      body?.style.setProperty("--uf-drawer-drag", "0px");
+      if (body == null) {
+        return;
+      }
+      const box = body.getBoundingClientRect();
+      const size = vertical ? box.height : box.width;
+      // A zero-sized box — a document that computes no layout — must not turn
+      // every release into a dismissal.
+      if (size <= 0 || Math.abs(moved) < size * DRAG_THRESHOLD) {
+        return;
+      }
+      step(moved < 0);
+    }),
+    role: "slider",
+    // A drag handle that is not in the tab sequence is the WCAG 2.1.1
+    // failure this part exists to avoid.
+    tabIndex: 0,
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /**

--- a/packages/ui/field.js
+++ b/packages/ui/field.js
@@ -96,7 +96,7 @@
 import * as React from "@uniflowed/react";
 import { createContext, useContext, useEffect, useId, useMemo, useState } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
 import { withProps } from "./internal/merge-props.js";
 
 /**
@@ -289,7 +289,7 @@ export component FieldLabel(children: React.Node, ...rest: Rest) {
  * `ref` and handlers *and* the field's attributes from one spread instead of
  * two that overwrite each other.
  */
-export component FieldControl(render: (props: Rest) => React.Node) {
+export component FieldControl(render: RenderProp) {
   const field = useField("Field.Control");
   // A group already carries the name, the description and the validity, and a
   // control repeating them makes a reader hear the error once for the set and

--- a/packages/ui/hover-card.js
+++ b/packages/ui/hover-card.js
@@ -45,7 +45,7 @@ import { useStableCallback } from "@uniflowed/hooks/lifecycle";
 
 import type { Align, LogicalSide } from "./internal/anchor.js";
 import type { HoverIntent } from "./internal/hover-intent.js";
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
 import { composeRefs, withProps, withoutComposed } from "./internal/merge-props.js";
 import {
   DEFAULT_CLOSE_DELAY,
@@ -127,11 +127,7 @@ export component HoverCardRoot(
  * reachable by keyboard, and `useFocusableTrigger` refuses anything else —
  * a hover card on a `<span>` is one a keyboard reader can never see.
  */
-export component HoverCardTrigger(
-  children?: React.Node,
-  render?: (props: Rest) => React.Node,
-  ...rest: Rest
-) {
+export component HoverCardTrigger(children?: React.Node, render?: RenderProp, ...rest: Rest) {
   const card = useHoverCard("HoverCard.Trigger");
   const { closeDelay, dismissed, intent, openDelay, triggerRef } = card;
   useFocusableTrigger(triggerRef, "HoverCard.Trigger");
@@ -187,15 +183,12 @@ export component HoverCardTrigger(
     triggerRef.current = element;
   });
 
-  if (render != null) {
-    return render(withProps(withoutComposed(rest, ["ref"]), { ref: attach }));
-  }
+  const props = withProps(withoutComposed(rest, ["ref"]), { children, ref: attach });
 
-  return (
-    <button {...withoutComposed(rest, ["ref"])} ref={attach} type="button">
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -32,6 +32,91 @@
 // A library written in TypeScript can document those constraints; it cannot
 // state them.
 //
+// # There is no copy step, and `render` is what replaces it
+//
+// shadcn's product is not a component. It is `npx shadcn add dialog`, which
+// writes the source into your repository so that you own it and change it —
+// and around that sit `init`, `view`, `search`, `build`, `migrate`, `eject`, an
+// MCP server, a `components.json` and a registry format anybody can publish to.
+// uf answers the headline question the other way. The roadmap says "typed
+// imports, preset styles, and **no copy step**", and that answer takes
+// something away, so it is argued here rather than assumed.
+// ubugeeei-prod/uf#303 is where it was argued; this is the decision.
+//
+// **Why not.** A copy is a fork with no upstream, and four things follow. A
+// focus trap fixed here reaches everyone who upgrades and reaches nobody who
+// copied. The composition constraints above are checked *across the boundary*:
+// `Tabs.List` declaring `renders* Tabs.Tab` means something while the library
+// is imported and means nothing once the source has been pasted into an
+// application, because then it is the application's own component and Flow has
+// nothing left to hold it to. `sideEffects: false` and one subpath per
+// primitive already give a bundler everything a copy would. And the
+// accessibility work stays in one place with one suite over it, rather than in
+// every consumer's repository at the version they took it at.
+//
+// **What a caller gets instead of owning the source.** The reason people copy
+// is to change the markup, so that has to be answered or this is a worse
+// library for the same use. The answer is `render`, which every part that
+// renders an element of its own is growing:
+//
+//     <Menu.Item render={(props) => <a href="/settings" {...props} />}>
+//       Settings
+//     </Menu.Item>
+//
+// The part computes every attribute, every id, every composed handler and every
+// ref exactly as it would have, and hands them to the caller to put on their
+// own element; `children` is among them, so a caller who spreads and
+// self-closes still gets what was written between the tags. What it does *not*
+// hand over is anything true of the element rather than of the part —
+// `type="button"` stays on the `<button>` branch.
+//
+// It is deliberately not Radix's `asChild`. Cloning a child hides which props
+// arrived and in what order; a function is handed the object, so a caller can
+// read it, order it themselves, and drop one on purpose. And the part is still
+// the part: `Menu.Body`'s `renders*` still rejects a `<div>` where a
+// `Menu.Item` belongs, because a `Menu.Item` rendered as an `<a>` is a
+// `Menu.Item`. That is the half a copied source cannot keep, and it is what
+// makes "no copy step" a trade rather than a loss.
+//
+// **Where it is, today.** `Dialog`, `AlertDialog`, `Sheet`, `Drawer`, `Menu`,
+// `ContextMenu`, `Menubar`, `Tabs`, `Switch` and `Checkbox` are complete —
+// every part of each either takes `render` or renders no element to hand over —
+// along with `Field.Control`, `Tooltip.Trigger`, `HoverCard.Trigger` and
+// `Sidebar.Item`, which had it first. The rest do not have it yet, and that is
+// the remainder of #303. A documented escape hatch that is not there is worse
+// than an undocumented one that is, so the state of every part is a table in
+// `tests/library/ui.test.js` rather than a claim in this paragraph: it names
+// all of them, in three lists, and four tests hold each list to the files. A
+// part added to this barrel is in none of them and the suite says so.
+//
+// **Are the `internal/` modules ever public?** No, and the consequence is
+// worth stating rather than leaving as an omission. `merge-props.js`,
+// `roving-focus.js`, `controlled-state.js` and the rest each explain in their
+// own header why exporting them would publish a weaker promise than the
+// components make — a consumer who could reach `merge-props.js` could build a
+// part that spreads `rest` last, which is the failure it exists to prevent. So
+// there is no third-party primitive that participates the way these do, and no
+// registry of them: the uf-shaped equivalent of publishing a component is a
+// pull request against this package, where its keyboard map gets the same suite
+// as everything else. That is a real cost of the decision and the right side of
+// it for a library whose value is that the hard parts are correct. What a third
+// party *can* build on is the escape hatch itself, which is the whole public
+// surface it needs: a component of theirs given to `render` receives the props
+// this package would have used, and their own composition sits inside a part
+// that is still checked.
+//
+// **What the CLI adds: nothing new.** There is no `uf add`, no
+// `components.json` and no registry, and none is planned. The one affordance
+// `shadcn view` has that is worth having is "tell me what this component is
+// made of", and `uf inspect --json` already answers it: every component, its
+// parts and its readiness, out of `crates/uf_lib/src/ui.rs`, which
+// `cargo test -p uf_lib` holds to this barrel in both directions. A
+// `uf explain Dialog` that also printed the keyboard map and the ARIA is the
+// one thing #303 leaves open; it is a nicer front end for a table that already
+// exists, not a copy step, and this decision does not depend on it.
+// `uf.config.js` is the one configuration surface by design, so a UI option, if
+// there is ever one to make, belongs there rather than in a second file.
+//
 // # Styling is a default, not a dependency
 //
 // Nothing here imports StyleX, and nothing here has a StyleX-shaped type. A
@@ -447,6 +532,15 @@ export type { Sort } from "./table.js";
 export type { Notification, ToastChanges, ToastOptions, Urgency } from "./toast.js";
 export type { ToggleGroupType } from "./toggle-group.js";
 
+/**
+ * The five that are one component rather than a namespace of parts.
+ *
+ * `Switch` and `Checkbox` take `render`, so the control a design system already
+ * has — a `<div>` with a knob drawn in it, somebody's `<Pressable>` — keeps the
+ * role, the state, the keys and the implicit form submission while being their
+ * element. `Progress`, `Separator` and `Toggle` do not have it yet; see the
+ * module header and the table in `tests/library/ui.test.js`.
+ */
 export { Checkbox, Progress, Separator, Switch, Toggle };
 
 /**
@@ -508,6 +602,11 @@ export const Field = {
  *     <Tabs.Panel value="one">…</Tabs.Panel>
  *     <Tabs.Panel value="two">…</Tabs.Panel>
  *   </Tabs.Root>
+ *
+ * Every part takes `render`, so a tab that is also a route — `<Tabs.Tab
+ * render={(props) => <a href="#billing" {...props} />}>` — is still a tab, with
+ * the roving tab stop and the `aria-controls` a tab has. `Tabs.List`'s
+ * `renders* Tabs.Tab` is unaffected, because it is the *part* it constrains.
  */
 export const Tabs = {
   Root: TabsRoot,
@@ -640,6 +739,12 @@ export const ToggleGroup = {
  *       </Dialog.Footer>
  *     </Dialog.Body>
  *   </Dialog.Root>
+ *
+ * Every part takes `render`. `Dialog.Title` is an `<h2>` by default and the
+ * level is a fact about the page around it rather than about the dialog, so
+ * `render={(props) => <h3 {...props} />}` is how a caller says which — without
+ * losing the id `aria-labelledby` points at. `AlertDialog`, `Sheet` and
+ * `Drawer` are made of these parts and pass `render` straight through.
  */
 export const Dialog = {
   Root: DialogRoot,
@@ -865,6 +970,17 @@ export const InputOtp = {
  *       </Menu.Sub>
  *     </Menu.Body>
  *   </Menu.Root>
+ *
+ * Every part takes `render`, which is what makes a menu of links possible — and
+ * a menu of links is the most ordinary menu there is:
+ *
+ *   <Menu.Item render={(props) => <a href="/settings" {...props} />}>
+ *     Settings
+ *   </Menu.Item>
+ *
+ * The `<a>` keeps the middle click, the context menu and the status bar; the
+ * item keeps the role, the id, the roving tab stop and the press that closes
+ * the tree. See the module header for why that is the answer to "no copy step".
  */
 export const Menu = {
   Root: MenuRoot,

--- a/packages/ui/internal/merge-props.js
+++ b/packages/ui/internal/merge-props.js
@@ -20,6 +20,16 @@
 // a caller legitimately wants *both* — event handlers and refs — they are
 // composed rather than one replacing the other.
 //
+// # The other half of the rule: which element the props land on
+//
+// Everything above decides what goes onto the element. `RenderProp` is what
+// decides *which element*, and it is here rather than in a module of its own
+// because it is the same policy read from the other end: a part computes one
+// props object, and either puts it on the element it would have chosen or hands
+// it to the caller to put on theirs. Two ways of composing a caller's props
+// would be two chances to get the order wrong; one shape, stated once, is what
+// keeps a part that renders somebody else's element from being a weaker part.
+//
 // # Why this is `internal/` and not a subpath
 //
 // It is not a "props utils" module and there is nothing else in it. It is the
@@ -27,6 +37,8 @@
 // primitive cannot quietly apply a different one. Exporting it would invite a
 // consumer to build a part that spreads `rest` last, which is the failure this
 // exists to prevent — so it stays unreachable from outside the package.
+
+import type { Node } from "@uniflowed/react";
 
 /**
  * Props on their way onto an element: what a caller hands a part, and what
@@ -76,6 +88,78 @@
 export type Rest = { readonly key?: empty, readonly [string]: mixed };
 
 /**
+ * The escape hatch: a caller's element in place of the part's own.
+ *
+ * `@uniflowed/ui` has no copy step — `packages/ui/index.js`'s header argues
+ * that at length — and the thing a copy step is *for* is changing the markup. A
+ * part that always renders a `<button>` cannot be the link a menu of links
+ * needs; a heading fixed at `<h2>` is wrong inside an accordion. This is what
+ * replaces owning the source: the part still computes every attribute, every
+ * composed handler and every id, and hands them to the caller to put on
+ * whatever element they wanted.
+ *
+ * One name and one signature everywhere, which is the point. `asChild` clones a
+ * child and hopes its props survive; this hands the props over explicitly, so a
+ * caller can see what they are getting, decide the order themselves, and drop
+ * one deliberately. The part is still the part — `Menu.Body`'s `renders*` still
+ * rejects a `<div>` where a `Menu.Item` belongs, because the escape hatch
+ * changes the element the item renders and not what the item *is*. That
+ * constraint is exactly what a copied source loses.
+ *
+ * # What is in the props, and what is not
+ *
+ * Everything the part would have put on its own element, in the order
+ * `withProps` fixes: the caller's `rest` underneath, the part's own semantics on
+ * top, handlers and refs composed rather than replaced. `children` is in there
+ * too, so `render={(props) => <a href={to} {...props} />}` renders what was
+ * written between the tags — a part whose children were silently dropped
+ * because the caller spread the props and forgot them is the kind of quiet
+ * wrongness this package exists to not have. JSX children win over a spread, so
+ * `<a {...props}>Other</a>` still says what it says.
+ *
+ * What is *not* in there is anything true of the element rather than of the
+ * part: `type="button"` is the only one in practice, and it stays on the
+ * `<button>` branch. Handing it to a caller rendering an `<a>` would put an
+ * attribute the HTML has no meaning for on their link.
+ */
+export type RenderProp = (props: Rest) => Node;
+
+/**
+ * What a part's own handler reads of the event it is handed.
+ *
+ * Inexact, and named rather than inferred, for the same reason `menu.js`'s
+ * `MenuSelect` is: what arrives is React's synthetic event, uf does not merge
+ * Flow's `jsx.js` environment so `lib/react.js` models no such thing, and these
+ * are the members the handlers in this package actually read.
+ *
+ * It exists because of `RenderProp`. A handler written inside a JSX attribute
+ * gets its parameter's type from the attribute, which for an intrinsic is
+ * `any`; the escape hatch has to build the props *before* there is an element
+ * to put them on, so the same handler in an object literal has an indexer's
+ * `mixed` for context and Flow asks for an annotation. This is that annotation,
+ * written once rather than at every handler in the package.
+ *
+ * One shape for keys and for presses, which is the one thing it is not honest
+ * about: `key` and the modifiers belong to a keyboard event and a click has no
+ * `key`. It is a parameter annotation for handlers this package writes rather
+ * than a description of an event, nothing widens `mixed` into it, and the day
+ * `$JSXIntrinsics` is real — the day `Rest` becomes `React.PropsOf`, which its
+ * own comment is waiting for — is the day this is React's event types instead.
+ */
+export type PartEvent = {
+  readonly defaultPrevented: boolean,
+  readonly key: string,
+  readonly altKey: boolean,
+  readonly ctrlKey: boolean,
+  readonly metaKey: boolean,
+  readonly shiftKey: boolean,
+  readonly currentTarget: mixed,
+  readonly preventDefault: () => mixed,
+  readonly stopPropagation: () => mixed,
+  ...
+};
+
+/**
  * A caller's props on their way to another *part of this package*, rather than
  * onto an intrinsic element.
  *
@@ -116,7 +200,7 @@ export function forwarded(rest: Rest): $FlowFixMe {
  * `defaultPrevented` is the caller's way of saying "I handled this", which is
  * the same contract the DOM uses.
  */
-export function composeHandlers<TEvent extends { readonly defaultPrevented?: boolean }>(
+export function composeHandlers<TEvent extends { readonly defaultPrevented?: boolean, ... }>(
   theirs: mixed,
   ours: (event: TEvent) => mixed,
 ): (event: TEvent) => mixed {

--- a/packages/ui/menu.js
+++ b/packages/ui/menu.js
@@ -108,8 +108,13 @@ import { useStableCallback } from "@uniflowed/hooks/lifecycle";
 
 import type { Align, LogicalSide } from "./internal/anchor.js";
 import { useAnchor } from "./internal/anchor.js";
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 import {
   directionOf,
   indexOfActive,
@@ -211,45 +216,43 @@ export component MenuSub(
 }
 
 /** The button that opens the menu. */
-export component MenuTrigger(children: React.Node, ...rest: Rest) {
+export component MenuTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const menu = useMenu("Menu.Trigger");
-  const passed = withoutComposed(rest, ["onClick", "onKeyDown", "ref"]);
   useTriggerRegistration(menu);
+  const props = withProps(withoutComposed(rest, ["onClick", "onKeyDown", "ref"]), {
+    // Named only while the menu is in the document, so a reader is never told
+    // to go somewhere that is not there.
+    "aria-controls": menu.open ? `${menu.base}-body` : undefined,
+    "aria-expanded": menu.open ? "true" : "false",
+    "aria-haspopup": "menu",
+    children,
+    id: `${menu.base}-trigger`,
+    onClick: composeHandlers(rest.onClick, () => menu.setOpen(!menu.open)),
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      // `ArrowUp` opening onto the *last* item is the behaviour that makes a
+      // long menu usable: the last entry is usually the destructive one, and
+      // reaching it should not mean arrowing past everything else.
+      const end = match (event.key) {
+        "ArrowDown" => "first",
+        "ArrowUp" => "last",
+        _ => null,
+      };
+      if (end == null) {
+        return;
+      }
+      event.preventDefault();
+      menu.pendingFocus.current = end;
+      menu.setOpen(true);
+    }),
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      menu.triggerRef.current = element;
+    }),
+  });
 
-  return (
-    <button
-      {...passed}
-      // Named only while the menu is in the document, so a reader is never told
-      // to go somewhere that is not there.
-      aria-controls={menu.open ? `${menu.base}-body` : undefined}
-      aria-expanded={menu.open ? "true" : "false"}
-      aria-haspopup="menu"
-      id={`${menu.base}-trigger`}
-      onClick={composeHandlers(rest.onClick, () => menu.setOpen(!menu.open))}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        // `ArrowUp` opening onto the *last* item is the behaviour that makes a
-        // long menu usable: the last entry is usually the destructive one, and
-        // reaching it should not mean arrowing past everything else.
-        const end = match (event.key) {
-          "ArrowDown" => "first",
-          "ArrowUp" => "last",
-          _ => null,
-        };
-        if (end == null) {
-          return;
-        }
-        event.preventDefault();
-        menu.pendingFocus.current = end;
-        menu.setOpen(true);
-      })}
-      ref={composeRefs(rest.ref, (element) => {
-        menu.triggerRef.current = element;
-      })}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -275,6 +278,7 @@ export component MenuBody(
   collisionPadding?: number = 0,
   side?: LogicalSide,
   sideOffset?: number = 0,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const menu = useMenu("Menu.Body");
@@ -377,87 +381,85 @@ export component MenuBody(
     return null;
   }
 
-  const passed = withoutComposed(rest, ["onKeyDown", "ref"]);
+  const props = withProps(withoutComposed(rest, ["onKeyDown", "ref"]), {
+    "aria-labelledby": menu.triggered ? `${menu.base}-trigger` : undefined,
+    "aria-orientation": "vertical",
+    children,
+    "data-align": anchored.align,
+    "data-side": anchored.side,
+    id: `${menu.base}-body`,
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      const body: $FlowFixMe = event.currentTarget;
+      const items = itemsOf(body, ITEM_SELECTOR, MENU_SELECTOR);
+      const at = indexOfActive(items, body.ownerDocument?.activeElement);
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        // This menu, not the one behind it and not the dialog around it.
+        // A submenu is a DOM descendant of its parent menu, so without this
+        // one Escape closed the whole tree at once.
+        event.stopPropagation();
+        menu.setOpen(false);
+        return;
+      }
+
+      if (event.key === "Tab") {
+        // Not prevented: the browser should carry on to the next control,
+        // which is what makes Tab a way *past* a menu rather than a way
+        // through its thirty items.
+        event.stopPropagation();
+        closeAll();
+        return;
+      }
+
+      // Asked once, here, and used for both questions below: which key
+      // closes this submenu, and — for a menu a caller has laid out
+      // horizontally one day — which way the arrows run.
+      const direction = directionOf(body);
+
+      if (!isRoot && event.key === submenuKeys(direction).close) {
+        event.preventDefault();
+        event.stopPropagation();
+        menu.setOpen(false);
+        return;
+      }
+
+      const movement = movementFor(event.key, "vertical", direction);
+      if (movement != null) {
+        // Before moving, or the arrow also scrolls the page under the item
+        // that just took focus.
+        event.preventDefault();
+        event.stopPropagation();
+        const next = moveTo(items, at, movement, true);
+        if (next != null) {
+          next.focus();
+          setActiveId(next.id);
+        }
+        return;
+      }
+
+      if (isTypeaheadKey(event)) {
+        const next = typeahead(items, at, event.key);
+        if (next != null) {
+          event.preventDefault();
+          event.stopPropagation();
+          next.focus();
+          setActiveId(next.id);
+        }
+      }
+    }),
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      bodyRef.current = element;
+    }),
+    role: "menu",
+    // So the menu can hold focus itself when it is empty, and so a press on
+    // its padding does not send focus to `<body>`.
+    tabIndex: -1,
+  });
 
   return (
     <MenuListContext.Provider value={list}>
-      <div
-        {...passed}
-        aria-labelledby={menu.triggered ? `${menu.base}-trigger` : undefined}
-        aria-orientation="vertical"
-        data-align={anchored.align}
-        data-side={anchored.side}
-        id={`${menu.base}-body`}
-        onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-          const body: $FlowFixMe = event.currentTarget;
-          const items = itemsOf(body, ITEM_SELECTOR, MENU_SELECTOR);
-          const at = indexOfActive(items, body.ownerDocument?.activeElement);
-
-          if (event.key === "Escape") {
-            event.preventDefault();
-            // This menu, not the one behind it and not the dialog around it.
-            // A submenu is a DOM descendant of its parent menu, so without this
-            // one Escape closed the whole tree at once.
-            event.stopPropagation();
-            menu.setOpen(false);
-            return;
-          }
-
-          if (event.key === "Tab") {
-            // Not prevented: the browser should carry on to the next control,
-            // which is what makes Tab a way *past* a menu rather than a way
-            // through its thirty items.
-            event.stopPropagation();
-            closeAll();
-            return;
-          }
-
-          // Asked once, here, and used for both questions below: which key
-          // closes this submenu, and — for a menu a caller has laid out
-          // horizontally one day — which way the arrows run.
-          const direction = directionOf(body);
-
-          if (!isRoot && event.key === submenuKeys(direction).close) {
-            event.preventDefault();
-            event.stopPropagation();
-            menu.setOpen(false);
-            return;
-          }
-
-          const movement = movementFor(event.key, "vertical", direction);
-          if (movement != null) {
-            // Before moving, or the arrow also scrolls the page under the item
-            // that just took focus.
-            event.preventDefault();
-            event.stopPropagation();
-            const next = moveTo(items, at, movement, true);
-            if (next != null) {
-              next.focus();
-              setActiveId(next.id);
-            }
-            return;
-          }
-
-          if (isTypeaheadKey(event)) {
-            const next = typeahead(items, at, event.key);
-            if (next != null) {
-              event.preventDefault();
-              event.stopPropagation();
-              next.focus();
-              setActiveId(next.id);
-            }
-          }
-        })}
-        ref={composeRefs(rest.ref, (element) => {
-          bodyRef.current = element;
-        })}
-        role="menu"
-        // So the menu can hold focus itself when it is empty, and so a press on
-        // its padding does not send focus to `<body>`.
-        tabIndex={-1}
-      >
-        {children}
-      </div>
+      {render == null ? <div {...props} /> : render(props)}
     </MenuListContext.Provider>
   );
 }
@@ -516,34 +518,46 @@ hook useMenuItem(
  * that the command exists and is unavailable, where a native `disabled` leaves
  * a silent gap they cannot ask about. The arrow keys and typeahead step over it
  * either way.
+ *
+ * `render` is what makes a menu of links possible, and a menu of links is the
+ * most ordinary menu there is:
+ *
+ *     <Menu.Item render={(props) => <a href="/settings" {...props} />}>
+ *       Settings
+ *     </Menu.Item>
+ *
+ * The `<a>` keeps everything a link is for — the middle click, the context
+ * menu, "open in new tab", the status bar showing where it goes — and the item
+ * keeps the id, the roving tab stop, the role and the press that closes the
+ * tree. That combination is what shadcn's copy step is usually reached for, and
+ * what this package offers instead of it.
  */
 export component MenuItem(
   children: React.Node,
   disabled?: boolean = false,
   closeOnSelect?: boolean = true,
   onSelect?: (event: MenuSelect) => mixed,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const item = useMenuItem("Menu.Item", disabled, closeOnSelect, onSelect, undefined);
-  const passed = withoutComposed(rest, ["onClick", "onFocus"]);
+  const props = withProps(withoutComposed(rest, ["onClick", "onFocus"]), {
+    "aria-disabled": disabled ? "true" : undefined,
+    children,
+    id: item.id,
+    onClick: composeHandlers(rest.onClick, item.onClick),
+    // The roving tab stop follows real focus rather than leading it, so a
+    // pointer that moves focus and a key that moves focus agree without the
+    // two of them having to be kept in step by hand.
+    onFocus: composeHandlers(rest.onFocus, item.onFocus),
+    role: "menuitem",
+    tabIndex: item.tabIndex,
+  });
 
-  return (
-    <button
-      {...passed}
-      aria-disabled={disabled ? "true" : undefined}
-      id={item.id}
-      onClick={composeHandlers(rest.onClick, item.onClick)}
-      // The roving tab stop follows real focus rather than leading it, so a
-      // pointer that moves focus and a key that moves focus agree without the
-      // two of them having to be kept in step by hand.
-      onFocus={composeHandlers(rest.onFocus, item.onFocus)}
-      role="menuitem"
-      tabIndex={item.tabIndex}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -570,28 +584,27 @@ export component MenuCheckboxItem(
   // header for why this default is the opposite of `Menu.Item`'s.
   closeOnSelect?: boolean = false,
   onSelect?: (event: MenuSelect) => mixed,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const [on, setOn] = useControlled(checked, defaultChecked, onCheckedChange);
   const toggle = useCallback(() => setOn(!on), [on, setOn]);
   const item = useMenuItem("Menu.CheckboxItem", disabled, closeOnSelect, onSelect, toggle);
-  const passed = withoutComposed(rest, ["onClick", "onFocus"]);
+  const props = withProps(withoutComposed(rest, ["onClick", "onFocus"]), {
+    "aria-checked": on ? "true" : "false",
+    "aria-disabled": disabled ? "true" : undefined,
+    children,
+    id: item.id,
+    onClick: composeHandlers(rest.onClick, item.onClick),
+    onFocus: composeHandlers(rest.onFocus, item.onFocus),
+    role: "menuitemcheckbox",
+    tabIndex: item.tabIndex,
+  });
 
-  return (
-    <button
-      {...passed}
-      aria-checked={on ? "true" : "false"}
-      aria-disabled={disabled ? "true" : undefined}
-      id={item.id}
-      onClick={composeHandlers(rest.onClick, item.onClick)}
-      onFocus={composeHandlers(rest.onFocus, item.onFocus)}
-      role="menuitemcheckbox"
-      tabIndex={item.tabIndex}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -613,6 +626,7 @@ export component MenuRadioGroup(
   defaultValue?: string | null = null,
   value?: string | null,
   onValueChange?: (value: string) => void,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const base = useId();
@@ -633,12 +647,16 @@ export component MenuRadioGroup(
     [selected, select],
   );
 
+  const props = withProps(rest, {
+    "aria-labelledby": labelled ? group.labelId : undefined,
+    children,
+    role: "group",
+  });
+
   return (
     <MenuGroupContext.Provider value={group}>
       <MenuRadioContext.Provider value={radio}>
-        <div {...rest} aria-labelledby={labelled ? group.labelId : undefined} role="group">
-          {children}
-        </div>
+        {render == null ? <div {...props} /> : render(props)}
       </MenuRadioContext.Provider>
     </MenuGroupContext.Provider>
   );
@@ -657,6 +675,7 @@ export component MenuRadioItem(
   disabled?: boolean = false,
   closeOnSelect?: boolean = false,
   onSelect?: (event: MenuSelect) => mixed,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const group = useContext(MenuRadioContext);
@@ -666,23 +685,21 @@ export component MenuRadioItem(
   const choose = group.choose;
   const pick = useCallback(() => choose(value), [choose, value]);
   const item = useMenuItem("Menu.RadioItem", disabled, closeOnSelect, onSelect, pick);
-  const passed = withoutComposed(rest, ["onClick", "onFocus"]);
+  const props = withProps(withoutComposed(rest, ["onClick", "onFocus"]), {
+    "aria-checked": group.value === value ? "true" : "false",
+    "aria-disabled": disabled ? "true" : undefined,
+    children,
+    id: item.id,
+    onClick: composeHandlers(rest.onClick, item.onClick),
+    onFocus: composeHandlers(rest.onFocus, item.onFocus),
+    role: "menuitemradio",
+    tabIndex: item.tabIndex,
+  });
 
-  return (
-    <button
-      {...passed}
-      aria-checked={group.value === value ? "true" : "false"}
-      aria-disabled={disabled ? "true" : undefined}
-      id={item.id}
-      onClick={composeHandlers(rest.onClick, item.onClick)}
-      onFocus={composeHandlers(rest.onFocus, item.onFocus)}
-      role="menuitemradio"
-      tabIndex={item.tabIndex}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -692,10 +709,9 @@ export component MenuRadioItem(
  * is why it reads the list context of the menu around it and the menu context
  * of the one below it.
  */
-export component MenuSubTrigger(children: React.Node, ...rest: Rest) {
+export component MenuSubTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const menu = useMenu("Menu.SubTrigger");
   const list = useContext(MenuListContext);
-  const passed = withoutComposed(rest, ["onClick", "onFocus", "onKeyDown", "ref"]);
   const setActiveId = list?.setActiveId;
   useTriggerRegistration(menu);
   // The submenu's own trigger id, not a fresh one: the submenu names itself
@@ -707,36 +723,36 @@ export component MenuSubTrigger(children: React.Node, ...rest: Rest) {
     menu.setOpen(true);
   };
 
-  return (
-    <button
-      {...passed}
-      aria-controls={menu.open ? `${menu.base}-body` : undefined}
-      aria-expanded={menu.open ? "true" : "false"}
-      aria-haspopup="menu"
-      id={id}
-      onClick={composeHandlers(rest.onClick, open)}
-      onFocus={composeHandlers(rest.onFocus, () => setActiveId?.(id))}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        const trigger: $FlowFixMe = event.currentTarget;
-        if (event.key !== submenuKeys(directionOf(trigger)).open) {
-          return;
-        }
-        event.preventDefault();
-        // The parent menu's own `ArrowRight` does nothing, but a menu three
-        // levels deep would otherwise see this key at every level.
-        event.stopPropagation();
-        open();
-      })}
-      ref={composeRefs(rest.ref, (element) => {
-        menu.triggerRef.current = element;
-      })}
-      role="menuitem"
-      tabIndex={list?.activeId === id ? 0 : -1}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  const props = withProps(withoutComposed(rest, ["onClick", "onFocus", "onKeyDown", "ref"]), {
+    "aria-controls": menu.open ? `${menu.base}-body` : undefined,
+    "aria-expanded": menu.open ? "true" : "false",
+    "aria-haspopup": "menu",
+    children,
+    id,
+    onClick: composeHandlers(rest.onClick, open),
+    onFocus: composeHandlers(rest.onFocus, () => setActiveId?.(id)),
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      const trigger: $FlowFixMe = event.currentTarget;
+      if (event.key !== submenuKeys(directionOf(trigger)).open) {
+        return;
+      }
+      event.preventDefault();
+      // The parent menu's own `ArrowRight` does nothing, but a menu three
+      // levels deep would otherwise see this key at every level.
+      event.stopPropagation();
+      open();
+    }),
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      menu.triggerRef.current = element;
+    }),
+    role: "menuitem",
+    tabIndex: list?.activeId === id ? 0 : -1,
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -746,8 +762,12 @@ export component MenuSubTrigger(children: React.Node, ...rest: Rest) {
  * moving through the menu is told the group changed. It is not focusable and
  * the arrow keys pass straight over it.
  */
-export component MenuSeparator(...rest: Rest) {
-  return <div {...rest} aria-orientation="horizontal" role="separator" />;
+export component MenuSeparator(render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { "aria-orientation": "horizontal", role: "separator" });
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /**
@@ -758,17 +778,20 @@ export component MenuSeparator(...rest: Rest) {
  * that is not in the document makes a screen reader announce *nothing*, which
  * is worse than an unnamed group.
  */
-export component MenuGroup(children: React.Node, ...rest: Rest) {
+export component MenuGroup(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const base = useId();
   const [labelled, setLabelled] = useState(false);
 
   const group = useMemo(() => ({ labelId: `${base}-label`, registerLabel: setLabelled }), [base]);
+  const props = withProps(rest, {
+    "aria-labelledby": labelled ? group.labelId : undefined,
+    children,
+    role: "group",
+  });
 
   return (
     <MenuGroupContext.Provider value={group}>
-      <div {...rest} aria-labelledby={labelled ? group.labelId : undefined} role="group">
-        {children}
-      </div>
+      {render == null ? <div {...props} /> : render(props)}
     </MenuGroupContext.Provider>
   );
 }
@@ -780,7 +803,7 @@ export component MenuGroup(children: React.Node, ...rest: Rest) {
  * as ordinary content would have a reader hear the heading once as the group's
  * name and again as a stray line of text between the items.
  */
-export component MenuLabel(children: React.Node, ...rest: Rest) {
+export component MenuLabel(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const group = useContext(MenuGroupContext);
   const register = group?.registerLabel;
 
@@ -792,9 +815,9 @@ export component MenuLabel(children: React.Node, ...rest: Rest) {
     return () => register(false);
   }, [register]);
 
-  return (
-    <div {...rest} id={group?.labelId} role="presentation">
-      {children}
-    </div>
-  );
+  const props = withProps(rest, { children, id: group?.labelId, role: "presentation" });
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }

--- a/packages/ui/menubar.js
+++ b/packages/ui/menubar.js
@@ -66,8 +66,13 @@ import {
   useState,
 } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 import type { RovingSet } from "./internal/roving-focus.js";
 import {
   directionOf,
@@ -123,7 +128,7 @@ hook useMenubar(part: string): MenubarState {
  * a page with an application menubar and a formatting toolbar has two, and
  * "menu bar" twice tells a reader nothing about which is which.
  */
-export component MenubarRoot(children: renders* MenubarMenu, ...rest: Rest) {
+export component MenubarRoot(children: renders* MenubarMenu, render?: RenderProp, ...rest: Rest) {
   const barRef = useRef<HTMLElement | null>(null);
   const [open, setOpenValue] = useState<string | null>(null);
   const [active, setActive] = useState<string | null>(null);
@@ -142,57 +147,55 @@ export component MenubarRoot(children: renders* MenubarMenu, ...rest: Rest) {
     () => ({ open, setOpen, active, setActive, firstId }),
     [open, setOpen, active, firstId],
   );
-  const passed = withoutComposed(rest, ["onKeyDown", "ref"]);
+  const props = withProps(withoutComposed(rest, ["onKeyDown", "ref"]), {
+    "aria-orientation": "horizontal",
+    children,
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      const bar: $FlowFixMe = event.currentTarget;
+      const movement = movementFor(event.key, "horizontal", directionOf(bar));
+      if (movement == null) {
+        return;
+      }
+      const triggers = itemsOf(bar, TRIGGERS.item, TRIGGERS.owner);
+      // With a menu open, focus is on one of *its* items rather than on a
+      // trigger, so "where am I in the bar" is the expanded trigger. This
+      // is the whole of walking File → Edit → View without pressing Escape.
+      const focused = indexOfActive(triggers, bar.ownerDocument?.activeElement);
+      const at =
+        focused >= 0
+          ? focused
+          : triggers.findIndex((each) => each.getAttribute("aria-expanded") === "true");
+      const next = moveTo(triggers, at, movement, TRIGGERS.wrap, TRIGGERS.skipDisabled);
+      if (next == null) {
+        return;
+      }
+      // Claimed before focus moves, or the browser scrolls the page under
+      // the trigger that has just taken it; `moveOnKey` says the same.
+      event.preventDefault();
+      event.stopPropagation();
+      const value = next.getAttribute("data-uf-menubar-value");
+      if (open != null && value != null) {
+        // Swap which menu is showing. Focus lands on the new menu's first
+        // item through `Menu.Body`'s own opening effect, so nothing here
+        // moves it: focusing the trigger as well would be two focus moves
+        // in one commit and the reader would see the second.
+        setOpen(value);
+        return;
+      }
+      next.focus();
+      if (value != null) {
+        setActive(value);
+      }
+    }),
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      barRef.current = element;
+    }),
+    role: "menubar",
+  });
 
   return (
     <MenubarContext.Provider value={state}>
-      <div
-        {...passed}
-        aria-orientation="horizontal"
-        onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-          const bar: $FlowFixMe = event.currentTarget;
-          const movement = movementFor(event.key, "horizontal", directionOf(bar));
-          if (movement == null) {
-            return;
-          }
-          const triggers = itemsOf(bar, TRIGGERS.item, TRIGGERS.owner);
-          // With a menu open, focus is on one of *its* items rather than on a
-          // trigger, so "where am I in the bar" is the expanded trigger. This
-          // is the whole of walking File → Edit → View without pressing Escape.
-          const focused = indexOfActive(triggers, bar.ownerDocument?.activeElement);
-          const at =
-            focused >= 0
-              ? focused
-              : triggers.findIndex((each) => each.getAttribute("aria-expanded") === "true");
-          const next = moveTo(triggers, at, movement, TRIGGERS.wrap, TRIGGERS.skipDisabled);
-          if (next == null) {
-            return;
-          }
-          // Claimed before focus moves, or the browser scrolls the page under
-          // the trigger that has just taken it; `moveOnKey` says the same.
-          event.preventDefault();
-          event.stopPropagation();
-          const value = next.getAttribute("data-uf-menubar-value");
-          if (open != null && value != null) {
-            // Swap which menu is showing. Focus lands on the new menu's first
-            // item through `Menu.Body`'s own opening effect, so nothing here
-            // moves it: focusing the trigger as well would be two focus moves
-            // in one commit and the reader would see the second.
-            setOpen(value);
-            return;
-          }
-          next.focus();
-          if (value != null) {
-            setActive(value);
-          }
-        })}
-        ref={composeRefs(rest.ref, (element) => {
-          barRef.current = element;
-        })}
-        role="menubar"
-      >
-        {children}
-      </div>
+      {render == null ? <div {...props} /> : render(props)}
     </MenubarContext.Provider>
   );
 }
@@ -232,54 +235,53 @@ export component MenubarMenu(children: React.Node, value: string) {
  * menubar — a reader is told "File, menu item, has popup, 1 of 3" — and it is
  * what makes the bar's arrow keys agree with what they were told is in it.
  */
-export component MenubarTrigger(children: React.Node, ...rest: Rest) {
+export component MenubarTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const bar = useMenubar("Menubar.Trigger");
   const menu = useMenu("Menubar.Trigger");
   const value = useContext(MenubarMenuContext);
   if (value == null) {
     throw new Error("Menubar.Trigger must be rendered inside a Menubar.Menu");
   }
-  const passed = withoutComposed(rest, ["onClick", "onFocus", "onKeyDown", "ref"]);
   const id = `${menu.base}-trigger`;
   // The bar's single tab stop. Before anything has been focused or opened it
   // belongs to the first trigger, which is a fact about the document rather
   // than about this component — `useFirstItem` reads it in the bar.
   const stop = bar.active == null ? bar.firstId === id : bar.active === value;
 
-  return (
-    <button
-      {...passed}
-      aria-controls={menu.open ? `${menu.base}-body` : undefined}
-      aria-expanded={menu.open ? "true" : "false"}
-      aria-haspopup="menu"
-      // How the bar's keyboard turns a trigger element back into the menu it
-      // opens; the module header says why this is an attribute and the rest of
-      // the bar's arithmetic is not.
-      data-uf-menubar-value={value}
-      id={id}
-      onClick={composeHandlers(rest.onClick, () => bar.setOpen(menu.open ? null : value))}
-      onFocus={composeHandlers(rest.onFocus, () => bar.setActive(value))}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        const end = match (event.key) {
-          "ArrowDown" => "first",
-          "ArrowUp" => "last",
-          _ => null,
-        };
-        if (end == null) {
-          return;
-        }
-        event.preventDefault();
-        menu.pendingFocus.current = end;
-        bar.setOpen(value);
-      })}
-      ref={composeRefs(rest.ref, (element) => {
-        menu.triggerRef.current = element;
-      })}
-      role="menuitem"
-      tabIndex={stop ? 0 : -1}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  const props = withProps(withoutComposed(rest, ["onClick", "onFocus", "onKeyDown", "ref"]), {
+    "aria-controls": menu.open ? `${menu.base}-body` : undefined,
+    "aria-expanded": menu.open ? "true" : "false",
+    "aria-haspopup": "menu",
+    children,
+    // How the bar's keyboard turns a trigger element back into the menu it
+    // opens; the module header says why this is an attribute and the rest of
+    // the bar's arithmetic is not.
+    "data-uf-menubar-value": value,
+    id,
+    onClick: composeHandlers(rest.onClick, () => bar.setOpen(menu.open ? null : value)),
+    onFocus: composeHandlers(rest.onFocus, () => bar.setActive(value)),
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      const end = match (event.key) {
+        "ArrowDown" => "first",
+        "ArrowUp" => "last",
+        _ => null,
+      };
+      if (end == null) {
+        return;
+      }
+      event.preventDefault();
+      menu.pendingFocus.current = end;
+      bar.setOpen(value);
+    }),
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      menu.triggerRef.current = element;
+    }),
+    role: "menuitem",
+    tabIndex: stop ? 0 : -1,
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }

--- a/packages/ui/sheet.js
+++ b/packages/ui/sheet.js
@@ -43,7 +43,7 @@
 import * as React from "@uniflowed/react";
 import { createContext, useContext, useMemo } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
 import { forwarded } from "./internal/merge-props.js";
 import {
   DialogBody,
@@ -110,17 +110,21 @@ export component SheetRoot(
 }
 
 /** What opens it, and what focus comes back to when it closes. */
-export component SheetTrigger(children: React.Node, ...rest: Rest) {
-  return <DialogTrigger {...forwarded(rest)}>{children}</DialogTrigger>;
+export component SheetTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogTrigger {...forwarded(rest)} render={render}>
+      {children}
+    </DialogTrigger>
+  );
 }
 
 /**
  * The backdrop, which knows the edge so a stylesheet does not have to be told
  * twice.
  */
-export component SheetOverlay(...rest: Rest) {
+export component SheetOverlay(render?: RenderProp, ...rest: Rest) {
   const sheet = useSheet("Sheet.Overlay");
-  return <DialogOverlay {...forwarded(rest)} data-side={sheet.side} />;
+  return <DialogOverlay {...forwarded(rest)} data-side={sheet.side} render={render} />;
 }
 
 /**
@@ -129,37 +133,57 @@ export component SheetOverlay(...rest: Rest) {
  * Every modal promise `dialog.js` makes is made here, unchanged. This part adds
  * `data-side` and nothing else, which is the honest size of the difference.
  */
-export component SheetBody(children: React.Node, ...rest: Rest) {
+export component SheetBody(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const sheet = useSheet("Sheet.Body");
 
   return (
-    <DialogBody {...forwarded(rest)} data-side={sheet.side}>
+    <DialogBody {...forwarded(rest)} data-side={sheet.side} render={render}>
       {children}
     </DialogBody>
   );
 }
 
 /** The top of the sheet. See `Dialog.Header` for why it is not a `<header>`. */
-export component SheetHeader(children: React.Node, ...rest: Rest) {
-  return <DialogHeader {...forwarded(rest)}>{children}</DialogHeader>;
+export component SheetHeader(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogHeader {...forwarded(rest)} render={render}>
+      {children}
+    </DialogHeader>
+  );
 }
 
 /** The bottom of the sheet, where the actions go. */
-export component SheetFooter(children: React.Node, ...rest: Rest) {
-  return <DialogFooter {...forwarded(rest)}>{children}</DialogFooter>;
+export component SheetFooter(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogFooter {...forwarded(rest)} render={render}>
+      {children}
+    </DialogFooter>
+  );
 }
 
 /** The sheet's accessible name. A modal without one is announced as "dialog". */
-export component SheetTitle(children: React.Node, ...rest: Rest) {
-  return <DialogTitle {...forwarded(rest)}>{children}</DialogTitle>;
+export component SheetTitle(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogTitle {...forwarded(rest)} render={render}>
+      {children}
+    </DialogTitle>
+  );
 }
 
 /** What the sheet is for, announced after its name. */
-export component SheetDescription(children: React.Node, ...rest: Rest) {
-  return <DialogDescription {...forwarded(rest)}>{children}</DialogDescription>;
+export component SheetDescription(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogDescription {...forwarded(rest)} render={render}>
+      {children}
+    </DialogDescription>
+  );
 }
 
 /** A button that closes the sheet. */
-export component SheetClose(children: React.Node, ...rest: Rest) {
-  return <DialogClose {...forwarded(rest)}>{children}</DialogClose>;
+export component SheetClose(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  return (
+    <DialogClose {...forwarded(rest)} render={render}>
+      {children}
+    </DialogClose>
+  );
 }

--- a/packages/ui/sidebar.js
+++ b/packages/ui/sidebar.js
@@ -55,7 +55,7 @@ import * as React from "@uniflowed/react";
 import { createContext, useContext, useId, useMemo } from "@uniflowed/react";
 import { useMediaQuery } from "@uniflowed/hooks/browser";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
 import { composeHandlers, forwarded, withProps, withoutComposed } from "./internal/merge-props.js";
 import { SheetBody, SheetOverlay, SheetRoot, SheetTrigger } from "./sheet.js";
 import { TooltipBody, TooltipRoot, TooltipTrigger } from "./tooltip.js";
@@ -263,25 +263,25 @@ export component SidebarFooter(children: React.Node, ...rest: Rest) {
 export component SidebarItem(
   children: React.Node,
   label: string,
-  render?: (props: Rest) => React.Node,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const sidebar = useSidebar("Sidebar.Item");
   const passed = withoutComposed(rest, ["ref"]);
   const mine: Rest = {
     "aria-label": sidebar.collapsed ? label : undefined,
+    children,
     "data-collapsed": sidebar.collapsed ? "true" : undefined,
   };
 
   const entry = (extra: Rest) => {
-    const props = withProps(withProps(passed, mine), extra);
-    return render == null ? (
-      <button {...props} type="button">
-        {children}
-      </button>
-    ) : (
-      render(props)
-    );
+    // `mine` on top, and the order is load-bearing now that a part's props
+    // carry its children: the collapsed branch hands this the props
+    // `Tooltip.Trigger` built, and those name `children` as `undefined`
+    // because that tooltip trigger has none of its own. Applied last, a named
+    // `undefined` would blank the entry.
+    const props = withProps(withProps(passed, extra), mine);
+    return render == null ? <button {...props} type="button" /> : render(props);
   };
 
   if (!sidebar.collapsed) {

--- a/packages/ui/switch.js
+++ b/packages/ui/switch.js
@@ -29,47 +29,53 @@
 
 import * as React from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import { composeHandlers, withProps, withoutComposed } from "./internal/merge-props.js";
 import { useControlled } from "./internal/controlled-state.js";
 
-/** A two-state switch: on or off. */
+/**
+ * A two-state switch: on or off.
+ *
+ * `render` is the escape hatch, and on a switch it is what a caller with their
+ * own `<Pressable>` or a `<div role="switch">` in a design system reaches for.
+ * `type="button"` is the one thing it does not hand over, because that is true
+ * of the element rather than of the switch.
+ */
 export component Switch(
   checked?: boolean,
   defaultChecked?: boolean = false,
   onCheckedChange?: (checked: boolean) => void,
   disabled?: boolean = false,
   children?: React.Node,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const [on, setOn] = useControlled(checked, defaultChecked, onCheckedChange);
-  const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);
-
-  return (
-    <button
-      {...passed}
-      aria-checked={on ? "true" : "false"}
-      disabled={disabled}
-      onClick={composeHandlers(rest.onClick, () => {
-        if (!disabled) {
-          setOn(!on);
-        }
-      })}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        if (disabled || (event.key !== " " && event.key !== "Enter")) {
-          return;
-        }
-        // Preventing the default is not decoration. It stops `Space` scrolling
-        // the page — which is what makes a hand-written toggle feel broken even
-        // when it works — and it stops the browser's own click from arriving
-        // after this handler and toggling the switch a second time.
-        event.preventDefault();
+  const props = withProps(withoutComposed(rest, ["onClick", "onKeyDown"]), {
+    "aria-checked": on ? "true" : "false",
+    children,
+    disabled,
+    onClick: composeHandlers(rest.onClick, () => {
+      if (!disabled) {
         setOn(!on);
-      })}
-      role="switch"
-      type="button"
-    >
-      {children}
-    </button>
-  );
+      }
+    }),
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      if (disabled || (event.key !== " " && event.key !== "Enter")) {
+        return;
+      }
+      // Preventing the default is not decoration. It stops `Space` scrolling
+      // the page — which is what makes a hand-written toggle feel broken even
+      // when it works — and it stops the browser's own click from arriving
+      // after this handler and toggling the switch a second time.
+      event.preventDefault();
+      setOn(!on);
+    }),
+    role: "switch",
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }

--- a/packages/ui/tabs.js
+++ b/packages/ui/tabs.js
@@ -50,8 +50,8 @@ import {
   useState,
 } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import { composeHandlers, withProps, withoutComposed } from "./internal/merge-props.js";
 import { moveOnKey } from "./internal/roving-focus.js";
 import { useControlled } from "./internal/controlled-state.js";
 import type { Orientation } from "./internal/roving-focus.js";
@@ -94,6 +94,7 @@ export component TabsRoot(
   onValueChange?: (value: string) => void,
   activationMode?: ActivationMode = "automatic",
   orientation?: Orientation = "horizontal",
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const base = useId();
@@ -125,9 +126,11 @@ export component TabsRoot(
     [base, selected, select, orientation, activationMode, mounted, registerPanel],
   );
 
+  const props = withProps(rest, { children });
+
   return (
     <TabsContext.Provider value={state}>
-      <div {...rest}>{children}</div>
+      {render == null ? <div {...props} /> : render(props)}
     </TabsContext.Provider>
   );
 }
@@ -142,38 +145,37 @@ export component TabsRoot(
  * tabs push themselves into as they mount answers with mount order, which stops
  * being document order the first time a tab is conditional.
  */
-export component TabsList(children: renders* TabsTab, ...rest: Rest) {
+export component TabsList(children: renders* TabsTab, render?: RenderProp, ...rest: Rest) {
   const tabs = useTabs("Tabs.List");
-  const passed = withoutComposed(rest, ["onKeyDown"]);
+  const props = withProps(withoutComposed(rest, ["onKeyDown"]), {
+    // A screen reader announces the axis, and it is also what tells a reader
+    // which arrow keys to try.
+    "aria-orientation": tabs.orientation,
+    children,
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      const list: $FlowFixMe = event.currentTarget;
+      // The list the key arrived on carries the answer to both halves of
+      // this: which items there are, and which way the page reads — so a tab
+      // set inside somebody else's `dir="rtl"` walks the right way without
+      // the caller having had to know it needed to say so.
+      const next = moveOnKey(event, list, {
+        item: '[role="tab"]',
+        owner: '[role="tablist"]',
+        orientation: tabs.orientation,
+        wrap: true,
+        skipDisabled: true,
+      });
+      if (next != null && tabs.activation === "automatic") {
+        tabs.select(next.getAttribute("data-value") ?? "");
+      }
+    }),
+    role: "tablist",
+  });
 
-  return (
-    <div
-      {...passed}
-      // A screen reader announces the axis, and it is also what tells a reader
-      // which arrow keys to try.
-      aria-orientation={tabs.orientation}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        const list: $FlowFixMe = event.currentTarget;
-        // The list the key arrived on carries the answer to both halves of
-        // this: which items there are, and which way the page reads — so a tab
-        // set inside somebody else's `dir="rtl"` walks the right way without
-        // the caller having had to know it needed to say so.
-        const next = moveOnKey(event, list, {
-          item: '[role="tab"]',
-          owner: '[role="tablist"]',
-          orientation: tabs.orientation,
-          wrap: true,
-          skipDisabled: true,
-        });
-        if (next != null && tabs.activation === "automatic") {
-          tabs.select(next.getAttribute("data-value") ?? "");
-        }
-      })}
-      role="tablist"
-    >
-      {children}
-    </div>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /**
@@ -188,54 +190,55 @@ export component TabsTab(
   value: string,
   children: React.Node,
   disabled?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const tabs = useTabs("Tabs.Tab");
   const active = tabs.selected === value;
-  const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);
+  // The caller's props first, and everything this component owns after them. A
+  // caller `onClick` used to replace the selection handler, so clicking a tab
+  // did nothing at all. `render` is handed this same object in this same
+  // order, which is why a tab rendered as somebody else's element is not a
+  // weaker tab.
+  const props = withProps(withoutComposed(rest, ["onClick", "onKeyDown"]), {
+    "aria-disabled": disabled ? "true" : undefined,
+    // Only when the panel is actually mounted. Panels are rendered on demand,
+    // and a tab pointing `aria-controls` at an id that is not in the document
+    // tells a reader there is somewhere to go and then has nowhere to send
+    // them.
+    "aria-controls": tabs.mounted.includes(value) ? `${tabs.base}-panel-${value}` : undefined,
+    "aria-selected": active ? "true" : "false",
+    children,
+    // Read by the list's key handler, which finds tabs in the document rather
+    // than in a registry and so needs each one to carry its own value.
+    "data-value": value,
+    id: `${tabs.base}-tab-${value}`,
+    onClick: composeHandlers(rest.onClick, () => {
+      if (!disabled) {
+        tabs.select(value);
+      }
+    }),
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      // Manual activation's other half: the arrows moved focus here without
+      // selecting, and this is how the reader says they meant it.
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      if (!disabled) {
+        tabs.select(value);
+      }
+    }),
+    role: "tab",
+    // The roving tabindex: Tab reaches the selected tab and nothing else in
+    // the list, so it moves past the whole set in one press.
+    tabIndex: active ? 0 : -1,
+  });
 
-  return (
-    <button
-      // `passed` first, and everything this component owns after it. A caller
-      // `onClick` used to replace the selection handler, so clicking a tab did
-      // nothing at all.
-      {...passed}
-      aria-disabled={disabled ? "true" : undefined}
-      // Only when the panel is actually mounted. Panels are rendered on demand,
-      // and a tab pointing `aria-controls` at an id that is not in the document
-      // tells a reader there is somewhere to go and then has nowhere to send
-      // them.
-      aria-controls={tabs.mounted.includes(value) ? `${tabs.base}-panel-${value}` : undefined}
-      aria-selected={active ? "true" : "false"}
-      // Read by the list's key handler, which finds tabs in the document rather
-      // than in a registry and so needs each one to carry its own value.
-      data-value={value}
-      id={`${tabs.base}-tab-${value}`}
-      onClick={composeHandlers(rest.onClick, () => {
-        if (!disabled) {
-          tabs.select(value);
-        }
-      })}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        // Manual activation's other half: the arrows moved focus here without
-        // selecting, and this is how the reader says they meant it.
-        if (event.key !== "Enter" && event.key !== " ") {
-          return;
-        }
-        event.preventDefault();
-        if (!disabled) {
-          tabs.select(value);
-        }
-      })}
-      role="tab"
-      // The roving tabindex: Tab reaches the selected tab and nothing else in
-      // the list, so it moves past the whole set in one press.
-      tabIndex={active ? 0 : -1}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -246,7 +249,12 @@ export component TabsTab(
  * subscription rather than "the selected value equals mine", because a caller
  * may render a subset of panels, or none at all until data arrives.
  */
-export component TabsPanel(value: string, children: React.Node, ...rest: Rest) {
+export component TabsPanel(
+  value: string,
+  children: React.Node,
+  render?: RenderProp,
+  ...rest: Rest
+) {
   const tabs = useTabs("Tabs.Panel");
   const register = tabs.registerPanel;
   const selected = tabs.selected === value;
@@ -263,18 +271,19 @@ export component TabsPanel(value: string, children: React.Node, ...rest: Rest) {
     return null;
   }
 
-  return (
-    <div
-      {...rest}
-      aria-labelledby={`${tabs.base}-tab-${value}`}
-      id={`${tabs.base}-panel-${value}`}
-      role="tabpanel"
-      // The panel itself is focusable so that Tab out of the tab list lands on
-      // the content the tab describes, which is where the reader expects to go
-      // and where a panel of plain prose has nothing else to offer.
-      tabIndex={0}
-    >
-      {children}
-    </div>
-  );
+  const props = withProps(rest, {
+    "aria-labelledby": `${tabs.base}-tab-${value}`,
+    children,
+    id: `${tabs.base}-panel-${value}`,
+    role: "tabpanel",
+    // The panel itself is focusable so that Tab out of the tab list lands on
+    // the content the tab describes, which is where the reader expects to go
+    // and where a panel of plain prose has nothing else to offer.
+    tabIndex: 0,
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }

--- a/packages/ui/tooltip.js
+++ b/packages/ui/tooltip.js
@@ -75,7 +75,7 @@ import { useStableCallback } from "@uniflowed/hooks/lifecycle";
 
 import type { Align, LogicalSide } from "./internal/anchor.js";
 import type { DelayGroup, HoverIntent } from "./internal/hover-intent.js";
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
 import { composeRefs, withProps, withoutComposed } from "./internal/merge-props.js";
 import {
   DEFAULT_CLOSE_DELAY,
@@ -243,11 +243,7 @@ export component TooltipRoot(
  * `render` function that forgets to spread something still gets a working
  * tooltip; see the module header.
  */
-export component TooltipTrigger(
-  children?: React.Node,
-  render?: (props: Rest) => React.Node,
-  ...rest: Rest
-) {
+export component TooltipTrigger(children?: React.Node, render?: RenderProp, ...rest: Rest) {
   const tooltip = useTooltip("Tooltip.Trigger");
   const { closeDelay, dismissed, intent, openDelay, setOpen, triggerRef } = tooltip;
   useFocusableTrigger(triggerRef, "Tooltip.Trigger");
@@ -301,25 +297,16 @@ export component TooltipTrigger(
   });
   // Only while it is there. `aria-describedby` pointing at an element that has
   // been removed is the dangling reference this package keeps coming back to.
-  const ours = {
+  const props = withProps(withoutComposed(rest, ["ref"]), {
     "aria-describedby": tooltip.open ? `${tooltip.base}-body` : undefined,
+    children,
     ref: attach,
-  };
+  });
 
   if (render != null) {
-    return render(withProps(withoutComposed(rest, ["ref"]), ours));
+    return render(props);
   }
-
-  return (
-    <button
-      {...withoutComposed(rest, ["ref"])}
-      aria-describedby={ours["aria-describedby"]}
-      ref={attach}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  return <button {...props} type="button" />;
 }
 
 /**

--- a/tests/library/ui.test.js
+++ b/tests/library/ui.test.js
@@ -16,6 +16,7 @@
 // promises too, and it is not a promise any amount of rendering can check.
 
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 import * as React from "@uniflowed/react";
@@ -8138,6 +8139,584 @@ describe("caller props never disable the component", () => {
 // Both blocks below run the checker; `./type-tests.js` holds what it takes to
 // run it — the checkout, the binary `uf test` named, and the marker harness
 // the three fixture blocks share with five other suites.
+
+describe("the escape hatch: which part hands its element to the caller", () => {
+  // ubugeeei-prod/uf#303. This package has no copy step, and the thing a copy
+  // step is *for* is changing the markup — so `render` is what has to answer
+  // "I need this to be an `<a>`", and the answer is only worth writing down
+  // where it exists. It existed on `Field.Control` alone when #303 was filed,
+  // which is why the issue calls a documented escape hatch that is not there
+  // worse than an undocumented one that is.
+  //
+  // The table below is the whole surface, part by part, in one of three states.
+  // It is a list held to the files, the way `hook_descriptors()` is held to
+  // `@uniflowed/hooks` in `crates/uf_lib/src/tests.rs` — and the shape matters
+  // more than the contents: a part added to `packages/ui/index.js` is in none
+  // of the three lists, so the first test below fails and whoever added it has
+  // to say which state it is in. That is the guard. Nothing else in this
+  // repository would have noticed.
+  //
+  //   * **`RENDER`** — takes `render?: RenderProp` and hands over the props it
+  //     would have put on its own element. Checked: the source declares the
+  //     prop and calls it.
+  //   * **`NO_ELEMENT`** — renders no element of its own. Two kinds live here,
+  //     and the difference is worth knowing: a context-only part like
+  //     `Dialog.Root` has nothing to hand over at all, while `Sheet.Title`-shaped
+  //     parts render *another part of this package* and the escape hatch is that
+  //     part's to offer. Every delegating part whose delegate has `render` today
+  //     forwards it, and is in `RENDER` rather than here; the ones left here
+  //     delegate to something that has not got one yet. Checked: no intrinsic
+  //     element anywhere in the body, so neither kind can be hiding a fixed
+  //     `<button>`.
+  //   * **`FIXED`** — still renders an element the caller cannot change. This
+  //     is the remainder of #303 and it is a closed list that only shrinks:
+  //     the third test fails if a part named here has grown a `render`, so
+  //     landing the hatch on one means moving its name, in the same change.
+  //
+  // What the escape hatch does *not* cost is the constraint: `Menu.Body`'s
+  // `renders*` still rejects a `<div>` where a `Menu.Item` belongs, because a
+  // `Menu.Item` rendered as an `<a>` is still a `Menu.Item`. That is the half a
+  // copied source cannot keep, and it is why "no copy step" is a trade rather
+  // than a loss.
+
+  /** Parts that take `render` and hand their props to the caller. */
+  const RENDER: $ReadOnlyArray<string> = [
+    "AlertDialog.Action",
+    "AlertDialog.Body",
+    "AlertDialog.Cancel",
+    "AlertDialog.Description",
+    "AlertDialog.Footer",
+    "AlertDialog.Header",
+    "AlertDialog.Overlay",
+    "AlertDialog.Title",
+    "AlertDialog.Trigger",
+    "Checkbox",
+    "ContextMenu.Body",
+    "ContextMenu.CheckboxItem",
+    "ContextMenu.Group",
+    "ContextMenu.Item",
+    "ContextMenu.Label",
+    "ContextMenu.RadioGroup",
+    "ContextMenu.RadioItem",
+    "ContextMenu.Separator",
+    "ContextMenu.SubTrigger",
+    "ContextMenu.Trigger",
+    "Dialog.Body",
+    "Dialog.Close",
+    "Dialog.Description",
+    "Dialog.Footer",
+    "Dialog.Header",
+    "Dialog.Overlay",
+    "Dialog.Title",
+    "Dialog.Trigger",
+    "Drawer.Body",
+    "Drawer.Close",
+    "Drawer.Description",
+    "Drawer.Footer",
+    "Drawer.Handle",
+    "Drawer.Header",
+    "Drawer.Overlay",
+    "Drawer.Title",
+    "Drawer.Trigger",
+    "Field.Control",
+    "HoverCard.Trigger",
+    "Menu.Body",
+    "Menu.CheckboxItem",
+    "Menu.Group",
+    "Menu.Item",
+    "Menu.Label",
+    "Menu.RadioGroup",
+    "Menu.RadioItem",
+    "Menu.Separator",
+    "Menu.SubTrigger",
+    "Menu.Trigger",
+    "Menubar.Body",
+    "Menubar.CheckboxItem",
+    "Menubar.Group",
+    "Menubar.Item",
+    "Menubar.Label",
+    "Menubar.RadioGroup",
+    "Menubar.RadioItem",
+    "Menubar.Root",
+    "Menubar.Separator",
+    "Menubar.SubTrigger",
+    "Menubar.Trigger",
+    "Sheet.Body",
+    "Sheet.Close",
+    "Sheet.Description",
+    "Sheet.Footer",
+    "Sheet.Header",
+    "Sheet.Overlay",
+    "Sheet.Title",
+    "Sheet.Trigger",
+    "Sidebar.Item",
+    "Switch",
+    "Tabs.List",
+    "Tabs.Panel",
+    "Tabs.Root",
+    "Tabs.Tab",
+    "Tooltip.Trigger",
+  ];
+
+  /** Parts with no element of their own: a context, or another part of this package. */
+  const NO_ELEMENT: $ReadOnlyArray<string> = [
+    "Accordion.Header",
+    "Alert.Title",
+    "AlertDialog.Root",
+    "Calendar.Next",
+    "Calendar.Previous",
+    "Carousel.Next",
+    "Carousel.Previous",
+    "Collapsible.Root",
+    "ContextMenu.Root",
+    "ContextMenu.Sub",
+    "DatePicker.Calendar",
+    "DatePicker.Trigger",
+    "Dialog.Root",
+    "Drawer.Root",
+    "HoverCard.Root",
+    "Menu.Root",
+    "Menu.Sub",
+    "Menubar.Menu",
+    "Menubar.Sub",
+    "Pagination.Item",
+    "Pagination.Next",
+    "Pagination.Previous",
+    "Popover.Root",
+    "Sheet.Root",
+    "Sidebar.Root",
+    "Table.RowSelect",
+    "Table.SelectAll",
+    "Tooltip.Provider",
+    "Tooltip.Root",
+  ];
+
+  /** Parts whose element a caller still cannot change. #303's remainder; it only shrinks. */
+  const FIXED: $ReadOnlyArray<string> = [
+    "Accordion.Content",
+    "Accordion.Item",
+    "Accordion.Root",
+    "Accordion.Trigger",
+    "Alert.Description",
+    "Alert.Root",
+    "Avatar.Fallback",
+    "Avatar.Image",
+    "Avatar.Root",
+    "Breadcrumb.Item",
+    "Breadcrumb.Link",
+    "Breadcrumb.List",
+    "Breadcrumb.Page",
+    "Breadcrumb.Root",
+    "Breadcrumb.Separator",
+    "Calendar.Day",
+    "Calendar.Month",
+    "Calendar.Root",
+    "Carousel.Content",
+    "Carousel.Item",
+    "Carousel.Pause",
+    "Carousel.Root",
+    "Collapsible.Content",
+    "Collapsible.Trigger",
+    "Combobox.Empty",
+    "Combobox.Group",
+    "Combobox.GroupLabel",
+    "Combobox.Input",
+    "Combobox.Label",
+    "Combobox.List",
+    "Combobox.Option",
+    "Combobox.Root",
+    "Combobox.Status",
+    "DatePicker.Input",
+    "DatePicker.Root",
+    "Field.Description",
+    "Field.Error",
+    "Field.Label",
+    "Field.Root",
+    "HoverCard.Body",
+    "InputOtp.Group",
+    "InputOtp.Root",
+    "InputOtp.Separator",
+    "InputOtp.Slot",
+    "NavigationMenu.Body",
+    "NavigationMenu.Item",
+    "NavigationMenu.Link",
+    "NavigationMenu.List",
+    "NavigationMenu.Root",
+    "NavigationMenu.Trigger",
+    "Pagination.Content",
+    "Pagination.Root",
+    "Popover.Body",
+    "Popover.Trigger",
+    "Progress",
+    "RadioGroup.Indicator",
+    "RadioGroup.Item",
+    "RadioGroup.Root",
+    "Resizable.Handle",
+    "Resizable.Panel",
+    "Resizable.PanelGroup",
+    "ScrollArea.Root",
+    "ScrollArea.Scrollbar",
+    "ScrollArea.Viewport",
+    "Select.Group",
+    "Select.GroupLabel",
+    "Select.Label",
+    "Select.List",
+    "Select.Option",
+    "Select.Root",
+    "Select.Separator",
+    "Select.Trigger",
+    "Select.Value",
+    "Separator",
+    "Sidebar.Body",
+    "Sidebar.Footer",
+    "Sidebar.Header",
+    "Sidebar.Trigger",
+    "Skeleton.Box",
+    "Skeleton.Root",
+    "Slider.Range",
+    "Slider.Root",
+    "Slider.Thumb",
+    "Slider.Track",
+    "Table.Body",
+    "Table.Caption",
+    "Table.Cell",
+    "Table.Head",
+    "Table.Header",
+    "Table.Root",
+    "Table.Row",
+    "Table.RowHeader",
+    "Toast.Action",
+    "Toast.Close",
+    "Toast.Description",
+    "Toast.Region",
+    "Toast.Root",
+    "Toast.Title",
+    "Toggle",
+    "ToggleGroup.Item",
+    "ToggleGroup.Root",
+    "Tooltip.Body",
+  ];
+
+  /** The parts `packages/ui/index.js` names, and the component behind each. */
+  function partsOfTheBarrel(): Map<string, string> {
+    const source = fs.readFileSync(path.join(repository, "packages", "ui", "index.js"), "utf8");
+    const parts = new Map<string, string>();
+    for (const namespace of source.matchAll(/^export const (\w+) = \{\n([\s\S]*?)^\};$/gm)) {
+      for (const part of namespace[2].matchAll(/^ {2}(\w+): (\w+),$/gm)) {
+        parts.set(`${namespace[1]}.${part[1]}`, part[2]);
+      }
+    }
+    // The five that are one component rather than a namespace of parts. They
+    // are exported by name and `the five that are one element` above is the
+    // suite that covers them.
+    for (const alone of ["Checkbox", "Progress", "Separator", "Switch", "Toggle"]) {
+      parts.set(alone, alone);
+    }
+    return parts;
+  }
+
+  /** Every `export component`'s source text, by component name. */
+  function componentSources(): Map<string, string> {
+    const directory = path.join(repository, "packages", "ui");
+    const sources = new Map<string, string>();
+    for (const file of fs.readdirSync(directory)) {
+      if (!file.endsWith(".js") || file === "index.js") {
+        continue;
+      }
+      const lines = fs.readFileSync(path.join(directory, file), "utf8").split("\n");
+      for (let at = 0; at < lines.length; at += 1) {
+        const declared = /^export component (\w+)\(/.exec(lines[at]);
+        if (declared == null) {
+          continue;
+        }
+        // To the closing brace in column one, which is where this package's
+        // formatter puts the end of a top-level declaration.
+        let end = at;
+        while (end < lines.length && lines[end] !== "}") {
+          end += 1;
+        }
+        sources.set(declared[1], lines.slice(at, end + 1).join("\n"));
+      }
+    }
+    return sources;
+  }
+
+  /** The source of the component behind a part, or a failure naming it. */
+  function sourceOf(part: string): string {
+    const component = partsOfTheBarrel().get(part);
+    if (component == null) {
+      throw new Error(`${part} is in the table and is not exported by packages/ui/index.js`);
+    }
+    const source = componentSources().get(component);
+    if (source == null) {
+      throw new Error(`${part} names ${component}, and no module declares that component`);
+    }
+    return source;
+  }
+
+  it("names every part the package exports, and nothing else", () => {
+    const tabled = [...RENDER, ...NO_ELEMENT, ...FIXED];
+    const duplicated = tabled.filter((part, at) => tabled.indexOf(part) !== at);
+    expect(duplicated).toEqual([]);
+
+    const exported = [...partsOfTheBarrel().keys()];
+    const untabled = exported.filter((part) => !tabled.includes(part));
+    const invented = tabled.filter((part) => !exported.includes(part));
+    expect({ untabled, invented }).toEqual({ untabled: [], invented: [] });
+
+    // A floor as well as an equality, so a barrel that stopped parsing into
+    // anything cannot make two empty lists agree. `crates/uf_lib/src/tests.rs`
+    // guards its hook table the same way and for the same reason.
+    expect(exported.length).toBeGreaterThan(150);
+  });
+
+  it("gives every part it calls an escape hatch a real one", () => {
+    const missing = RENDER.filter((part) => {
+      const source = sourceOf(part);
+      return !/\brender\??: RenderProp[,)]/.test(source) || !source.includes("render(");
+    });
+    // `render={render}` is how a part that delegates to another part passes it
+    // on, and that spelling contains `render(` nowhere — so those are named by
+    // the forwarding form instead.
+    const unforwarded = missing.filter((part) => !sourceOf(part).includes("render={render}"));
+    expect(unforwarded).toEqual([]);
+  });
+
+  it("keeps the fixed list shrinking rather than growing", () => {
+    const hatched = FIXED.filter((part) => /\brender\??: RenderProp[,)]/.test(sourceOf(part)));
+    // A part that has grown the escape hatch belongs in `RENDER`. Moving it is
+    // the point: the two lists are what #303's remainder is counted from, and
+    // a stale one is a remainder nobody can trust.
+    expect(hatched).toEqual([]);
+  });
+
+  it("keeps the parts that render nothing rendering nothing", () => {
+    const withElements = NO_ELEMENT.filter((part) => {
+      const source = sourceOf(part);
+      const body = source.slice(source.indexOf(") {"));
+      return /<[a-z][a-zA-Z0-9]*[\s/>]/.test(body);
+    });
+    expect(withElements).toEqual([]);
+  });
+});
+
+describe("the escape hatch, exercised", () => {
+  // The other half of the guard above: that the props a part hands over are the
+  // props it would have used, so the element a caller renders is not a weaker
+  // one. Every case here fails without the `render` prop the part now takes —
+  // the part renders its own element and the assertion about the caller's is
+  // about something that is not there.
+
+  it("renders a menu item as a link, and it is still a menu item", async () => {
+    const onSelect = fn();
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>File</Menu.Trigger>
+        <Menu.Body>
+          <Menu.Item onSelect={onSelect} render={(props) => <a href="/settings" {...props} />}>
+            Settings
+          </Menu.Item>
+        </Menu.Body>
+      </Menu.Root>,
+    );
+
+    // The role is the part's and the element is the caller's, which is the
+    // whole claim: a menu of links is announced as a menu of menu items and
+    // still has the middle click, the context menu and the status bar.
+    const item = screen.getByRole("menuitem", { name: "Settings" });
+    expect(item.tagName).toBe("A");
+    expect(item.getAttribute("href")).toBe("/settings");
+    // The children were written between the tags and the caller spread the
+    // props onto a self-closing element; they arrived anyway.
+    expect(item.textContent).toBe("Settings");
+
+    await userEvent.click(item);
+    expect(onSelect).toHaveBeenCalled();
+    // And choosing it still closes the tree, which is the behaviour the item
+    // owns rather than the element.
+    expect(screen.queryByRole("menu")).toBe(null);
+  });
+
+  it("keeps the roving tab stop on a menu item the caller rendered", async () => {
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>File</Menu.Trigger>
+        <Menu.Body>
+          <Menu.Item render={(props) => <a href="/one" {...props} />}>One</Menu.Item>
+          <Menu.Item>Two</Menu.Item>
+        </Menu.Body>
+      </Menu.Root>,
+    );
+    const [first, second] = screen.getAllByRole("menuitem");
+    expect(first.tagName).toBe("A");
+    expect(first).toHaveFocus();
+    expect(first.getAttribute("tabindex")).toBe("0");
+    expect(second.getAttribute("tabindex")).toBe("-1");
+
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+    expect(second).toHaveFocus();
+  });
+
+  it("renders a dialog title as the heading the page around it needs", () => {
+    render(
+      <Dialog.Root defaultOpen>
+        <Dialog.Body>
+          <Dialog.Title render={(props) => <h3 {...props} />}>Rename project</Dialog.Title>
+        </Dialog.Body>
+      </Dialog.Root>,
+    );
+    const heading = screen.getByRole("heading", { level: 3, name: "Rename project" });
+    // The dialog still names itself after it, which is the reason the id has to
+    // survive the change of element. ubugeeei-prod/uf#276 is the same
+    // observation about an accordion's header.
+    expect(screen.getByRole("dialog").getAttribute("aria-labelledby")).toBe(heading.id);
+    expect(danglingReferences()).toEqual([]);
+  });
+
+  it("gives a dialog trigger's ref to whatever the caller rendered", async () => {
+    render(
+      <Dialog.Root>
+        <Dialog.Trigger render={(props) => <span {...props} tabIndex={0} />}>Open</Dialog.Trigger>
+        <Dialog.Body>
+          <Dialog.Title>Title</Dialog.Title>
+          <Dialog.Close>Done</Dialog.Close>
+        </Dialog.Body>
+      </Dialog.Root>,
+    );
+    const trigger = screen.getByText("Open");
+    expect(trigger.tagName).toBe("SPAN");
+    expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
+
+    await userEvent.click(trigger);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    // Focus goes back to the caller's element, which only works because the
+    // composed ref went across with the rest of the props.
+    expect(trigger).toHaveFocus();
+  });
+
+  it("renders a tab as a link without losing the roving tab stop", async () => {
+    render(
+      <Tabs.Root defaultValue="one">
+        <Tabs.List>
+          <Tabs.Tab render={(props) => <a href="#one" {...props} />} value="one">
+            One
+          </Tabs.Tab>
+          <Tabs.Tab value="two">Two</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="one">first</Tabs.Panel>
+        <Tabs.Panel value="two">second</Tabs.Panel>
+      </Tabs.Root>,
+    );
+    const first = screen.getByRole("tab", { name: "One" });
+    expect(first.tagName).toBe("A");
+    expect(first.getAttribute("aria-selected")).toBe("true");
+    expect(first.getAttribute("tabindex")).toBe("0");
+    expect(screen.getByRole("tab", { name: "Two" }).getAttribute("tabindex")).toBe("-1");
+
+    await userEvent.click(screen.getByRole("tab", { name: "Two" }));
+    expect(screen.getByRole("tabpanel").textContent).toBe("second");
+  });
+
+  it("keeps a switch a switch when the caller renders a div", async () => {
+    const changed = fn();
+    render(
+      <Switch onCheckedChange={changed} render={(props) => <div {...props} tabIndex={0} />}>
+        Notifications
+      </Switch>,
+    );
+    const control = screen.getByRole("switch", { name: "Notifications" });
+    expect(control.tagName).toBe("DIV");
+    expect(control.getAttribute("aria-checked")).toBe("false");
+
+    control.focus();
+    await userEvent.keyboard(" ");
+    expect(control.getAttribute("aria-checked")).toBe("true");
+    expect(changed).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps a checkbox's mixed state when the caller renders a span", () => {
+    render(
+      <Checkbox indeterminate render={(props) => <span {...props} tabIndex={0} />}>
+        Select all
+      </Checkbox>,
+    );
+    const control = screen.getByRole("checkbox", { name: "Select all" });
+    expect(control.tagName).toBe("SPAN");
+    expect(control.getAttribute("aria-checked")).toBe("mixed");
+  });
+
+  it("puts the part's own semantics on top of the caller's props", async () => {
+    const theirs = fn();
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>File</Menu.Trigger>
+        <Menu.Body>
+          <Menu.Item onClick={theirs} render={(props) => <a href="/open" role="link" {...props} />}>
+            Open
+          </Menu.Item>
+        </Menu.Body>
+      </Menu.Root>,
+    );
+    // The caller wrote `role="link"` *before* the spread, so the part's
+    // `role="menuitem"` is what survives — the same rule
+    // `internal/merge-props.js` states for a caller's props on a part's own
+    // element, applied where the element is the caller's.
+    const item = screen.getByRole("menuitem", { name: "Open" });
+    expect(item.tagName).toBe("A");
+    expect(item.getAttribute("role")).toBe("menuitem");
+
+    // And the caller's handler still runs beside the part's rather than
+    // instead of it.
+    await userEvent.click(item);
+    expect(theirs.mock.calls.length).toBe(1);
+  });
+
+  it("carries the hatch through a sheet to the dialog underneath it", async () => {
+    render(
+      <Sheet.Root defaultOpen>
+        <Sheet.Body>
+          <Sheet.Title render={(props) => <h4 {...props} />}>Filters</Sheet.Title>
+          <Sheet.Close render={(props) => <a href="#close" {...props} />}>Done</Sheet.Close>
+        </Sheet.Body>
+      </Sheet.Root>,
+    );
+    const heading = screen.getByRole("heading", { level: 4, name: "Filters" });
+    expect(screen.getByRole("dialog").getAttribute("aria-labelledby")).toBe(heading.id);
+
+    const close = screen.getByRole("link", { name: "Done" });
+    expect(close.tagName).toBe("A");
+    await userEvent.click(close);
+    // A sheet part forwards `render` to the dialog part it is made of, so the
+    // close still closes.
+    expect(screen.queryByRole("dialog")).toBe(null);
+  });
+
+  it("renders a menubar trigger through the hatch and keeps the bar's keys", async () => {
+    render(
+      <Menubar.Root aria-label="Application">
+        <Menubar.Menu value="file">
+          <Menubar.Trigger render={(props) => <a href="#file" {...props} />}>File</Menubar.Trigger>
+          <Menubar.Body>
+            <Menubar.Item>New</Menubar.Item>
+          </Menubar.Body>
+        </Menubar.Menu>
+        <Menubar.Menu value="edit">
+          <Menubar.Trigger>Edit</Menubar.Trigger>
+          <Menubar.Body>
+            <Menubar.Item>Undo</Menubar.Item>
+          </Menubar.Body>
+        </Menubar.Menu>
+      </Menubar.Root>,
+    );
+    const file = screen.getByRole("menuitem", { name: "File" });
+    expect(file.tagName).toBe("A");
+
+    file.focus();
+    fireEvent.keyDown(screen.getByRole("menubar"), { key: "ArrowRight" });
+    expect(screen.getByRole("menuitem", { name: "Edit" })).toHaveFocus();
+  });
+});
 
 describe("the props a part spreads onto its element", () => {
   // A type is a promise the same way a role is, and this is the only test here


### PR DESCRIPTION
#303 says the roadmap's "no copy step" is the right answer and that it owes
something back: the reason people copy is to change the markup, and
`@uniflowed/ui` could only answer that on one part. It also says the decision
must not be written down until the escape hatch is shipped, which is why #628
recorded the classification and stopped. This ships it, and then writes the
decision.

## The escape hatch, generalised

`render?: RenderProp` is the same shape `Field.Control`, `Tooltip.Trigger`,
`HoverCard.Trigger` and `Sidebar.Item` already had, applied everywhere it
belongs rather than joined by a second mechanism. The type is declared once, in
`packages/ui/internal/merge-props.js`, beside the prop-order rule it is the
other half of: a part computes **one** props object and either puts it on the
element it would have chosen or hands it to the caller for theirs.

```jsx
<Menu.Item render={(props) => <a href="/settings" {...props} />}>Settings</Menu.Item>
```

* `children` travels in the props, so a caller who spreads and self-closes
  still gets what was written between the tags. A part whose children vanished
  because the props were spread is the kind of silent wrongness this package
  exists not to have. JSX children still win over the spread.
* `type="button"` does **not** travel — it is true of the element, not of the
  part — so a caller rendering an `<a>` does not get an attribute HTML has no
  meaning for.
* It is deliberately not `asChild`: cloning a child hides which props arrived
  and in what order, and a function is handed the object.
* The part stays the part. `Menu.Body`'s `renders*` still rejects a `<div>`
  where a `Menu.Item` belongs, even when that item renders an `<a>`. That is
  the half a copied source cannot keep, and it is what makes "no copy step" a
  trade rather than a loss.

**Complete for ten components** — every part of each either takes `render` or
renders no element to hand over: `Dialog`, `AlertDialog`, `Sheet`, `Drawer`,
`Menu`, `ContextMenu`, `Menubar`, `Tabs`, `Switch`, `Checkbox`. The three modal
families are built out of `Dialog`'s parts and forward it. That covers every
gap #303 names by hand: `Menu.Item` as an `<a href>`, the fixed `<button>`s on
`Dialog.Trigger` / `Menu.Trigger` / `Menu.SubTrigger` / `Tabs.Tab` / `Switch` /
`Checkbox`, and `Dialog.Title`'s `<h2>` (#276).

## The list, and the test that holds it to the files

`tests/library/ui.test.js` now carries a table of **all 206 parts** in three
lists — `RENDER` (75), `NO_ELEMENT` (29), `FIXED` (102) — with four tests over
it, in the convention of
`the_hook_table_names_exactly_the_hooks_the_package_exports`:

1. the three lists name exactly the parts the barrel exports, with a floor so
   an unparsed barrel cannot make two empty lists agree. **A part added to
   `packages/ui/index.js` is in none of them, so this fails and whoever added
   it has to say which state it is in.**
2. every part in `RENDER` really declares `render` and really calls it (or
   forwards it, for a part made of another part).
3. no part in `FIXED` has grown a `render` — the list is closed and only
   shrinks, so landing the hatch on one means moving its name in the same
   change.
4. no part in `NO_ELEMENT` renders an intrinsic element, so neither a context
   provider nor a delegating part can hide a fixed `<button>` there.

Plus ten behavioural cases: a menu item that is a link and still a menu item, a
dialog title as an `<h3>` still naming its dialog, a dialog trigger as a
`<span>` that focus still comes back to, a tab as an `<a>` with its roving tab
stop, a switch as a `<div>` that still toggles on Space, a checkbox as a
`<span>` that keeps `aria-checked="mixed"`, a sheet forwarding through to the
dialog underneath it, and the rule that the part's own props go on top of the
caller's.

**They fail without the change.** Verified by stashing `packages/ui` and running
the block against `main`'s package: **11 of the 14 fail** (all ten behavioural
cases plus guard 2). The three that still pass are the invariants that are
supposed to hold either way — the table names the right parts, nothing in
`FIXED` has a hatch, nothing in `NO_ELEMENT` renders an element.

## The decision, recorded

`packages/ui/index.js`'s header — where the rest of this package's reasoning
lives — now has **"There is no copy step, and `render` is what replaces it"**,
answering #303's four Done bullets: why not (a copy is a fork with no upstream,
and the `renders*` constraints are checked across the boundary), what a caller
gets instead, whether `internal/` is ever public (**no**, with the cost stated:
there is no third-party primitive that participates the way these do, and the
uf-shaped equivalent of publishing one is a pull request), and what the CLI adds
(**nothing new** — `uf inspect --json` already prints the component table out of
`crates/uf_lib/src/ui.rs`; a `uf explain Dialog` is a nicer front end for a
table that exists, and the decision does not depend on it).

## One stale sentence

`docs/app/guide/ui` said "one part renders no element and so forwards nothing:
`Field.Control`", which this change makes false. The guide now has a **Changing
the element a part renders** section saying what `render` is, which components
have it, and where the table that tracks the rest lives.

## Two repairs that fell out

* `composeHandlers`'s bound was an exact object type, so no named event type
  could satisfy it and every call was relying on inferring `any` from a JSX
  attribute. It is inexact now, and `PartEvent` is the annotation a handler
  needs once it is built before its element exists.
* `ContextMenu.Trigger`'s `tabIndex` default now goes under the caller's props
  through `withProps` instead of above a spread, which removes the one
  `cannot-spread-indexer` error `uf check packages/ui` reported.

## What remains, and why

The other 102 parts. `Combobox`, `Select`, `Calendar`, `Toast`, `Table`,
`Slider`, `Accordion`, `RadioGroup`, `Carousel` and the rest still render fixed
elements, and so do `Progress`, `Separator` and `Toggle`. Each is mechanical in
the same way as the ones here and each wants its own behavioural cases —
`Combobox` and `Select` alone are eighteen parts with `aria-activedescendant`
and typeahead over them, and a change that touched every module in the package
at once would be one nobody could review against the promises each part makes.
The table is what keeps that honest: the remainder is enumerated, the list only
shrinks, and #303's Done conditions are met for the escape hatch as a shipped
mechanism and for the decision as a recorded one.

## What was run

* `uf test#library` — **2878 passed, 0 failed, 1 skipped** (82 files), which is
  the `Library` job.
* `uf lint` — **0 errors, 14 warnings** over 481 files, unchanged from `main`'s
  documented state.
* `uf fmt --check` — every file already formatted.
* `uf check packages/ui --json` — **8 diagnostics, down from 9**; the one that
  went is the context-menu spread above.
* One flake, seen once in four full runs and not reproducible: `hooks.test.js`
  failed to start with `unhandled rejection: redirect to /`. It passes alone and
  in the other three runs, and it is `packages/hooks`, which this change does
  not touch.

Not run locally: the cargo jobs. Another agent's build removed
`target/release/uf` mid-session and the disk cannot hold a second 15 GB target,
so these ran on the debug binary in the shared target directory. Nothing here
touches Rust, and the `uf_lib` tests that read `packages/ui/index.js` parse it
with the real Flow parser — this change adds only comments to the namespace
objects they read.

Refs #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
