### PR TITLE
fix(config, cli, rm): the four runtime names that are not hosts, and the key that is

### DIFF
--- a/crates/uf_cli/src/commands/explain.rs
+++ b/crates/uf_cli/src/commands/explain.rs
@@ -763,11 +763,45 @@ fn env_stage(resolved: &ResolvedConfig, default_mode: &str) -> Stage {
     }
 }
 
+/// The host this project's commands start.
+///
+/// It reads `capabilityJsHost.default`, which is the key `commands::vite`'s
+/// `resolve_host` actually resolves through. It used to read
+/// `app.runtime.default`, which resolves nothing: that key names the runtime a
+/// project is *written for*, it accepted `edge`, `serverless`, `container` and
+/// `uf` until ubugeeei-prod/uf#246, and a project that wrote one of those was
+/// told by this very stage that Vite runs on it. `uf explain` describing a run
+/// that cannot happen is worse than not describing it.
+///
+/// Named rather than resolved, for the reason [`permissions_stage`] gives:
+/// `uf explain` prints a plan and must not fail because the machine it is run
+/// on has no host installed. So the detail says how the name becomes a
+/// process, which is the half a reader cannot see from the key alone.
 fn host_stage(resolved: &ResolvedConfig) -> Stage {
+    let hosts = &resolved.config.app.runtime.capability_js_host;
+    let fallbacks = hosts
+        .hosts
+        .iter()
+        .copied()
+        .filter(|host| *host != hosts.default)
+        .map(uf_config::CapabilityJsHost::as_str)
+        .collect::<Vec<_>>();
+    let detail = if hosts.auto_detect && !fallbacks.is_empty() {
+        format!(
+            "runs Vite and any JavaScript plugin; `app.runtime.capabilityJsHost.default`, \
+             falling back to {} when it is not on PATH",
+            fallbacks.join(" then ")
+        )
+    } else {
+        String::from(
+            "runs Vite and any JavaScript plugin; `app.runtime.capabilityJsHost.default`, \
+             with no fallback — a machine without it is told so rather than run on another host",
+        )
+    };
     Stage {
         name: "JavaScript host",
-        provider: format!("{:?}", resolved.config.app.runtime.default).to_lowercase(),
-        detail: "runs Vite and any JavaScript plugin".to_string(),
+        provider: hosts.default.as_str().to_string(),
+        detail,
     }
 }
 

--- a/crates/uf_cli/tests/cli.rs
+++ b/crates/uf_cli/tests/cli.rs
@@ -1390,6 +1390,96 @@ fn explain_names_the_provider_for_every_stage() {
     assert!(stdout.contains("VITE_"), "{stdout}");
 }
 
+/// The host `uf explain` names is the host that will start.
+///
+/// It named `app.runtime.default`, which resolves nothing: `commands::vite`'s
+/// `resolve_host` reads `capabilityJsHost`, and the two keys disagree the
+/// moment a project sets one of them. `app.runtime.default` also accepted
+/// `edge`, `serverless`, `container` and `uf` — so this stage would report
+/// that Vite runs on a runtime uf has no host for, which is
+/// ubugeeei-prod/uf#246's sentence printed by the command whose job is to say
+/// what will happen.
+#[test]
+fn explain_names_the_host_the_run_will_actually_start() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "// @flow\nexport default defineConfig({\n  app: { runtime: { capabilityJsHost: \
+         { default: \"bun\" } } },\n});\n",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["explain", "dev"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let provider = stdout
+        .lines()
+        .skip_while(|line| !line.contains("JavaScript host"))
+        .nth(1)
+        .expect("the host stage names a provider");
+
+    assert!(provider.contains("provider"), "{stdout}");
+    // `bun`, because that is what this project's `capabilityJsHost.default`
+    // says. `app.runtime.default` is still `node` here and is not this
+    // question's answer.
+    assert!(provider.contains("bun"), "{stdout}");
+    assert!(!provider.contains("node"), "{stdout}");
+    // And the detail says how the name becomes a process, which is the half a
+    // reader cannot get from the key.
+    assert!(
+        stdout.contains("app.runtime.capabilityJsHost.default"),
+        "{stdout}"
+    );
+}
+
+/// A project may not name a runtime uf has no host for.
+///
+/// The refusal is the feature. `app.runtime.default: "edge"` used to load, and
+/// the only trace of it was `uf explain` calling `edge` the JavaScript host and
+/// `.uf/install.json` recording it among the hosts that must be available —
+/// while every command went on running on Node. See ubugeeei-prod/uf#246.
+#[test]
+fn a_runtime_with_no_host_is_refused_before_anything_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("uf.config.js"),
+        "// @flow\nexport default defineConfig({ app: { runtime: { default: \"edge\" } } });\n",
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["explain", "dev"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "a runtime with no host is refused"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("app.runtime.default"), "{stderr}");
+    assert!(stderr.contains("edge"), "{stderr}");
+    // The two keys that do something, because one of them is what was meant.
+    assert!(
+        stderr.contains("app.runtime.capabilityJsHost.default"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("app.runtime.deploy.adapter"), "{stderr}");
+    assert!(stderr.contains("246"), "{stderr}");
+}
+
 #[test]
 fn explain_says_which_commands_it_knows() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/uf_cli/tests/workflow.rs
+++ b/crates/uf_cli/tests/workflow.rs
@@ -161,6 +161,16 @@ fn install_runs_the_package_manager_that_drives_the_project() {
     );
     assert_eq!(plan["runtimeManager"]["engine"], "node");
     assert_eq!(plan["runtimeManager"]["acquisition"], "auto");
+    // And the hosts it records are hosts. `runtimeManager.hosts` is documented
+    // as the hosts that must be available, and every project uf installed used
+    // to be told it ran on `edge`, `serverless` and `container` — three rows
+    // `uf_runtime::HOSTS` grades planned with no Flow loader, so three
+    // runtimes that cannot import the project's first file. A claim uf writes
+    // into a file it hands the reader is the exact shape ubugeeei-prod/uf#246
+    // is named after.
+    let hosts = plan["runtimeManager"]["hosts"].as_array().unwrap();
+    let hosts: Vec<&str> = hosts.iter().map(|host| host.as_str().unwrap()).collect();
+    assert_eq!(hosts, vec!["node", "bun", "deno"], "{hosts:?}");
 }
 
 #[test]

--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -1723,6 +1723,36 @@ pub enum ConfigError {
         path: Utf8PathBuf,
         key: &'static str,
     },
+    /// A runtime named as this project's, with no host behind the name.
+    ///
+    /// `uf`, `edge`, `serverless` and `container` parse here and are graded
+    /// `planned` with no Flow loader in `uf_runtime::HOSTS`, so a project that
+    /// names one cannot import its own first file there. Naming one changed
+    /// nothing a command does and two things a reader sees — `uf explain`
+    /// printed it as the JavaScript host, and `.uf/install.json` recorded it
+    /// among the hosts that must be available — which is the failure
+    /// ubugeeei-prod/uf#246 is named after.
+    #[error(
+        "{path}: {key} names `{engine}`, and uf has no host for it — \
+         `uf_runtime::HOSTS` grades `{engine}` {level} with no Flow loader, so a project that \
+         names it still runs on whichever of {hosts} the machine has. \
+         Which host a command starts is `app.runtime.capabilityJsHost.default`; \
+         which target `uf build` writes an artefact for is `app.runtime.deploy.adapter`. \
+         Name one of {hosts} here, or drop the key. See {tracking}."
+    )]
+    RuntimeEngineWithoutHost {
+        path: Utf8PathBuf,
+        /// The key that named it, so a reader knows which of the two to edit.
+        key: &'static str,
+        /// The refused name, as it is written.
+        engine: &'static str,
+        /// How `uf_runtime::HOSTS` grades it.
+        level: &'static str,
+        /// The names that are hosts, from the same table.
+        hosts: String,
+        /// Where the rest of the answer is.
+        tracking: String,
+    },
     /// A `rendering.modes` that leaves the build with nothing it can do.
     ///
     /// The list is an allowlist, so naming a strategy uf has not written is
@@ -1892,6 +1922,12 @@ pub fn load_config_file(path: &Utf8Path) -> Result<UniflowedConfig, ConfigError>
                     message: source.to_string(),
                 })?;
             check_cache_switches(path, &config.app.rendering.cache)?;
+            // Which runtime this project says it is written for, checked
+            // against the table that says which runtimes have a host. Before
+            // the rendering and library checks only because it is the
+            // cheapest of the three; the three are independent. See
+            // ubugeeei-prod/uf#246.
+            runtime::check(path, &config)?;
             // What the project says a build may produce, checked where it was
             // written. `rendering::check` refuses the two combinations that
             // have no build behind them; `RenderingPlan::resolve` is

--- a/crates/uf_config/src/runtime.rs
+++ b/crates/uf_config/src/runtime.rs
@@ -1,13 +1,23 @@
+use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
+use uf_runtime::{HostSupport, RuntimeHost};
+
+use crate::{ConfigError, UniflowedConfig};
 
 /// App runtime and deployment defaults.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct RuntimeConfig {
-    /// Default JavaScript host.
+    /// The runtime this project is written for.
+    ///
+    /// Not the host a command starts — that is
+    /// [`CapabilityJsHostConfig::default`], which is the key `uf dev`,
+    /// `uf test` and `uf build` resolve through. This one is the project's own
+    /// statement of what it targets, and [`check`] holds it to the runtimes uf
+    /// has a host for.
     pub default: RuntimeEngine,
-    /// Compatible runtime/deployment targets.
+    /// The other runtimes this project states it runs on.
     pub compatibility: Vec<RuntimeEngine>,
     /// Capability JS Host configuration for Node.js, Deno, and Bun.
     pub capability_js_host: CapabilityJsHostConfig,
@@ -16,17 +26,29 @@ pub struct RuntimeConfig {
 }
 
 impl Default for RuntimeConfig {
+    /// The runtimes a uf project runs on, and no others.
+    ///
+    /// This listed six, and three of them — `edge`, `serverless`,
+    /// `container` — are rows `uf_runtime::HOSTS` grades **planned** with no
+    /// Flow loader at all. The list was written into `.uf/install.json` under
+    /// `runtimeManager.hosts`, which is documented as the hosts that must be
+    /// available, and printed by `uf inspect --json`: every project uf
+    /// installed recorded that it ran on three runtimes that cannot import a
+    /// line of its source. That is ubugeeei-prod/uf#246's own sentence — a
+    /// name in an enum is not compatibility — written by uf itself.
+    ///
+    /// So the default is what [`RuntimeEngine::is_a_host`] says is true, the
+    /// same way [`DeployAnywhereConfig::default`] is what
+    /// [`DeployAdapter::is_implemented`] says is true. A host that earns a
+    /// Flow loader joins this list by earning it.
     fn default() -> Self {
         Self {
             default: RuntimeEngine::Node,
-            compatibility: vec![
-                RuntimeEngine::Node,
-                RuntimeEngine::Deno,
-                RuntimeEngine::Bun,
-                RuntimeEngine::Edge,
-                RuntimeEngine::Serverless,
-                RuntimeEngine::Container,
-            ],
+            compatibility: RuntimeEngine::ALL
+                .iter()
+                .copied()
+                .filter(|engine| engine.is_a_host())
+                .collect(),
             capability_js_host: CapabilityJsHostConfig::default(),
             deploy: DeployAnywhereConfig::default(),
         }
@@ -52,6 +74,114 @@ pub enum RuntimeEngine {
     Serverless,
     /// Container runtime.
     Container,
+}
+
+impl RuntimeEngine {
+    /// Every engine, host or not, in the order `uf_runtime::HOSTS` lists them.
+    ///
+    /// The variants stay even though [`check`] refuses four of them, and that
+    /// is the point: a name uf accepted for a year is refused with a sentence
+    /// naming the key its writer meant, rather than with serde's "unknown
+    /// variant", which reads like a typo in a word that was correct.
+    pub const ALL: &'static [Self] = &[
+        Self::Node,
+        Self::Bun,
+        Self::Deno,
+        Self::Edge,
+        Self::Serverless,
+        Self::Container,
+        Self::Uf,
+    ];
+
+    /// The name a person writes in `uf.config.js`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Uf => "uf",
+            Self::Node => "node",
+            Self::Deno => "deno",
+            Self::Bun => "bun",
+            Self::Edge => "edge",
+            Self::Serverless => "serverless",
+            Self::Container => "container",
+        }
+    }
+
+    /// The row in `uf_runtime::HOSTS` this engine is a name for.
+    #[must_use]
+    pub const fn host(self) -> RuntimeHost {
+        match self {
+            Self::Uf => RuntimeHost::Uf,
+            Self::Node => RuntimeHost::Node,
+            Self::Deno => RuntimeHost::Deno,
+            Self::Bun => RuntimeHost::Bun,
+            Self::Edge => RuntimeHost::Edge,
+            Self::Serverless => RuntimeHost::Serverless,
+            Self::Container => RuntimeHost::Container,
+        }
+    }
+
+    /// Whether uf can run a project on it.
+    ///
+    /// Read off the table rather than written down twice: an engine is a host
+    /// when its row has a Flow loader, because a runtime that cannot import a
+    /// Flow module cannot import a uf project's first file. `uf_config`'s own
+    /// tests assert the two agree, so a host that gains a loader opens its
+    /// name here and one that loses it closes it.
+    #[must_use]
+    pub fn is_a_host(self) -> bool {
+        HostSupport::for_host(self.host()).loads_flow()
+    }
+}
+
+/// Refuse a runtime this project could not run on.
+///
+/// The keys are a statement about the project, and until now they were a
+/// statement nothing could be wrong: all seven names parsed, and four of them
+/// named runtimes with no host. Naming one changed nothing a command does —
+/// which host runs is [`CapabilityJsHostConfig::default`] — and it changed two
+/// things a reader sees: `uf explain` printed it as the JavaScript host, and
+/// `.uf/install.json` recorded it among the hosts that must be available.
+///
+/// Refused where it is written, for the reason `check_cache_switches` refuses
+/// an unimplemented cache: the request cannot be honoured, and the failure
+/// belongs at the place the request was made rather than in a manifest
+/// somebody reads later. See ubugeeei-prod/uf#246.
+pub(crate) fn check(path: &Utf8Path, config: &UniflowedConfig) -> Result<(), ConfigError> {
+    let runtime = &config.app.runtime;
+    for (key, engine) in std::iter::once(("app.runtime.default", runtime.default)).chain(
+        runtime
+            .compatibility
+            .iter()
+            .map(|engine| ("app.runtime.compatibility", *engine)),
+    ) {
+        if engine.is_a_host() {
+            continue;
+        }
+        let support = HostSupport::for_host(engine.host());
+        return Err(ConfigError::RuntimeEngineWithoutHost {
+            path: path.to_path_buf(),
+            key,
+            engine: engine.as_str(),
+            level: support.level.as_str(),
+            hosts: host_names(),
+            tracking: support.tracking_issue.map_or_else(
+                || String::from("docs/hosts.md"),
+                |issue| format!("docs/hosts.md and ubugeeei-prod/uf#{issue}"),
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// The engines a project may name, as the message lists them.
+fn host_names() -> String {
+    RuntimeEngine::ALL
+        .iter()
+        .filter(|engine| engine.is_a_host())
+        .map(|engine| format!("`{}`", engine.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Host-provided JavaScript engine selection.
@@ -92,6 +222,18 @@ pub enum CapabilityJsHost {
     Deno,
     /// Bun.
     Bun,
+}
+
+impl CapabilityJsHost {
+    /// The name a person writes, which is also the executable's name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Node => "node",
+            Self::Deno => "deno",
+            Self::Bun => "bun",
+        }
+    }
 }
 
 /// Deploy-anywhere adapter selection.

--- a/crates/uf_config/src/tests.rs
+++ b/crates/uf_config/src/tests.rs
@@ -606,6 +606,116 @@ fn refuses_a_cache_switch_uf_does_not_implement() {
     }
 }
 
+/// The runtimes a project may name are the ones that have a host.
+///
+/// Read off `uf_runtime::HOSTS` rather than listed here, which is the whole
+/// point: the table is where a host's Flow loader is recorded, and a name a
+/// project may write is a name uf can run. The two lists were independent, and
+/// this crate's was the longer one — `edge`, `serverless` and `container` were
+/// in the default `compatibility` while their rows had no loader at all.
+///
+/// See ubugeeei-prod/uf#246.
+#[test]
+fn the_runtimes_a_project_may_name_are_the_ones_with_a_host() {
+    let with_a_loader: Vec<uf_runtime::RuntimeHost> = uf_runtime::HOSTS
+        .iter()
+        .filter(|support| support.loads_flow())
+        .map(|support| support.host)
+        .collect();
+    let may_be_named: Vec<uf_runtime::RuntimeHost> = RuntimeEngine::ALL
+        .iter()
+        .filter(|engine| engine.is_a_host())
+        .map(|engine| engine.host())
+        .collect();
+
+    assert_eq!(may_be_named, with_a_loader);
+    // And the default is that list rather than a wish. This is what
+    // `.uf/install.json` records as the hosts that must be available and what
+    // `uf inspect --json` prints, so a name here is a claim uf publishes about
+    // every project it installs.
+    let compatibility: Vec<&str> = UniflowedConfig::default()
+        .app
+        .runtime
+        .compatibility
+        .iter()
+        .map(|engine| engine.as_str())
+        .collect();
+    assert_eq!(compatibility, vec!["node", "bun", "deno"]);
+}
+
+/// A runtime with no host is refused at the key that named it.
+///
+/// All seven names parsed and four of them named runtimes that cannot import a
+/// Flow module, so writing one changed nothing a command does and two things a
+/// reader sees: `uf explain` printed it as the JavaScript host, and
+/// `.uf/install.json` recorded it among the hosts that must be available. The
+/// message has to name the two keys that *do* something, because a person who
+/// wrote `edge` here meant one of them.
+#[test]
+fn refuses_a_runtime_it_has_no_host_for() {
+    for (key, body, issue) in [
+        ("app.runtime.default", "default: \"edge\"", "246"),
+        // A different row, so the issue in the message is the one the table
+        // records for *that* host rather than a constant written beside it.
+        (
+            "app.runtime.compatibility",
+            "compatibility: [\"node\", \"serverless\"]",
+            "391",
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Utf8PathBuf::from_path_buf(dir.path().join("uf.config.js")).unwrap();
+        fs::write(
+            &path,
+            format!("export default defineConfig({{ app: {{ runtime: {{ {body} }} }} }});"),
+        )
+        .unwrap();
+
+        let error = load_config_file(&path).expect_err("a runtime with no host is refused");
+
+        assert!(
+            matches!(&error, ConfigError::RuntimeEngineWithoutHost { key: named, .. } if *named == key),
+            "{key}: {error:?}"
+        );
+        let message = error.to_string();
+        assert!(message.contains(key), "{message}");
+        assert!(message.contains("planned"), "{message}");
+        // The key that chooses a host, and the key that chooses a deployment
+        // target. Between them they are what the refused name was reaching for.
+        assert!(
+            message.contains("app.runtime.capabilityJsHost.default"),
+            "{message}"
+        );
+        assert!(message.contains("app.runtime.deploy.adapter"), "{message}");
+        assert!(message.contains(issue), "{message}");
+    }
+}
+
+/// And the three that do have a host still load.
+#[test]
+fn accepts_every_runtime_it_has_a_host_for() {
+    for engine in RuntimeEngine::ALL
+        .iter()
+        .filter(|engine| engine.is_a_host())
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Utf8PathBuf::from_path_buf(dir.path().join("uf.config.js")).unwrap();
+        fs::write(
+            &path,
+            format!(
+                "export default defineConfig({{ app: {{ runtime: {{ default: \"{}\" }} }} }});",
+                engine.as_str()
+            ),
+        )
+        .unwrap();
+
+        let config =
+            load_config_file(&path).unwrap_or_else(|error| panic!("{}: {error}", engine.as_str()));
+
+        assert_eq!(config.app.runtime.default, *engine);
+    }
+}
+
 /// `false` is the default and says the same thing with or without a cache.
 #[test]
 fn a_cache_switch_that_is_off_is_never_refused() {

--- a/crates/uf_rm/src/lib.rs
+++ b/crates/uf_rm/src/lib.rs
@@ -376,16 +376,13 @@ pub enum RuntimeUseStep {
     ActivateVersion,
 }
 
-fn runtime_engine_to_host(engine: RuntimeEngine) -> RuntimeHost {
-    match engine {
-        RuntimeEngine::Uf => RuntimeHost::Uf,
-        RuntimeEngine::Node => RuntimeHost::Node,
-        RuntimeEngine::Bun => RuntimeHost::Bun,
-        RuntimeEngine::Deno => RuntimeHost::Deno,
-        RuntimeEngine::Edge => RuntimeHost::Edge,
-        RuntimeEngine::Serverless => RuntimeHost::Serverless,
-        RuntimeEngine::Container => RuntimeHost::Container,
-    }
+/// The host a configured engine names.
+///
+/// One arm each, once, in `uf_config`: this mapping used to be written out
+/// here as well, and a second copy of "which row is this name" is how a name
+/// and its row drift apart.
+const fn runtime_engine_to_host(engine: RuntimeEngine) -> RuntimeHost {
+    engine.host()
 }
 
 /// Runtime acquisition strategy.

--- a/docs/app/reference/config/_uf.page.mdx
+++ b/docs/app/reference/config/_uf.page.mdx
@@ -56,7 +56,9 @@ which is the fastest way to answer "what is it actually using".
 | `router.entry` | `"app.js"` | The module exporting `routerView()` |
 | `router.root` | `"app"` | The directory scanned for routes |
 | `router.enabled` | `true` | Turning it off makes the project a library, and makes `uf build` [build one](#buildlib) |
-| `runtime.default` | `"node"` | The JavaScript host to prefer |
+| `runtime.default` | `"node"` | The runtime this project is written for. `node`, `deno` and `bun`; naming a runtime uf has no host for is an error that says which key was meant ([#246](https://github.com/ubugeeei-prod/uf/issues/246)) |
+| `runtime.compatibility` | `["node", "bun", "deno"]` | The other runtimes it states it runs on, from the same three. Written into `.uf/install.json` as the hosts that must be available |
+| `runtime.capabilityJsHost.default` | `"node"` | **The host a command actually starts.** `uf dev`, `uf test` and `uf build` resolve through this key, not through `runtime.default` |
 | `runtime.capabilityJsHost.hosts` | `["node", "deno", "bun"]` | Hosts uf may use |
 | `runtime.capabilityJsHost.autoDetect` | `true` | Pick a host by what is installed |
 | `runtime.deploy.adapter` | none | The deploy target `uf build` writes an artefact for; `--adapter` overrides it |

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -35,6 +35,34 @@ Deno's row is *experimental* rather than implemented, which is the distinction
 the middle grade exists for: a uf project runs there, and the way it is made to
 run has a gap a person can meet. See [Deno](#deno) for what the gap is.
 
+## What a project may name, and which key decides
+
+Three keys in `uf.config.js` mention a runtime, and only one of them chooses
+the process that starts:
+
+| key | what it decides | what it accepts |
+| --- | --- | --- |
+| `app.runtime.capabilityJsHost.default` | **the host `uf dev`, `uf test` and `uf build` actually start**, tried first and then the rest of `hosts` while `autoDetect` is on | `node`, `deno`, `bun` |
+| `app.runtime.default`, `app.runtime.compatibility` | what this project *says* it is written for; it reaches `.uf/install.json` and `uf inspect --json` as the hosts that must be available | the rows above that have a Flow loader — today `node`, `deno`, `bun` |
+| `app.runtime.deploy.adapter` | which artefact `uf build` writes | the deploy adapters, which are a longer list and a different question |
+
+The second row used to accept all seven names in the table, `edge`,
+`serverless`, `container` and `uf` included, and the default `compatibility`
+claimed three of them. Nothing enforced the claim and nothing could: those four
+rows have no Flow loader, so a uf project cannot import its own first file
+there. What naming one changed was not the run — it went on being Node — but
+what uf told the reader afterwards: `uf explain` printed the name as the
+JavaScript host, and every `uf install` wrote it into `.uf/install.json` among
+the hosts that must be available. That is this page's own sentence, produced by
+uf: a name in an enum is not compatibility.
+
+So a name uf has no host for is refused at the key that wrote it, and the
+message names the level the table gives it, the two keys that do decide
+something, and the issue tracking the host. The accepted set is read off
+`uf_runtime::HOSTS` rather than listed a second time — `uf_config`'s tests fail
+if the two disagree — so a host that earns a loader opens its name here by
+earning it. See ubugeeei-prod/uf#246.
+
 ## Node.js
 
 The reference host. `node --import @uniflowed/host/register app.js` installs
@@ -171,6 +199,31 @@ application target; it should not be read as one.
 
 This is the same ahead-of-time question Deno's loader asks, and answering it
 once serves both. Tracked by ubugeeei-prod/uf#246.
+
+### Nothing here has been checked on a worker runtime
+
+Worth stating in the column's own terms rather than leaving as an em dash.
+`uf build --adapter edge` does write a Cloudflare Worker — `worker.js`,
+`wrangler.json` and `static/` — and `tests/library/deploy.test.js` drives that
+handler's answers and compares them with `uf start`'s. **None of that starts a
+worker runtime.** The handler runs in Node, in process, and a `wrangler.json`
+being the shape Cloudflare documents is not the same claim as Cloudflare
+accepting it.
+
+Nor could it be checked here yet. No test in this repository starts `workerd`,
+`wrangler dev` or any other worker runtime; the machine uf is developed on has
+none installed; and CI installs Node, Bun and Deno and nothing else — see
+`.github/workflows/ci.yml`. The one place `wrangler` is run at all is
+`docs.yml`, which deploys the documentation site, and a `--dry-run` there
+bundles a script rather than executing one.
+
+So this row stays **planned** with an empty "Checked by", which is what that
+column is for. Grading it on the strength of an in-process handler test would
+be the same move Bun's row made for a year on the strength of a README
+sentence, and [the matrix](#the-matrix) says what that was worth.
+
+Tracked by ubugeeei-prod/uf#246, which is also where the shape a real edge host
+would take is written down.
 
 ## Serverless and containers
 

--- a/packages/config/internal/schema.js
+++ b/packages/config/internal/schema.js
@@ -74,7 +74,17 @@ export type PackageManagerPreference =
   | "bun";
 // uf-lint-enable uniflowed/no-npm-script-invocation
 
-export type RuntimeEngine = "uf" | "node" | "deno" | "bun" | "edge" | "serverless" | "container";
+// The runtimes a project may say it is written for, which are the runtimes uf
+// has a host for. It read `"uf" | ... | "edge" | "serverless" | "container"`,
+// and those four are rows `uf_runtime::HOSTS` grades planned with no Flow
+// loader — so a project that named one could not import its own first file
+// there, and every command went on running on Node anyway. uf refuses them at
+// the key that named them now; this type is where a reader finds that out
+// before `uf check` does. See docs/hosts.md and ubugeeei-prod/uf#246.
+//
+// A deployment target is `DeployAdapter`, on `app.runtime.deploy`, and is a
+// different question with a longer list.
+export type RuntimeEngine = "node" | "deno" | "bun";
 
 export type DeployAdapter =
   | "node"

--- a/packages/rm/index.js
+++ b/packages/rm/index.js
@@ -7,7 +7,14 @@ import { nativeRuntimeRequired } from "@uniflowed/core/native";
 
 const MODULE = "@uniflowed/core/rm";
 
-export type RuntimeEngine = "uf" | "node" | "deno" | "bun" | "edge" | "serverless" | "container";
+// `engine` and `hosts` below are both read off `app.runtime.default` and
+// `app.runtime.compatibility`, so this union is that key's, and it named seven
+// runtimes of which four have no Flow loader in `uf_runtime::HOSTS`. The plan
+// this file types is what `uf install` writes to `.uf/install.json`, so the
+// declaration said a project's hosts could include runtimes no uf project can
+// be imported on — and it wrote exactly that until ubugeeei-prod/uf#246. See
+// docs/hosts.md.
+export type RuntimeEngine = "node" | "deno" | "bun";
 
 export type RuntimeHost = RuntimeEngine;
 export type RuntimeAcquisition = "auto";


### PR DESCRIPTION
`app.runtime.default` and `app.runtime.compatibility` took all seven names in
`uf_runtime::HOSTS`, and four of them — `uf`, `edge`, `serverless`, `container` —
are rows that table grades `planned` with **no Flow loader**. A runtime with no
Flow loader cannot import a uf project's first file, so those four were names
rather than targets: the failure this issue is titled after, in a config enum
rather than in the test runner's.

## What naming one did

Nothing to the run. Which host starts is `app.runtime.capabilityJsHost.default`,
and a project that wrote `default: "edge"` went on running on Node. What it
changed is what uf then told the reader about that run:

```
$ uf explain dev
  2. JavaScript host
      provider  edge
      what      runs Vite and any JavaScript plugin
```

And the default `compatibility` — which no project had to write — reached
`.uf/install.json`, on every install of every project:

```json
"runtimeManager": {
  "engine": "node",
  "hosts": ["node", "deno", "bun", "edge", "serverless", "container"]
}
```

`RuntimeManagerPlan.hosts` is documented as the hosts that must be available
after adaptation, and `uf inspect --json` prints the same list back. uf was
publishing the claim #246 was filed against, about every project it installed.

## What changes

* **The names a project may write are read off the table** rather than listed a
  second time: `RuntimeEngine::is_a_host` is
  `HostSupport::for_host(..).loads_flow()`. A host that earns a loader opens its
  name by earning it, and `uf_config`'s tests fail if the two lists disagree.
* **`RuntimeConfig::default`'s `compatibility` is that list** — `node`, `bun`,
  `deno` — the same way `DeployAnywhereConfig::default` is what
  `DeployAdapter::is_implemented` says is true. `.uf/install.json` and
  `uf inspect --json` follow.
* **Naming one of the four is refused where it was written**, with the level the
  table gives it, the two keys that do decide something, and the issue tracking
  that host:

  ```
  uf.config.js: app.runtime.default names `edge`, and uf has no host for it —
  `uf_runtime::HOSTS` grades `edge` planned with no Flow loader, so a project
  that names it still runs on whichever of `node`, `bun`, `deno` the machine
  has. Which host a command starts is `app.runtime.capabilityJsHost.default`;
  which target `uf build` writes an artefact for is `app.runtime.deploy.adapter`.
  Name one of `node`, `bun`, `deno` here, or drop the key.
  See docs/hosts.md and ubugeeei-prod/uf#246.
  ```

* **`uf explain`'s host stage reads `capabilityJsHost.default`**, which is the
  key `commands::vite::resolve_host` actually resolves, and its detail now says
  how that name becomes a process. Named rather than resolved, for the reason
  `permissions_stage` already gives: `uf explain` prints a plan and must not
  fail because the machine has no host installed.
* `packages/config` and `packages/rm` narrow the Flow type a project writes
  against, and `uf_rm`'s second copy of the engine → host mapping is deleted in
  favour of `uf_config`'s.
* `docs/hosts.md` gains **What a project may name, and which key decides**, and
  `docs/app/reference/config` stops describing `runtime.default` as "the
  JavaScript host to prefer" — it prefers nothing.

## What this does not change: the edge host

The edge row is still `planned` and still has no host, and this PR does not
pretend otherwise. `docs/hosts.md` now says so in the column's own terms rather
than leaving an em dash: `uf build --adapter edge` does write a Worker and
`tests/library/deploy.test.js` drives that handler — **in Node, in process**.
No test in this repository starts `workerd`, `wrangler dev` or any other worker
runtime; the machine this was developed on has none, and CI installs Node, Bun
and Deno and nothing else. Grading the row on an in-process handler test would
be the move Bun's row made for a year on the strength of a README sentence.

## Verification

* `cargo fmt --all` — clean.
* `cargo clippy -p uf_cli -p uf_config -p uf_rm -p uf_runtime --all-targets -- -D warnings`
  — clean.
* `cargo test -p uf_cli` (the whole suite, not `--lib`), plus `-p uf_config
  -p uf_rm -p uf_runtime -p uf_lib`. Every target green except `tests/vite.rs`,
  which came back 51 passed / 5 failed on the machine this was written on —
  `build_renders_the_docs_site_through_vite`,
  `compile_writes_one_file_that_serves_the_site_from_an_empty_directory`,
  `the_static_adapter_writes_the_site_it_can_serve`,
  `preview_and_start_serve_the_whole_of_a_build` and
  `compile_refuses_a_native_addon_and_names_it`. The message is the same one
  each time and names no code of this change:

  ```
  [plugin vite:prepare-out-dir]
  Error: ENOTEMPTY, Directory not empty: docs/.uf/build/server/assets
      at emptyDir (vite/dist/node/chunks/node.js) at prepareOutDir
  ```

  Four tests take `dist_lock()` before building the docs fixture and more than
  four build it, so they empty `docs/.uf/build/server` under one another. It is
  a pre-existing isolation gap rather than a flake: it stayed invisible here
  because `node_modules` was absent, which made `fixture_ready()` skip every
  test that touches the fixture. The same five pass in CI on this branch — see
  the checks: **Test**, **Library**, **Docs build**, **Flow lint**, **Upstream
  Flow Typecheck**, **Clippy** and **Format** are all green.
* Every new test was watched failing first, by putting back the three lines the
  fix is made of — the default `compatibility` list, the `runtime::check` call,
  and `host_stage`'s `provider` — and then restoring them. With them reverted:

  ```
  tests::the_runtimes_a_project_may_name_are_the_ones_with_a_host ... FAILED
  tests::refuses_a_runtime_it_has_no_host_for ... FAILED
  explain_names_the_host_the_run_will_actually_start ... FAILED
  a_runtime_with_no_host_is_refused_before_anything_runs ... FAILED
  install_runs_the_package_manager_that_drives_the_project ... FAILED
    left: ["node", "deno", "bun", "edge", "serverless", "container"]
   right: ["node", "bun", "deno"]
  ```
* **Out of the repository**, with the binary from this branch:
  `uf create app` → `uf install` → `uf build` → `uf test` → `uf dev`, curled with
  `Accept: text/html` for a 200. `.uf/install.json` came back
  `"hosts": ["node","bun","deno"]`.
* The same project with `capabilityJsHost.default: "bun"`: `uf explain dev` says
  `provider bun`, and `uf test` then reports `host bun` — the stage and the run
  agree, which is the whole of that half of the fix.
* The same project with `runtime.default: "edge"`: `uf explain dev`, `uf build`
  and `uf test` each exit 1 with the message above.

## What is left of #246

Two of the four items, and one of them cannot be worked on this machine at all:

* **Item 2, `uf test` on Deno running the library suite with honest skips.** The
  Deno Flow loader landed in #720, so that host is real; what is missing is the
  suite and the reasons on its skips. Deno is not installed on the machine this
  was written on, so nothing about its behaviour is claimed here.
* **Item 1's edge half.** Absent, and unverifiable both here and in CI until a
  worker runtime is installed in one of them. That is now written down rather
  than implied.

Item 3 was finished by #617, and item 4 stands where the earlier comments left
it: the audit exists in `package_surface.rs`, and giving the `SERVER_ONLY`
exceptions a portable path is still open.

One thing left deliberately: `uf_rm::RuntimeManagerPlan::includes_uf_runtime`
can no longer be true, because the only way into it was
`app.runtime.default: "uf"`. Removing a `pub fn` is a semver event and this PR
is not that; it is a one-line follow-up for whoever touches `uf_rm` next.

Refs #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
