### PR TITLE
feat(tui, lib, docs): a drag that selects the cells it crossed, and the one default preventDefault now has

### DIFF
--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -777,6 +777,7 @@ pub fn builtin_modules() -> Vec<NativeModule> {
                 "parseColor",
                 "plainCapabilities",
                 "render",
+                "selectionContains",
                 "testRender",
                 "useKeyboard",
                 "useRenderer",

--- a/crates/uf_tui/src/lib.rs
+++ b/crates/uf_tui/src/lib.rs
@@ -61,11 +61,11 @@ impl Default for TuiFrameworkContract {
             standard: TuiStandard::OpenTui,
             renderer: TuiRenderer::CellDiff,
             layout: TuiLayoutEngine::FlexboxCells,
-            input: TuiInputModel::KeyboardMouseFocus,
+            input: TuiInputModel::KeyboardMouseSelectionFocus,
             runtime_binding: TuiRuntimeBinding::FlowReact,
-            // Nine, not twenty-three. Every one of these is exercised by
+            // Ten, not twenty-three. Every one of these is exercised by
             // `tests/library/tui.test.js` against a rendered frame; the other
-            // fourteen variants of `TuiFeature` name parts of OpenTUI that uf
+            // thirteen variants of `TuiFeature` name parts of OpenTUI that uf
             // does not implement yet, and listing them here is how a reader
             // ends up importing a component that does not exist.
             features: smallvec::smallvec![
@@ -73,6 +73,7 @@ impl Default for TuiFrameworkContract {
                 TuiFeature::CellDiff,
                 TuiFeature::Keyboard,
                 TuiFeature::Mouse,
+                TuiFeature::Selection,
                 TuiFeature::Focus,
                 TuiFeature::RichText,
                 TuiFeature::Scrollback,
@@ -151,18 +152,21 @@ pub enum TuiLayoutEngine {
 #[serde(rename_all = "kebab-case")]
 pub enum TuiInputModel {
     /// Keyboard events to one declaratively focused node; mouse events to
-    /// whatever is under the pointer, bubbling to its parents.
+    /// whatever is under the pointer, bubbling to its parents; and a drag over
+    /// selectable text, which selects it.
     ///
-    /// It said `keyboard-focus` until the mouse landed, and the two halves are
-    /// named separately because they are routed differently and a reader has
-    /// to know which: focus is a prop the application sets, and a hit target
-    /// is a fact about the frame that the renderer works out.
+    /// It said `keyboard-focus` until the mouse landed and `keyboard-mouse-focus`
+    /// until selection did, and the parts are named separately because they are
+    /// routed differently and a reader has to know which. Focus is a prop the
+    /// application sets. A hit target is a fact about the frame that the
+    /// renderer works out. A selection is two *cells* of that frame rather than
+    /// a node at all, which is why it is a third name and not a detail of the
+    /// second.
     ///
-    /// Text selection is OpenTUI's third input source and is still not
-    /// implemented; it is ubugeeei-prod/uf#314. So is key *release*, which
-    /// needs the Kitty keyboard protocol — `KeyEvent.eventType` is always
-    /// `"press"`.
-    KeyboardMouseFocus,
+    /// Key *release* is still not implemented — it needs the Kitty keyboard
+    /// protocol, and `KeyEvent.eventType` is always `"press"`. That is
+    /// ubugeeei-prod/uf#314.
+    KeyboardMouseSelectionFocus,
 }
 
 /// How the framework reaches an application's code.
@@ -199,7 +203,23 @@ pub enum TuiFeature {
     Mouse,
     /// Focus management.
     Focus,
-    /// Text and item selection.
+    /// Text selection.
+    ///
+    /// A left press on selectable text and a drag from it: the cells between
+    /// the two are highlighted, `getSelectedText()` reads them back, and
+    /// `event.preventDefault()` on the press is how a box that means its own
+    /// thing by a drag keeps out of it. One selection per renderer, which is
+    /// OpenTUI's rule and a terminal's.
+    ///
+    /// Three things a reader might expect from the word are not behind it. A
+    /// selection is two *cells*, not a range inside the text, so what it
+    /// covers after a commit is whatever the frame now holds there — the same
+    /// answer a terminal's own selection gives, and stated because the DOM's
+    /// is different. OpenTUI's repeated-press gestures, which widen a
+    /// selection to the word or the logical line under the pointer, are not
+    /// implemented; there is no `behavior` to report because there is only one.
+    /// And *item* selection — `Select`, `TabSelect` — is a component rather
+    /// than this, and is still ubugeeei-prod/uf#314.
     Selection,
     /// A window onto content taller than it, and a bar saying where.
     ///

--- a/crates/uf_tui/src/tests.rs
+++ b/crates/uf_tui/src/tests.rs
@@ -8,7 +8,7 @@ fn describes_a_flow_react_renderer_that_follows_opentui() {
     assert_eq!(contract.standard, TuiStandard::OpenTui);
     assert_eq!(contract.renderer, TuiRenderer::CellDiff);
     assert_eq!(contract.layout, TuiLayoutEngine::FlexboxCells);
-    assert_eq!(contract.input, TuiInputModel::KeyboardMouseFocus);
+    assert_eq!(contract.input, TuiInputModel::KeyboardMouseSelectionFocus);
     assert_eq!(contract.runtime_binding, TuiRuntimeBinding::FlowReact);
 }
 
@@ -21,6 +21,7 @@ fn claims_only_the_features_the_package_implements() {
         TuiFeature::CellDiff,
         TuiFeature::Keyboard,
         TuiFeature::Mouse,
+        TuiFeature::Selection,
         TuiFeature::Focus,
         TuiFeature::RichText,
         TuiFeature::Scrollback,
@@ -35,7 +36,6 @@ fn claims_only_the_features_the_package_implements() {
     // function that threw. Removing one from this list is how a feature gets
     // announced, so announcing one requires deleting a line here.
     for feature in [
-        TuiFeature::Selection,
         TuiFeature::Keymap,
         TuiFeature::TerminalAutomation,
         TuiFeature::CodeHighlight,
@@ -105,7 +105,7 @@ fn serialises_the_contract_as_the_names_the_cli_prints() {
     assert_eq!(json["engine"], "flow-react-open-tui-compatible");
     assert_eq!(json["renderer"], "cell-diff");
     assert_eq!(json["layout"], "flexbox-cells");
-    assert_eq!(json["input"], "keyboard-mouse-focus");
+    assert_eq!(json["input"], "keyboard-mouse-selection-focus");
     assert_eq!(
         json["reactInkTarget"]["performanceTarget"],
         "writes-only-changed-cells"

--- a/docs/app/guide/tui/_uf.page.mdx
+++ b/docs/app/guide/tui/_uf.page.mdx
@@ -380,6 +380,11 @@ modifier key nobody mentioned. An application that handles the mouse is trading
 that away on purpose; one that ignores it should not have it traded away on its
 behalf. `testRender` turns it on, because there is no terminal there to damage.
 
+What the trade buys back is the next section: with the mouse on, this renderer
+draws and reports the selection itself, so the gesture a reader knows still
+works — over a smaller amount of text than the terminal could offer, but with
+the same hand.
+
 With it on, every `Box` takes OpenTUI's handlers — `onMouseDown`, `onMouseUp`,
 `onMouseMove`, `onMouseDrag`, `onMouseDragEnd`, `onMouseDrop`, `onMouseOver`,
 `onMouseOut`, `onMouseScroll`, and `onMouse` for all of them:
@@ -451,6 +456,88 @@ old for SGR-encoded reports gets no mouse rather than a wrong one — its
 encoding cannot express a column past 223, and this decoder recognises those
 reports only to discard them, so a click on such a terminal does nothing
 instead of typing three characters into whatever has focus.
+
+## Selecting text
+
+Turning the mouse on takes the terminal's own click-and-drag selection away
+from the reader, so the mouse brings a replacement with it. **A left press on
+text and a drag from it selects the cells between the two**, drawn inverse, and
+the application reads them back:
+
+```js
+component Output(lines: Array<string>) {
+  const renderer = useRenderer();
+  const [yanked, setYanked] = useState<string>("");
+  useKeyboard((key) => {
+    if (key.name === "y" && renderer.hasSelection()) {
+      setYanked(renderer.getSelectedText());
+      renderer.clearSelection();
+    }
+  });
+  return (
+    <Box>
+      {lines.map((line) => (
+        <Text key={line}>{line}</Text>
+      ))}
+      <Text dim={true}>{yanked}</Text>
+    </Box>
+  );
+}
+```
+
+That example keeps the text rather than copying it, and the reason is that
+there is no clipboard here: `getSelectedText()` hands back a string and
+OpenTUI's clipboard API is still
+[#314](https://github.com/ubugeeei-prod/uf/issues/314). What the renderer owns
+is the selection: one per renderer, because a frame has one way of showing that
+a cell is selected.
+
+**A selection is two cells of the screen, not a range inside your text.** That
+is the same thing a terminal's own selection is, and it is why dragging works
+over a `ScrollBox`, over clipped content, and over two `Text`s in a row without
+any of them knowing about each other. It also has a consequence worth saying
+out loud: a selection survives a re-render, and if the text under it moved, the
+selection now covers what moved in. A terminal behaves the same way, and the
+alternative — dropping the selection on every commit — would drop it on the
+keystroke that scrolled the window somebody was selecting from. A *resize* does
+drop it, because the emulator reflowed the screen in a way this renderer
+neither performed nor can predict.
+
+Each row of a selection runs from its first selectable cell to its last and
+keeps what is between them, so a row laid out as two columns comes back with
+the gap in it rather than as one run-on word. Blanks outside that span are the
+shape of the box and are not copied.
+
+**Text is selectable unless something says otherwise**, which is OpenTUI's
+default. `selectable={false}` is inherited like a colour, so one prop keeps a
+whole status bar or a decorative frame out of a copy:
+
+```js
+<Box selectable={false}>
+  <Text dim={true}>3 workers · 12 files · 1.2s</Text>
+</Box>
+```
+
+`selectionFg` and `selectionBg` name the colours instead of inverting, and are
+inherited the same way. Inverse is the default because `SGR 7` exists on
+terminals with no colour at all, and because toggling it — rather than setting
+it — leaves the cell an `Input` draws its cursor in visible as a hole in the
+highlight.
+
+**A press clears the selection, and `preventDefault()` is how a box keeps it.**
+That is the renderer's one default and therefore the only thing that method
+does. A box that means its own thing by a drag — a splitter, a canvas, a slider
+— suppresses it and leaves the reader's highlight alone:
+
+```js
+<Box id="splitter" onMouseDown={(event) => event.preventDefault()} onMouseDrag={resize} />
+```
+
+What is not here is OpenTUI's repeated-press gestures: a second press does not
+select the word under the pointer and a third does not select the line. There
+is one selection behaviour rather than three, so there is no `behavior` to
+report, and that is [#314](https://github.com/ubugeeei-prod/uf/issues/314) as
+well.
 
 ## Terminals that cannot do what yours can
 
@@ -536,18 +623,20 @@ behind it, which is the thing this was fixing.
 
 ## What is not here yet
 
-Text selection, key release, images, the rich-content components (`Code`,
-`Markdown`, `Diff`, `TextTable`) and OpenTUI's application APIs — clipboard,
-notifications, audio, animation — are not implemented. They are
+Key release, images, the rich-content components (`Code`, `Markdown`, `Diff`,
+`TextTable`) and OpenTUI's application APIs — clipboard, notifications, audio,
+animation — are not implemented. They are
 [#314](https://github.com/ubugeeei-prod/uf/issues/314), and they are *absent*
 rather than present as functions that throw: `uf inspect` reports four
 components because there are four.
 
-Selection is the one to expect next, and it is the mouse's other half: drag
-over `selectable` text, one selection per renderer, `getSelectedText()`. It is
-also where `preventDefault()` on a mouse event starts to mean something —
-there is no such method today, because nothing this renderer does to a mouse
-event by default could be prevented.
+The clipboard is the one to expect next, and it is the half of the section
+above that is missing: `getSelectedText()` hands back a string, and putting a
+string where the reader's next paste will find it is an OSC 52 sequence, a
+terminal that may refuse it, and a fallback nobody has argued out yet. The
+other near one is *item* selection — `Select` and `TabSelect`, which are
+components rather than a renderer capability, and which is why `uf inspect`
+reports text selection as implemented and neither of them as existing.
 
 Nor does uf's own CLI draw through this yet. `uf` is a Rust binary and this is
 JavaScript, and the two cannot meet without either a native bridge uf does not

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -203,7 +203,13 @@
       a hundred thousand rows measures none of them and lays out, paints and
       diffs the twenty-four on the screen, counted in
       `tests/library/tui.test.js` and timed by `tools/bench/tui/window.js`.
-      Selection, key release and rich content are ubugeeei-prod/uf#314.
+      Text selection is in with the mouse it belongs to: a drag over
+      `selectable` text highlights the cells between the two ends,
+      `getSelectedText()` reads them back out of the frame, and
+      `preventDefault()` on the press is how a box that means its own thing by
+      a drag keeps out of it. Key release, the clipboard that would carry the
+      selected text somewhere, the repeated-press gestures that widen one to a
+      word or a line, and rich content are ubugeeei-prod/uf#314.
 - [ ] Cover the shadcn-style component catalog with typed imports, preset styles, and no copy step.
 - [ ] Keep compound UI APIs cohesive, for example `Dialog.Body`.
 - [x] Add UI `renders` type utility declarations under `packages/ui`.

--- a/packages/tui/components.js
+++ b/packages/tui/components.js
@@ -123,6 +123,26 @@ export type TextStyleProps = {
   readonly blink?: boolean,
   readonly inverse?: boolean,
   readonly strikethrough?: boolean,
+  /**
+   * Whether a reader may select this text with the mouse.
+   *
+   * `true` unless something says otherwise, which is OpenTUI's default for
+   * text and a terminal's for everything. It is inherited the way a colour
+   * is, so `selectable={false}` on a `Box` covers everything inside it — which
+   * is how a status bar or a decorative frame stays out of a copy without
+   * every `Text` in it repeating the prop.
+   */
+  readonly selectable?: boolean,
+  /**
+   * How a selection over this text looks.
+   *
+   * Both default to unset, and unset means inverse video: `SGR 7` exists on
+   * terminals with no colour at all, and it is what the terminal's own
+   * selection would have looked like. Naming either colour replaces that
+   * rather than adding to it.
+   */
+  readonly selectionFg?: ColorValue,
+  readonly selectionBg?: ColorValue,
 };
 
 /**
@@ -144,6 +164,12 @@ export type TextStyleProps = {
  * with handlers on it and `mouse: false` is not an error and is not silently
  * broken either — it is an application that has not turned the device on, and
  * `testRender` turns it on by default so that a test does not have to.
+ *
+ * `event.preventDefault()` in an `onMouseDown` keeps the press from clearing
+ * the reader's selection and from starting a new one. That is the renderer's
+ * only default, so it is the only thing that method does; a box that means
+ * something else by a drag — a slider, a splitter, a canvas — is what it is
+ * for.
  */
 export type MouseProps = {
   /** Every mouse event, after the handler for its own type. */

--- a/packages/tui/index.js
+++ b/packages/tui/index.js
@@ -71,15 +71,18 @@
 // only changed cells, keyboard input with OpenTUI's key names and propagation
 // rules, bracketed paste, declarative focus, mouse input — press, release,
 // hover, drag with capture, drop and wheel, routed by a hit grid the painter
-// records — a scrolling window onto content taller than it, terminal
-// capability and *size* detection that agrees with the CLI's, and an in-memory
-// renderer that runs the same code the terminal one does.
+// records — text selection by drag, one per renderer, read back with
+// `getSelectedText()`, a scrolling window onto content taller than it,
+// terminal capability and *size* detection that agrees with the CLI's, and an
+// in-memory renderer that runs the same code the terminal one does.
 //
-// Not here: text selection, key *release* (which needs the Kitty keyboard
-// protocol), images, the rich content components, and everything under
-// OpenTUI's "application APIs". They are ubugeeei-prod/uf#314, and they are
-// absent rather than present as functions that throw — because a stub is what
-// this package used to be.
+// Not here: key *release* (which needs the Kitty keyboard protocol), the
+// repeated-press gestures that widen a selection to a word or a line, images,
+// the rich content components, and everything under OpenTUI's "application
+// APIs" — including the clipboard, which is why `getSelectedText()` hands a
+// string back rather than putting it somewhere. They are
+// ubugeeei-prod/uf#314, and they are absent rather than present as functions
+// that throw — because a stub is what this package used to be.
 //
 // Also not here, and worth saying because ubugeeei-prod/uf#247 asked for it:
 // uf's own CLI does not draw through this. It cannot — `crates/uf_term` is
@@ -110,6 +113,7 @@
 // - `diff.js` — two frames, as the bytes that turn one into the other.
 // - `keys.js` — terminal bytes, as key events, and a paste as one of them.
 // - `mouse.js` — the other half of that stream: what the pointer did.
+// - `selection.js` — what a drag over the frame selected, as two cells.
 // - `capability.js` — what this terminal can render and how big it is, by the
 //   CLI's own rules.
 // - `terminal.js` — a real terminal, and the in-memory one tests use.
@@ -166,6 +170,14 @@ export { createInputDecoder, decodeInput, decodeKeys } from "./keys.js";
 
 export type { MouseEvent, MouseEventType, Scroll, ScrollDirection } from "./mouse.js";
 export { MouseButton } from "./mouse.js";
+
+export type { Selection, SelectionPoint } from "./selection.js";
+// `selectionContains` and not `selectionBetween`: the first answers a question
+// a caller has about a selection the renderer handed them, and the second
+// builds one, which is the renderer's job — there is no way to hand a
+// selection *back*, and an export that produced a value nothing accepts would
+// be a promise that there is.
+export { selectionContains } from "./selection.js";
 
 export type { Renderer, Root } from "./internal/host.js";
 

--- a/packages/tui/internal/hits.js
+++ b/packages/tui/internal/hits.js
@@ -1,6 +1,6 @@
 // @flow
 //
-// What is under the pointer.
+// What is under the pointer, and what a drag over it would select.
 //
 // # Internal to `@uniflowed/tui`
 //
@@ -28,6 +28,24 @@
 // The grid costs one entry per cell of the frame — 1,920 of them on an 80×24
 // terminal — and is built only when a renderer has mouse reporting on, so an
 // application that does not use the mouse pays nothing for it.
+//
+// # Two answers, one walk
+//
+// A second array rides along, and it answers a second question: which cells
+// hold text a reader is allowed to select. It is here rather than in a grid of
+// its own because it is the same question asked of the same walk — *who wrote
+// this cell* — and because both answers are only true of the frame that
+// produced them, which is the whole reason this module is internal. Two grids
+// would be two allocations and two chances to keep one of them a frame too
+// long.
+//
+// They are separate arrays rather than one, because the two answers are about
+// different nodes and resolve differently. A hit is the innermost *box*, and a
+// box claims its whole rectangle whether it painted anything into it. A
+// selectable cell is the `<Text>` whose grapheme is actually in that cell, and
+// only where one is: a box's background is not text, so `recordHit` clears the
+// text array over the area it claims, and the painter fills it back in for
+// each cluster it writes. Last writer wins, exactly as it does in the frame.
 
 import type { Rect } from "../cells.js";
 import { intersect } from "../cells.js";
@@ -39,11 +57,26 @@ export type HitGrid = {
   readonly height: number,
   /** One entry per cell, row-major, `null` where nothing was drawn. */
   readonly nodes: Array<TuiNode | null>,
+  /**
+   * The selectable `<Text>` whose grapheme is in each cell, or `null`.
+   *
+   * `null` covers three different cells and deliberately does not distinguish
+   * them: one nothing was drawn in, one a box's background or border owns, and
+   * one holding text that said `selectable={false}`. Nothing routed by this
+   * array cares which — a drag selects a cell or it does not.
+   */
+  readonly text: Array<TuiNode | null>,
 };
 
 /** An empty grid the size of a frame. */
 export function createHitGrid(width: number, height: number): HitGrid {
-  return { width, height, nodes: new Array(width * height).fill(null) };
+  const size = width * height;
+  return {
+    width,
+    height,
+    nodes: new Array(size).fill(null),
+    text: new Array(size).fill(null),
+  };
 }
 
 /**
@@ -52,6 +85,12 @@ export function createHitGrid(width: number, height: number): HitGrid {
  * Called by the painter as it descends, so a child overwrites its parent and
  * a later sibling overwrites an earlier one — which is the order they are
  * drawn in, and therefore the order a reader sees them stacked.
+ *
+ * It also *un*claims those cells for selection, because a box is about to
+ * paint over them: the text array is filled in afterwards by the clusters this
+ * box's descendants write. Without it a panel dropped over a paragraph would
+ * leave the paragraph selectable through its background — text a reader can no
+ * longer see, in a copy they did not expect it in.
  */
 export function recordHit(grid: HitGrid, node: TuiNode, area: Rect, clip: Rect): void {
   const box = intersect(clip, area);
@@ -61,7 +100,42 @@ export function recordHit(grid: HitGrid, node: TuiNode, area: Rect, clip: Rect):
     const row = y * grid.width;
     for (let x = Math.max(0, box.x); x < right; x += 1) {
       grid.nodes[row + x] = node;
+      grid.text[row + x] = null;
     }
+  }
+}
+
+/**
+ * Say that `node`'s text occupies `width` columns from `x`, `y`.
+ *
+ * The two guards are `writeGrapheme`'s, repeated rather than shared, and the
+ * reason is what this array means: a cell a clip refused is a cell the node
+ * did not write, so it is not a cell the node owns. Deriving that from the
+ * write itself would be better, but `writeGrapheme` reports the columns a
+ * caller should advance by whether or not it wrote anything — it has to, or a
+ * clipped line would come out with its remaining clusters bunched up.
+ *
+ * `node` may be `null`, which is how the painter takes a cell back for
+ * something that is not selectable text — a scrollbar drawn over a line that
+ * ran into its column.
+ */
+export function recordText(
+  grid: HitGrid,
+  node: TuiNode | null,
+  x: number,
+  y: number,
+  width: number,
+  clip: Rect,
+): void {
+  if (y < clip.y || y >= clip.y + clip.height || y < 0 || y >= grid.height) {
+    return;
+  }
+  if (x < clip.x || x + width > clip.x + clip.width || x < 0 || x + width > grid.width) {
+    return;
+  }
+  const row = y * grid.width;
+  for (let column = x; column < x + width; column += 1) {
+    grid.text[row + column] = node;
   }
 }
 
@@ -71,4 +145,12 @@ export function hitAt(grid: HitGrid, x: number, y: number): TuiNode | null {
     return null;
   }
   return grid.nodes[y * grid.width + x];
+}
+
+/** The selectable text node at a cell, or `null` when there is none. */
+export function textAt(grid: HitGrid, x: number, y: number): TuiNode | null {
+  if (x < 0 || y < 0 || x >= grid.width || y >= grid.height) {
+    return null;
+  }
+  return grid.text[y * grid.width + x];
 }

--- a/packages/tui/internal/host.js
+++ b/packages/tui/internal/host.js
@@ -68,9 +68,11 @@ import type { KeyEvent } from "../keys.js";
 import { layout } from "../layout.js";
 import type { MouseEvent } from "../mouse.js";
 import { MouseButton, derive } from "../mouse.js";
+import type { Selection, SelectionPoint } from "../selection.js";
+import { selectionBetween } from "../selection.js";
 import type { HitGrid } from "./hits.js";
-import { createHitGrid, hitAt } from "./hits.js";
-import { measureText, paint, wrapModeOf } from "./paint.js";
+import { createHitGrid, hitAt, textAt } from "./hits.js";
+import { measureText, paint, paintSelection, selectionText, wrapModeOf } from "./paint.js";
 import type { TuiNode, TuiProps } from "./tree.js";
 import { applyProps, createNode, invalidate } from "./tree.js";
 
@@ -128,16 +130,53 @@ export type Renderer = {
   dragSource: TuiNode | null,
   /** Whether that press has actually moved yet: a click is not a drag. */
   dragging: boolean,
+  /**
+   * The reader's selection, or `null`.
+   *
+   * One per renderer, which is OpenTUI's rule and a terminal's: a frame has
+   * one way of showing that a cell is selected, so a second selection would
+   * have nowhere to be.
+   */
+  selection: Selection | null,
+  /**
+   * Where the press that is building a selection landed, while it still is.
+   *
+   * Separate from `selection.anchor` because a press that has not moved yet
+   * has an anchor and no selection: a click is not a selection of one cell,
+   * it is a click. It is also separate from `dragSource`, which is a node —
+   * this is a cell, because that is what a selection is made of.
+   */
+  selectionAnchor: SelectionPoint | null,
+  /** What OpenTUI calls a selection, and the four things a caller does with one. */
+  getSelection(): Selection | null,
+  hasSelection(): boolean,
+  clearSelection(): void,
+  getSelectedText(): string,
 };
 
-/** A renderer that draws into a `width` by `height` rectangle. */
+/**
+ * A renderer that draws into a `width` by `height` rectangle.
+ *
+ * The four selection functions are closures over the object rather than
+ * methods with a `this`, for the reason `mouseEvent` builds its events the
+ * same way: a caller reaches them through `useRenderer()` and may hold one in
+ * a variable, and a `this` would make `const copy = renderer.getSelectedText`
+ * a different function from the one it was read off.
+ *
+ * `hasSelection` is a call and not a field, which is the one place this
+ * deliberately spells an OpenTUI name differently. OpenTUI reads
+ * `renderer.hasSelection`; a plain boolean field here would be a second copy
+ * of `selection != null` that something has to remember to keep true, and a
+ * getter is what `flow/unsafe-getters-setters` warns about — a property whose
+ * read runs code.
+ */
 export function createRenderer(
   width: number,
   height: number,
   capabilities: Capabilities,
   mouseEnabled: boolean = false,
 ): Renderer {
-  return {
+  const renderer: Renderer = {
     root: createNode("root", {}),
     capabilities,
     width,
@@ -152,7 +191,49 @@ export function createRenderer(
     hovered: null,
     dragSource: null,
     dragging: false,
+    selection: null,
+    selectionAnchor: null,
+    getSelection() {
+      return renderer.selection;
+    },
+    hasSelection() {
+      return renderer.selection != null;
+    },
+    clearSelection() {
+      renderer.selection = null;
+      renderer.selectionAnchor = null;
+    },
+    getSelectedText() {
+      return selectedText(renderer);
+    },
   };
+  return renderer;
+}
+
+/**
+ * The text of this renderer's selection, or `""` when there is none.
+ *
+ * It draws a frame to answer, and that is not a shortcut around some cheaper
+ * path — it is the only correct one. The selection is two cells, and what is
+ * *in* a cell is a fact about a painted frame; the last one drawn is thrown
+ * away by every commit, because a commit is exactly the thing that can have
+ * moved the text. Laying out and painting a terminal is microseconds, and the
+ * caller of this is a reader who has just pressed a key to copy something.
+ *
+ * It lives beside the renderer rather than on `Selection` for the same reason.
+ * A selection is two points and knows nothing about a frame; a value that
+ * could answer this would have to hold the renderer that draws them, and then
+ * an application could keep one across a commit and read it back as if it
+ * were still true.
+ */
+function selectedText(renderer: Renderer): string {
+  const selection = renderer.selection;
+  if (selection == null) {
+    return "";
+  }
+  const frame = renderFrame(renderer);
+  const grid = renderer.hits;
+  return grid == null ? "" : selectionText(frame, grid, selection);
 }
 
 /** The context every hook in this package reads to find its renderer. */
@@ -182,6 +263,15 @@ export function renderFrame(renderer: Renderer): Frame {
   paint(root, frame, renderer.capabilities, full, hits);
   if (hits != null) {
     renderer.hits = hits;
+    // After the walk, because a selection is not something a node has: it is
+    // two cells of the frame the walk just produced, and the cells between
+    // them are only known once everything that could have painted over them
+    // has. Doing it here rather than in the painter is also what keeps a
+    // re-render honest — the highlight is recomputed from the current picture,
+    // so text that moved under a selection is shown selected where it is now.
+    if (renderer.selection != null) {
+      paintSelection(frame, hits, renderer.selection);
+    }
   }
   return frame;
 }
@@ -353,6 +443,24 @@ function bubble(
 }
 
 /**
+ * Take the selection out to where the pointer has reached.
+ *
+ * Only while a press armed one, which is what makes a drag that began on a
+ * border or on a slider's handle a drag and not a selection. The focus is
+ * wherever the pointer is now, selectable or not: a reader dragging down a
+ * paragraph passes over the blank end of every short line, and a selection
+ * that stopped at the last character it recognised would jump backwards under
+ * their hand.
+ */
+function extendSelection(renderer: Renderer, event: MouseEvent): void {
+  const anchor = renderer.selectionAnchor;
+  if (anchor == null) {
+    return;
+  }
+  renderer.selection = selectionBetween(anchor, { x: event.x, y: event.y });
+}
+
+/**
  * Deliver one mouse report.
  *
  * The node under the pointer comes from the hit grid the last paint recorded,
@@ -378,6 +486,13 @@ function bubble(
  *   `up` there too unless that is the source again — one release is one `up`
  *   per node.
  *
+ * A fourth thing happens that OpenTUI also specifies, and it is the renderer's
+ * *default* rather than something delivered: a left press clears the selection
+ * and, when it landed on selectable text, arms a new one that the drag then
+ * extends. It runs after the handlers, so that `event.preventDefault()` on the
+ * `down` can suppress it — a box that means its own thing by a drag keeps the
+ * reader's selection instead of wiping it on the way past.
+ *
  * A renderer with `mouseEnabled` false has no grid and drops the report. That
  * is not a silent failure to guard against: nothing turns mouse reporting on
  * in the terminal either, so a report can only arrive from a caller who
@@ -396,6 +511,10 @@ export function dispatchMouse(renderer: Renderer, event: MouseEvent): void {
   }
 
   const hit = hitAt(grid, event.x, event.y);
+  // Read before anything is delivered, because a handler can commit — a click
+  // that opens a menu — and a commit drops the grid this came out of. What is
+  // selectable under a press is a fact about the frame the reader pressed on.
+  const overText = textAt(grid, event.x, event.y) != null;
   if (hit !== renderer.hovered) {
     const left = renderer.hovered;
     renderer.hovered = hit;
@@ -415,6 +534,15 @@ export function dispatchMouse(renderer: Renderer, event: MouseEvent): void {
     if (hit != null) {
       bubble(hit, event, hit, null);
     }
+    if (event.button === MouseButton.LEFT && !event.defaultPrevented) {
+      // A press ends the selection the reader had, whether or not it starts
+      // one: that is what clicking somewhere else means, and it is why a
+      // click that never moves leaves nothing selected. The new anchor is
+      // only armed over selectable text, so a drag from a border or from the
+      // gap between two panels moves nothing but the pointer.
+      renderer.selection = null;
+      renderer.selectionAnchor = overText ? { x: event.x, y: event.y } : null;
+    }
     return;
   }
 
@@ -423,11 +551,13 @@ export function dispatchMouse(renderer: Renderer, event: MouseEvent): void {
     if (source != null && attached(renderer, source)) {
       renderer.dragging = true;
       bubble(source, event, hit, source);
+      extendSelection(renderer, event);
       return;
     }
     if (hit != null) {
       bubble(hit, event, hit, null);
     }
+    extendSelection(renderer, event);
     return;
   }
 
@@ -436,6 +566,10 @@ export function dispatchMouse(renderer: Renderer, event: MouseEvent): void {
     const dragged = renderer.dragging;
     renderer.dragSource = null;
     renderer.dragging = false;
+    // The gesture is over; the selection it made is not. Dropping the anchor
+    // rather than the selection is the difference between "the reader has
+    // stopped dragging" and "the reader has stopped selecting".
+    renderer.selectionAnchor = null;
     if (source != null && dragged && attached(renderer, source)) {
       // Each of these is its own event object: they are four separate
       // deliveries, and one handler calling `stopPropagation()` must not
@@ -771,6 +905,12 @@ export function resize(renderer: Renderer, width: number, height: number): void 
   // the wrong row.
   renderer.hits = null;
   renderer.hovered = null;
+  // And a selection is two cells of a frame that has been reflowed by
+  // something this renderer did not perform. It survives a re-render, where
+  // the cells still mean what they meant; it cannot survive a resize, where
+  // they do not.
+  renderer.selection = null;
+  renderer.selectionAnchor = null;
   withPriority(DiscreteEventPriority, () => {
     for (const listener of Array.from(renderer.sizeListeners)) {
       listener();

--- a/packages/tui/internal/paint.js
+++ b/packages/tui/internal/paint.js
@@ -37,9 +37,18 @@
 import type { BorderStyle, Capabilities } from "../capability.js";
 import { borderGlyphs } from "../capability.js";
 import type { Frame, Rect, Style } from "../cells.js";
-import { INHERIT, PLAIN, fillRect, intersect, parseColor, writeGrapheme } from "../cells.js";
+import {
+  Attributes,
+  INHERIT,
+  PLAIN,
+  fillRect,
+  intersect,
+  parseColor,
+  writeGrapheme,
+} from "../cells.js";
+import type { Selection } from "../selection.js";
 import type { HitGrid } from "./hits.js";
-import { recordHit } from "./hits.js";
+import { recordHit, recordText } from "./hits.js";
 import type { TuiNode } from "./tree.js";
 import { ROOT_TEXT_STYLE, borderOf, textRuns, textStyleFromProps } from "./tree.js";
 import type { Grapheme } from "../widths.js";
@@ -156,6 +165,14 @@ export function wrapModeOf(node: TuiNode): WrapMode {
  * has no mouse. It is filled here rather than by a second walk because the
  * question it answers — which node was allowed to draw this cell — is the
  * question `clip` is already the answer to; see `hits.js`.
+ *
+ * `selectable` descends the same way `clip` does, and for the same reason it
+ * is a parameter rather than something read back off a node: whether a cell
+ * may be selected is a fact about the whole chain above it, and walking up
+ * from each `<Text>` to find out would ask the same question of the same
+ * ancestors once per leaf. It starts `true`, which is OpenTUI's default for
+ * text, and a `selectable={false}` anywhere on the way down turns it off for
+ * everything under that node.
  */
 export function paint(
   node: TuiNode,
@@ -163,6 +180,7 @@ export function paint(
   capabilities: Capabilities,
   clip: Rect,
   hits: HitGrid | null = null,
+  selectable: boolean = true,
 ): void {
   // `hideInstance` — React's for a Suspense fallback and for `<Activity>` —
   // sets `width: 0, height: 0, hidden: true`. The zero size is not enough on
@@ -173,17 +191,18 @@ export function paint(
   if (node.props.hidden === true) {
     return;
   }
+  const inherited = selectableOf(node, selectable);
   switch (node.type) {
     case "root":
       for (const child of node.children) {
-        paint(child, frame, capabilities, clip, hits);
+        paint(child, frame, capabilities, clip, hits, inherited);
       }
       return;
     case "box":
-      paintBox(node, frame, capabilities, clip, hits);
+      paintBox(node, frame, capabilities, clip, hits, inherited);
       return;
     case "text":
-      paintText(node, frame, clip);
+      paintText(node, frame, clip, hits, inherited);
       return;
     default:
       // A `"chars"` node is only ever reached through its `"text"` parent,
@@ -194,12 +213,27 @@ export function paint(
   }
 }
 
+/**
+ * Whether text under `node` may be selected.
+ *
+ * A boolean prop wins over what was inherited; anything else — including the
+ * prop being absent — leaves the answer where its ancestors put it. Only the
+ * direct prop is read, and not `style.selectable`: `style` is where OpenTUI
+ * puts the things that *paint* a node, and whether a reader may copy a line
+ * out of it is not one of them.
+ */
+function selectableOf(node: TuiNode, inherited: boolean): boolean {
+  const own = node.props.selectable;
+  return typeof own === "boolean" ? own : inherited;
+}
+
 function paintBox(
   node: TuiNode,
   frame: Frame,
   capabilities: Capabilities,
   clip: Rect,
   hits: HitGrid | null,
+  selectable: boolean,
 ): void {
   const area = { x: node.x, y: node.y, width: node.width, height: node.height };
   // Before the children, so that a child overwrites its parent — a click on a
@@ -244,18 +278,18 @@ function paintBox(
     // hundred and seventy-six of them are elsewhere.
     const end = node.scrollFirst + node.scrollCount;
     for (let index = node.scrollFirst; index < end; index += 1) {
-      paint(node.children[index], frame, capabilities, childClip, hits);
+      paint(node.children[index], frame, capabilities, childClip, hits, selectable);
     }
   } else {
     for (const child of node.children) {
-      paint(child, frame, capabilities, childClip, hits);
+      paint(child, frame, capabilities, childClip, hits, selectable);
     }
   }
 
   if (node.style.overflow === "scroll" && node.props.scrollbar === true) {
     // `childClip` rather than `clip`: the bar belongs to this box and must be
     // cut by the same rectangle its rows are.
-    paintScrollbar(node, frame, capabilities, childClip, style);
+    paintScrollbar(node, frame, capabilities, childClip, style, hits);
   }
 }
 
@@ -280,6 +314,7 @@ function paintScrollbar(
   capabilities: Capabilities,
   clip: Rect,
   style: Style,
+  hits: HitGrid | null,
 ): void {
   const top = node.scrollViewTop;
   const viewport = node.scrollViewRows;
@@ -305,6 +340,12 @@ function paintScrollbar(
   for (let row = 0; row < viewport; row += 1) {
     const glyph = row >= start && row < start + thumb ? thumbGlyph : trackGlyph;
     writeGrapheme(frame, column, top + row, glyph, 1, trackStyle, clip);
+    // The bar is drawn after the children, so a line with `wrap="none"` that
+    // ran into this column has already claimed it. It is not that line any
+    // more, and a selection dragged over the bar must not copy one.
+    if (hits != null) {
+      recordText(hits, null, column, top + row, 1, clip);
+    }
   }
 }
 
@@ -399,10 +440,21 @@ function paintTitle(
   }
 }
 
-function paintText(node: TuiNode, frame: Frame, clip: Rect): void {
+function paintText(
+  node: TuiNode,
+  frame: Frame,
+  clip: Rect,
+  hits: HitGrid | null,
+  selectable: boolean,
+): void {
   const own = textStyleFromProps(node.props, ROOT_TEXT_STYLE);
   const runs = textRuns(node, own);
   const lines = wrapRuns(runs, node.width, wrapModeOf(node));
+  // The outermost `<Text>` of a nest is the one recorded, because it is the
+  // one that paints: `textRuns` has already flattened its children into runs,
+  // so a `<Text bold>` inside it never reaches the frame under its own name.
+  // That is the right owner anyway — `selectionBg` is inherited like every
+  // other text style, and a nested run has no separate existence to select.
   for (let index = 0; index < lines.length && index < node.height; index += 1) {
     let column = node.x;
     for (const cluster of lines[index].clusters) {
@@ -415,9 +467,180 @@ function paintText(node: TuiNode, frame: Frame, clip: Rect): void {
         cluster.style,
         clip,
       );
+      if (hits != null && selectable) {
+        recordText(hits, node, column, node.y + index, cluster.width, clip);
+      }
       column += cluster.width;
     }
   }
+}
+
+/**
+ * One row of a selection: the cells of it a reader would read across.
+ *
+ * `from` is after `to` for a row the selection covers but that holds no
+ * selectable text — a gap between two paragraphs, the padding of a box, the
+ * blank half of a half-filled screen. Those rows are still rows of the
+ * selection, which is why they are reported rather than dropped: the text
+ * copied out of a selection has a line for each of them, the same way dragging
+ * across a blank line in a terminal gives you the blank line.
+ */
+type SelectedRow = {
+  readonly y: number,
+  readonly from: number,
+  readonly to: number,
+};
+
+/**
+ * Which cells of each row a selection covers.
+ *
+ * A row's span runs from its first selectable cell to its last, and *includes
+ * whatever is between them*, selectable or not. That is the one rule this
+ * module applies twice — once to draw the highlight and once to read the text
+ * back out — and it exists because of what the alternative does to a layout.
+ * Two `<Text>`s in a row with a gap between them are `left` and `right` on the
+ * screen; taking only the cells they own would copy `leftright`, and drawing
+ * the highlight only over them would leave a hole in the middle of a selection
+ * a reader dragged straight through. Cells before the first and after the last
+ * are not part of it: trailing blanks are the shape of the box, not something
+ * anyone selected.
+ *
+ * Spans are snapped outwards onto whole graphemes. A selection that begins on
+ * the right-hand cell of a two-column character would otherwise style half of
+ * it, and the two halves would then differ in a comparison the diff makes per
+ * cell — which is a repaint of a character nobody selected.
+ */
+function selectedRows(frame: Frame, grid: HitGrid, selection: Selection): Array<SelectedRow> {
+  const rows: Array<SelectedRow> = [];
+  const top = Math.max(0, selection.start.y);
+  const bottom = Math.min(frame.height - 1, selection.end.y);
+  for (let y = top; y <= bottom; y += 1) {
+    const base = y * frame.width;
+    const last = frame.width - 1;
+    const left = y === selection.start.y ? Math.max(0, selection.start.x) : 0;
+    const right = y === selection.end.y ? Math.min(last, selection.end.x) : last;
+    let from = -1;
+    let to = -2;
+    for (let x = left; x <= right; x += 1) {
+      if (grid.text[base + x] != null) {
+        if (from < 0) {
+          from = x;
+        }
+        to = x;
+      }
+    }
+    if (from >= 0) {
+      while (from > 0 && frame.chars[base + from] === "") {
+        from -= 1;
+      }
+      while (to + 1 < frame.width && frame.chars[base + to + 1] === "") {
+        to += 1;
+      }
+    }
+    rows.push({ y, from, to });
+  }
+  return rows;
+}
+
+/**
+ * Show a selection in a frame that has already been painted.
+ *
+ * A pass over the selected rows rather than something the walk above knows
+ * about, and that is the whole reason it is cheap and the reason it is
+ * correct. A selection is two cells of the *frame*; the tree does not have it
+ * and could not apply it without every node asking whether each of its cells
+ * is selected. Here the answer is already on the screen.
+ *
+ * The default is inverse video, toggled rather than set. A terminal with no
+ * colour at all still has it — this is `SGR 7`, not a palette entry — and
+ * toggling is what makes a selection dragged over something already inverse,
+ * such as the cell an `Input` draws its cursor in, show as a hole in the
+ * highlight instead of vanishing into it. A `selectionBg` or `selectionFg` on
+ * the text, or on anything above it, replaces that with the colours it names
+ * and leaves the attributes alone: an application that has said how a
+ * selection looks has said it.
+ */
+export function paintSelection(frame: Frame, grid: HitGrid, selection: Selection): void {
+  for (const row of selectedRows(frame, grid, selection)) {
+    if (row.from > row.to) {
+      // A row of the selection with no selectable text on it. It is a line in
+      // what gets copied and nothing at all in what gets drawn.
+      continue;
+    }
+    const base = row.y * frame.width;
+    let owner = grid.text[base + row.from];
+    let style = selectionStyleOf(owner);
+    for (let x = row.from; x <= row.to; x += 1) {
+      const at = grid.text[base + x];
+      if (at != null && at !== owner) {
+        owner = at;
+        style = selectionStyleOf(owner);
+      }
+      const index = base + x;
+      if (style.fg === INHERIT && style.bg === INHERIT) {
+        frame.attributes[index] ^= Attributes.INVERSE;
+        continue;
+      }
+      if (style.fg !== INHERIT) {
+        frame.fg[index] = style.fg;
+      }
+      if (style.bg !== INHERIT) {
+        frame.bg[index] = style.bg;
+      }
+    }
+  }
+}
+
+/**
+ * The colours a node's selection is drawn in, or `INHERIT` for both.
+ *
+ * `selectionFg` and `selectionBg` inherit the way `fg` and `bg` do, and
+ * independently of each other, so one prop on a panel covers everything inside
+ * it. They are resolved by walking *up* from the node that owns the cell,
+ * rather than threaded down the paint the way `selectable` is, because the two
+ * are asked about at different times: `selectable` decides whether a cell is
+ * recorded at all and so is needed for every cell of every frame, while these
+ * are needed only for the handful of cells a selection covers — and only when
+ * there is one. A walk bounded by the depth of a terminal's tree, taken once
+ * per run of one owner, is cheaper than a lookup nothing usually reads.
+ */
+function selectionStyleOf(node: TuiNode | null): { fg: number, bg: number } {
+  let fg = INHERIT;
+  let bg = INHERIT;
+  let current = node;
+  while (current != null && (fg === INHERIT || bg === INHERIT)) {
+    if (fg === INHERIT) {
+      fg = parseColor(readColor(current.props, ["selectionFg"]));
+    }
+    if (bg === INHERIT) {
+      bg = parseColor(readColor(current.props, ["selectionBg"]));
+    }
+    current = current.parent;
+  }
+  return { fg, bg };
+}
+
+/**
+ * The text a selection covers, as a reader would copy it.
+ *
+ * Read out of the frame rather than out of the tree, which is what makes it
+ * agree with the highlight down to the cell: a wide grapheme contributes its
+ * cluster once and its continuation cell contributes the empty string, a line
+ * that was wrapped comes back wrapped, and a row that was clipped comes back
+ * clipped. Rows are joined top to bottom with `\n`, which is OpenTUI's
+ * documented order and the only thing a clipboard can do with two rows.
+ */
+export function selectionText(frame: Frame, grid: HitGrid, selection: Selection): string {
+  const lines: Array<string> = [];
+  for (const row of selectedRows(frame, grid, selection)) {
+    const base = row.y * frame.width;
+    let line = "";
+    for (let x = row.from; x <= row.to; x += 1) {
+      line += frame.chars[base + x];
+    }
+    lines.push(line);
+  }
+  return lines.join("\n");
 }
 
 function readColor(

--- a/packages/tui/mouse.js
+++ b/packages/tui/mouse.js
@@ -34,12 +34,20 @@
 // the node under the pointer up through its parents. A component written
 // against OpenTUI's interaction page behaves the same way here.
 //
-// What is *not* here is `preventDefault()`. OpenTUI has one because it has a
-// default to prevent — a drag over selectable text selects it. This renderer
-// has no text selection yet (ubugeeei-prod/uf#314) and does not move focus on
-// a click, so nothing happens to a mouse event that a handler could suppress,
-// and a `preventDefault()` that suppressed nothing would be a promise rather
-// than a method. It arrives with selection.
+// `preventDefault()` is here now, and it is worth saying what it prevents,
+// because a method that suppressed nothing would be a promise rather than a
+// method — which is why this module did not have one until there was a default
+// to suppress. There is exactly one: a left press clears the selection and, if
+// it landed on selectable text, starts a new one. A handler that calls
+// `preventDefault()` on that `down` keeps the selection the reader already
+// had and starts none, which is what a box that does its own thing with a
+// drag — a slider, a canvas, a splitter — needs in order not to leave a
+// highlight behind it. Nothing else this renderer does to a mouse event can be
+// prevented, and no other event type has anything to prevent.
+//
+// It is not a severity of `stopPropagation()`, the same way it is not one for
+// a key: one of them decides whether anybody else sees the event, the other
+// decides whether the renderer acts on it.
 
 /** OpenTUI's nine mouse event types. */
 export type MouseEventType =
@@ -130,8 +138,18 @@ export type MouseEvent = {
   source: string | null,
   /** Stop the event reaching this node's ancestors. */
   stopPropagation(): void,
+  /**
+   * Keep the renderer from doing its own thing with this event.
+   *
+   * On a left `"down"` that is the selection: the one the reader had is kept,
+   * and no new one begins under this press. Every other event type has no
+   * default, so calling this on one is harmless and does nothing.
+   */
+  preventDefault(): void,
   /** Whether `stopPropagation()` was called. */
   propagationStopped: boolean,
+  /** Whether `preventDefault()` was called. */
+  defaultPrevented: boolean,
 };
 
 /** The fields a decoded report carries before routing fills the rest in. */
@@ -164,8 +182,12 @@ export function mouseEvent(fields: MouseFields): MouseEvent {
     currentTarget: null,
     source: null,
     propagationStopped: false,
+    defaultPrevented: false,
     stopPropagation() {
       event.propagationStopped = true;
+    },
+    preventDefault() {
+      event.defaultPrevented = true;
     },
   };
   return event;

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -19,6 +19,7 @@
     "./keys": "./keys.js",
     "./layout": "./layout.js",
     "./mouse": "./mouse.js",
+    "./selection": "./selection.js",
     "./terminal": "./terminal.js",
     "./widths": "./widths.js",
     "./package.json": "./package.json"

--- a/packages/tui/selection.js
+++ b/packages/tui/selection.js
@@ -1,0 +1,101 @@
+// @flow
+//
+// What a drag over the frame selected: two cells, and the order between them.
+//
+// A selection here is geometry and nothing else. It is not a range of
+// characters inside a string, and it is not a pair of nodes with offsets into
+// them — it is the cell the pointer went down on and the cell it has reached,
+// in the coordinates every other part of this package already uses.
+//
+// # Why two points on the screen rather than an offset into the text
+//
+// The obvious model is the DOM's: a start node and an offset, an end node and
+// an offset. It is the wrong one here for the same reason the hit test is a
+// grid rather than a walk over the tree. What a reader is selecting is what
+// they can *see*, and what they can see is the frame: a row scrolled out of a
+// `ScrollBox` has last frame's geometry on it, `overflow: "hidden"` cut a
+// child off somewhere its geometry does not admit to, and a box painted later
+// erased the text under it. Two screen cells are true about the picture in
+// front of the reader; a node and an offset are true about a tree that
+// disagrees with it.
+//
+// It is also what a terminal's own selection is, which matters more than it
+// looks: a reader who drags across this renderer's output and a reader who
+// drags across `cat`'s output are performing the same gesture, and the second
+// one has taught them what to expect from the first.
+//
+// The cost of the model is stated rather than hidden. A selection survives a
+// re-render, because two cells are still two cells; if the content under them
+// moved, the selection now covers whatever moved into those cells. That is
+// again what a terminal does, and the alternative — dropping the selection on
+// every commit — would drop it on the keystroke that scrolled the window a
+// reader was selecting from.
+//
+// # Reading order, not a rectangle
+//
+// `start` and `end` are the two points sorted by row and then by column, which
+// is the order text is read in and the order OpenTUI documents
+// `getSelectedText()` as joining in: top to bottom, left to right. A selection
+// from the middle of one line to the middle of the line below it therefore
+// covers the end of the first line, and not a rectangle standing on the two
+// columns. Column selection is a different gesture and this is not it.
+
+/** One cell of the frame, counted from zero at the top left. */
+export type SelectionPoint = {
+  readonly x: number,
+  readonly y: number,
+};
+
+/**
+ * One selection, as the renderer holds it.
+ *
+ * There is at most one per renderer, which is OpenTUI's rule and a terminal's:
+ * a second selection would have to be shown, and the frame has one way of
+ * showing a cell is selected.
+ *
+ * `anchor` and `focus` are the gesture — where the press landed and where the
+ * pointer has reached — and are kept because that is what an application
+ * asking "which way is this drag going" needs. `start` and `end` are the same
+ * two points in reading order, which is what everything that walks the
+ * selection needs, and they are stored rather than recomputed so that no two
+ * readers of one selection can sort it differently.
+ */
+export type Selection = {
+  /** The cell the press that began this selection landed on. */
+  readonly anchor: SelectionPoint,
+  /** The cell the pointer has reached. Moves as the drag continues. */
+  readonly focus: SelectionPoint,
+  /** The earlier of the two, by row and then by column. */
+  readonly start: SelectionPoint,
+  /** The later of the two. Both ends are *inside* the selection. */
+  readonly end: SelectionPoint,
+};
+
+/** Whether `a` is at or before `b` in reading order. */
+function atOrBefore(a: SelectionPoint, b: SelectionPoint): boolean {
+  return a.y < b.y || (a.y === b.y && a.x <= b.x);
+}
+
+/**
+ * The selection a drag from `anchor` to `focus` describes.
+ *
+ * Both ends are inclusive: a press and a release on the same cell select that
+ * one cell rather than nothing. A reader who drags across a single character
+ * expects to have selected it, and a half-open range would make the shortest
+ * possible selection the empty one.
+ */
+export function selectionBetween(anchor: SelectionPoint, focus: SelectionPoint): Selection {
+  const forwards = atOrBefore(anchor, focus);
+  return {
+    anchor,
+    focus,
+    start: forwards ? anchor : focus,
+    end: forwards ? focus : anchor,
+  };
+}
+
+/** Whether a cell is inside a selection, in reading order. */
+export function selectionContains(selection: Selection, x: number, y: number): boolean {
+  const point = { x, y };
+  return atOrBefore(selection.start, point) && atOrBefore(point, selection.end);
+}

--- a/packages/tui/terminal.js
+++ b/packages/tui/terminal.js
@@ -51,6 +51,7 @@ import {
 } from "./internal/host.js";
 import type { InputEvent } from "./keys.js";
 import { createInputDecoder } from "./keys.js";
+import type { Selection } from "./selection.js";
 
 /** Enter the alternate screen buffer, so the shell's scrollback survives. */
 const ENTER_ALTERNATE = "\u001b[?1049h";
@@ -101,6 +102,18 @@ export type Handle = {
   frame(): Frame,
   /** That frame as text, which is what a snapshot asserts on. */
   text(): string,
+  /**
+   * What the reader has selected with the mouse, or `""`.
+   *
+   * The same answer `useRenderer().getSelectedText()` gives a component, from
+   * outside the tree — which is where the caller wiring it to a clipboard
+   * usually is, since a program that wants to copy on Ctrl+C has a signal
+   * handler and not a component. `selection()` is the gesture behind it, for
+   * an application that wants to say something about how far it reaches.
+   */
+  selectedText(): string,
+  /** The reader's selection, or `null` when there is none. */
+  selection(): Selection | null,
 };
 
 /** What `testRender` gives back: a `Handle`, plus the terminal's side. */
@@ -166,6 +179,13 @@ export type RenderOptions = {
    * that ignores the mouse anyway needs a modifier key the reader has to know
    * about. An application that handles the mouse is trading that away on
    * purpose; one that does not should not trade it away by default.
+   *
+   * What it trades it away *for* is this renderer's own selection, which
+   * arrives with the mouse and not separately: a drag over selectable text
+   * highlights it and `getSelectedText()` reads it back. That is a smaller
+   * promise than the terminal's, because the text it can offer is the text on
+   * the screen — but it is the same gesture, so a reader does not have to be
+   * told that this window is the one where dragging does nothing.
    */
   readonly mouse?: boolean,
 };
@@ -253,6 +273,12 @@ export function testRender(
     },
     text() {
       return frameText(renderFrame(renderer));
+    },
+    selectedText() {
+      return renderer.getSelectedText();
+    },
+    selection() {
+      return renderer.getSelection();
     },
     stop() {
       root.unmount();
@@ -420,6 +446,12 @@ export function render(element: React.Node, options: RenderOptions = {}): Handle
     },
     text() {
       return frameText(renderFrame(renderer));
+    },
+    selectedText() {
+      return renderer.getSelectedText();
+    },
+    selection() {
+      return renderer.getSelection();
     },
   };
 }

--- a/tests/library/tui.test.js
+++ b/tests/library/tui.test.js
@@ -44,6 +44,7 @@ import {
   render,
   testRender,
   useKeyboard,
+  useRenderer,
   useTerminalSize,
 } from "@uniflowed/tui";
 import type { Frame, MouseEvent } from "@uniflowed/tui";
@@ -1595,6 +1596,349 @@ describe("the mouse reaches what is under it", () => {
     });
     handle.press("\u001b[<0;1;1M");
     expect(clicked).not.toHaveBeenCalled();
+    handle.stop();
+  });
+});
+
+describe("a drag selects what it crossed", () => {
+  // The gesture, as the three reports a terminal sends for it. A press, a
+  // motion with the left button held — bit 32 is motion and the low bits are
+  // the button — and a release, which is the same parameters with a lowercase
+  // final byte. Terminals count from one; these take cells and convert, so a
+  // test says where on the screen it meant.
+  const press = (x: number, y: number) => `\u001b[<0;${x + 1};${y + 1}M`;
+  const moveTo = (x: number, y: number) => `\u001b[<32;${x + 1};${y + 1}M`;
+  const release = (x: number, y: number) => `\u001b[<0;${x + 1};${y + 1}m`;
+
+  /** One escape byte, which a chunk ending on is the Escape key. */
+  const ESCAPE = "\u001b";
+
+  /** Drag from one cell to another, as the three reports in one chunk. */
+  const dragBetween = (from: [number, number], to: [number, number]) =>
+    press(from[0], from[1]) + moveTo(to[0], to[1]) + release(to[0], to[1]);
+
+  /** Whether a cell is drawn inverse, which is what an unstyled selection is. */
+  const inverted = (frame: Frame, x: number, y: number) =>
+    (cell(frame, x, y).attributes & Attributes.INVERSE) !== 0;
+
+  it("reads back the cells the pointer crossed, and draws them inverse", () => {
+    const handle = testRender(<Text>hello world</Text>, { width: 12, height: 1 });
+
+    handle.press(dragBetween([0, 0], [4, 0]));
+
+    expect(handle.selectedText()).toBe("hello");
+    const frame = handle.frame();
+    expect([0, 1, 2, 3, 4].map((x) => inverted(frame, x, 0))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+    // Both ends are inside the selection, so the cell after the focus is not.
+    expect(inverted(frame, 5, 0)).toBe(false);
+    handle.stop();
+  });
+
+  it("is a click and not a selection when the pointer never moved", () => {
+    const handle = testRender(<Text>hello</Text>, { width: 8, height: 1 });
+
+    handle.press(dragBetween([0, 0], [3, 0]));
+    expect(handle.selectedText()).toBe("hell");
+
+    // And the next press puts it back: clicking somewhere else is how a reader
+    // says they are done with a selection, in every terminal they have used. A
+    // press that selected the one cell under it would make that impossible.
+    handle.press(press(1, 0) + release(1, 0));
+    expect(handle.selection()).toBe(null);
+    expect(handle.selectedText()).toBe("");
+    expect(inverted(handle.frame(), 0, 0)).toBe(false);
+    handle.stop();
+  });
+
+  it("runs in reading order however the drag went", () => {
+    const handle = testRender(<Text>hello</Text>, { width: 8, height: 1 });
+
+    handle.press(dragBetween([4, 0], [1, 0]));
+
+    // The gesture is kept as it happened — a drag leftwards has its anchor on
+    // the right — and the *order* is the one text is read in.
+    expect(handle.selection()?.anchor).toEqual({ x: 4, y: 0 });
+    expect(handle.selection()?.focus).toEqual({ x: 1, y: 0 });
+    expect(handle.selection()?.start).toEqual({ x: 1, y: 0 });
+    expect(handle.selectedText()).toBe("ello");
+    handle.stop();
+  });
+
+  it("takes whole rows between the two ends rather than a rectangle", () => {
+    const handle = testRender(
+      <Box width={6}>
+        <Text>one</Text>
+        <Text>two</Text>
+      </Box>,
+      { width: 6, height: 2 },
+    );
+
+    handle.press(dragBetween([1, 0], [1, 1]));
+
+    // A rectangle standing on column 1 would be "n" and "w". What a reader
+    // dragging down a page means is the end of the first line and the start of
+    // the second.
+    expect(handle.selectedText()).toBe("ne\ntw");
+    handle.stop();
+  });
+
+  it("keeps the gap between two boxes on a row, and drops the blanks outside them", () => {
+    const handle = testRender(
+      <Box flexDirection="row" justifyContent="space-between" width={12}>
+        <Text>ab</Text>
+        <Text>cd</Text>
+      </Box>,
+      { width: 12, height: 1 },
+    );
+
+    handle.press(dragBetween([0, 0], [11, 0]));
+
+    // A row's selection runs from its first selectable cell to its last and
+    // includes whatever is between them, because that is what the reader
+    // dragged across. Taking only the cells the two `Text`s own would copy
+    // `abcd` and lose the layout; taking the whole row would add trailing
+    // blanks that are the shape of the box rather than anything selected.
+    expect(handle.selectedText()).toBe("ab        cd");
+    handle.stop();
+  });
+
+  it("leaves out a subtree that said it may not be selected", () => {
+    const handle = testRender(
+      <Box>
+        <Text>copy me</Text>
+        <Box selectable={false}>
+          <Text>not me</Text>
+        </Box>
+      </Box>,
+      { width: 8, height: 2 },
+    );
+
+    handle.press(dragBetween([0, 0], [7, 1]));
+
+    // `selectable` is inherited like a colour, so the inner `Text` never had to
+    // repeat it. The second row is still a row of the selection and still
+    // contributes a line — it contributes an empty one.
+    expect(handle.selectedText()).toBe("copy me\n");
+    expect(inverted(handle.frame(), 0, 1)).toBe(false);
+    handle.stop();
+  });
+
+  it("draws the colours the text named instead of inverting it", () => {
+    // One colour on the panel and one on the text, because they inherit the
+    // way `fg` and `bg` do and independently of each other — a panel that says
+    // how a selection looks says it for everything inside.
+    const handle = testRender(
+      <Box selectionBg="blue">
+        <Text selectionFg="white">hi</Text>
+      </Box>,
+      { width: 4, height: 1 },
+    );
+
+    handle.press(dragBetween([0, 0], [1, 0]));
+
+    const first = cell(handle.frame(), 0, 0);
+    expect([first.fg, first.bg]).toEqual([parseColor("white"), parseColor("blue")]);
+    // An application that has said how a selection looks has said it: the
+    // inverse default is replaced rather than added to.
+    expect(first.attributes).toBe(0);
+    handle.stop();
+  });
+
+  it("keeps a two-column grapheme whole when the drag lands on its second cell", () => {
+    const handle = testRender(<Text>界a</Text>, { width: 4, height: 1 });
+
+    // Column 1 is the continuation cell of `界`. Styling it alone would leave
+    // the two halves of one character disagreeing, which the diff compares per
+    // cell and would then repaint.
+    handle.press(dragBetween([1, 0], [1, 0]));
+
+    expect(handle.selectedText()).toBe("界");
+    expect([inverted(handle.frame(), 0, 0), inverted(handle.frame(), 1, 0)]).toEqual([true, true]);
+    expect(inverted(handle.frame(), 2, 0)).toBe(false);
+    handle.stop();
+  });
+
+  it("copies what is inside a border and not the border itself", () => {
+    const handle = testRender(
+      <Box border={true} width={9} height={3}>
+        <Text>ok</Text>
+      </Box>,
+      { width: 9, height: 3 },
+    );
+
+    handle.press(dragBetween([1, 1], [8, 1]));
+
+    // A box claims every cell of its rectangle for the *mouse* and claims none
+    // of them for selection: a border is not text. Dragging off the end of the
+    // line and onto the frame around it therefore copies the line.
+    expect(handle.selectedText()).toBe("ok");
+    expect(inverted(handle.frame(), 8, 1)).toBe(false);
+    handle.stop();
+  });
+
+  it("does not copy the scrollbar a line ran into", () => {
+    const wide = (count: number) =>
+      Array.from({ length: count }, (_, index) =>
+        React.createElement(Text, { key: String(index), wrap: "none" }, "abcdefghij"),
+      );
+    const handle = testRender(
+      <ScrollBox height={4} width={8} scrollTop={0}>
+        {wide(5)}
+      </ScrollBox>,
+      { width: 8, height: 4 },
+    );
+    // Padding is not a clip anywhere in this renderer, so an unwrapped line
+    // reaches the column the bar reserved, and the bar — drawn after the
+    // children — wins.
+    expect(frameRow(handle.frame(), 0)).toBe("abcdefg█");
+
+    handle.press(dragBetween([0, 0], [7, 0]));
+
+    expect(handle.selectedText()).toBe("abcdefg");
+    handle.stop();
+  });
+
+  it("selects nothing when the press did not land on text", () => {
+    const handle = testRender(
+      <Box paddingTop={1}>
+        <Text>hello</Text>
+      </Box>,
+      { width: 8, height: 2 },
+    );
+
+    handle.press(dragBetween([0, 0], [4, 1]));
+
+    // The press was on the box's padding. A drag from there is a drag, and a
+    // box that means something by one — a splitter, a canvas — has its
+    // handlers called with no highlight left behind them.
+    expect(handle.selection()).toBe(null);
+    expect(handle.selectedText()).toBe("");
+    handle.stop();
+  });
+
+  it("lets a handler keep the reader's selection with preventDefault", () => {
+    const handle = testRender(
+      <Box>
+        <Text>hello</Text>
+        <Box id="grip" onMouseDown={(event: MouseEvent) => event.preventDefault()}>
+          <Text>grip</Text>
+        </Box>
+      </Box>,
+      { width: 8, height: 2 },
+    );
+
+    handle.press(dragBetween([0, 0], [4, 0]));
+    expect(handle.selectedText()).toBe("hello");
+
+    // The renderer's one default: a press clears the selection and may start
+    // another. A box that means its own thing by a drag suppresses both, and
+    // the reader keeps what they had.
+    handle.press(dragBetween([0, 1], [3, 1]));
+    expect(handle.selectedText()).toBe("hello");
+    handle.stop();
+  });
+
+  it("shows the selection where the text moved to when the tree re-renders", () => {
+    component Row() {
+      const [n, setN] = useState<number>(0);
+      useKeyboard((key) => {
+        if (key.name === "down") {
+          setN((value) => value + 1);
+        }
+      });
+      return <Text>{`row ${n}`}</Text>;
+    }
+    const handle = testRender(<Row />, { width: 8, height: 1 });
+
+    handle.press(dragBetween([0, 0], [4, 0]));
+    expect(handle.selectedText()).toBe("row 0");
+
+    // Two cells of the screen, and not a range inside a string: what they hold
+    // after a commit is what is selected, the same way a terminal's own
+    // selection stays where the reader left it while the program writes.
+    handle.press("\u001b[B");
+    expect(handle.selectedText()).toBe("row 1");
+    expect(inverted(handle.frame(), 4, 0)).toBe(true);
+    handle.stop();
+  });
+
+  it("forgets the selection when the terminal is resized", () => {
+    const handle = testRender(<Text>hello</Text>, { width: 8, height: 1 });
+
+    handle.press(dragBetween([0, 0], [4, 0]));
+    expect(handle.selection()).not.toBe(null);
+
+    // A resize reflows the screen in a way this renderer did not perform and
+    // cannot predict, so the two cells no longer name what they named. That is
+    // the one thing a selection does not survive.
+    handle.resize(20, 3);
+    expect(handle.selection()).toBe(null);
+    expect(handle.selectedText()).toBe("");
+    handle.stop();
+  });
+
+  it("hands a component the selection through useRenderer", () => {
+    // What an application does with a selection, written the way one would be:
+    // a key yanks the text, and another puts the highlight away. Nothing here
+    // reaches past the package's public surface, and nothing writes to an
+    // outer variable during a render to observe it.
+    component Copier() {
+      const renderer = useRenderer();
+      const [copied, setCopied] = useState<string>("");
+      useKeyboard((key) => {
+        if (key.name === "y") {
+          setCopied(renderer.hasSelection() ? renderer.getSelectedText() : "-");
+        }
+        if (key.name === "escape") {
+          renderer.clearSelection();
+        }
+      });
+      return (
+        <Box>
+          <Text>hello</Text>
+          <Text>{copied}</Text>
+        </Box>
+      );
+    }
+    const handle = testRender(<Copier />, { width: 8, height: 2 });
+
+    handle.press(dragBetween([1, 0], [3, 0]));
+    handle.press("y");
+    expect(frameRow(handle.frame(), 1)).toBe("ell     ");
+
+    handle.press(ESCAPE);
+    expect(inverted(handle.frame(), 1, 0)).toBe(false);
+    handle.press("y");
+    expect(frameRow(handle.frame(), 1)).toBe("-       ");
+    handle.stop();
+  });
+
+  it("selects nothing at all when the application did not ask for the mouse", () => {
+    const handle = testRender(<Text>hello</Text>, { width: 8, height: 1, mouse: false });
+
+    handle.press(dragBetween([0, 0], [4, 0]));
+
+    expect(handle.selection()).toBe(null);
+    expect(handle.selectedText()).toBe("");
+    expect(inverted(handle.frame(), 0, 0)).toBe(false);
+    handle.stop();
+  });
+
+  it("costs the cells it highlighted and no others", () => {
+    const handle = testRender(<Text>hello world</Text>, { width: 12, height: 1 });
+    expect(handle.update().cells).toBe(12);
+
+    handle.press(dragBetween([0, 0], [4, 0]));
+
+    // The highlight is a change to five cells, so it is five cells on the wire.
+    // A selection is not a reason to reprint the screen.
+    expect(handle.update().cells).toBe(5);
     handle.stop();
   });
 });


### PR DESCRIPTION
Refs #314.

`mouse.js` said a `preventDefault()` that suppressed nothing would be a promise
rather than a method, and that it "arrives with selection". The guide said
selection was "the one to expect next". `crates/uf_tui` kept
`TuiFeature::Selection` in the list `claims_only_the_features_the_package_implements`
asserts is *not* claimed. This is that feature, and that line is deleted on
purpose.

## What lands

A left press on selectable text arms an anchor; a drag from it selects the
cells between the two ends and highlights them; `renderer.getSelectedText()`
reads them back. One selection per renderer — a frame has one way of showing
that a cell is selected, so a second one would have nowhere to be.

| surface | |
| --- | --- |
| `renderer.getSelection()` / `hasSelection()` / `clearSelection()` / `getSelectedText()` | OpenTUI's names, reached through `useRenderer()` |
| `handle.selection()` / `handle.selectedText()` | the same, from outside the tree — a program that copies on a key has a signal handler, not a component |
| `selectable`, `selectionFg`, `selectionBg` | props on `Text` and `Box`, inherited the way `fg` is |
| `event.preventDefault()` / `event.defaultPrevented` | on `MouseEvent`, at last with something to prevent |
| `Selection`, `SelectionPoint`, `selectionContains` | exported; `@uniflowed/tui/selection` is the module |

## The decisions worth reviewing

**A selection is two cells of the frame, not a range inside the text.** This is
the hit grid's argument one level up: what a reader is selecting is what they
can *see*, and a row scrolled out of a `ScrollBox`, a child cut off by
`overflow: "hidden"`, and text a later box painted over all have geometry that
says otherwise. It is also what a terminal's own selection is — which matters,
because mouse reporting is precisely what takes that gesture away from the
reader, so this is the thing that hands it back. The cost is written down
rather than hidden: a selection survives a re-render and then covers whatever
moved into those cells, exactly as a terminal's does; a **resize** drops it,
because the emulator reflowed the screen in a way this renderer neither
performed nor can predict.

**The cells are recorded where the answer is already known.** `paintText`
claims the cells it writes, in a second array of the hit grid; `recordHit`
unclaims the rectangle a box is about to paint; the scrollbar unclaims the
column it draws over. Last writer wins there exactly as it does in the frame,
so a border is not text and a panel dropped over a paragraph does not leave the
paragraph selectable through its own background. `selectable` descends with the
paint the way `clip` does, so one prop covers a subtree.

**The highlight is a pass over the selected rows, not something the tree knows
about.** That is what keeps it right after a commit, and it is why
`getSelectedText()` draws a frame to answer: what is *in* a cell is a fact
about a painted frame, and every commit throws the last one away.

**One row rule, applied twice.** A row runs from its first selectable cell to
its last and keeps whatever is between them — so two `Text`s in a row with a
gap come back with the gap rather than as `leftright`, and the highlight has no
hole in the middle of a drag that went straight through it. Blanks outside that
span are the shape of the box and are not copied. Spans snap outwards onto
whole graphemes, or the two halves of `界` would differ in a comparison the
diff makes per cell.

**Inverse video is the default, toggled rather than set.** `SGR 7` is on
terminals with no colour at all, and toggling is what makes the cell an `Input`
draws its cursor in read as a hole in the highlight instead of vanishing into
it. `selectionFg`/`selectionBg` replace that rather than adding to it.

**`preventDefault()` on a left `down`** keeps the selection the reader had and
starts none. That is the renderer's only default, so it is the only thing the
method does — a splitter, a canvas or a slider is what it is for.

## The contract moves with the code

- `TuiFeature::Selection` is claimed, and deleted from the not-claimed list in
  `crates/uf_tui/src/tests.rs` — the mechanism #314 asked for.
- `TuiInputModel` is `keyboard-mouse-selection-focus`. It said `keyboard-focus`
  until the mouse landed and `keyboard-mouse-focus` until this did.
- The feature's own doc names the three things that are **not** behind the
  word: the two-cell model, OpenTUI's repeated-press word/line gestures, and
  *item* selection — `Select`/`TabSelect` — which is a component and not this.

## Tests

Seventeen cases in `tests/library/tui.test.js`, under "a drag selects what it
crossed". Every one drives the real SGR-1006 byte path — `ESC[<0;5;3M`,
`ESC[<32;…M`, `ESC[<0;…m` — and asserts a frame, or the bytes that would put
one on a terminal. All seventeen fail on `main`.

They cover: the text and the inverse cells a drag produces; a click clearing
one and a press that never moved not making one; reading order for a backwards
drag; whole rows rather than a rectangle; the gap between two boxes on a row;
`selectable={false}` inherited through a `Box`; `selectionFg`/`selectionBg`
resolved independently up the tree; a two-column grapheme when the drag lands
on its continuation cell; a border that is not copied; a scrollbar an unwrapped
line ran into that is not copied; a press on padding selecting nothing;
`preventDefault()`; the selection following the text through a commit; a resize
dropping it; the whole thing through `useRenderer()` in a component that yanks
on a key; nothing at all with `mouse: false`; and the diff cost — five
highlighted cells is five cells on the wire.

## What was run

| | |
| --- | --- |
| `uf test#library` | **2881 passed, 0 failed, 1 skipped** (82 files) |
| `uf test#library tui.test.js` | **118 passed** (101 before this change) |
| the same, with `packages/tui` reverted | **101 passed, 17 failed** |
| `cargo test -p uf_tui -p uf_lib` | **ok** — 14, 34 and 5 |
| `uf lint` | 0 errors, 14 warnings — the pre-existing four rules |
| `uf fmt --check` | every file already formatted |

## What is still #314

Unchanged by this PR, and the issue comment says the same: key **release**
(needs the Kitty keyboard protocol), the repeated-press gestures that widen a
selection to a word or a line, all three layout gaps (`flexWrap`,
`position: "absolute"`, `auto` margins), the fifteen remaining components, and
the four application APIs — clipboard included, which is why
`getSelectedText()` hands back a string rather than putting it anywhere. The
issue's bracketed-paste bullet was already stale: `keys.js` has decoded
`ESC[200~ … ESC[201~` since #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791546296&installation_model_id=422833&pr_number=741&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F741&signature=f1eaa8a00e31bf8b144cf9945ac321be8e29ce1f4b2fca4346f4bad4ac1cf99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->