### PR TITLE
feat(router, docs): the rows a payload arrives in, and the boundary each one resolves

### DIFF
--- a/docs/app/guide/routing/_uf.page.mdx
+++ b/docs/app/guide/routing/_uf.page.mdx
@@ -306,6 +306,61 @@ export default component Post(data: {| +post: Post |}) {
 rather than returned, so the type of the data does not have to admit "or a
 redirect".
 
+### Deferring part of the answer
+
+A loader may leave a promise in what it returns. The page is rendered with the
+promise still pending, and the value arrives in the same response, later:
+
+```js
+export async function loader({ params }: LoaderArgs) {
+  return {
+    post: await readPost(params.slug),      // waited for
+    comments: readComments(params.slug),    // not waited for
+  };
+}
+
+export default component Post(data: {| +post: Post, +comments: Promise<Array<Comment>> |}) {
+  return (
+    <article>
+      <h1>{data.post.title}</h1>
+      <Suspense fallback={<p>Loading comments…</p>}>
+        <Comments comments={data.comments} />
+      </Suspense>
+    </article>
+  );
+}
+
+component Comments(comments: Promise<Array<Comment>>) {
+  return <ul>{use(comments).map((one) => <li key={one.id}>{one.body}</li>)}</ul>;
+}
+```
+
+The document the server writes carries the post, the heading and the fallback
+immediately; when `readComments` settles, the comments' markup **and** the data
+behind them are appended to the same response, and the browser resolves that
+boundary without a second request. Each deferred value is its own boundary, so
+three of them arrive in the order they resolved rather than in the order they
+were written.
+
+This is uf's payload format, and `<Suspense>` is the whole of the API: there is
+no `defer()` to call and no `<Await>` to render, because a promise in the data
+already says everything either of them would have.
+
+Three things are worth knowing about it:
+
+- **What a promise resolves to is data.** The same values a loader could always
+  return — JSON's — and not a promise of its own. A deferred value that is
+  itself deferred is refused, because the payload numbers its rows once.
+- **A rejected promise reaches the boundary that was reading it.** The browser
+  is told the value failed and not why; the reason stays on the server, where
+  it is logged, and reaches the error boundary above whatever used the value.
+- **The response is already a 200.** The same rule as a deferred loader: bytes
+  that have gone cannot be unsent, so a `notFound()` thrown from inside one of
+  these arrives at the error boundary rather than at the 404 page.
+
+`uf build` waits for every one of them: a file on disk has nothing to stream to,
+so a prerendered page contains the finished comments.
+
 ## Metadata
 
 A page or layout may export a `metadata` object, or a `generateMetadata`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -701,9 +701,42 @@ process, a worker thread started with those `execArgv`, or a bundler
 environment resolved with that condition — which is the shape `@uniflowed/vite`
 would have to grow, since the first two are Node-only and uf's edge, serverless
 and workerd adapters all serve the same `handler.js`. That is the size of
-ubugeeei-prod/uf#519, and it is why the answer is not a smaller version of
-itself: half a payload format in the tree is the worst state for the thing
-whose whole risk is deserialisation.
+ubugeeei-prod/uf#519, and it is why the *element* half of the answer is not a
+smaller version of itself: half of it in the tree is the worst state for the
+thing whose whole risk is deserialisation.
+
+The framing is separable from that, and it has landed.
+`packages/router/internal/payload.js` is the wire format: a payload is a
+sequence of numbered rows rather than one value, row 0 is the model with each
+unresolved value replaced by a `"$P<n>"` reference, and each later row is a
+`<script type="application/json" data-uf-row="n">` React streams into the
+document at the moment that value settles. A loader may therefore leave a
+promise in what it returns — the shell goes out with a fallback and the value
+follows in the same response — and rows arrive in the order they resolved
+rather than the order they were written.
+
+It carries **one** reference kind, and that is the whole of why it could land
+alone: `$P<n>` names a position in the payload the reader itself created a
+promise for, so nothing in a payload names a constructor, a module, an export or
+a class. The two references the element payload needs — a client module and an
+element — are the ones a decoder resolves by *calling* something the payload
+named, and those still wait for the module graph above. `$` is a closed
+namespace and an unrecognised tag is refused rather than passed through, so
+adding one later is a change to a list rather than to a decoder that had already
+been letting it through.
+
+One thing that fell out of writing it is worth recording, because it is not
+about the payload. React's renderer cannot flush a segment while that segment
+holds an unresolved boundary, and every component between uf's render root and
+the route — `RenderProvider`, `RouterProvider`, `RouteView`, the error
+boundaries — renders no element of its own. So a `<Suspense>` at the top of
+uf's tree is a direct child of the *root* segment, and a document with one
+streams nothing at all: measured against React 19.2.8, `[<div>, <Suspense>]`
+writes its first byte when the boundary resolves, and the same tree with the
+boundary inside any host element writes it immediately. The payload's rows are
+inside a `<span hidden>` for that reason. A route whose `_uf.loading.js` sits
+above no layout is in exactly the same position and is still affected;
+ubugeeei-prod/uf#519 carries it.
 
 Until that lands, which modules the browser gets is a decision a reader has to
 be able to see, and `"use client"` is a directive whose cost is invisible until

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -157,6 +157,13 @@ in `uf`.
   `uf dev` reports what moved across the client bundle on each save and names
   the shortest chain of imports that put it there, so `"use client"` costs what
   it costs in the terminal rather than in a bundle somebody measures later.
+  **And the payload's framing is done**: a document carries numbered rows
+  rather than one finished value, so a loader may leave a promise in what it
+  returns and the value arrives in the same response, in the order it resolved
+  — see "Deferring part of the answer" in the routing guide. It carries one
+  reference kind, `$P<n>`, which names a row of the payload itself; the two the
+  element half needs, a client module and an element, are the ones that need
+  the second graph.
 - Server action transform and request bridge. **Done for a module export**: a
   `"use server"` module is replaced in the client graph by one reference per
   callable export, the browser posts the keyed id to the page's own URL, and

--- a/docs/security.md
+++ b/docs/security.md
@@ -120,9 +120,13 @@ Four things are outside it deliberately, each because admitting it would mean
 admitting a tag in the payload that says which constructor to call:
 
 - **A reference format.** React's Flight payload carries references to client
-  modules, promises and elements. uf has no such payload
-  ([#252](https://github.com/ubugeeei-prod/uf/issues/252)), and this grammar is
-  not the place to grow one quietly.
+  modules, promises and elements. uf's own payload
+  (`packages/router/internal/payload.js`) carries exactly one of the three and
+  it travels the other way — `"$P<n>"`, in a document the server writes, naming
+  a row of that same payload rather than anything to construct. This grammar is
+  the one an untrusted *sender* is decoded under, and it has none: an action's
+  arguments arrive from the network, so a tag there is a tag somebody else
+  chose.
 - **Class instances, `Map`, `Set`, `Date`, `RegExp`, typed arrays.** An action
   that wants a date takes an ISO string and parses it, where the parse is the
   application's and is checked.

--- a/packages/router/client.js
+++ b/packages/router/client.js
@@ -14,6 +14,18 @@
 // *before* `hydrateRoot`, so the first client render is synchronous and
 // matches the server's markup exactly.
 //
+// # What "its loader data" means once the loader can defer
+//
+// It is a payload rather than a value: `internal/payload.js` writes the model
+// into `<script id="__uf_data">` with a `"$P<n>"` reference wherever the loader
+// left a promise, and each of those arrives later in a `<script data-uf-row>`
+// of its own. So two things happen before `hydrateRoot` rather than one — the
+// model is decoded, and `internal/payload-rows.js` starts watching for the
+// rows it referred to. Both have to be first: the decoded model is what the
+// first render is handed, and a row that landed while nothing was watching
+// would be a boundary that never resolves. A document with nothing deferred
+// has no references, so the reader is handed no ids and installs nothing.
+//
 // # A hydration that fails says what differed
 //
 // React reports a mismatch with one sentence and a list of the six things that
@@ -94,6 +106,8 @@ import {
   resolveMatch,
 } from "./internal/runtime.js";
 import { DATA_ID, ROOT_ID } from "./internal/document.js";
+import { decodePayload } from "./internal/payload.js";
+import { createPayloadReader, domObserver } from "./internal/payload-rows.js";
 
 /**
  * Hydrate the current document.
@@ -130,8 +144,23 @@ export async function hydrate(options: {|
   }
 
   const url = window.location.pathname + window.location.search;
+  // Row 0 of the payload, and the reader that will fill in the rows it refers
+  // to. Both before `hydrateRoot`, and in this order: `decodePayload` is what
+  // tells the reader which rows the page is waiting for, and `watch` is what
+  // makes it notice the ones the server has not written yet. A document with
+  // nothing deferred has no references, so the reader is handed no ids, and
+  // `watch` returns without installing anything — see `internal/payload.js`.
   const embedded = document.getElementById(DATA_ID);
-  const data = embedded != null ? JSON.parse(embedded.textContent ?? "null") : undefined;
+  const reader = createPayloadReader(document, domObserver(document));
+  const data =
+    embedded != null
+      ? decodePayload(
+          JSON.parse(embedded.textContent ?? "null"),
+          reader.resolve,
+          "the route's loader data",
+        )
+      : undefined;
+  reader.watch();
   const resolved = await resolveMatch(table, url, { data, skipLoader: embedded != null });
 
   const { App } = options;

--- a/packages/router/internal/action-wire.js
+++ b/packages/router/internal/action-wire.js
@@ -61,9 +61,12 @@
 //
 // * **A reference format.** React's Flight payload can carry a reference to a
 //   client module, a promise, or an element, and a decoder that reconstructs
-//   those is a decoder that constructs attacker-chosen objects. uf has no such
-//   payload (ubugeeei-prod/uf#252) and this grammar is not the place to grow
-//   one quietly.
+//   those is a decoder that constructs attacker-chosen objects. uf's payload
+//   (`./payload.js`) now carries one of the three — a reference to a *row of
+//   itself*, which names nothing to construct — and it is a document the
+//   server writes rather than a body somebody sends. This grammar is the one
+//   an untrusted sender is decoded under, so it still has none, and it is
+//   still not the place to grow one quietly (ubugeeei-prod/uf#252).
 // * **Class instances, `Map`, `Set`, `Date`, `RegExp`, typed arrays.** Each
 //   would need a tag in the payload saying which constructor to call, and a
 //   tag naming a constructor is the oracle every deserialisation CVE is made

--- a/packages/router/internal/payload-rows.js
+++ b/packages/router/internal/payload-rows.js
@@ -80,14 +80,14 @@ export type PayloadReader = {|
 
 /** The parts of a `Document` this module uses, so it needs no DOM lib. */
 type DocumentLike = interface {
-  +querySelectorAll: (selector: string) => Iterable<ElementLike>,
-  +documentElement: mixed,
+  readonly querySelectorAll: (selector: string) => Iterable<ElementLike>,
+  readonly documentElement: mixed,
 };
 
 /** The parts of an `Element` this module uses. */
 type ElementLike = interface {
-  +getAttribute: (name: string) => string | null,
-  +textContent: string | null,
+  readonly getAttribute: (name: string) => string | null,
+  readonly textContent: string | null,
 };
 
 /** One row the page is waiting for. */

--- a/packages/router/internal/payload-rows.js
+++ b/packages/router/internal/payload-rows.js
@@ -1,0 +1,258 @@
+// @flow
+//
+// Internal to `@uniflowed/router`: reading the payload's rows out of a
+// streaming document.
+//
+// `./payload.js` is the format and knows nothing about a browser. This is the
+// other half: row 0 arrives in the document's `<script id="__uf_data">` and
+// every later row arrives in a `<script data-uf-row="n">` React inserts when
+// the value it holds resolves — which is *after* the parser reached the end of
+// what had been sent, and usually after `hydrateRoot` has already been called.
+// So a reader that only looked once would see the rows that happened to be
+// early and wait forever for the rest.
+//
+// # A `MutationObserver`, and not an executable script
+//
+// The obvious mechanism is React's own: an inline `<script>` that pushes into
+// a global. `internal/runtime.js` explains at length why uf's data element is
+// `application/json` instead — "a script that is executed is a script a
+// content security policy has to allow" — and the payload inherits the whole
+// of that argument, several times over: there is now one element per deferred
+// value rather than one per document, and each one carries application data
+// that a `script` element with no type would hand to the JavaScript parser.
+//
+// The cost of keeping that property is that nothing calls uf when a row lands,
+// so uf has to watch. A `MutationObserver` on the document, `childList` and
+// `subtree`, is the whole of it. It is installed before `hydrateRoot` and
+// disconnects itself the moment the last row the model named has arrived, so a
+// page with no deferred values never has one and a page with three has one for
+// as long as its slowest value takes.
+//
+// # Why the observer beats React to the row
+//
+// It has to, or a boundary that the server completed would be hydrated while
+// this side still thought the value was pending. It does, for two reasons that
+// are each sufficient. React writes a completed boundary's content into a
+// hidden `<div>` *before* the inline script that moves it into place, so the
+// row element is in the document one mutation earlier than React's own
+// completion path; and a `MutationObserver` callback is a microtask, while
+// React's hydration of a completed boundary is scheduled work in a later task.
+//
+// If it ever lost that race the failure is still bounded rather than wrong:
+// `use` on a pending promise suspends, React keeps the boundary's fallback for
+// one more microtask, and the row resolves it. What must not happen — and
+// cannot, since both sides render the row element from the same value through
+// the same `payloadJson` — is the two sides writing different bytes into it.
+//
+// # Rows nobody asked for
+//
+// Ignored. The ids that matter are the ones row 0 referred to, `resolve` is
+// what records them, and an element carrying any other id is a document that
+// says more than its model does. Refusing the page over it would be a
+// hydration that fails because of something no component rendered; dropping it
+// is the reading this module can defend.
+
+import {
+  type PayloadRowMessage,
+  PAYLOAD_ROW_ATTRIBUTE,
+  PayloadRowError,
+  PayloadValueError,
+  parseRowMessage,
+} from "./payload.js";
+
+/** The document half of a payload: the promises, and the watch that fills them. */
+export type PayloadReader = {|
+  /**
+   * The value of row `id`, as a promise.
+   *
+   * The `RowResolver` `decodePayload` is handed. Calling it is what tells this
+   * reader that the id is one the page is waiting for.
+   */
+  readonly resolve: (id: number) => Promise<mixed>,
+  /**
+   * Start reading. Applies every row already in the document, then watches for
+   * the rest; returns without waiting for any of them.
+   */
+  readonly watch: () => void,
+  /** Stop watching, whether or not every row arrived. */
+  readonly stop: () => void,
+|};
+
+/** The parts of a `Document` this module uses, so it needs no DOM lib. */
+type DocumentLike = interface {
+  +querySelectorAll: (selector: string) => Iterable<ElementLike>,
+  +documentElement: mixed,
+};
+
+/** The parts of an `Element` this module uses. */
+type ElementLike = interface {
+  +getAttribute: (name: string) => string | null,
+  +textContent: string | null,
+};
+
+/** One row the page is waiting for. */
+type Slot = {|
+  readonly promise: Promise<mixed>,
+  readonly settle: (message: PayloadRowMessage) => void,
+  arrived: boolean,
+|};
+
+/**
+ * A reader over one document.
+ *
+ * `observe` is passed in rather than reached for so that this module needs no
+ * `MutationObserver` global to be *loaded* — the tests drive it with a
+ * document they mutate by hand, and a runtime without the constructor gets a
+ * reader that reads what is already there and never watches, which is exactly
+ * what a prerendered document needs.
+ */
+export function createPayloadReader(
+  document: DocumentLike,
+  observe?: ?(callback: () => void) => (() => void) | null,
+): PayloadReader {
+  const slots: Map<number, Slot> = new Map();
+  let disconnect: (() => void) | null = null;
+  let watching = false;
+
+  function slotFor(id: number): Slot {
+    const existing = slots.get(id);
+    if (existing != null) {
+      return existing;
+    }
+    let settle: (message: PayloadRowMessage) => void = () => {};
+    const promise = new Promise<mixed>((fulfil, reject) => {
+      settle = (message) => {
+        if (message.error !== undefined) {
+          // A `PayloadRowError` rather than a plain one, carrying the row's
+          // exact text: the page's error boundary sees an `Error` either way,
+          // and `internal/runtime.js` needs the text back verbatim when it
+          // re-renders this row's element. See `PayloadRowError`.
+          reject(new PayloadRowError(message.error));
+          return;
+        }
+        fulfil(message.value);
+      };
+    });
+    // Marked handled the moment it exists. A row that says the value failed
+    // rejects this promise, and whether anything is listening by then depends
+    // on whether React has rendered the row's element yet — so without this an
+    // ordinary loader failure would arrive as an unhandled rejection, which
+    // recent Node turns into an exit.
+    promise.catch(() => {});
+    const slot: Slot = { promise, settle, arrived: false };
+    slots.set(id, slot);
+    return slot;
+  }
+
+  function apply(element: ElementLike): void {
+    const attribute = element.getAttribute(PAYLOAD_ROW_ATTRIBUTE);
+    if (attribute == null) {
+      return;
+    }
+    const id = Number.parseInt(attribute, 10);
+    if (!Number.isSafeInteger(id)) {
+      return;
+    }
+    const slot = slots.get(id);
+    // A row for an id the model never referred to, or one already applied. See
+    // the header: neither is this reader's to complain about.
+    if (slot == null || slot.arrived) {
+      return;
+    }
+    slot.arrived = true;
+    try {
+      slot.settle(parseRowMessage(element.textContent ?? "", id));
+    } catch (error) {
+      slot.settle({
+        error:
+          error instanceof PayloadValueError
+            ? error.message
+            : `@uniflowed/router: row ${String(id)} could not be read.`,
+      });
+    }
+    if (finished()) {
+      stop();
+    }
+  }
+
+  function sweep(): void {
+    for (const element of document.querySelectorAll(`script[${PAYLOAD_ROW_ATTRIBUTE}]`)) {
+      apply(element);
+    }
+  }
+
+  function finished(): boolean {
+    for (const slot of slots.values()) {
+      if (!slot.arrived) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function stop(): void {
+    watching = false;
+    const off = disconnect;
+    disconnect = null;
+    if (off != null) {
+      off();
+    }
+  }
+
+  return {
+    resolve(id: number): Promise<mixed> {
+      const slot = slotFor(id);
+      // A reference discovered after the watch started — a client navigation
+      // decoding a payload of its own — still gets whatever is already in the
+      // document, so the order the two calls happen in does not matter.
+      if (watching) {
+        sweep();
+      }
+      return slot.promise;
+    },
+    watch(): void {
+      if (watching || slots.size === 0) {
+        return;
+      }
+      watching = true;
+      sweep();
+      if (finished() || observe == null) {
+        watching = false;
+        return;
+      }
+      disconnect = observe(sweep);
+    },
+    stop,
+  };
+}
+
+/**
+ * The `observe` a browser has.
+ *
+ * Separate from [`createPayloadReader`] so the reader itself stays testable
+ * without one, and so the `MutationObserver` global is touched in exactly one
+ * place — a runtime that has no such constructor gets `null` and a reader that
+ * reads the document once, which is the right answer for a prerendered file
+ * where every row is already in it.
+ */
+export function domObserver(
+  document: DocumentLike,
+): ((callback: () => void) => (() => void) | null) | null {
+  if (typeof MutationObserver === "undefined") {
+    return null;
+  }
+  const root = document.documentElement;
+  if (root == null) {
+    return null;
+  }
+  return (callback) => {
+    const observer = new MutationObserver(() => {
+      callback();
+    });
+    // $FlowFixMe[incompatible-call] `documentElement` is a `Node`; the interface above says only what is read.
+    observer.observe(root, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+    };
+  };
+}

--- a/packages/router/internal/payload.js
+++ b/packages/router/internal/payload.js
@@ -1,0 +1,669 @@
+// @flow
+//
+// Internal to `@uniflowed/router`: the payload, and what may be in it.
+//
+// A document uf streams has always carried one thing the browser reads back:
+// the loader's answer, in `<script id="__uf_data" type="application/json">`.
+// That element is written once, from a value that is complete by the time it
+// is written, so everything in it had to have resolved before the byte after
+// it could be sent. A page whose data is one slow thing and four fast ones
+// therefore waited for the slow one to say anything about the other four, and
+// a promise anywhere in that value was `JSON.stringify`'d to `{}` — silently,
+// which is the worse half.
+//
+// This module is the format that stops it waiting. It is **Flight-shaped** in
+// the one sense that matters: a payload is not a value, it is a sequence of
+// numbered *rows*, the first of which may name rows that have not been written
+// yet. Row 0 is the model — the loader's answer with each unresolved value
+// replaced by a reference — and each later row is one of those values,
+// arriving in whatever order it resolved in, in a `<script>` React streams
+// into the document at the moment it settles.
+//
+//   0  {"user":{"name":"ada"},"comments":"$P1","related":"$P2"}
+//   2  {"value":[{"id":7}]}
+//   1  {"value":[{"body":"…"}]}
+//
+// Two rows out of order, because row 2 resolved first, and that is the whole
+// point: the reader has the page and the user's name while the comments are
+// still being fetched, and the boundary around the comments resolves on its
+// own rather than behind the slowest thing on the page.
+//
+// # One reference kind, and the reason there is only one
+//
+// `./action-wire.js` says, under "What is deliberately absent", that React's
+// Flight payload can carry a reference to a client module, a promise, or an
+// element, and that "a decoder that reconstructs those is a decoder that
+// constructs attacker-chosen objects" — so the action grammar has no reference
+// format and "this grammar is not the place to grow one quietly". This is the
+// place, and it grows exactly one:
+//
+//   `"$P<n>"`  the value written by row `n` of this same payload.
+//
+// A row reference names a *position in this payload*, and it is resolved by
+// this module's own reader with a promise this module made. Nothing in a
+// payload names a constructor, a module, a function, an export or a class, and
+// no string in one is looked up in any registry. That is the difference
+// between the reference this format has and the two it does not: a module
+// reference and an element reference are decoded by *calling* something the
+// payload named, and the payload the client re-renders a *tree* from needs
+// both. Those wait for ubugeeei-prod/uf#519's other half, which needs a second
+// module graph before it needs a format. This half is the framing and the
+// streaming, and it is written so that adding a tag later is a change to a
+// closed list rather than to a decoder that already passes strings through:
+// an unrecognised `$` string is **refused**, because a decoder that ignored
+// `"$X1"` today would accept it silently on the day `$X` means something.
+//
+// # What the model may hold is unchanged, and that is deliberate
+//
+// Everything else in a payload is what `JSON.stringify` carries, because that
+// is what the loader data element has always been. Narrowing it to the closed
+// grammar `./action-wire.js` applies to a server action would be a change to a
+// contract this format is not about — and it would be a change made in a
+// throw, inside a loader, on somebody whose page worked yesterday. An action's
+// arguments arrive from the network and are somebody else's bytes; a loader's
+// answer is the application's own value on its way out, and the two do not
+// need the same answer.
+//
+// So the encoder does exactly two things: it replaces promises with references
+// and it escapes strings that would read as one. A `Date`, a class with a
+// `toJSON`, an `undefined` property, a `NaN` — each crosses exactly as it did
+// before this file existed, which is to say as `JSON.stringify` renders it.
+// The one shape that is outside this and says so is a cycle: the walk is
+// bounded by [`MAX_PAYLOAD_DEPTH`], and `JSON.stringify` threw on one anyway.
+//
+// The escape is applied to every string the walk *reaches*, which is every
+// string inside a plain object or an array. A string that only appears because
+// something's `toJSON` produced it is not reached and not escaped — so a
+// `toJSON` returning a string that begins with `$` is the one value this
+// format cannot round-trip, and it is named here rather than left to be found.
+//
+// # Nothing changes for a payload with nothing deferred
+//
+// Both walks answer with the value they were handed when there is nothing to
+// do — no promise anywhere, no string starting with `$`. So a page whose
+// loader returns ordinary data produces the same bytes it produced before this
+// module existed, and the browser hands the application the object
+// `JSON.parse` made rather than a copy of it. That is worth more than the
+// walk it saves: it is what makes "the payload changed nothing here" a
+// property rather than a hope.
+//
+// # Why both sides run this file
+//
+// The same reason `./action-wire.js` gives: two implementations of one grammar
+// is how the two come to disagree. Here it is load-bearing beyond that. The
+// row `<script>` is rendered by React *on both sides* — the server writes it
+// from the promise it resolved, the browser writes it from the value it read
+// out of that same element — so the two renders have to produce the same bytes
+// or the page is a hydration mismatch. They do, because both call
+// [`payloadJson`] on a value that has been through one `JSON.parse`, and
+// `JSON.stringify` is stable over its own output.
+//
+// Pure: no imports, no platform APIs beyond `JSON`, so the browser's half of
+// `@uniflowed/router` can reach it without reaching anything server-only. The
+// document half — finding the row elements and noticing the ones that have not
+// arrived yet — is `./payload-rows.js`, which is the only part that needs a DOM.
+
+/** The attribute naming a late row's script element. */
+export const PAYLOAD_ROW_ATTRIBUTE: string = "data-uf-row";
+
+/**
+ * The prefix every reference in this format starts with.
+ *
+ * One character, so that escaping a string that starts with it costs one
+ * character too. React's own Flight payload uses the same one, and a format
+ * that reads as Flight does to somebody who knows Flight is worth more than a
+ * prefix nobody has ever seen.
+ */
+const REFERENCE_PREFIX = "$";
+
+/** The tag that makes a reference a row reference. `$P1` is "the value of row 1". */
+const ROW_TAG = "P";
+
+/**
+ * Most rows one payload may have.
+ *
+ * A ceiling on the number of `<script>` elements one document can be made to
+ * carry, and on the number of promises the browser holds open waiting for
+ * them. A loader that defers more than this is a loader that wants one request
+ * per thing rather than one page.
+ */
+export const MAX_PAYLOAD_ROWS: number = 64;
+
+/**
+ * Deepest nesting either walk will follow.
+ *
+ * A guard rather than a policy. `JSON.stringify` refuses a cycle by throwing,
+ * and the walks below would follow one forever, so the depth is what keeps the
+ * two failing the same way. Deep enough that no data shaped like data reaches
+ * it: `MAX_ACTION_DEPTH` is 24, and this is not the place to be stricter than
+ * the wire an application already has.
+ */
+export const MAX_PAYLOAD_DEPTH: number = 64;
+
+/** A value that could not be encoded, and where in the loader's answer it was. */
+export class PayloadValueError extends Error {
+  /** Where the offending value sat, e.g. `data.filters`. */
+  path: string;
+
+  constructor(path: string, reason: string) {
+    super(`@uniflowed/router: ${path} ${reason}.`);
+    this.name = "PayloadValueError";
+    this.path = path;
+  }
+}
+
+/**
+ * A row that said the value failed, carried back as a rejection.
+ *
+ * The class exists so the reading side can rewrite the row it read without
+ * having to guess. A row is rendered by React on *both* sides, so whatever the
+ * browser puts in the element has to be what the server put there — and the
+ * server's choice of words depends on whether it is a development build. This
+ * carries the row's own text past that decision: the browser echoes `wire`
+ * rather than deciding again, and the two agree whichever build wrote which.
+ */
+export class PayloadRowError extends Error {
+  /** Exactly what the row's `error` said. */
+  wire: string;
+
+  constructor(wire: string) {
+    super(wire);
+    this.name = "PayloadRowError";
+    this.wire = wire;
+  }
+}
+
+/** One value the model referred to and that has not resolved yet. */
+export type PendingRow = {|
+  /** Row number, 1-based; row 0 is the model itself. */
+  readonly id: number,
+  /** The promise whose settlement writes the row. */
+  readonly value: Promise<mixed>,
+|};
+
+/** The model, and every row it named. */
+export type EncodedPayload = {|
+  /** Row 0: the value with each promise replaced by a `"$P<n>"` reference. */
+  readonly model: mixed,
+  /** The promises those references name, in ascending id order. */
+  readonly rows: $ReadOnlyArray<PendingRow>,
+|};
+
+/**
+ * What one late row's script says.
+ *
+ * Two shapes rather than one so that a rejected promise is a rejected promise
+ * on the other side too, instead of a value that never arrives and a boundary
+ * that spins. What is in the message is decided by the caller rather than here
+ * — see `internal/runtime.js`, which sends the server's own words only where
+ * `import.meta.hot` says a developer is reading them.
+ *
+ * One exact object with two optional fields rather than a union of two, and
+ * the reason is `JSON.stringify`: the value that gets written has to have
+ * exactly one key in it, so the type the writer holds has to be the one that
+ * can express either. [`parseRowMessage`] enforces "exactly one" on the way
+ * back in, which is the direction where it is a claim about somebody else's
+ * bytes rather than about uf's own.
+ */
+export type PayloadRowMessage = {|
+  readonly value?: mixed,
+  readonly error?: string,
+|};
+
+/**
+ * The prototype every object literal has, captured rather than named.
+ *
+ * `./action-wire.js` explains the choice; the same one is made here so the two
+ * agree about what a plain object is. Only a plain object and an array are
+ * walked into — everything else is `JSON.stringify`'s business, as it was.
+ */
+const PLAIN_PROTOTYPE: mixed = Object.getPrototypeOf({});
+
+function isPlainObject(value: mixed): boolean {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const prototype: mixed = Object.getPrototypeOf(value);
+  return prototype === PLAIN_PROTOTYPE || prototype === null;
+}
+
+/**
+ * The value as a promise, or `null`.
+ *
+ * A `then` method and nothing else, which is the one duck-type this file makes
+ * and the one it has to: a loader's promise may come from a different realm
+ * than the one this module was loaded in, and `instanceof Promise` is false
+ * across realms. It is safe in a way it would not be in `./action-wire.js`
+ * because a thenable here is never *reconstructed* — it is awaited, and what
+ * it produces is written by `JSON.stringify` like any other value.
+ */
+function asThenable(value: mixed): Promise<mixed> | null {
+  if (value == null || (typeof value !== "object" && typeof value !== "function")) {
+    return null;
+  }
+  const then: mixed = (value: $FlowFixMe).then;
+  return typeof then === "function" ? (value: $FlowFixMe) : null;
+}
+
+/** Whether a string would be read as a reference and so has to be escaped. */
+function isReferenceLike(value: mixed): boolean {
+  return typeof value === "string" && value.startsWith(REFERENCE_PREFIX);
+}
+
+/**
+ * Write a key without letting `__proto__` mean what assignment makes it mean.
+ *
+ * `JSON.parse` gives `__proto__` an *own* data property; `target[key] = value`
+ * calls the setter on `Object.prototype` and changes the object's prototype
+ * instead. Rebuilding a parsed object with plain assignment would therefore
+ * turn a payload that was inert into prototype pollution — a hazard these
+ * walks would introduce rather than inherit. `defineProperty` is what
+ * `JSON.parse` does, spelled out.
+ */
+function setKey(target: { [string]: mixed }, key: string, value: mixed): void {
+  if (key === "__proto__") {
+    Object.defineProperty(target, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    return;
+  }
+  target[key] = value;
+}
+
+/** One entry of an explicit walk stack, with the slot to write the result into. */
+type Frame = {|
+  readonly value: mixed,
+  readonly path: string,
+  readonly depth: number,
+  readonly emit: (encoded: mixed) => void,
+|};
+
+/**
+ * Whether anything in `root` needs encoding at all.
+ *
+ * A promise, or a string that would read as a reference. Answering `false`
+ * here is what lets [`encodePayload`] hand back the value it was given — see
+ * the header on why that matters more than the walk it saves.
+ *
+ * An explicit stack rather than recursion, for the reason `checkActionValue`
+ * gives: nesting is the application's choice, and a recursive walk over it is
+ * a stack overflow with somebody's hand on the depth.
+ */
+function needsEncoding(root: mixed, label: string): boolean {
+  const stack: Array<{| value: mixed, path: string, depth: number |}> = [
+    { value: root, path: label, depth: 0 },
+  ];
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame == null) {
+      break;
+    }
+    const { value, path, depth } = frame;
+    if (depth > MAX_PAYLOAD_DEPTH) {
+      throw new PayloadValueError(path, `is nested deeper than ${String(MAX_PAYLOAD_DEPTH)}`);
+    }
+    if (isReferenceLike(value) || asThenable(value) != null) {
+      return true;
+    }
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        stack.push({ value: value[index], path: `${path}[${String(index)}]`, depth: depth + 1 });
+      }
+      continue;
+    }
+    if (isPlainObject(value)) {
+      const source: { +[string]: mixed } = (value: $FlowFixMe);
+      for (const key of Object.keys(source)) {
+        stack.push({ value: source[key], path: `${path}.${key}`, depth: depth + 1 });
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Split a value into the model that goes out now and the rows that follow.
+ *
+ * The walk is **ordered**: children are visited in array order and in
+ * `Object.keys` order, so the id a promise gets is a function of where it sits
+ * in the model and of nothing else.
+ *
+ * That determinism is what lets the browser encode the same model to the same
+ * bytes, which is what lets both sides render the row `<script>`. It holds
+ * across a `JSON.parse` because parsing preserves both orders, and it is why
+ * ids come from this walk rather than from the order the promises were created
+ * in — which is a fact about the loader, not about the data, and would differ
+ * between the two sides.
+ */
+export function encodePayload(root: mixed, label: string): EncodedPayload {
+  if (!needsEncoding(root, label)) {
+    return { model: root, rows: [] };
+  }
+
+  const rows: Array<PendingRow> = [];
+  let model: mixed = null;
+  const stack: Array<Frame> = [
+    {
+      value: root,
+      path: label,
+      depth: 0,
+      emit: (encoded) => {
+        model = encoded;
+      },
+    },
+  ];
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame == null) {
+      break;
+    }
+    const { value, path, depth, emit } = frame;
+    if (depth > MAX_PAYLOAD_DEPTH) {
+      throw new PayloadValueError(path, `is nested deeper than ${String(MAX_PAYLOAD_DEPTH)}`);
+    }
+
+    const thenable = asThenable(value);
+    if (thenable != null) {
+      if (rows.length >= MAX_PAYLOAD_ROWS) {
+        throw new PayloadValueError(label, `defers more than ${String(MAX_PAYLOAD_ROWS)} values`);
+      }
+      const id = rows.length + 1;
+      rows.push({ id, value: thenable });
+      emit(`${REFERENCE_PREFIX}${ROW_TAG}${String(id)}`);
+      continue;
+    }
+    if (isReferenceLike(value)) {
+      emit(REFERENCE_PREFIX + String(value));
+      continue;
+    }
+    if (Array.isArray(value)) {
+      const encoded: Array<mixed> = new Array(value.length).fill(null);
+      emit(encoded);
+      // Pushed in reverse so that popping visits index 0 first: the id a
+      // promise is given has to follow the order the payload reads in.
+      for (let index = value.length - 1; index >= 0; index -= 1) {
+        stack.push({
+          value: value[index],
+          path: `${path}[${String(index)}]`,
+          depth: depth + 1,
+          emit: (child) => {
+            encoded[index] = child;
+          },
+        });
+      }
+      continue;
+    }
+    if (!isPlainObject(value)) {
+      // A `Date`, a `Map`, a class instance, a number, `undefined`: whatever
+      // `JSON.stringify` would have made of it, unchanged. See the header.
+      emit(value);
+      continue;
+    }
+    const source: { +[string]: mixed } = (value: $FlowFixMe);
+    const encoded: { [string]: mixed } = {};
+    emit(encoded);
+    const keys = Object.keys(source);
+    for (let index = keys.length - 1; index >= 0; index -= 1) {
+      const key = keys[index];
+      stack.push({
+        value: source[key],
+        path: `${path}.${key}`,
+        depth: depth + 1,
+        emit: (child) => {
+          setKey(encoded, key, child);
+        },
+      });
+    }
+  }
+
+  return { model, rows };
+}
+
+/**
+ * Encode what one row resolved to.
+ *
+ * The same walk, and then the one rule a row has that the model does not: it
+ * may not itself defer. Row ids are handed out by a single walk of the model,
+ * which is the only structure both sides hold before anything has resolved, so
+ * a row that could add ids as it settled would be a numbering that depends on
+ * the order things finished in — and the browser, which re-renders the row
+ * element from the value it read, would number them differently.
+ *
+ * Reusing the encoder and refusing the rows it found is the shortest honest
+ * spelling: one walk, one escape rule, and no second implementation to drift
+ * from the first.
+ */
+export function encodeRowValue(root: mixed, label: string): mixed {
+  const { model, rows } = encodePayload(root, label);
+  if (rows.length > 0) {
+    throw new PayloadValueError(label, "resolved to a value that is itself deferred");
+  }
+  return model;
+}
+
+/** How a decoder is told what a reference stands for. */
+export type RowResolver = (id: number) => mixed;
+
+/**
+ * Rebuild a value from a model, with every reference replaced.
+ *
+ * `resolve` is handed a row id and answers with whatever should stand in the
+ * slot — a promise, on the reading side, which is the whole point. A callback
+ * rather than a map, so a reader can create the promise on first sight of a
+ * reference and never for a row nothing refers to.
+ *
+ * A model with no `$` string in it is handed straight back, so the application
+ * gets the object `JSON.parse` made. See the header.
+ */
+export function decodePayload(root: mixed, resolve: RowResolver, label: string): mixed {
+  if (!hasReference(root, label)) {
+    return root;
+  }
+
+  let out: mixed = null;
+  const stack: Array<Frame> = [
+    {
+      value: root,
+      path: label,
+      depth: 0,
+      emit: (value) => {
+        out = value;
+      },
+    },
+  ];
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame == null) {
+      break;
+    }
+    const { value, path, depth, emit } = frame;
+    if (depth > MAX_PAYLOAD_DEPTH) {
+      throw new PayloadValueError(path, `is nested deeper than ${String(MAX_PAYLOAD_DEPTH)}`);
+    }
+
+    if (isReferenceLike(value)) {
+      emit(decodeReference(String(value), path, resolve));
+      continue;
+    }
+    if (Array.isArray(value)) {
+      const rebuilt: Array<mixed> = new Array(value.length).fill(null);
+      emit(rebuilt);
+      for (let index = value.length - 1; index >= 0; index -= 1) {
+        stack.push({
+          value: value[index],
+          path: `${path}[${String(index)}]`,
+          depth: depth + 1,
+          emit: (child) => {
+            rebuilt[index] = child;
+          },
+        });
+      }
+      continue;
+    }
+    if (!isPlainObject(value)) {
+      emit(value);
+      continue;
+    }
+    const source: { +[string]: mixed } = (value: $FlowFixMe);
+    const rebuilt: { [string]: mixed } = {};
+    emit(rebuilt);
+    const keys = Object.keys(source);
+    for (let index = keys.length - 1; index >= 0; index -= 1) {
+      const key = keys[index];
+      stack.push({
+        value: source[key],
+        path: `${path}.${key}`,
+        depth: depth + 1,
+        emit: (child) => {
+          setKey(rebuilt, key, child);
+        },
+      });
+    }
+  }
+
+  return out;
+}
+
+/** Whether a model holds anything the decoder has to look at. */
+function hasReference(root: mixed, label: string): boolean {
+  const stack: Array<{| value: mixed, path: string, depth: number |}> = [
+    { value: root, path: label, depth: 0 },
+  ];
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame == null) {
+      break;
+    }
+    const { value, path, depth } = frame;
+    if (depth > MAX_PAYLOAD_DEPTH) {
+      throw new PayloadValueError(path, `is nested deeper than ${String(MAX_PAYLOAD_DEPTH)}`);
+    }
+    if (isReferenceLike(value)) {
+      return true;
+    }
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        stack.push({ value: value[index], path: `${path}[${String(index)}]`, depth: depth + 1 });
+      }
+      continue;
+    }
+    if (isPlainObject(value)) {
+      const source: { +[string]: mixed } = (value: $FlowFixMe);
+      for (const key of Object.keys(source)) {
+        stack.push({ value: source[key], path: `${path}.${key}`, depth: depth + 1 });
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * One `$` string: an escaped literal, or a row reference.
+ *
+ * The unrecognised case throws. See the header: a decoder that passed `"$X1"`
+ * through would be one that accepts a tag it does not implement, from a
+ * payload it did not write.
+ */
+function decodeReference(value: string, path: string, resolve: RowResolver): mixed {
+  if (value.startsWith(REFERENCE_PREFIX + REFERENCE_PREFIX)) {
+    return value.slice(1);
+  }
+  const id = rowId(value);
+  if (id == null) {
+    throw new PayloadValueError(path, "names a reference this payload format has no tag for");
+  }
+  return resolve(id);
+}
+
+/**
+ * The row a reference names, or `null` when the string is not one.
+ *
+ * Digits only, and read by hand rather than with `Number`, which accepts
+ * `"1e3"`, `" 1"`, `"0x1"` and `"Infinity"` — four spellings of a row id this
+ * format does not have.
+ */
+function rowId(value: string): number | null {
+  if (!value.startsWith(REFERENCE_PREFIX + ROW_TAG)) {
+    return null;
+  }
+  const digits = value.slice(2);
+  if (digits.length === 0 || digits.length > 3) {
+    return null;
+  }
+  for (let index = 0; index < digits.length; index += 1) {
+    const code = digits.charCodeAt(index);
+    if (code < 48 || code > 57) {
+      return null;
+    }
+  }
+  const id = Number.parseInt(digits, 10);
+  return id >= 1 && id <= MAX_PAYLOAD_ROWS ? id : null;
+}
+
+/**
+ * A payload row, or the model, as the text of a `<script type="application/json">`.
+ *
+ * `<` is escaped so a string holding `</script>` cannot end the element early,
+ * and U+2028 and U+2029 because a JSON document is not JavaScript source but is
+ * sometimes read as if it were. This is the escape `internal/runtime.js`
+ * applied inline before there was a payload; it lives here now because the
+ * model and every row have to be written the same way and there is no longer
+ * only one of them.
+ */
+export function payloadJson(value: mixed): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+/**
+ * Read one late row's script text.
+ *
+ * Refuses anything that is not exactly one of the two shapes, and refuses a
+ * message carrying both — a row is a value or a failure, never a choice the
+ * reader has to make. The value goes through [`decodePayload`] with a resolver
+ * that refuses every reference, which is where "a row may not itself be
+ * deferred" is enforced on the reading side: ids are handed out by one walk of
+ * the model, and a row that could add more would be a numbering that depends
+ * on the order things finished in.
+ */
+export function parseRowMessage(text: string, id: number): PayloadRowMessage {
+  const label = `row ${String(id)}`;
+  let parsed: mixed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new PayloadValueError(label, "is not JSON");
+  }
+  if (!isPlainObject(parsed)) {
+    throw new PayloadValueError(label, "is not a row message");
+  }
+  const message: { +[string]: mixed } = (parsed: $FlowFixMe);
+  const hasValue = Object.prototype.hasOwnProperty.call(message, "value");
+  const hasError = Object.prototype.hasOwnProperty.call(message, "error");
+  if (hasValue === hasError) {
+    throw new PayloadValueError(label, "must carry exactly one of `value` and `error`");
+  }
+  if (hasError) {
+    const error = message.error;
+    if (typeof error !== "string") {
+      throw new PayloadValueError(label, "carries an `error` that is not a string");
+    }
+    return { error };
+  }
+  return {
+    value: decodePayload(
+      message.value,
+      () => {
+        throw new PayloadValueError(label, "refers to another row");
+      },
+      label,
+    ),
+  };
+}

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -36,9 +36,23 @@ import { flushSync } from "react-dom";
 import { RenderProvider } from "@uniflowed/hooks/render";
 
 // The id of the script the loader data is embedded in. It moved out of the
-// head and into the tree with ubugeeei-prod/uf#373 — see [`loaderDataScript`]
+// head and into the tree with ubugeeei-prod/uf#373 — see [`payloadElements`]
 // — so the module that renders it is this one rather than `../server.js`.
 import { DATA_ID } from "./document.js";
+
+// The payload the loader's answer is written as, and the rows it defers. Row 0
+// is the element `DATA_ID` names and is byte-identical to what this file wrote
+// inline before the payload existed whenever nothing is deferred; a promise
+// anywhere in the data turns into a reference and a row of its own. See
+// `./payload.js` for the format and ubugeeei-prod/uf#519 for the half of it
+// that is still an element payload rather than a data one.
+import {
+  type PayloadRowMessage,
+  PayloadRowError,
+  encodePayload,
+  encodeRowValue,
+  payloadJson,
+} from "./payload.js";
 
 // The development-only half of [`RouteView`]: the marks that say which DOM
 // subtree each boundary owns, and the report that reads them. Every reference
@@ -2400,6 +2414,12 @@ export component RouteView() {
  * innermost `<Suspense>` when the route deferred its loader on the server, and
  * exactly there again on the client, where the data is already in hand and
  * nothing suspends at all.
+ *
+ * "The loader's answer" is now a payload rather than a value, so what
+ * [`payloadElements`] renders is that script plus one boundary per value the
+ * answer deferred. The same argument covers all of them: the browser's copy of
+ * this component renders the same rows in the same places, from the values it
+ * read out of those very elements.
  */
 component RenderedPage(data: mixed) {
   const { resolved } = useRouterState();
@@ -2407,7 +2427,7 @@ component RenderedPage(data: mixed) {
   return (
     <>
       <Page params={resolved.params} searchParams={resolved.searchParams} data={data} />
-      {loaderDataScript(data)}
+      {payloadElements(data)}
     </>
   );
 }
@@ -2446,25 +2466,159 @@ component AwaitedPage(loader: Promise<mixed>) {
  *
  * `<` is escaped inside the JSON so a string holding `</script>` cannot end the
  * element early, and U+2028 and U+2029 because a JSON document is not
- * JavaScript source but is sometimes read as if it were.
+ * JavaScript source but is sometimes read as if it were — the escape moved to
+ * `./payload.js` when the model stopped being the only thing written that way.
  * `dangerouslySetInnerHTML` rather than a text child because React escapes a
  * text child and `&quot;` is not JSON any more. `security/no-dangerously-set-
  * inner-html` is about markup that came from somewhere and has to be sanitized
  * before a browser parses it as HTML; this is `JSON.stringify`'s output with
  * `<` escaped, in an element the browser never parses as HTML and never runs.
  * `docs/app/_uf.layout.js` carries the same suppression for the same reason.
+ *
+ * # And the rows the model deferred
+ *
+ * A promise anywhere in the loader's answer used to be `JSON.stringify`'d to
+ * `{}`. It is now a `"$P<n>"` reference in the element above and a `<script
+ * data-uf-row="n">` of its own, inside a `<Suspense fallback={null}>` — which
+ * is what makes React stream it at the moment the promise settles rather than
+ * holding the document for it. Each row is its own boundary, so two deferred
+ * values arrive in the order they resolved in and not in the order they were
+ * written. `./payload.js` is the format; `./payload-rows.js` is the browser
+ * reading them back.
+ *
+ * The boundaries sit after the page rather than before it, where the data
+ * element already was. A page that suspends with no `_uf.loading.js` above it
+ * holds the whole shell — that is React's rule and uf does not work around it
+ * — so the position buys nothing either way, and "the scripts are where the
+ * script was" is worth more than a rearrangement that is not.
+ *
+ * # Why the rows are inside an element
+ *
+ * Because a `<Suspense>` that is a direct child of the *render root* stops the
+ * shell being flushed at all. React's renderer can only write a segment once
+ * the segment is complete, and the root segment holds an unresolved boundary
+ * open: measured against React 19.2.8, a tree of `[<div>, <Suspense>]` writes
+ * its first byte when the boundary resolves, and the same tree with the
+ * boundary inside any host element writes it immediately. Every component
+ * between the root and here — `RenderProvider`, `RouterProvider`, `RouteView`,
+ * `RouteErrorBoundary` — renders no element of its own, so without this
+ * `<span>` the rows would be exactly that first shape and a payload would have
+ * streamed nothing.
+ *
+ * `hidden` because it holds no content a reader is meant to see: `<script
+ * type="application/json">` renders nothing either way, and the attribute is
+ * what says so to anything that inspects the document. One element for all the
+ * rows rather than one each — the boundaries inside it still resolve
+ * independently, since each is its own.
+ *
+ * The same rule catches a route whose `_uf.loading.js` sits above no layout:
+ * `RouteView` puts that boundary in the same position, and it does not stream
+ * either. That is a bug this file did not introduce and does not fix; it is
+ * written down in ubugeeei-prod/uf#519 rather than left to be rediscovered.
  */
-function loaderDataScript(data: mixed): React.Node {
+function payloadElements(data: mixed): React.Node {
   if (data === undefined) {
     return null;
   }
-  const json = JSON.stringify(data)
-    .replace(/</g, "\\u003c")
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029");
-  const html = { __html: json };
+  const { model, rows } = encodePayload(data, "the route's loader data");
+  // Before anything renders, so a promise that has already rejected is one
+  // somebody is listening to. `settledRow` is memoized, so the components
+  // below get these same promises rather than a second set.
+  for (const row of rows) {
+    settledRow(row.value);
+  }
+  const html = { __html: payloadJson(model) };
   // uf-lint-disable-next-line security/no-dangerously-set-inner-html
-  return <script id={DATA_ID} type="application/json" dangerouslySetInnerHTML={html} />;
+  const row0 = <script id={DATA_ID} type="application/json" dangerouslySetInnerHTML={html} />;
+  return (
+    <>
+      {row0}
+      {rows.length === 0 ? null : (
+        <span hidden>
+          {rows.map((row) => (
+            <Suspense key={row.id} fallback={null}>
+              <PayloadRow id={row.id} value={row.value} />
+            </Suspense>
+          ))}
+        </span>
+      )}
+    </>
+  );
+}
+
+/**
+ * One deferred value, written when it settles.
+ *
+ * Rendered on both sides, which is the thing to keep in mind about it. On the
+ * server `value` is the loader's own promise; in the browser it is the promise
+ * `./payload-rows.js` created for this row and resolved out of this very
+ * element. Both then write the element from the settled result through the
+ * same [`payloadJson`], so the bytes agree and hydration has nothing to
+ * report. `encodeRowValue` is what re-applies the reference escape to a value
+ * the browser has already had it removed from.
+ *
+ * It never rejects. `use` on a rejected promise throws, and a throw here would
+ * put the *row's* boundary into the error boundary above it — which is the
+ * page, for a value the page may not even be reading. The failure travels as a
+ * row instead, and the page's own `use` of the same promise is what reaches
+ * the page's boundary, exactly as it would have without a payload.
+ */
+component PayloadRow(id: number, value: Promise<mixed>) {
+  const message = use(settledRow(value));
+  const html = { __html: payloadJson(message) };
+  return (
+    // uf-lint-disable-next-line security/no-dangerously-set-inner-html
+    <script type="application/json" data-uf-row={String(id)} dangerouslySetInnerHTML={html} />
+  );
+}
+
+/**
+ * The message a row will carry, as a promise that always fulfils.
+ *
+ * Keyed by the promise rather than recomputed, because `use` wants the same
+ * promise every render and a render is repeated: React renders a component
+ * again after it suspends, and Strict Mode renders it twice more. A `WeakMap`
+ * so a route that has navigated away takes its rows with it.
+ */
+const settledRows: WeakMap<Promise<mixed>, Promise<PayloadRowMessage>> = new WeakMap();
+
+function settledRow(value: Promise<mixed>): Promise<PayloadRowMessage> {
+  const existing = settledRows.get(value);
+  if (existing != null) {
+    return existing;
+  }
+  const settled = value.then(
+    (resolved) => ({ value: encodeRowValue(resolved, "a deferred value") }),
+    (error) => ({ error: rowFailure(error) }),
+  );
+  settledRows.set(value, settled);
+  return settled;
+}
+
+/**
+ * What a row says when the value failed.
+ *
+ * A fixed sentence in a build, and the error's own words where
+ * `import.meta.hot` says a developer is reading them — the same gate
+ * [`BOUNDARY_MARKS`] uses, and the same argument: a message that came out of a
+ * loader can name a table, a query or a file path, and a browser is not where
+ * any of those belong.
+ *
+ * A `PayloadRowError` short-circuits both, and has to. That error is what the
+ * browser's reader rejects with, carrying the row's own text, so echoing it is
+ * what makes the element the browser renders equal the one the server sent
+ * whichever of the two builds was the development one.
+ */
+const ROW_FAILURE = "@uniflowed/router: a deferred value failed on the server.";
+
+function rowFailure(error: mixed): string {
+  if (error instanceof PayloadRowError) {
+    return error.wire;
+  }
+  if (!BOUNDARY_MARKS) {
+    return ROW_FAILURE;
+  }
+  return error instanceof Error ? `${ROW_FAILURE} ${error.message}` : ROW_FAILURE;
 }
 
 /**

--- a/packages/vite/internal/rsc.js
+++ b/packages/vite/internal/rsc.js
@@ -17,10 +17,13 @@
 //
 // Dropping a single Server Component from the client bundle is what Next.js
 // does, and it works there because the browser is handed a Flight payload
-// describing the tree the server rendered. uf has no such payload yet:
-// `packages/router/client.js` hydrates by re-rendering the matched tree from
-// the same modules the server rendered it from, so a module missing from the
-// client bundle is a module React cannot hydrate. What *can* be dropped is a
+// describing the tree the server rendered. uf's payload
+// (`packages/router/internal/payload.js`) carries the route's *data* and not
+// its tree — that half needs a second React module graph, see
+// ubugeeei-prod/uf#519 — so `packages/router/client.js` still hydrates by
+// re-rendering the matched tree from the same modules the server rendered it
+// from, and a module missing from the client bundle is a module React cannot
+// hydrate. What *can* be dropped is a
 // route the browser never renders at all — one where no client boundary is
 // reachable from the page, its layouts, its loading fallbacks or the
 // boundaries that cover it. Nothing under it is ever re-rendered in the

--- a/tests/library/payload.test.js
+++ b/tests/library/payload.test.js
@@ -266,8 +266,8 @@ function rowDocument(): {|
   readonly watchers: () => number,
 |} {
   const elements: Array<{|
-    +getAttribute: (name: string) => string | null,
-    +textContent: string,
+    readonly getAttribute: (name: string) => string | null,
+    readonly textContent: string,
   |}> = [];
   let callbacks: Array<() => void> = [];
   return {

--- a/tests/library/payload.test.js
+++ b/tests/library/payload.test.js
@@ -1,0 +1,716 @@
+// @flow
+//
+// The payload, and the rows that arrive after the document did.
+//
+// `streaming.test.js` covers the half of ubugeeei-prod/uf#519 that was already
+// true: a page that suspends sends its layouts and its fallback first, and the
+// content follows. What it could not cover is the other half — the loader's
+// *data* was one `JSON.stringify` of one finished value, so a page whose data
+// was one slow thing and four fast ones said nothing about the four until the
+// one arrived, and a promise anywhere in it became `{}` without a word.
+//
+// So this file asserts four claims, in the order they have to be true in:
+//
+//   1. the format round-trips, and refuses what it says it refuses;
+//   2. a browser can read rows out of a document that is still arriving;
+//   3. the bytes arrive in the right order — the model before any row, and the
+//      row that resolved first before the row that was written first;
+//   4. the browser applies them, and each boundary resolves on its own.
+//
+// # Why (3) is asserted on chunks, and without a clock
+//
+// "The model went out before the value did" is a claim about order, and a
+// document that is correct at the end and streamed nothing would pass every
+// assertion made on the finished string. So the assertions are made on the
+// chunks: the first one is read while neither promise has settled and nothing
+// is scheduled to settle them, and only then is one of them resolved.
+//
+// `streaming.test.js` makes the same claim against a deadline — "the shell was
+// out before 120 ms" — which is the more direct spelling and the one that fails
+// on a machine running eight test files at once. Reading the shell first and
+// resolving afterwards says the same thing and cannot be outrun: a renderer
+// that waited for the data would still be waiting at the assertion, with no
+// timer coming to rescue it.
+
+import * as React from "react";
+import { Suspense, use } from "@uniflowed/react";
+import { act } from "@uniflowed/react-testing";
+import { routerView } from "@uniflowed/router";
+import { createRenderer } from "@uniflowed/router/server";
+import { describe, expect, it } from "@uniflowed/test";
+
+// Not package exports: the payload is internal to `@uniflowed/router` on
+// purpose — it is a wire format between two halves of one build, not something
+// an application writes — so the format is driven directly, the way
+// `streaming.test.js` drives `renderWithReadableStream`.
+import {
+  MAX_PAYLOAD_DEPTH,
+  PAYLOAD_ROW_ATTRIBUTE,
+  PayloadValueError,
+  decodePayload,
+  encodePayload,
+  encodeRowValue,
+  parseRowMessage,
+  payloadJson,
+} from "../../packages/router/internal/payload.js";
+import { createPayloadReader } from "../../packages/router/internal/payload-rows.js";
+
+// `@uniflowed/router/client` statically imports `react-dom/client`, which reads
+// `document` while it is being evaluated — so the DOM has to exist before the
+// *import* and not merely before the first render. `streaming.test.js` and
+// `rsc-split.test.js` reach for the same two for the same reason.
+import { installDom } from "../../packages/react-testing/internal/dom.js";
+
+async function clientModule() {
+  installDom();
+  return import("@uniflowed/router/client");
+}
+
+const assets = { scripts: [], styles: [], preloads: [] };
+
+/** A promise with its settle functions in hand. */
+function deferred<T>(): {|
+  readonly promise: Promise<T>,
+  readonly resolve: (value: T) => void,
+  readonly reject: (error: mixed) => void,
+|} {
+  let settle: (value: T) => void = () => {};
+  let fail: (error: mixed) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
+  return { promise, resolve: settle, reject: fail };
+}
+
+/**
+ * A render's chunks, read one at a time.
+ *
+ * `first` rather than a whole document, because the claim these tests make is
+ * about what had happened when the shell went out — and the honest way to
+ * assert it is to read the shell while nothing has resolved yet and *then*
+ * resolve something. A wall-clock deadline would say the same thing on an idle
+ * machine and something else entirely on a machine running eight of these at
+ * once; this says it either way.
+ */
+function chunksOf(result: { readonly stream: () => ReadableStream, ... }): {|
+  readonly next: () => Promise<string>,
+  readonly rest: () => Promise<Array<string>>,
+|} {
+  const decoder = new TextDecoder();
+  const reader = result.stream().getReader();
+  return {
+    async next(): Promise<string> {
+      const { done, value } = await reader.read();
+      return done === true ? "" : decoder.decode(value, { stream: true });
+    },
+    async rest(): Promise<Array<string>> {
+      const out = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done === true) {
+          return out;
+        }
+        out.push(decoder.decode(value, { stream: true }));
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. The format
+// ---------------------------------------------------------------------------
+
+describe("the payload format", () => {
+  it("hands back the value it was given when nothing is deferred", () => {
+    // Identity, not equality. A payload that rebuilt every object would mean
+    // every page paid a copy of its data for a feature it is not using, and
+    // that "nothing changed here" was a hope rather than a property.
+    const data = { user: { name: "ada" }, tags: ["a", "b"] };
+    const encoded = encodePayload(data, "data");
+    expect(encoded.model).toBe(data);
+    expect(encoded.rows.length).toBe(0);
+    expect(decodePayload(data, () => null, "data")).toBe(data);
+  });
+
+  it("replaces a promise with a reference and keeps it as a row", () => {
+    const comments = Promise.resolve([{ body: "hi" }]);
+    const encoded = encodePayload({ user: "ada", comments }, "data");
+    expect(encoded.model).toEqual({ user: "ada", comments: "$P1" });
+    expect(encoded.rows.length).toBe(1);
+    expect(encoded.rows[0].id).toBe(1);
+    expect(encoded.rows[0].value).toBe(comments);
+  });
+
+  it("numbers rows by where they sit rather than by when they were made", () => {
+    // The id has to be a function of the model and of nothing else: the
+    // browser re-encodes the same model to render the same row elements, and
+    // it has no idea in which order the loader created these.
+    const second = Promise.resolve("second");
+    const first = Promise.resolve("first");
+    const encoded = encodePayload({ a: first, nested: { list: [1, second] } }, "data");
+    expect(encoded.model).toEqual({ a: "$P1", nested: { list: [1, "$P2"] } });
+    expect(encoded.rows.map((row) => row.value)).toEqual([first, second]);
+  });
+
+  it("escapes a string that would read as a reference, and gives it back", () => {
+    const encoded = encodePayload({ price: "$100", tag: "$P1" }, "data");
+    expect(encoded.model).toEqual({ price: "$$100", tag: "$$P1" });
+    expect(decodePayload(encoded.model, () => "never", "data")).toEqual({
+      price: "$100",
+      tag: "$P1",
+    });
+  });
+
+  it("round-trips a deferred model through JSON and back", () => {
+    const encoded = encodePayload({ now: "$here", later: Promise.resolve(1) }, "data");
+    const overTheWire = JSON.parse(payloadJson(encoded.model));
+    const rebuilt = decodePayload(overTheWire, (id) => `row ${String(id)}`, "data");
+    expect(rebuilt).toEqual({ now: "$here", later: "row 1" });
+  });
+
+  it("refuses a reference tag it has no meaning for", () => {
+    // The whole reason `$` is a closed namespace. A decoder that passed `$X1`
+    // through would accept it silently on the day `$X` means a client module.
+    expect(() => decodePayload({ a: "$X1" }, () => null, "data")).toThrow(PayloadValueError);
+    expect(() => decodePayload({ a: "$P0" }, () => null, "data")).toThrow(PayloadValueError);
+    expect(() => decodePayload({ a: "$P1e3" }, () => null, "data")).toThrow(PayloadValueError);
+    expect(() => decodePayload({ a: "$P9999" }, () => null, "data")).toThrow(PayloadValueError);
+  });
+
+  it("names where in the loader's answer the trouble was", () => {
+    let caught: mixed = null;
+    try {
+      decodePayload({ page: { items: [{ kind: "$nope" }] } }, () => null, "data");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught instanceof PayloadValueError).toBe(true);
+    expect(caught instanceof PayloadValueError ? caught.path : "").toBe("data.page.items[0].kind");
+  });
+
+  it("refuses a row that is itself deferred", () => {
+    // Ids come from one walk of the model, which is the only structure both
+    // sides hold before anything resolves. A row that could add more would be
+    // a numbering that depends on what finished first.
+    expect(() => encodeRowValue({ more: Promise.resolve(1) }, "row 1")).toThrow(PayloadValueError);
+    expect(encodeRowValue({ ok: "$x" }, "row 1")).toEqual({ ok: "$$x" });
+  });
+
+  it("stops rather than following a cycle", () => {
+    const loop: { self?: mixed, ... } = {};
+    loop.self = loop;
+    expect(() => encodePayload({ loop, later: Promise.resolve(1) }, "data")).toThrow(
+      PayloadValueError,
+    );
+    expect(MAX_PAYLOAD_DEPTH > 24).toBe(true);
+  });
+
+  it("leaves everything JSON.stringify already decided about alone", () => {
+    // The model is not the action wire. A `Date`, a `Map` and an `undefined`
+    // property crossed as `JSON.stringify` renders them before the payload
+    // existed, and a payload with a promise in it must not change that.
+    const when = new Date(0);
+    const encoded = encodePayload(
+      { when, set: new Map([["a", 1]]), missing: undefined, later: Promise.resolve(1) },
+      "data",
+    );
+    expect(payloadJson(encoded.model)).toBe(
+      `{"when":"1970-01-01T00:00:00.000Z","set":{},"later":"$P1"}`,
+    );
+  });
+
+  it("writes a model no `</script>` can end early", () => {
+    const encoded = encodePayload({ html: "</script><b>", later: Promise.resolve(1) }, "data");
+    const json = payloadJson(encoded.model);
+    expect(json).not.toContain("</script>");
+    expect(JSON.parse(json).html).toBe("</script><b>");
+  });
+
+  it("does not let `__proto__` become a prototype on the way back", () => {
+    // The hazard the rebuild introduces and `JSON.parse` does not: assignment
+    // calls the setter on `Object.prototype`, `defineProperty` does not.
+    const rebuilt = decodePayload(
+      JSON.parse(`{"__proto__":{"polluted":true},"tag":"$$x"}`),
+      () => null,
+      "data",
+    );
+    expect(({}: $FlowFixMe).polluted).toBe(undefined);
+    expect(Object.getPrototypeOf(rebuilt)).toBe(Object.getPrototypeOf({}));
+    expect(Object.prototype.hasOwnProperty.call(rebuilt, "__proto__")).toBe(true);
+  });
+
+  it("reads a row message, and refuses one that says two things or none", () => {
+    expect(parseRowMessage(`{"value":{"ok":true}}`, 1)).toEqual({ value: { ok: true } });
+    expect(parseRowMessage(`{"error":"boom"}`, 1)).toEqual({ error: "boom" });
+    expect(parseRowMessage(`{"value":"$$x"}`, 1)).toEqual({ value: "$x" });
+    expect(() => parseRowMessage(`{}`, 1)).toThrow(PayloadValueError);
+    expect(() => parseRowMessage(`{"value":1,"error":"b"}`, 1)).toThrow(PayloadValueError);
+    expect(() => parseRowMessage(`{"error":7}`, 1)).toThrow(PayloadValueError);
+    expect(() => parseRowMessage(`not json`, 1)).toThrow(PayloadValueError);
+    expect(() => parseRowMessage(`[1]`, 1)).toThrow(PayloadValueError);
+    // A row may not name another row.
+    expect(() => parseRowMessage(`{"value":"$P2"}`, 1)).toThrow(PayloadValueError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Reading rows out of a document that is still arriving
+// ---------------------------------------------------------------------------
+
+/** A document with a growing list of row scripts, and nothing else in it. */
+function rowDocument(): {|
+  readonly document: $FlowFixMe,
+  readonly write: (id: number, text: string) => void,
+  readonly observe: (callback: () => void) => () => void,
+  readonly watchers: () => number,
+|} {
+  const elements: Array<{|
+    +getAttribute: (name: string) => string | null,
+    +textContent: string,
+  |}> = [];
+  let callbacks: Array<() => void> = [];
+  return {
+    document: {
+      querySelectorAll: () => elements,
+      documentElement: null,
+    },
+    write(id: number, text: string) {
+      elements.push({
+        getAttribute: (name) => (name === PAYLOAD_ROW_ATTRIBUTE ? String(id) : null),
+        textContent: text,
+      });
+      for (const callback of [...callbacks]) {
+        callback();
+      }
+    },
+    observe(callback: () => void) {
+      callbacks.push(callback);
+      return () => {
+        callbacks = callbacks.filter((entry) => entry !== callback);
+      };
+    },
+    watchers: () => callbacks.length,
+  };
+}
+
+describe("reading rows out of a document", () => {
+  it("applies the rows that are already there, and then the ones that follow", async () => {
+    const doc = rowDocument();
+    const reader = createPayloadReader(doc.document, doc.observe);
+    const first = reader.resolve(1);
+    const second = reader.resolve(2);
+    doc.write(2, `{"value":"second"}`);
+    reader.watch();
+
+    // The one that was in the document before the watch started, and the one
+    // that arrived after it: the same promise either way.
+    expect(await second).toBe("second");
+    expect(doc.watchers()).toBe(1);
+    doc.write(1, `{"value":"first"}`);
+    expect(await first).toBe("first");
+    // Every row the model named has arrived, so the watch is over.
+    expect(doc.watchers()).toBe(0);
+  });
+
+  it("rejects the row the server said failed, and nothing else", async () => {
+    const doc = rowDocument();
+    const reader = createPayloadReader(doc.document, doc.observe);
+    const failed = reader.resolve(1);
+    const fine = reader.resolve(2);
+    reader.watch();
+    doc.write(1, `{"error":"@uniflowed/router: a deferred value failed on the server."}`);
+    doc.write(2, `{"value":7}`);
+
+    await expect(failed).rejects.toThrow("failed on the server");
+    expect(await fine).toBe(7);
+  });
+
+  it("rejects a row it cannot read rather than the page", async () => {
+    const doc = rowDocument();
+    const reader = createPayloadReader(doc.document, doc.observe);
+    const row = reader.resolve(1);
+    reader.watch();
+    doc.write(1, `{"value":`);
+    await expect(row).rejects.toThrow("row 1 is not JSON");
+  });
+
+  it("ignores a row nothing referred to, and a second copy of one", async () => {
+    const doc = rowDocument();
+    const reader = createPayloadReader(doc.document, doc.observe);
+    const row = reader.resolve(1);
+    reader.watch();
+    doc.write(4, `{"value":"nobody asked"}`);
+    doc.write(1, `{"value":"first"}`);
+    doc.write(1, `{"value":"second"}`);
+    expect(await row).toBe("first");
+  });
+
+  it("never watches a document with nothing deferred in it", () => {
+    const doc = rowDocument();
+    createPayloadReader(doc.document, doc.observe).watch();
+    expect(doc.watchers()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The order the bytes arrive in
+// ---------------------------------------------------------------------------
+
+/**
+ * A route whose loader answers with one value now and two later.
+ *
+ * The page renders a `<Suspense>` of its own around each deferred value, which
+ * is what "a boundary that resolves on its own" means here: neither wraps the
+ * other, and neither is the route's `_uf.loading.js`.
+ */
+function deferringTable(slow: Promise<string>, quick: Promise<string>) {
+  component Deferred(value: Promise<string>) {
+    return <p>{use(value)}</p>;
+  }
+  component DataPage(data: mixed) {
+    const answer: $FlowFixMe = data;
+    return (
+      <div>
+        <p>{String(answer.now)}</p>
+        <Suspense fallback={<p>waiting for the slow one</p>}>
+          <Deferred value={answer.slow} />
+        </Suspense>
+        <Suspense fallback={<p>waiting for the quick one</p>}>
+          <Deferred value={answer.quick} />
+        </Suspense>
+      </div>
+    );
+  }
+  return {
+    routes: [
+      {
+        path: "/deferred",
+        params: [],
+        mdx: false,
+        file: "app/deferred/_uf.page.js",
+        page: () =>
+          Promise.resolve({
+            default: DataPage,
+            loader: () => ({ now: "the model is here", slow, quick }),
+          }),
+        layouts: [],
+        loading: [],
+      },
+    ],
+    notFound: [],
+    errors: [],
+  };
+}
+
+describe("streaming a payload", () => {
+  it("sends the model before either deferred value has resolved", async () => {
+    const slow = deferred<string>();
+    const quick = deferred<string>();
+    const renderer = createRenderer({
+      App: routerView("./app"),
+      ...deferringTable(slow.promise, quick.promise),
+    });
+
+    const result = await renderer.render("/deferred", assets);
+    // Read the shell with neither promise settled and nothing scheduled to
+    // settle them. A renderer that waited for the data would still be waiting
+    // here, and no timer would rescue it.
+    const shell = await chunksOf(result).next();
+
+    // The model, with a reference standing where each promise was. This is the
+    // assertion the old `JSON.stringify` could not have passed: it wrote `{}`
+    // for a promise, and it wrote nothing at all until both had settled.
+    expect(shell).toContain('"now":"the model is here"');
+    expect(shell).toContain('"slow":"$P1"');
+    expect(shell).toContain('"quick":"$P2"');
+    expect(shell).toContain("waiting for the slow one");
+    expect(shell).toContain("waiting for the quick one");
+    expect(shell).not.toContain("the quick one is here");
+    expect(shell).not.toContain(PAYLOAD_ROW_ATTRIBUTE);
+
+    // And the render is still live rather than finished: settling both is what
+    // ends it, which is the other half of "the shell went first".
+    quick.resolve("the quick one is here");
+    slow.resolve("the slow one is here");
+  });
+
+  it("writes the row that resolved first first, whatever order they were written in", async () => {
+    // Row 1 is the slow one because it is earlier in the model; row 2 is the
+    // quick one. If the rows arrived in id order the payload would be a list
+    // that streams and a document that waits, which is the failure this issue
+    // is about.
+    const slow = deferred<string>();
+    const quick = deferred<string>();
+    const renderer = createRenderer({
+      App: routerView("./app"),
+      ...deferringTable(slow.promise, quick.promise),
+    });
+
+    const result = await renderer.render("/deferred", assets);
+    const stream = chunksOf(result);
+    const shell = await stream.next();
+    // The quick one first, and the slow one only once the quick one's row has
+    // had every chance to be written: the order of the two settlements is the
+    // input, and the order of the two rows is what is being measured.
+    quick.resolve("the quick one is here");
+    setTimeout(() => slow.resolve("the slow one is here"), 40);
+    const chunks = [shell, ...(await stream.rest())];
+
+    const at = (needle: string): number => {
+      const index = chunks.findIndex((chunk) => chunk.includes(needle));
+      expect(index).not.toBe(-1);
+      return index;
+    };
+    const document = chunks.join("");
+    expect(document).toContain(`${PAYLOAD_ROW_ATTRIBUTE}="1"`);
+    expect(document).toContain(`${PAYLOAD_ROW_ATTRIBUTE}="2"`);
+
+    // Row 2 — the quick one — before row 1, in the bytes.
+    expect(at(`{"value":"the quick one is here"}`)).toBeLessThan(
+      at(`{"value":"the slow one is here"}`),
+    );
+    // And the page's own boundary for it resolved on its own, in the same
+    // chunk range rather than at the end: the quick value's markup is out
+    // before the slow one's row is.
+    expect(at("the quick one is here")).toBeLessThan(at("the slow one is here"));
+    // Neither of them is in the shell.
+    expect(at("the quick one is here") > 0).toBe(true);
+    // And the model is still exactly one element with one id.
+    expect(document.split(`${PAYLOAD_ROW_ATTRIBUTE}="2"`).length).toBe(2);
+  });
+
+  it("says a row failed instead of leaving its boundary open", async () => {
+    const slow = deferred<string>();
+    const quick = deferred<string>();
+    const renderer = createRenderer({
+      App: routerView("./app"),
+      ...deferringTable(slow.promise, quick.promise),
+      // A rejected deferred value reaches the page's error boundary, which is
+      // the framework's own here; the assertion is about the row.
+    });
+    const result = await renderer.render("/deferred", assets);
+    const stream = chunksOf(result);
+    const shell = await stream.next();
+    quick.resolve("the quick one is here");
+    slow.reject(new Error("the loader could not answer"));
+    const document = shell + (await stream.rest()).join("");
+
+    const rows = [
+      ...document.matchAll(/<script type="application\/json" data-uf-row="(\d)">([^<]*)</g),
+    ];
+    const row = new Map(rows.map((match) => [match[1], match[2]]));
+    expect(row.get("1")).toBe(
+      `{"error":"@uniflowed/router: a deferred value failed on the server."}`,
+    );
+    // The row says the value failed and does not say what the loader said. The
+    // words are the server's and stay there — React puts them in the page's own
+    // boundary in a development render, which is React's decision and not this
+    // element's.
+    expect(row.get("1") ?? "").not.toContain("the loader could not answer");
+    // And the other value is unaffected: one failure is one row.
+    expect(row.get("2")).toBe(`{"value":"the quick one is here"}`);
+  });
+
+  it("writes the same document it always did when nothing is deferred", async () => {
+    // The property that makes this format safe to have landed: a page with
+    // ordinary data produces the bytes it produced before the payload existed.
+    component Page(data: mixed) {
+      return <p>{String(data)}</p>;
+    }
+    const table = {
+      routes: [
+        {
+          path: "/plain",
+          params: [],
+          mdx: false,
+          file: "app/plain/_uf.page.js",
+          page: () => Promise.resolve({ default: Page, loader: () => "the page is here" }),
+          layouts: [],
+          loading: [],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    };
+    const { html } = await createRenderer({ App: routerView("./app"), ...table }).prerender(
+      "/plain",
+      assets,
+    );
+    expect(html).toContain('<script id="__uf_data" type="application/json">"the page is here"');
+    expect(html).not.toContain(PAYLOAD_ROW_ATTRIBUTE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The browser applying it
+// ---------------------------------------------------------------------------
+
+describe("the browser applying a payload", () => {
+  it("hydrates from the rows the document carried, without running the loader again", async () => {
+    const seen = { loads: 0 };
+    component Deferred(value: Promise<string>) {
+      return <p>{use(value)}</p>;
+    }
+    component DataPage(data: mixed) {
+      const answer: $FlowFixMe = data;
+      return (
+        <div>
+          <p>{String(answer.now)}</p>
+          <Suspense fallback={<p>waiting</p>}>
+            <Deferred value={answer.later} />
+          </Suspense>
+        </div>
+      );
+    }
+    // One table for both renders: `loadOnce` caches a module by the identity of
+    // the function that loads it, and hydration is React comparing two renders
+    // of the same components. `streaming.test.js` says the same at length.
+    const table = {
+      routes: [
+        {
+          path: "/deferred",
+          params: [],
+          mdx: false,
+          file: "app/deferred/_uf.page.js",
+          page: () =>
+            Promise.resolve({
+              default: DataPage,
+              loader: () => {
+                seen.loads += 1;
+                return { now: "the model is here", later: Promise.resolve("the row is here") };
+              },
+            }),
+          layouts: [],
+          loading: [],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    };
+
+    const { html } = await createRenderer({ App: routerView("./app"), ...table }).prerender(
+      "/deferred",
+      assets,
+    );
+    expect(seen.loads).toBe(1);
+    expect(html).toContain('"later":"$P1"');
+    expect(html).toContain(`${PAYLOAD_ROW_ATTRIBUTE}="1"`);
+
+    installDom();
+    const parsed = new globalThis.DOMParser().parseFromString(html, "text/html");
+    const rendered = parsed.getElementById("uf-root");
+    const root = globalThis.document.createElement("div");
+    root.id = "uf-root";
+    root.innerHTML = rendered?.innerHTML ?? "";
+    globalThis.document.body.replaceChildren(root);
+    globalThis.window.history.pushState(null, "", "/deferred");
+
+    const { hydrate } = await clientModule();
+    await act(async () => {
+      await hydrate({ App: routerView("./app"), ...table });
+    });
+
+    // Still one: the browser read the model and the row rather than fetching
+    // either of them again.
+    expect(seen.loads).toBe(1);
+    const text = globalThis.document.getElementById("uf-root")?.textContent ?? "";
+    expect(text).toContain("the model is here");
+    expect(text).toContain("the row is here");
+    expect(text).not.toContain("waiting");
+  });
+
+  it("resolves a boundary from a row that arrives after hydration", async () => {
+    // The claim the whole format exists for, on the reading side: the document
+    // that reached the browser did not have the value in it, the page hydrated
+    // with a fallback on screen, and the row that landed afterwards is what
+    // filled it in — with no second request and no second render of the page.
+    const late = deferred<string>();
+    const seen = { loads: 0 };
+    component Deferred(value: Promise<string>) {
+      return <p>{use(value)}</p>;
+    }
+    component DataPage(data: mixed) {
+      const answer: $FlowFixMe = data;
+      return (
+        <div>
+          <p>{String(answer.now)}</p>
+          <Suspense fallback={<p>waiting for the row</p>}>
+            <Deferred value={answer.later} />
+          </Suspense>
+        </div>
+      );
+    }
+    const table = {
+      routes: [
+        {
+          path: "/late",
+          params: [],
+          mdx: false,
+          file: "app/late/_uf.page.js",
+          page: () =>
+            Promise.resolve({
+              default: DataPage,
+              loader: () => {
+                seen.loads += 1;
+                return { now: "the model is here", later: late.promise };
+              },
+            }),
+          layouts: [],
+          loading: [],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    };
+
+    // The shell, as the browser would have received it: everything up to the
+    // point the row would have been streamed into, and not the row.
+    const renderer = createRenderer({ App: routerView("./app"), ...table });
+    const result = await renderer.render("/late", assets);
+    const stream = chunksOf(result);
+    const shell = await stream.next();
+    expect(shell).toContain("waiting for the row");
+    expect(shell).not.toContain("the row is here");
+    // The rest of the render, which this test deliberately never delivers to
+    // the browser: what it is asserting is that the row can arrive on its own.
+    late.resolve("the row is here");
+    await stream.rest();
+
+    installDom();
+    const parsed = new globalThis.DOMParser().parseFromString(shell, "text/html");
+    const rendered = parsed.getElementById("uf-root");
+    const root = globalThis.document.createElement("div");
+    root.id = "uf-root";
+    root.innerHTML = rendered?.innerHTML ?? "";
+    globalThis.document.body.replaceChildren(root);
+    globalThis.window.history.pushState(null, "", "/late");
+
+    const { hydrate } = await clientModule();
+    await act(async () => {
+      await hydrate({ App: routerView("./app"), ...table });
+    });
+    expect(seen.loads).toBe(1);
+    expect(globalThis.document.getElementById("uf-root")?.textContent ?? "").toContain(
+      "waiting for the row",
+    );
+
+    // The row, arriving the way the rest of the stream would have delivered it:
+    // an element appended to the document while React is already attached.
+    await act(async () => {
+      const row = globalThis.document.createElement("script");
+      row.setAttribute("type", "application/json");
+      row.setAttribute(PAYLOAD_ROW_ATTRIBUTE, "1");
+      row.textContent = `{"value":"the row is here"}`;
+      globalThis.document.body.append(row);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const text = globalThis.document.getElementById("uf-root")?.textContent ?? "";
+    expect(text).toContain("the row is here");
+    expect(text).not.toContain("waiting for the row");
+    // And the loader still ran exactly once, on the server.
+    expect(seen.loads).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

#519 asks for four things: a Flight-shaped payload, a client that applies it, a
boundary that resolves on its own, and a test that asserts the *order* bytes
arrive in. This is all four, for the payload's **data** half. The element half —
a client re-rendering a *tree* — is not here, and the last section says exactly
why and what is left.

A document uf streams carried one thing the browser read back: the loader's
answer, as one `JSON.stringify` of one finished value in `<script
id="__uf_data">`. So a page whose data was one slow thing and four fast ones
said nothing about the four until the one arrived, and a promise anywhere in
that value became `{}` — silently, which is the worse half.

`packages/router/internal/payload.js` makes it a payload rather than a value:

```
0  {"post":{"title":"…"},"comments":"$P1","related":"$P2"}
2  {"value":[{"id":7}]}
1  {"value":[{"body":"…"}]}
```

Row 0 is the model, with a `"$P<n>"` reference wherever the loader left a
promise. Each later row is one of those values, in a `<script
data-uf-row="n">` React streams into the *same response* when it settles — each
inside its own `<Suspense>`, so two of them arrive in the order they resolved
and not in the order they were written.

`packages/router/internal/payload-rows.js` is the browser's half: it reads the
rows already in the document, watches for the rest, and hands each one to the
promise the model referred to. So a boundary the server completes *after*
`hydrateRoot` resolves with no second request.

The API is `<Suspense>` and nothing else — no `defer()` to call, no `<Await>` to
render, because a promise in the loader's answer already says what either of
them would:

```js
export async function loader({ params }: LoaderArgs) {
  return {
    post: await readPost(params.slug),     // waited for
    comments: readComments(params.slug),   // not waited for
  };
}
```

## Why only one reference kind

`internal/action-wire.js` already said, under "What is deliberately absent",
that a decoder which reconstructs Flight's references "is a decoder that
constructs attacker-chosen objects", and that its grammar "is not the place to
grow one quietly". This is the place, and it grows exactly one: `"$P<n>"` names
a **row of this same payload**, resolved by a promise this module made.
Nothing in a payload names a constructor, a module, an export or a class, and
no string in one is looked up in any registry.

The two references the element payload needs — a client module and an element —
are precisely the ones a decoder resolves by *calling* something the payload
named, and those are what wait for the second React module graph. `$` is a
closed namespace: an unrecognised tag is **refused** rather than passed
through, so adding one later is a change to a list rather than to a decoder
that had already been letting it through.

## Why nothing else changed

Everything else in a payload is what `JSON.stringify` carries, unchanged. A
`Date`, a class with a `toJSON`, an `undefined` property, a `NaN` — each
crosses exactly as it did. Narrowing the loader's answer to the action wire's
closed grammar would be a contract change this issue is not about, made in a
throw, inside a loader, on somebody whose page worked yesterday.

Both walks hand back the value they were given when there is no promise and no
`$` string anywhere in it, so:

* a page with ordinary data produces the bytes it produced before this existed
  (asserted), and
* the browser hands the application the object `JSON.parse` made rather than a
  copy of it (asserted by identity, not equality).

The one hazard the rebuild would have introduced and `JSON.parse` does not —
`target[key] = value` for `__proto__` calling the setter on `Object.prototype`
— is closed with `defineProperty`, and asserted.

## A streaming bug found on the way, which is not the payload's

React cannot flush a segment while that segment holds an unresolved boundary,
and every component between uf's render root and a route — `RenderProvider`,
`RouterProvider`, `RouteView`, the error boundaries — renders no element of its
own. So a `<Suspense>` at the top of uf's tree is a direct child of the **root**
segment, and a document with one streams nothing at all.

Measured against the pinned React 19.2.8, four shapes, same promise, same
120 ms:

| tree | first byte |
| --- | --- |
| `[<div>, <Suspense>]` | 122 ms |
| `[<div>, <Suspense>, <div>]` | 122 ms |
| `<Suspense>` alone | 121 ms |
| `[<div>, <span><Suspense></span>]` | 2 ms |
| `<div><p/><Suspense></div>` | 1 ms |

Any host element between the root and the boundary fixes it. The payload's rows
are inside a `<span hidden>` for that reason, and removing it fails four of the
tests here.

**A route whose `_uf.loading.js` sits above no layout is in exactly the same
position and is still affected** — `RouteView` puts that boundary at the same
depth, and such a route does not stream today. That is not this change's bug and
this change does not fix it: the fix is a host element at uf's render root,
which is markup every document would grow, and that is a decision rather than a
patch. It is written down in `docs/architecture.md` and reported on #519.

## Tests, and that they fail without this

`tests/library/payload.test.js`, 24 tests in four sections: the format, the
document reader, the order the bytes arrive in, and the browser applying them.

The streaming assertions are made on chunks and **without a clock**. The first
chunk is read while neither promise has settled and nothing is scheduled to
settle them, so a renderer that waited for the data would still be waiting at
the assertion — no timer coming to rescue it. (`streaming.test.js` uses a
120 ms deadline for the same claim; that is the more direct spelling and the one
that flakes on a machine running eight test files at once, which it did here
before this was rewritten.)

Verified by reverting rather than by assertion:

* `git stash` of the two wired files (`internal/runtime.js`, `client.js`), with
  the new modules left in place → **5 failed**, and they are the five
  behavioural ones: all three streaming tests and both browser tests. The pure
  format tests still pass, because they drive modules that would not exist at
  all without this change.
* removing only the `<span hidden>` → **4 failed**: nothing streams, and the
  three tests that read a first chunk time out.

## Checks

| command | result |
| --- | --- |
| `cargo fmt --all` | clean, no Rust file changed |
| `cargo clippy -p uf_rsc --all-targets -- -D warnings` | `Finished dev profile in 4m 53s`, exit 0 |
| `cargo test -p uf_rsc` | `227 passed; 0 failed` plus `1 passed` doc-test, exit 0 |
| `uf test#library` (2888 tests, 83 files) | `✓ 2888 passed, 0 failed, 1 skipped` |
| `uf lint` | 0 errors, 14 warnings (all pre-existing) |
| `uf fmt --check` | every file already formatted |
| `tools/docs/build.sh` | build succeeded |
| `tools/ci/links-resolve.sh` | 2480 links, ok |

No Rust changed, so `uf_rsc` is unaffected by this branch; it is reported
because the issue asked for it.

One thing the local run did not cover and CI did: `uf_lib`'s
`the_shipped_surface_uses_modern_flow_spellings` refuses the deprecated `+prop`
variance sigil in a published package, and `payload-rows.js`'s two `interface`
types were written with it. Fixed in the two commits after the first, and
`cargo test -p uf_lib --test package_surface` is green locally (36 passed).
The indexer form `{ +[string]: … }` the payload itself uses is a different
thing the rule does not touch, and ten shipped modules already spell it that
way.

## What is left of #519, and why

Not done, and each for a reason rather than for time:

1. **The element payload** — a client re-rendering a *tree*. It needs
   `react-server-dom-*`, which loads only under the `react-server` export
   condition, which resolves `react` to the build with no `useState` in it while
   `react-dom/server` needs the ordinary one. That is a second module graph, so
   `@uniflowed/vite` grows an environment first. Unchanged from what
   `docs/architecture.md` and this issue's own comments already record.
2. **A client-module reference in the payload** — `$` has room for the tag and
   deliberately no meaning for it yet. Naming a client boundary by chunk id
   versus by specifier is an open contract decision on #718, and this change
   does not settle it: `RscManifest`'s boundary shape is untouched.
3. **The router redesign** the element half needs: `ResolvedRoute` split by
   serializability, `RouteView` rendering a node it was handed, and
   `@uniflowed/router`'s export map split so a root layout can be a server
   component. This change touches none of it — the payload carries data, and
   data has no modules in it.
4. **A `<Suspense>` at uf's render root still does not stream**, above.

Refs #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
