### PR TITLE
fix(fmt): a member chain is its own fixed point

### DIFF
--- a/crates/uf_fmt/src/flow/print/member_chain.rs
+++ b/crates/uf_fmt/src/flow/print/member_chain.rs
@@ -251,6 +251,20 @@ impl<'a> Printer<'a> {
             .filter(|node| is_call(node))
             .collect();
 
+        // Whether the chain's last call is handed a function. That is the one
+        // reason a flat chain is allowed to contain a break, and the branch
+        // below turns on it.
+        let last_call_takes_a_function = groups
+            .last()
+            .and_then(|group| group.last())
+            .map(|index| printed_nodes[*index].node)
+            .is_some_and(|last| {
+                is_call(last)
+                    && call_arguments_of(last)
+                        .iter()
+                        .any(|argument| is_function_or_arrow(argument))
+            });
+
         let last_group_will_break_and_other_calls_are_function_arguments = {
             let last_node = groups
                 .last()
@@ -286,6 +300,32 @@ impl<'a> Printer<'a> {
             || last_group_will_break_and_other_calls_are_function_arguments
         {
             self.group(expanded)
+        } else if will_break(one_line) && !last_call_takes_a_function {
+            // The flat form already contains a forced break, and it did not
+            // come from a callback body. Offering it to `conditional_group` is
+            // what made this printer disagree with itself: a conditional group
+            // measures a candidate only as far as its first line break, so
+            // `at.until(later).total({` measures as fitting however long the
+            // rest is, and the chain stays on one line — while the *same chain*
+            // with the same object written flat does not fit, and expands. Both
+            // spellings are the same program, and one of them is this printer's
+            // own previous output, because an object keeps the line break its
+            // author wrote after `{`.
+            //
+            // `packages/core/temporal.test.js` in ubugeeei-prod/uf#729 is where
+            // it surfaced, and it needs three things at once to show: an object
+            // argument, an outer chain, and enough indentation that the flat
+            // form does not fit.
+            //
+            // The exception is the whole of why this is not simply
+            // `will_break(one_line)`. A chain whose last call takes a function
+            // is *supposed* to stay flat and let the body break —
+            // `permissions.query({ name }).then((result) => { … })` is one line
+            // plus a body, not a three-line chain — and refusing the flat form
+            // there reformats correct code for the worse. That callback breaks
+            // because it is a callback, not because of anything the previous
+            // pass wrote.
+            self.concat([&BREAK_PARENT, self.group(expanded)])
         } else {
             let leading = if will_break(one_line) || has_empty_line_after_head {
                 &BREAK_PARENT

--- a/crates/uf_fmt/tests/guarantees.rs
+++ b/crates/uf_fmt/tests/guarantees.rs
@@ -851,3 +851,59 @@ fn a_mapped_types_variance_operator_is_not_dropped() {
     // And the tree says so too, not just the text.
     similar_asserts::assert_eq!(support::structure(source), support::structure(&output));
 }
+
+/// The chain that was not its own fixed point, and the one that must stay flat.
+///
+/// `shipped_sources_are_formatted_idempotently` catches this only when a file
+/// in `packages/` happens to contain the shape, which is how it was found —
+/// `packages/core/temporal.test.js`, moving into `packages/` in
+/// ubugeeei-prod/uf#729, put the printer's output back through the printer and
+/// got something else. Written down here as the shape rather than left to a
+/// file that might be edited.
+///
+/// It takes three things at once: an object argument, an outer chain, and
+/// enough indentation that the flat form does not fit. A conditional group
+/// measures a candidate as far as its first line break, so once the object
+/// carries the break its author wrote — which, after one pass, is the break
+/// *this printer* wrote — `at.until(later).total({` measures as fitting and the
+/// chain that expanded a moment ago stays flat.
+///
+/// The second case is the one that makes the fix narrow rather than blunt.
+/// Refusing every flat form that breaks also breaks
+/// `permissions.query({ name }).then(cb)`, which is one line plus a body and is
+/// meant to be: `packages/hooks/browser.js`, `packages/i18n/negotiate.js` and
+/// `packages/router/internal/runtime.js` all reformat for the worse under that
+/// version. A callback breaks because it is a callback, not because of what the
+/// previous pass wrote.
+#[test]
+fn a_member_chain_is_its_own_fixed_point() {
+    const OBJECT_ARGUMENT: &str = "// @flow\ndescribe(\"d\", () => {\n  it(\"x\", () => {\n    \
+         expect(at.until(later).total({ unit: \"minute\" })).toBeCloseTo(3.0917, 3);\n  });\n});\n";
+    const CALLBACK_ARGUMENT: &str = "// @flow\ndescribe(\"d\", () => {\n  it(\"x\", () => {\n    \
+         permissions.query({ name }).then((result) => {\n      use(result);\n    });\n  });\n});\n";
+
+    for (label, source) in [
+        ("an object argument", OBJECT_ARGUMENT),
+        ("a callback argument", CALLBACK_ARGUMENT),
+    ] {
+        for config in configurations() {
+            let once = format_source(source, &config)
+                .unwrap_or_else(|error| panic!("{label} formats: {error}"))
+                .output;
+            let twice = format_source(&once, &config)
+                .unwrap_or_else(|error| panic!("{label} reformats: {error}"))
+                .output;
+            similar_asserts::assert_eq!(once, twice, "{label} is not idempotent");
+        }
+    }
+
+    // And the callback chain is still *flat*, which the equality above cannot
+    // say: two passes agreeing on a needlessly expanded chain would pass it.
+    let flat = format_source(CALLBACK_ARGUMENT, &FmtConfig::default())
+        .expect("a callback chain formats")
+        .output;
+    assert!(
+        flat.contains("permissions.query({ name }).then("),
+        "the callback chain was broken up:\n{flat}"
+    );
+}


### PR DESCRIPTION
## The bug

`uf fmt` did not agree with itself. Under the narrow configuration the
formatter's own guarantee test uses (`line_width` 40, `indent_width` 4), pass
one gives

```js
        expect(
            at
                .until(later)
                .total({
                    unit: 'minute',
                }),
        ).toBeCloseTo(3.0917, 3)
```

and pass two, over that output, gives

```js
        expect(
            at.until(later).total({
                unit: 'minute',
            }),
        ).toBeCloseTo(3.0917, 3)
```

Pass three equals pass two. One transition — which is exactly the one
`shipped_sources_are_formatted_idempotently` asserts against.

## Why

`print_member_chain` ends in `conditional_group([one_line, expanded])`, and a
conditional group measures a candidate only as far as its first line break.

Pass one's object is flat, so `one_line` is flat, does not fit at that indent,
and `expanded` wins — the chain breaks. Pass two's object now carries a forced
break, because an object keeps the line break its author wrote after `{`, and
after one pass that author is `uf fmt`. `one_line` now measures as
`at.until(later).total({`, which fits, so the chain stays flat.

The printer's output is the input to a rule about the input.

It takes three things at once to surface — an object argument, an outer chain,
and enough indentation that the flat form does not fit — which is why it lived
here until `packages/core/temporal.test.js` moved into `packages/` in
ubugeeei-prod/uf#729 and brought the shape inside the guarantee's reach.

## The fix, and why it is narrow

A chain whose flat form already contains a forced break is not flat, so it is
not offered as the flat candidate — **unless the last call takes a function**.

That exception is the entire difference between a fix and a regression. I tried
it without first:

```diff
-    permissions.query({ name }).then(
-      (result: PermissionStatus) => { … },
+    permissions
+      .query({ name })
+      .then(
+        (result: PermissionStatus) => { … },
```

`packages/hooks/browser.js`, `packages/i18n/negotiate.js` and
`packages/router/internal/runtime.js` all reformat for the worse under that
version, and they are right as they stand: a chain whose last call takes a
callback is one line plus a body. That callback breaks because it is a
callback, not because of what the previous pass wrote.

With the exception, **none of the 302 shipped and templated `.js`/`.jsx` files
changes at all** — measured by formatting every one of them and diffing against
what is committed, before and after.

## Test plan

- [x] `a_member_chain_is_its_own_fixed_point` — both halves: the chain that was
      not stable, and the chain that must stay flat. The second is asserted by
      its text, not only by two passes agreeing, because two passes agree on a
      needlessly expanded chain too.
- [x] Verified to **fail** without the change: `an object argument is not
      idempotent`.
- [x] `packages/core/temporal.test.js` from #729 — stable under all three of
      the guarantee's configurations.
- [x] Churn: 0 of 302 committed files reformat.
- [x] `cargo test -p uf_fmt` — 5 binaries green, 27 in `guarantees`.
- [x] `cargo clippy -p uf_fmt --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791547944&installation_model_id=422833&pr_number=746&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F746&signature=1c12a2e3e76e3aea708cc35bdc8d0de4fae70707a3e4ef21cd804e66e664002b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->