### PR TITLE
feat(infra, ci): a front door for uniflowed.dev, and the redirect it must not break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,15 @@ jobs:
       # first thing anybody sees from `curl … | sh`, and a line wider than the
       # window wraps without its indent.
       - run: ./target/release/uf run install:banner
+      # And what `uniflowed.dev` answers. The apex serves a landing page now
+      # and hands every other path to the documentation host exactly as it did
+      # when that was all it did — which is a promise about `/guide`,
+      # `/og.png` and `/sitemap.xml`, paths written down in issues and in
+      # other people's pages. Nothing else in this repository would notice
+      # them turning into 404s, because the failure is invisible from the
+      # machine of whoever changed the worker.
+      - run: ./target/release/uf run apex:routes
+      - run: ./target/release/uf run apex:routes:test
       - run: ./target/release/uf run scripts:parse
       - run: ./target/release/uf run scripts:parse:test
       # And that the three CI integrations still configure the installer with

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,10 @@ on:
       - "docs/**"
       - "infra/cloudflare/setup-assets/**"
       - "infra/cloudflare/workers/docs.js"
+      - "infra/cloudflare/workers/root.js"
       - "infra/cloudflare/workers/setup.js"
       - "infra/cloudflare/wrangler.docs.jsonc"
+      - "infra/cloudflare/wrangler.root.jsonc"
       - "infra/cloudflare/wrangler.setup.jsonc"
       - "tools/docs/**"
   push:
@@ -25,8 +27,10 @@ on:
       - "docs/**"
       - "infra/cloudflare/setup-assets/**"
       - "infra/cloudflare/workers/docs.js"
+      - "infra/cloudflare/workers/root.js"
       - "infra/cloudflare/workers/setup.js"
       - "infra/cloudflare/wrangler.docs.jsonc"
+      - "infra/cloudflare/wrangler.root.jsonc"
       - "infra/cloudflare/wrangler.setup.jsonc"
       - "tools/docs/**"
   workflow_dispatch:
@@ -67,6 +71,11 @@ jobs:
           UF_BIN: ./target/release/uf
       - run: npx --yes wrangler@4.128.0 deploy --dry-run --config infra/cloudflare/wrangler.docs.jsonc
       - run: npx --yes wrangler@4.128.0 deploy --dry-run --config infra/cloudflare/wrangler.setup.jsonc
+      # The apex worker bundles and finds its assets. What it *answers* is
+      # `uf run apex:routes` in `ci.yml`, which drives the handler; this is the
+      # half that only wrangler can tell us — that the config resolves and the
+      # `brand/` directory is where it says it is.
+      - run: npx --yes wrangler@4.128.0 deploy --dry-run --config infra/cloudflare/wrangler.root.jsonc
 
   deploy:
     name: Deploy docs
@@ -101,3 +110,11 @@ jobs:
           UF_BIN: ./target/release/uf
       - run: npx --yes wrangler@4.128.0 deploy --config infra/cloudflare/wrangler.docs.jsonc
       - run: npx --yes wrangler@4.128.0 deploy --config infra/cloudflare/wrangler.setup.jsonc
+      # No `uf-root` here, deliberately. The apex is the one hostname whose
+      # worker is managed by `infra/cloudflare/main.tf`, and a push that
+      # deployed it from here would leave Terraform's state describing a script
+      # it no longer owns — two systems writing one resource, which is how a
+      # `tofu apply` months later silently reverts a landing page. Deploy it
+      # with `tofu apply`, or with
+      # `wrangler deploy --config infra/cloudflare/wrangler.root.jsonc` if you
+      # would rather, and pick one.

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ coverage/
 node_modules/
 .uf/
 /.wrangler/
+# `wrangler dev` writes its state beside the config it was given, and
+# `infra/cloudflare/wrangler.root.jsonc` is one anybody can run locally — the
+# apex worker needs no account to serve. The anchored entry above does not
+# reach it.
+infra/cloudflare/.wrangler/
 /.direnv/
 .terraform/
 *.tfplan

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -4,7 +4,17 @@ This directory is the IaC source of truth for `uniflowed.dev`.
 
 ## Topology
 
-- `uniflowed.dev` and `www.uniflowed.dev`: redirect to docs.
+- `uniflowed.dev`: the landing page, from `workers/root.js`. It answers `/`,
+  `/robots.txt` and `/brand/*` — the last out of the repository's own `brand/`
+  directory, bound as `ASSETS` and read in place rather than copied — and
+  **308s every other path to `docs.uniflowed.dev`**, which is the whole of what
+  this worker used to do. That fallthrough is the compatibility rule: links to
+  `uniflowed.dev/guide`, `/og.png` and `/sitemap.xml` exist in issues and in
+  other people's pages, and none of them may stop resolving.
+  `tools/ci/apex-routes.sh` drives the handler and fails when one does.
+- `www.uniflowed.dev`: 308 to the apex, same path. One origin is canonical;
+  two hostnames serving one document split the cache and need a `rel=canonical`
+  afterwards to say which of them counts.
 - `docs.uniflowed.dev`: Workers Static Assets for the generated docs site.
 - `setup.uniflowed.dev`: Worker endpoint for `curl -fsSL https://setup.uniflowed.dev | sh`.
 - `releases.uniflowed.dev`: public R2 custom domain for release archives.
@@ -52,6 +62,40 @@ npx --yes wrangler@4.128.0 deploy --config infra/cloudflare/wrangler.setup.jsonc
 `.github/workflows/docs.yml` builds docs for pull requests and deploys the
 existing `uf-docs` and `uf-setup` Workers from `main` when
 `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` are available.
+
+## The apex
+
+`uf-root` is **not** in that deploy job, and that is deliberate: it is the one
+Worker whose script `main.tf` owns, and two systems writing one resource is how
+a `tofu apply` months later silently reverts a landing page. Pick one. Terraform
+is the default because the apex and `www` custom domains are declared there too:
+
+```sh
+tofu -chdir=infra/cloudflare apply -var account_id=... -var zone_id=...
+```
+
+Wrangler deploys the same script and assets without touching DNS, which is the
+faster loop while editing the page:
+
+```sh
+npx --yes wrangler@4.128.0 deploy --dry-run --config infra/cloudflare/wrangler.root.jsonc
+npx --yes wrangler@4.128.0 deploy --config infra/cloudflare/wrangler.root.jsonc
+```
+
+Locally, `wrangler dev` serves the real thing — the page, the `brand/` assets
+and every redirect — with no account and no credentials:
+
+```sh
+npx --yes wrangler@4.128.0 dev --config infra/cloudflare/wrangler.root.jsonc
+```
+
+What it answers is checked rather than described. `uf run apex:routes` imports
+the worker, calls its `fetch` with an `ASSETS` binding over `brand/`, and fails
+when `/` stops being a page, when a path that used to redirect stops resolving
+at the same path, when `www` points anywhere but the apex, when the page loads
+something this worker cannot serve, or when the `style-src` hash no longer
+matches the stylesheet the page returned. `uf run apex:routes:test` checks that
+that check still catches each of those.
 
 ## Release Upload
 

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -113,6 +113,21 @@ resource "cloudflare_workers_script" "root" {
   content_file       = "${path.module}/workers/root.js"
   content_sha256     = filesha256("${path.module}/workers/root.js")
   main_module        = "root.js"
+
+  # The repository's `brand/` directory, which the worker serves under
+  # `/brand/` after stripping the prefix. It is the same directory
+  # `tools/docs/build.sh` stages into the documentation site, read in place
+  # rather than copied, and it is what lets the landing page load the mark
+  # from its own origin under `img-src 'self'`.
+  #
+  # `run_worker_first` is `true` so that the worker decides every path. Without
+  # it the asset router would answer `/README.md` and `/og.html` out of this
+  # directory ahead of the redirect that is supposed to answer them.
+  assets = {
+    directory        = "${path.module}/../../brand"
+    binding          = "ASSETS"
+    run_worker_first = true
+  }
 }
 
 resource "cloudflare_workers_custom_domain" "apex" {

--- a/infra/cloudflare/workers/root.js
+++ b/infra/cloudflare/workers/root.js
@@ -1,9 +1,705 @@
-const DOCS_HOST = "docs.uniflowed.dev";
+// The front door: `uniflowed.dev`.
+//
+// This worker used to be nine lines. It set `url.hostname` to the docs host and
+// returned a 308, so somebody who typed `uniflowed.dev` landed halfway down the
+// manual with no idea what they had installed or whether they should. The zone
+// carries real weight — `setup.` is what `curl … | sh` resolves, `releases.`
+// holds the archives — and the apex was the one hostname with nothing behind
+// it.
+//
+// So the apex answers three things itself and hands over everything else:
+//
+//   * `/` is a page. One document, no scripts, no webfonts, no CDN, no build
+//     step: the markup and the stylesheet below are the whole of it, and the
+//     only subresources are files that already live in `brand/`.
+//   * `/robots.txt` is written here rather than borrowed. A redirect for
+//     `robots.txt` resolves, but what it resolves to is the *documentation
+//     host's* rules, which is a different origin with a different sitemap.
+//   * `/brand/*` is served from `brand/` through the `ASSETS` binding, so the
+//     mark on this page is same-origin and `img-src 'self'` can stay closed.
+//     A name that is not in that directory falls through to the redirect, so
+//     nothing that used to resolve stops resolving.
+//
+// **Everything else 308s to the documentation host exactly as it did before.**
+// That is the compatibility rule and it is deliberately the default rather than
+// a list: `/guide`, `/og.png`, `/brand/uf.png`, `/sitemap.xml` and every other
+// path anybody has ever written down keep working because the fallthrough did
+// not change, not because somebody remembered to enumerate them.
+// `tools/ci/apex-routes.sh` drives this handler and fails when any of that
+// stops being true.
+//
+// `www` redirects to the apex rather than serving the same bytes. One origin is
+// canonical, and two hostnames serving one document split the cache, split the
+// referrers, and need a `rel=canonical` afterwards to say which of them counts.
+// A 308 is one hop, once, and browsers cache it. It is the same status the old
+// worker sent; only the target changed.
+//
+// There is no JavaScript on the page and the policy below says so, which is the
+// one place this deliberately does not copy the documentation site. That site
+// has a theme toggle, so it needs an inline bootstrap to apply a stored choice
+// before first paint. This page has no toggle — `localStorage` is per-origin,
+// so a choice made on `docs.` would not be here to read anyway — and a page
+// with nothing to remember can respect `prefers-color-scheme` in CSS and ship
+// `script-src 'none'`.
+
+/** Where every path this worker does not answer itself goes. */
+const DOCS_ORIGIN = "https://docs.uniflowed.dev";
+
+/**
+ * The canonical origin, for the three absolute URLs a document cannot express
+ * relatively: `rel=canonical`, `og:url` and `og:image`. Hard-coded rather than
+ * read off the request because that is what those three fields mean — a card
+ * scraped from a preview deployment should still name the real page.
+ */
+const SITE_ORIGIN = "https://uniflowed.dev";
+
+const GITHUB = "https://github.com/ubugeeei-prod/uf";
+
+/**
+ * The stylesheet.
+ *
+ * A subset of `docs/app/_design/seam.css` with the same tokens and the same
+ * refusals, so the front door and the manual read as one system: warm paper,
+ * rules instead of cards, no shadow, no radius, no transition, and the brand
+ * spectrum exactly once — down the first 9rem of the seam. `brand/tokens.css`
+ * is inlined here rather than linked because a stylesheet the page cannot
+ * render without is a round trip before first paint, and this is one document.
+ *
+ * Dark mode is `prefers-color-scheme` alone. The manual also honours a
+ * `data-theme` attribute, because it has a control that sets one; this page has
+ * no control, so the attribute would be a selector nothing can ever match.
+ *
+ * Every byte of this string is hashed into `style-src` at first request, so the
+ * policy cannot go stale against the stylesheet it is a policy for.
+ */
+const STYLE = `
+:root {
+  color-scheme: light;
+
+  --uf-color-cyan-500: #35d6f6;
+  --uf-color-blue-500: #2677ff;
+  --uf-color-violet-500: #8f4bff;
+  --uf-color-magenta-500: #d84bff;
+  --uf-font-display: "Satoshi", "Inter", ui-sans-serif, system-ui, sans-serif;
+  --uf-font-body: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --uf-font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --doc-paper: #fbfaf8;
+  --doc-ink: #16171a;
+  --doc-ink-muted: #5b6068;
+  --doc-ink-faint: #8b9098;
+  --doc-rule: #e0ddd6;
+  --doc-rule-strong: #c9c5bc;
+  --doc-link: #1a56d6;
+  --doc-link-visited: #6b3fb8;
+  --doc-code-ground: #f4f2ee;
+  --doc-selection: #dfe7fb;
+
+  --doc-measure: 68ch;
+  --doc-seam: 1px;
+  --doc-gutter: clamp(1.25rem, 4vw, 3rem);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+
+    --doc-paper: #0c0d0f;
+    --doc-ink: #e8e6e1;
+    --doc-ink-muted: #9aa0a8;
+    --doc-ink-faint: #6a7078;
+    --doc-rule: #24272c;
+    --doc-rule-strong: #363a41;
+    --doc-link: #7fb0ff;
+    --doc-link-visited: #c0a2ff;
+    --doc-code-ground: #131518;
+    --doc-selection: #1d2c4d;
+  }
+}
+
+html {
+  background: var(--doc-paper);
+  color: var(--doc-ink);
+  font-family: var(--uf-font-body);
+  font-size: 17px;
+  line-height: 1.7;
+  -webkit-text-size-adjust: 100%;
+  text-rendering: optimizeLegibility;
+}
+
+body { margin: 0; min-width: 320px; }
+::selection { background: var(--doc-selection); }
+
+a {
+  color: var(--doc-link);
+  text-decoration-color: color-mix(in srgb, var(--doc-link) 35%, transparent);
+  text-underline-offset: 0.18em;
+}
+a:hover { text-decoration-color: currentColor; }
+a:visited { color: var(--doc-link-visited); }
+strong { font-weight: 630; }
+img { max-width: 100%; }
+
+h1, h2 {
+  font-family: var(--uf-font-display);
+  font-weight: 640;
+  letter-spacing: -0.021em;
+  line-height: 1.2;
+  margin: 0;
+  text-wrap: balance;
+}
+h1 { font-size: clamp(2rem, 1.4rem + 2.4vw, 3.1rem); letter-spacing: -0.03em; }
+h2 { font-size: 1.55rem; margin-block: 3.6rem 1.35rem; }
+p { margin: 1.1em 0; }
+h2 + p { margin-top: 0; }
+
+code {
+  font-family: var(--uf-font-mono);
+  font-size: 0.87em;
+  font-variant-ligatures: none;
+}
+:not(pre) > code {
+  background: var(--doc-code-ground);
+  border-radius: 3px;
+  padding: 0.1em 0.32em;
+  white-space: nowrap;
+}
+
+/* The skip link is visible the moment it is focused and nowhere else. */
+.skip {
+  background: var(--doc-paper);
+  border: 1px solid var(--doc-rule-strong);
+  clip-path: inset(50%);
+  height: 1px;
+  left: 0.5rem;
+  overflow: hidden;
+  padding: 0.5rem 0.9rem;
+  position: absolute;
+  top: 0.5rem;
+  white-space: nowrap;
+  width: 1px;
+  z-index: 10;
+}
+.skip:focus-visible { clip-path: none; height: auto; width: auto; }
+
+:focus-visible { outline: 2px solid var(--doc-link); outline-offset: 3px; }
+
+.shell { margin: 0 auto; max-width: 82rem; padding: 0 var(--doc-gutter); }
+
+.masthead {
+  align-items: baseline;
+  border-bottom: 1px solid var(--doc-rule);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  padding: 1.4rem 0;
+}
+.masthead-brand {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  font-family: var(--uf-font-display);
+  font-size: 1.05rem;
+  font-weight: 660;
+  gap: 0.55rem;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+.masthead-brand img { display: block; height: 22px; width: 22px; }
+.masthead-brand .version {
+  color: var(--doc-ink-faint);
+  font-family: var(--uf-font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+.masthead-nav {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.92rem;
+  gap: 1.35rem;
+}
+.masthead-nav a { color: var(--doc-ink-muted); text-decoration: none; }
+.masthead-nav a:hover { color: var(--doc-ink); }
+
+/* The seam. One hairline down the page, carrying the brand spectrum over its
+   first 9rem and nothing else anywhere. Content hangs off it. */
+.seam { position: relative; padding-left: 1.75rem; }
+.seam::before {
+  background:
+    linear-gradient(
+      180deg,
+      var(--uf-color-cyan-500) 0%,
+      var(--uf-color-blue-500) 22%,
+      var(--uf-color-violet-500) 48%,
+      var(--uf-color-magenta-500) 66%,
+      transparent 100%
+    )
+    no-repeat 0 0 / var(--doc-seam) 9rem,
+    linear-gradient(var(--doc-rule), var(--doc-rule));
+  bottom: 0;
+  content: "";
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: var(--doc-seam);
+}
+.seam-mark { position: relative; }
+.seam-mark::before {
+  background: var(--doc-paper);
+  border: 1px solid var(--doc-rule-strong);
+  border-radius: 50%;
+  content: "";
+  height: 7px;
+  left: calc(-1.75rem - 3px);
+  position: absolute;
+  top: 0.62em;
+  width: 7px;
+}
+
+.home { max-width: 64rem; }
+
+.hero {
+  align-items: center;
+  column-gap: 3rem;
+  display: flex;
+  flex-wrap: wrap-reverse;
+  justify-content: space-between;
+  padding-block: 4.5rem 0;
+}
+.hero-copy { flex: 1 1 26rem; }
+.hero-mark {
+  flex: 0 1 auto;
+  height: auto;
+  margin-bottom: 1.5rem;
+  width: clamp(9rem, 46vw, 22rem);
+}
+.hero h1 { margin-top: 0; }
+
+/* The small mono label above a heading that says what kind of thing follows. */
+.eyebrow {
+  color: var(--doc-ink-faint);
+  font-family: var(--uf-font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+}
+
+/* The one paragraph that says what this is. */
+.lede {
+  color: var(--doc-ink-muted);
+  font-size: 1.32rem;
+  line-height: 1.55;
+  margin-top: 1rem;
+  max-width: 46ch;
+}
+
+.install { padding-block: 0 1rem; }
+.install p { max-width: var(--doc-measure); }
+
+/* The prompt is drawn by CSS so that copying the line copies the command
+   and not the dollar sign in front of it. */
+.command {
+  background: var(--doc-code-ground);
+  border-left: 2px solid var(--uf-color-blue-500);
+  display: flex;
+  gap: 0.7rem;
+  margin: 1.25rem 0;
+  overflow-x: auto;
+  padding: 0.8rem 1.1rem;
+}
+.command::before { color: var(--doc-ink-faint); content: "$"; flex: none; user-select: none; }
+.command code { background: none; padding: 0; white-space: pre; }
+
+.actions { align-items: center; display: flex; flex-wrap: wrap; gap: 1.4rem; margin-top: 2.2rem; }
+.button {
+  background: var(--doc-ink);
+  border: 1px solid var(--doc-ink);
+  color: var(--doc-paper);
+  display: inline-block;
+  font-size: 0.95rem;
+  font-weight: 560;
+  padding: 0.55rem 1.15rem;
+  text-decoration: none;
+}
+.button:visited { color: var(--doc-paper); }
+.button:hover { background: transparent; color: var(--doc-ink); }
+.button-quiet { background: transparent; border-color: var(--doc-rule-strong); color: var(--doc-ink); }
+.button-quiet:visited { color: var(--doc-ink); }
+.button-quiet:hover { border-color: var(--doc-ink); }
+
+.section { margin-top: 4.5rem; }
+.section > h2 { margin-bottom: 1.35rem; }
+.section > p { max-width: var(--doc-measure); }
+
+/* Each row is a fact and the page that backs it. No icons, no cards — which is
+   what a definition list is for. */
+.facts { border-top: 1px solid var(--doc-rule); margin: 2.5rem 0 0; }
+.facts > div {
+  border-bottom: 1px solid var(--doc-rule);
+  display: grid;
+  gap: 0.35rem 2.5rem;
+  padding: 1.35rem 0;
+}
+@media (min-width: 48rem) {
+  .facts > div { grid-template-columns: 15rem minmax(0, 1fr); }
+}
+.facts dt {
+  font-family: var(--uf-font-display);
+  font-size: 1rem;
+  font-weight: 620;
+  letter-spacing: -0.015em;
+}
+.facts dd { color: var(--doc-ink-muted); margin: 0; max-width: 60ch; }
+.facts dd a { white-space: nowrap; }
+
+.colophon {
+  border-top: 1px solid var(--doc-rule);
+  color: var(--doc-ink-faint);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  gap: 1.25rem;
+  justify-content: space-between;
+  margin-top: 5rem;
+  padding: 1.6rem 0 3rem;
+}
+.colophon a { color: inherit; }
+
+@media (max-width: 40rem) {
+  html { font-size: 16px; }
+  :root { --doc-gutter: 1.1rem; }
+  .masthead { gap: 0.75rem 1.1rem; padding: 1rem 0; }
+  .masthead-nav { font-size: 0.88rem; gap: 1rem; width: 100%; }
+  .seam { padding-left: 1.1rem; }
+  .seam-mark::before { left: calc(-1.1rem - 3px); }
+  .hero { padding-block: 2rem 0; }
+  .lede { font-size: 1.1rem; }
+  /* A command on a phone is read by scrolling it, so it may use the whole
+     screen rather than sitting inside the gutter. */
+  .command {
+    margin-inline: calc(-1 * var(--doc-gutter) - 1.1rem) calc(-1 * var(--doc-gutter));
+    padding-inline: calc(var(--doc-gutter) + 1.1rem) var(--doc-gutter);
+  }
+  .colophon { gap: 0.6rem; margin-top: 3rem; }
+}
+`;
+
+/**
+ * The page.
+ *
+ * What it says, and why each part of it is there. A reader who types the domain
+ * has two questions — *what is this* and *should I install it* — and the answer
+ * to the second one here is mostly "not yet, and here is exactly why", because
+ * that is true and every other document in this repository says so.
+ *
+ * It does not restate the documentation home page. That page argues the
+ * toolchain: five claims, each with the page that proves it, and a pasted
+ * `uf build` run. This one is a door — the sentence, the command, and the
+ * shape of the word "alpha" — and its own section is the one the manual only
+ * has room for a two-line notice about.
+ *
+ * No version number smaller than `0.0.0-alpha` appears anywhere on it. The
+ * README's list of rough edges is scoped to a release on purpose and says so;
+ * a second copy of it here is a second thing to keep true, and this one deploys
+ * on a different schedule from the file it was copied from.
+ */
+const PAGE = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>uf — Unified Toolchain for Flow</title>
+<meta name="description" content="uf runs, builds, tests, formats and lints a React application written in Flow, from one native binary. It is 0.0.0-alpha and nothing in it is stable yet.">
+<link rel="canonical" href="${SITE_ORIGIN}/">
+<link rel="icon" href="/brand/favicon.svg">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="uf">
+<meta property="og:url" content="${SITE_ORIGIN}/">
+<meta property="og:title" content="uf — Unified Toolchain for Flow">
+<meta property="og:description" content="One native binary that runs, builds, tests, formats and lints a React application written in Flow.">
+<meta property="og:image" content="${SITE_ORIGIN}/brand/og.png">
+<meta property="og:image:alt" content="The uf mark beside the word uf, on a dark ground.">
+<meta name="twitter:card" content="summary_large_image">
+<style>${STYLE}</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to content</a>
+<div class="shell">
+
+<header class="masthead">
+  <a class="masthead-brand" href="/">
+    <img src="/brand/uniflowed-mark.svg" alt="" width="22" height="22">
+    uf
+    <span class="version">0.0.0-alpha</span>
+  </a>
+  <nav class="masthead-nav" aria-label="Site">
+    <a href="${DOCS_ORIGIN}">Documentation</a>
+    <a href="${DOCS_ORIGIN}/guide/install">Install</a>
+    <a href="${GITHUB}">Source</a>
+  </nav>
+</header>
+
+<main class="home seam" id="content">
+
+  <section class="hero">
+    <div class="hero-copy">
+      <p class="eyebrow">Unified toolchain for Flow</p>
+      <h1>One binary for React<br>written in Flow.</h1>
+      <p class="lede">
+        uf runs, builds, tests, formats, lints and type-checks a React
+        application written in Flow — every command reading one syntax tree,
+        produced once by Meta&#39;s own Flow parser, compiled into the binary.
+      </p>
+    </div>
+    <img
+      class="hero-mark"
+      src="/brand/uniflowed-mark.png"
+      srcset="/brand/uniflowed-mark.png 512w, /brand/uf.png 1254w"
+      sizes="(max-width: 48rem) 46vw, 22rem"
+      alt=""
+      width="1254"
+      height="1254"
+      fetchpriority="high"
+    >
+  </section>
+
+  <section class="install">
+    <div class="command"><code>curl -fsSL https://setup.uniflowed.dev | sh</code></div>
+    <p>
+      macOS and Linux, on x86-64 and ARM64. There is no Windows build. The
+      script checks the archive against the sha256 in the release manifest
+      before it unpacks anything, and it is served from
+      <a href="https://setup.uniflowed.dev/install.sh">setup.uniflowed.dev/install.sh</a>
+      if you would rather read it before you run it. uf still needs Node.js or
+      Bun on the machine, because Vite and your test bodies run there.
+    </p>
+    <p>
+      The command is <code>uf</code>. The package scope on npm is
+      <code>@uniflowed</code>, and every release there so far is a prerelease
+      under the <code>alpha</code> tag.
+    </p>
+    <div class="actions">
+      <a class="button" href="${DOCS_ORIGIN}">Read the manual</a>
+      <a class="button button-quiet" href="${GITHUB}">Source</a>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 class="seam-mark">Before you spend an afternoon on it</h2>
+    <p>
+      uf is <code>0.0.0-alpha</code>. It installs in seconds and scaffolds a
+      project that builds, and it changes under you. These four things are true
+      of every version so far; what is broken in the current one is in the
+      README, which is written per release rather than copied here.
+    </p>
+    <dl class="facts">
+      <div>
+        <dt>Nothing is stable</dt>
+        <dd>
+          Commands, config keys and package exports move without a deprecation
+          cycle, and no version promises compatibility with the one before it.
+          <a href="${GITHUB}#where-it-stands">Where it stands</a>
+        </dd>
+      </div>
+      <div>
+        <dt>Every gap has an issue number</dt>
+        <dd>
+          What uf refuses to do and what is simply not written yet are two
+          different lists, kept apart, with a reason on every refusal and an
+          issue on every gap.
+          <a href="${DOCS_ORIGIN}/guide/scope">What uf does not do</a>
+        </dd>
+      </div>
+      <div>
+        <dt>It does not check your types, and it is not a bundler</dt>
+        <dd>
+          Flow type-checks; <code>uf check</code> runs it. The dev server and
+          the production build are Vite, driven over a JSON protocol, so Vite
+          plugins keep working.
+          <a href="${DOCS_ORIGIN}/guide/dev">Dev and build</a>
+        </dd>
+      </div>
+      <div>
+        <dt>It knows how this shape fails</dt>
+        <dd>
+          An all-in-one toolchain is the shape of
+          <code>create-react-app</code>, and the way that failed is a
+          specification for how uf could. The rules, and an audit of where uf
+          does not meet them yet.
+          <a href="${GITHUB}/blob/main/docs/red-lines.md">Architecture red lines</a>
+        </dd>
+      </div>
+    </dl>
+  </section>
+
+</main>
+
+<footer class="colophon">
+  <span>uf is MIT licensed and pre-release. Nothing here is stable yet.</span>
+  <span>
+    This page is one Worker, in
+    <a href="${GITHUB}/blob/main/infra/cloudflare/workers/root.js">infra/cloudflare</a>.
+  </span>
+</footer>
+
+</div>
+</body>
+</html>
+`;
+
+/**
+ * The apex's own `robots.txt`.
+ *
+ * Written here rather than inherited through the redirect, because what the
+ * redirect resolves to is the documentation host's file: its `Sitemap:` line
+ * names `docs.uniflowed.dev/sitemap.xml`, which is the right sitemap for that
+ * host and no statement at all about this one. The apex has exactly one
+ * indexable URL — everything else is a 308 — so there is nothing here to
+ * disallow and one thing worth pointing at.
+ */
+const ROBOTS = `User-agent: *
+Allow: /
+
+Sitemap: ${DOCS_ORIGIN}/sitemap.xml
+`;
+
+/**
+ * The response headers every answer carries, and the policy behind them.
+ *
+ * The policy is computed rather than written down. `style-src` names the
+ * sha256 of `STYLE` itself, so the two cannot disagree: a stylesheet edited
+ * without touching the policy would be a blank page on the site's front door,
+ * and that is exactly the failure a hand-maintained hash produces. One digest,
+ * once per isolate, memoised below.
+ *
+ * `default-src 'none'` is the whole policy for everything the page does not do,
+ * and the page does almost nothing: no script, no font, no fetch, no frame, no
+ * form. The two openings are `img-src 'self'` for the mark — which is why
+ * `/brand/*` is served here rather than redirected — and the one style hash.
+ * `script-src` and `object-src` are spelled out even though `default-src`
+ * already covers them, so that a reader sees the two that matter said rather
+ * than inferred.
+ */
+let policyText = null;
+
+async function policy() {
+  if (policyText === null) {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(STYLE));
+    const hash = btoa(String.fromCharCode(...new Uint8Array(digest)));
+    policyText = [
+      "default-src 'none'",
+      "img-src 'self'",
+      `style-src 'sha256-${hash}'`,
+      "script-src 'none'",
+      "object-src 'none'",
+      "base-uri 'none'",
+      "form-action 'none'",
+      "frame-ancestors 'none'",
+      "upgrade-insecure-requests",
+    ].join("; ");
+  }
+  return policyText;
+}
+
+async function withHeaders(response, extra) {
+  const headers = new Headers(response.headers);
+  headers.set("content-security-policy", await policy());
+  headers.set("x-content-type-options", "nosniff");
+  headers.set("referrer-policy", "strict-origin-when-cross-origin");
+  headers.set("permissions-policy", "interest-cohort=()");
+  for (const [name, value] of Object.entries(extra ?? {})) {
+    headers.set(name, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/** Where a path goes when the apex does not answer it itself. */
+function docsRedirect(url) {
+  return new Response(null, {
+    status: 308,
+    headers: {
+      location: `${DOCS_ORIGIN}${url.pathname}${url.search}`,
+      "cache-control": "public, max-age=3600",
+    },
+  });
+}
 
 export default {
-  fetch(request) {
+  async fetch(request, env) {
     const url = new URL(request.url);
-    url.hostname = DOCS_HOST;
-    return Response.redirect(url.toString(), 308);
+
+    // `www` is the apex, one hop away. Before anything else, because a `www`
+    // request for `/` should reach the canonical origin rather than a second
+    // copy of the page served under a second name.
+    if (url.hostname.startsWith("www.")) {
+      return withHeaders(
+        new Response(null, {
+          status: 308,
+          headers: {
+            location: `https://${url.hostname.slice("www.".length)}${url.pathname}${url.search}`,
+            "cache-control": "public, max-age=3600",
+          },
+        }),
+      );
+    }
+
+    const readOnly = request.method === "GET" || request.method === "HEAD";
+
+    if (url.pathname === "/") {
+      if (!readOnly) {
+        return withHeaders(
+          new Response("method not allowed\n", {
+            status: 405,
+            headers: { "content-type": "text/plain; charset=utf-8", allow: "GET, HEAD" },
+          }),
+        );
+      }
+      return withHeaders(
+        new Response(PAGE, {
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+            "cache-control": "public, max-age=300",
+          },
+        }),
+      );
+    }
+
+    if (url.pathname === "/robots.txt" && readOnly) {
+      return withHeaders(
+        new Response(ROBOTS, {
+          headers: {
+            "content-type": "text/plain; charset=utf-8",
+            "cache-control": "public, max-age=3600",
+          },
+        }),
+      );
+    }
+
+    // `/brand/<name>` is the repository's `brand/` directory, one level up in
+    // the URL because that is the path the documentation site publishes it at
+    // and the path everything already written points to. A name that is not
+    // there — and every path when there is no `ASSETS` binding at all — falls
+    // through to the redirect, which is what answered it before.
+    if (url.pathname.startsWith("/brand/") && readOnly && env?.ASSETS != null) {
+      const asset = new URL(url);
+      asset.pathname = url.pathname.slice("/brand".length);
+      asset.search = "";
+      const response = await env.ASSETS.fetch(new Request(asset, { method: "GET" }));
+      if (response.status === 200) {
+        return withHeaders(response, { "cache-control": "public, max-age=3600" });
+      }
+    }
+
+    return withHeaders(docsRedirect(url));
   },
 };

--- a/infra/cloudflare/wrangler.root.jsonc
+++ b/infra/cloudflare/wrangler.root.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://unpkg.com/wrangler@4.128.0/config-schema.json",
+  "name": "uf-root",
+  "main": "workers/root.js",
+  "compatibility_date": "2026-09-02",
+  "workers_dev": false,
+  "preview_urls": false,
+  // The repository's `brand/` directory, served under `/brand/` by the worker.
+  // Not a copy: `tools/docs/build.sh` stages the same files into the docs
+  // site's public directory, and a third copy here would be a third thing to
+  // keep in step. The worker strips the `/brand` prefix before it asks.
+  //
+  // `run_worker_first` is `true` because the worker decides every path — the
+  // asset router would otherwise answer `/README.md` and `/og.html` out of this
+  // directory under names nothing links to, ahead of the redirect that is
+  // supposed to answer them.
+  "assets": {
+    "directory": "../../brand",
+    "binding": "ASSETS",
+    "run_worker_first": true
+  }
+}

--- a/tools/ci/apex-routes.sh
+++ b/tools/ci/apex-routes.sh
@@ -1,0 +1,502 @@
+#!/bin/sh
+# What `uniflowed.dev` answers, checked by asking it.
+#
+# The apex worker used to be nine lines: every path 308'd to the documentation
+# host, so there was one behaviour and nothing to get wrong. Now `/` is a page,
+# `/robots.txt` is a file, `/brand/*` comes out of the repository's `brand/`
+# directory, and everything else still redirects — and "everything else still
+# redirects" is a promise about paths nobody in this repository can enumerate.
+# Links to `uniflowed.dev/guide`, `uniflowed.dev/og.png` and
+# `uniflowed.dev/sitemap.xml` are in issues, in other people's blog posts, and
+# in the address bars of anyone who bookmarked one. A landing page that quietly
+# turned those into 404s would look perfect on the screen of the person who
+# added it.
+#
+# So this is the check, and — the same argument `tools/ci/docs-csp.sh` makes for
+# response headers — it is deliberately not a grep. It imports
+# `infra/cloudflare/workers/root.js`, calls its `fetch` with an `ASSETS` binding
+# over `brand/`, and reads the answers. `security-scan.sh` said it first:
+# *"asserting their behaviour by reading their source would be asserting the
+# text of a file and calling it a server."*
+#
+# Five things it will not let go quiet.
+#
+# ## 1. The apex is a page
+#
+# `/` must answer `200 text/html` with the install command in it, a `<title>`,
+# a `lang`, a viewport, a skip link and the element it skips to. The old worker
+# failed every one of those, which is the point: this check is red on the
+# commit before the one that added the page.
+#
+# ## 2. Every path that resolved still resolves
+#
+# A table of the paths that are actually written down somewhere — `/guide`,
+# `/og.png`, `/brand/uf.png`, `/sitemap.xml`, a reference page, a query string,
+# and a path nobody has ever used — and each must come back either as something
+# the apex serves itself or as a 308 to the *same* path on the documentation
+# host. A redirect that drops the query string or rewrites the path is a link
+# that resolves to the wrong page, which is worse than one that 404s.
+#
+# The fallthrough is also checked with no `ASSETS` binding at all, because
+# compatibility must not depend on a binding being configured: a worker deployed
+# without one should still redirect `/brand/uf.png` rather than 404 it.
+#
+# ## 3. `www` reaches the apex, and stops
+#
+# One hop to the canonical origin, never to another `www` URL. A redirect loop
+# on the front door is a site that is down.
+#
+# ## 4. The page loads only what it can serve
+#
+# Every `src` and `href` in the markup that is a *load* rather than a navigation
+# must be same-origin, and must actually be answered `200` by this same worker.
+# `img-src 'self'` is the whole policy for them, so an off-origin one is a
+# broken image on a page whose own header forbids it — and a same-origin one
+# naming a file that is not in `brand/` is a broken image with no error anywhere.
+#
+# ## 5. The policy is a policy about *this* page
+#
+# `style-src` names a sha256, and the digest is recomputed here from the
+# `<style>` the page actually returned. A hash that has gone stale is a
+# completely unstyled front door, which is why the worker derives it at runtime
+# rather than carrying a literal — this asserts that it still does. The page
+# must contain no `<script>` at all and the policy must say `script-src 'none'`,
+# which together are the reason there is no inline-script exemption here of the
+# kind the documentation site needs.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+worker="infra/cloudflare/workers/root.js"
+brand="brand"
+
+usage() {
+  cat <<'USAGE'
+usage: apex-routes.sh [--worker FILE] [--brand DIR]
+
+  --worker FILE   the worker whose handler to drive
+                  (default: infra/cloudflare/workers/root.js)
+  --brand DIR     the directory its `ASSETS` binding answers from
+                  (default: brand)
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --worker) shift; worker="${1:-}" ;;
+    --worker=*) worker="${1#--worker=}" ;;
+    --brand) shift; brand="${1:-}" ;;
+    --brand=*) brand="${1#--brand=}" ;;
+    -h | --help) usage; exit 0 ;;
+    *)
+      printf 'apex-routes: unknown argument `%s`\n\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ ! -f "$worker" ]; then
+  printf 'apex-routes: no worker at `%s`\n' "$worker" >&2
+  exit 1
+fi
+
+if [ ! -d "$brand" ]; then
+  printf 'apex-routes: `%s` does not exist, and it is what the `ASSETS` binding\n' "$brand" >&2
+  printf 'answers from. Pass `--brand DIR` for a directory somewhere else.\n' >&2
+  exit 1
+fi
+
+UF_APEX_WORKER="$worker" UF_APEX_BRAND="$brand" node - <<'NODE'
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const workerFile = process.env.UF_APEX_WORKER;
+const brand = process.env.UF_APEX_BRAND;
+
+const APEX = "https://uniflowed.dev";
+const WWW = "https://www.uniflowed.dev";
+const DOCS = "https://docs.uniflowed.dev";
+
+const findings = [];
+function finding(where, message) {
+  findings.push({ where, message });
+}
+
+/**
+ * The `ASSETS` binding, over `brand/`.
+ *
+ * One line of Cloudflare's documentation is the whole contract: it answers a
+ * `Request` with a `Response`, and `404` where there is no such asset. No
+ * `html_handling` and no `not_found_handling` here, because the worker's
+ * config asks for neither — it strips its own prefix and asks for one file.
+ */
+const TYPES = {
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+};
+
+function assetsBinding(root) {
+  return {
+    fetch: async (request) => {
+      const { pathname } = new URL(request.url);
+      const file = path.join(root, pathname);
+      // A path that climbs out of the directory is not an asset, and the
+      // platform would not answer it either.
+      if (!path.resolve(file).startsWith(path.resolve(root) + path.sep)) {
+        return new Response("not found", { status: 404 });
+      }
+      if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response(fs.readFileSync(file), {
+        headers: { "content-type": TYPES[path.extname(file)] ?? "application/octet-stream" },
+      });
+    },
+  };
+}
+
+/** A directive's values, from a policy string. */
+function directive(policy, name) {
+  for (const part of policy.split(";")) {
+    const words = part.trim().split(/\s+/).filter(Boolean);
+    if (words[0] === name) {
+      return words.slice(1);
+    }
+  }
+  return null;
+}
+
+/**
+ * Every URL the page *loads*, which is not every URL it names.
+ *
+ * An `<a href>` is a navigation and is left alone — the page links to the
+ * documentation host on purpose, and `default-src` has no opinion about where
+ * a person clicks to.
+ */
+function subresources(html) {
+  const found = [];
+  for (const match of html.matchAll(/<(script|link|img|source|iframe|embed|object)\b([^>]*)>/gi)) {
+    const [, tag, attributes] = match;
+    if (tag.toLowerCase() === "link" && /rel="(canonical|alternate|author)"/i.test(attributes)) {
+      continue;
+    }
+    for (const attribute of ["src", "href", "data", "srcset"]) {
+      const value = attributes.match(new RegExp(`\\s${attribute}="([^"]*)"`, "i"));
+      if (value == null) continue;
+      for (const candidate of value[1].split(",")) {
+        const url = candidate.trim().split(/\s+/)[0];
+        if (url !== "") found.push({ tag: tag.toLowerCase(), attribute, url });
+      }
+    }
+  }
+  return found;
+}
+
+async function main() {
+  const module = await import(pathToFileURL(path.resolve(workerFile)).href);
+  const handler = module.default;
+  if (handler == null || typeof handler.fetch !== "function") {
+    console.error(`apex-routes: \`${workerFile}\` has no default export with a \`fetch\``);
+    process.exit(2);
+  }
+
+  const env = { ASSETS: assetsBinding(brand) };
+  const ask = (url, init) => handler.fetch(new Request(url, init), env, { waitUntil: () => {} });
+  const askBare = (url, init) =>
+    handler.fetch(new Request(url, init), {}, { waitUntil: () => {} });
+
+  // 1. The apex is a page.
+  const home = await ask(`${APEX}/`);
+  let html = "";
+  if (home.status !== 200) {
+    finding(
+      `${workerFile} /`,
+      `answered ${home.status} and the apex is supposed to be a page. A domain that ` +
+        "bounces its own front door into the middle of the manual is the thing this " +
+        "worker was changed to stop doing",
+    );
+  } else {
+    const type = home.headers.get("content-type") ?? "";
+    if (!type.startsWith("text/html")) {
+      finding(`${workerFile} /`, `answered \`content-type: ${type}\`, and a page is text/html`);
+    }
+    html = await home.text();
+    const required = [
+      ["<html lang=", "a `lang` on the root element, which is what a screen reader reads it in"],
+      ["<title>", "a `<title>`"],
+      ['name="viewport"', "a viewport meta, without which it renders at desktop width on a phone"],
+      ['class="skip"', "a skip link, which is the first thing a keyboard reaches"],
+      ['id="content"', "the element the skip link skips to"],
+      ["curl -fsSL https://setup.uniflowed.dev | sh", "the install command"],
+      ["0.0.0-alpha", "the version, which is the one fact that decides whether to install it"],
+      ["prefers-color-scheme: dark", "a dark scheme"],
+    ];
+    for (const [needle, what] of required) {
+      if (!html.includes(needle)) {
+        finding(`${workerFile} /`, `the page has no ${what} (looked for \`${needle}\`)`);
+      }
+    }
+  }
+
+  // A page is a GET. Anything else is answered rather than redirected onward.
+  const posted = await ask(`${APEX}/`, { method: "POST" });
+  if (posted.status !== 405 || posted.headers.get("allow") == null) {
+    finding(
+      `${workerFile} POST /`,
+      `answered ${posted.status} with \`allow: ${posted.headers.get("allow")}\`, and a page ` +
+        "that is only ever read should say so",
+    );
+  }
+
+  // 2. Every path that resolved still resolves.
+  //
+  // `serve` is a path the apex answers itself; `docs` is one it hands on, and
+  // the target has to be the same path on the documentation host — a redirect
+  // that rewrites the path resolves to the wrong page.
+  const ROUTES = [
+    ["/robots.txt", "serve", "written here rather than borrowed from another host"],
+    ["/brand/uf.png", "serve", "the source mark, out of `brand/`"],
+    ["/brand/uniflowed-mark.svg", "serve", "the mark the page and the manual both use"],
+    ["/brand/og.png", "serve", "the share card"],
+    ["/brand/favicon.svg", "serve", "the icon"],
+    ["/brand/tokens.css", "serve", "the design tokens, which examples link to"],
+    ["/guide", "docs", "linked from the README and from issues"],
+    ["/guide/install", "docs", "the install page"],
+    ["/guide/scope", "docs", "what uf does not do"],
+    ["/reference/cli", "docs", "the command reference"],
+    ["/og.png", "docs", "an older share-card path"],
+    ["/sitemap.xml", "docs", "the sitemap, which is a crawler's entry point"],
+    ["/setup", "docs", "the documentation site's own redirect to the installer"],
+    ["/brand/not-a-file.png", "docs", "a brand name that is not in the directory"],
+    ["/nothing/here", "docs", "a path nobody has ever used, which is the default"],
+    ["/guide?from=readme", "docs", "a path with a query string, which has to survive"],
+  ];
+
+  for (const [route, kind, why] of ROUTES) {
+    const response = await ask(`${APEX}${route}`);
+    if (kind === "serve") {
+      if (response.status !== 200) {
+        finding(
+          `${workerFile} ${route}`,
+          `answered ${response.status}, and this path is ${why}. It resolved before this ` +
+            "worker served anything itself, so it has to resolve now",
+        );
+      }
+      continue;
+    }
+    if (response.status !== 308) {
+      finding(
+        `${workerFile} ${route}`,
+        `answered ${response.status} rather than a 308 to the documentation host, and ` +
+          `this path is ${why}`,
+      );
+      continue;
+    }
+    const location = response.headers.get("location");
+    const wanted = `${DOCS}${route}`;
+    if (location !== wanted) {
+      finding(
+        `${workerFile} ${route}`,
+        `redirects to \`${location}\` and the path it was asked for is \`${route}\`. ` +
+          `Wanted \`${wanted}\` — a redirect that rewrites the path resolves to the wrong page`,
+      );
+    }
+  }
+
+  // And the same fallthrough with no binding configured at all. Compatibility
+  // is not allowed to depend on a deployment detail.
+  for (const route of ["/brand/uf.png", "/guide", "/sitemap.xml"]) {
+    const response = await askBare(`${APEX}${route}`);
+    if (response.status !== 308 || response.headers.get("location") !== `${DOCS}${route}`) {
+      finding(
+        `${workerFile} ${route} (no ASSETS binding)`,
+        `answered ${response.status} → \`${response.headers.get("location")}\`. A worker ` +
+          "deployed without its assets should still hand every path to the documentation " +
+          "host, which is what it did before it had any",
+      );
+    }
+  }
+
+  // 3. `www` reaches the apex, and stops.
+  for (const route of ["/", "/guide", "/brand/uf.png"]) {
+    const response = await ask(`${WWW}${route}`);
+    const location = response.headers.get("location");
+    if (response.status < 300 || response.status >= 400 || location == null) {
+      finding(
+        `${workerFile} www${route}`,
+        `answered ${response.status}. \`www\` is the apex one hop away, not a second copy ` +
+          "of it under a second name",
+      );
+      continue;
+    }
+    if (location !== `${APEX}${route}`) {
+      finding(
+        `${workerFile} www${route}`,
+        `redirects to \`${location}\`, wanted \`${APEX}${route}\``,
+      );
+    }
+    if (new URL(location).hostname.startsWith("www.")) {
+      finding(`${workerFile} www${route}`, `redirects to \`${location}\`, which is a loop`);
+    }
+  }
+
+  // 4. The headers, on every branch there is.
+  const REQUIRED = {
+    "content-security-policy": null,
+    "x-content-type-options": "nosniff",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "permissions-policy": "interest-cohort=()",
+  };
+  let policy = null;
+  for (const url of [`${APEX}/`, `${APEX}/robots.txt`, `${APEX}/brand/uf.png`, `${APEX}/guide`, `${WWW}/`]) {
+    const response = await ask(url);
+    for (const [name, expected] of Object.entries(REQUIRED)) {
+      const sent = response.headers.get(name);
+      if (sent == null || sent === "") {
+        finding(`${workerFile} ${url}`, `sent no \`${name}\``);
+        continue;
+      }
+      if (expected != null && sent !== expected) {
+        finding(`${workerFile} ${url}`, `sent \`${name}: ${sent}\`, wanted \`${expected}\``);
+      }
+    }
+    const sent = response.headers.get("content-security-policy");
+    if (sent != null && policy != null && sent !== policy) {
+      finding(
+        `${workerFile} ${url}`,
+        "sent a different policy from the one it sent for `/`. One origin, one policy",
+      );
+    }
+    policy ??= sent;
+  }
+
+  // 5. The policy is a policy about this page.
+  if (policy == null) {
+    finding(workerFile, "sent no `content-security-policy` at all");
+  } else if (html !== "") {
+    for (const name of ["default-src", "script-src", "object-src", "base-uri", "form-action", "frame-ancestors"]) {
+      const values = directive(policy, name);
+      if (values == null || values.join(" ") !== "'none'") {
+        finding(
+          workerFile,
+          `\`${name}\` is ${values == null ? "absent" : `\`${values.join(" ")}\``}. This page ` +
+            "has no script, no plugin, no `<base>`, no form and nothing to frame, so every " +
+            "one of these costs nothing and closes a class",
+        );
+      }
+    }
+    if (directive(policy, "img-src")?.join(" ") !== "'self'") {
+      finding(
+        workerFile,
+        "`img-src` is not `'self'`. The mark is served from this origin so that it does not " +
+          "have to be anything else",
+      );
+    }
+
+    const styleSrc = directive(policy, "style-src") ?? [];
+    if (styleSrc.includes("'unsafe-inline'")) {
+      finding(
+        workerFile,
+        "`style-src` holds `'unsafe-inline'`. The page has one `<style>` and its bytes are " +
+          "a constant in the worker, so it can be named by its hash",
+      );
+    }
+
+    // The digest, recomputed from what came back. This is the one that catches
+    // a stylesheet edited without the policy following it — which on this page
+    // is not a subtle degradation, it is the front door with no styles at all.
+    const open = html.indexOf("<style>");
+    const close = html.indexOf("</style>");
+    if (open === -1 || close === -1) {
+      finding(`${workerFile} /`, "the page has no `<style>`, and its stylesheet is inline");
+    } else {
+      const css = html.slice(open + "<style>".length, close);
+      const hash = `'sha256-${crypto.createHash("sha256").update(css, "utf8").digest("base64")}'`;
+      if (!styleSrc.includes(hash)) {
+        finding(
+          `${workerFile} /`,
+          "`style-src` does not name the hash of the `<style>` the page returned, so a " +
+            `browser would drop it and serve the front door unstyled. It is:\n             ${hash}`,
+        );
+      }
+    }
+
+    if (/<script[\s>]/i.test(html)) {
+      finding(
+        `${workerFile} /`,
+        "the page has a `<script>` and the policy says `script-src 'none'`, so it would not " +
+          "run. The documentation site needs an inline script for its theme toggle; this " +
+          "page has no toggle and no other reason for one",
+      );
+    }
+  }
+
+  // 6. Everything the page loads, it can serve.
+  let loads = 0;
+  for (const { tag, attribute, url } of subresources(html)) {
+    let resolved;
+    try {
+      resolved = new URL(url, `${APEX}/`);
+    } catch {
+      finding(`${workerFile} /`, `a <${tag} ${attribute}> names \`${url}\`, which is not a URL`);
+      continue;
+    }
+    if (resolved.origin !== APEX) {
+      finding(
+        `${workerFile} /`,
+        `a <${tag} ${attribute}> loads \`${url}\` from \`${resolved.origin}\`, and the policy ` +
+          "is `img-src 'self'` under `default-src 'none'`. The browser would block it",
+      );
+      continue;
+    }
+    loads += 1;
+    const response = await ask(resolved.toString());
+    if (response.status !== 200) {
+      finding(
+        `${workerFile} /`,
+        `a <${tag} ${attribute}> loads \`${url}\` and this worker answers it ${response.status}. ` +
+          `Nothing in \`${brand}/\` is at that name`,
+      );
+    }
+  }
+
+  console.log(`apex-routes: ${workerFile}`);
+  console.log(
+    `  ${ROUTES.length} routes, ${loads} subresources, ` +
+      `${Object.keys(REQUIRED).length} headers on 5 paths, ${html.length} bytes of page`,
+  );
+
+  if (findings.length === 0) {
+    console.log("apex-routes: ok");
+    return;
+  }
+  console.error("");
+  for (const item of findings) {
+    console.error(`  finding    ${item.where}`);
+    console.error(`             ${item.message}`);
+  }
+  console.error(
+    `\n${findings.length} finding(s). The apex serves a page and hands every other path to\n` +
+      "the documentation host; a link that resolved yesterday has to resolve today, and\n" +
+      "the page has to load only what this same worker can answer.",
+  );
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(`apex-routes: ${error?.stack ?? String(error)}`);
+  process.exit(2);
+});
+NODE

--- a/tools/ci/test-apex-routes.sh
+++ b/tools/ci/test-apex-routes.sh
@@ -1,0 +1,223 @@
+#!/bin/sh
+# `apex-routes.sh` against workers it can safely make wrong.
+#
+# A check on a redirect table is only worth the job it runs in if it fails when
+# the table is wrong, and the failure mode of one that does not is silence:
+# every deploy is green and somebody else finds the 404, months later, from a
+# link in an issue.
+#
+# So each rule is planted here as the defect it is meant to catch. The planted
+# workers are wrappers: each one imports the real worker, takes its answer, and
+# breaks exactly one thing about it. That is deliberate — a hand-written stub
+# would drift away from the real handler and end up testing a worker nobody
+# deploys, and the interesting failures here are all *one* change away from
+# correct. A worker that drops the query string from a redirect is otherwise
+# perfect, which is exactly why nobody notices it.
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root"
+
+script="$repo_root/tools/ci/apex-routes.sh"
+real="$repo_root/infra/cloudflare/workers/root.js"
+brand="$repo_root/brand"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/uf-test-apex-routes.XXXXXX")"
+trap 'rm -rf "$work"' EXIT INT TERM
+
+fail() {
+  echo "test-apex-routes: FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok  $*"
+}
+
+# A wrapper around the real worker, with `__REAL__` replaced by its path. The
+# body arrives on stdin and runs with `response` and `request` in scope; what it
+# returns is what the planted worker answers.
+plant() {
+  name="$1"
+  cat > "$work/$name.js" <<PLANT
+import real from "__REAL__";
+
+export default {
+  async fetch(request, env, ctx) {
+    const response = await real.fetch(request, env, ctx);
+    return await (async () => {
+$(cat)
+    })();
+  },
+};
+PLANT
+  # `sed` rather than interpolating the path into the heredoc: a repository
+  # checked out under a directory whose name holds a backslash would otherwise
+  # write a string literal that does not parse.
+  sed -i.bak "s|__REAL__|file://$real|" "$work/$name.js"
+  rm -f "$work/$name.js.bak"
+}
+
+# The checker must fail on this worker, and its output must say why in a way
+# somebody can act on.
+expect_fail() {
+  name="$1"
+  needle="$2"
+  if "$script" --worker "$work/$name.js" --brand "$brand" > "$work/$name.out" 2>&1; then
+    cat "$work/$name.out" >&2
+    fail "$name passed and it is broken"
+  fi
+  if ! grep -q -- "$needle" "$work/$name.out"; then
+    cat "$work/$name.out" >&2
+    fail "$name failed, but nothing in the output said \`$needle\`"
+  fi
+  pass "$name"
+}
+
+# --- The worker that is deployed ------------------------------------------
+#
+# First, so that a failure below is a statement about the planted defect rather
+# than about the repository being red already.
+if ! "$script" > "$work/real.out" 2>&1; then
+  cat "$work/real.out" >&2
+  fail "the real worker does not pass its own check"
+fi
+pass "the deployed worker passes"
+
+# --- 1. The apex stops being a page ---------------------------------------
+#
+# The nine-line worker this replaced. Somebody who types the domain lands in
+# the middle of the manual, and every fact on the front door goes with it.
+plant front-door <<'CASE'
+const url = new URL(request.url);
+if (url.pathname === "/") {
+  return new Response(null, { status: 308, headers: { location: "https://docs.uniflowed.dev/" } });
+}
+return response;
+CASE
+expect_fail front-door "the apex is supposed to be a page"
+
+# --- 2. A redirect that drops the query string ----------------------------
+#
+# `?from=readme` is how somebody finds out where a visitor came from, and a
+# campaign link that silently loses it looks like it worked.
+plant drops-the-query <<'CASE'
+const location = response.headers.get("location");
+if (location == null) return response;
+const target = new URL(location);
+target.search = "";
+const headers = new Headers(response.headers);
+headers.set("location", target.toString());
+return new Response(null, { status: response.status, headers });
+CASE
+expect_fail drops-the-query "a redirect that rewrites the path resolves to the wrong page"
+
+# --- 3. A redirect that rewrites the path ---------------------------------
+#
+# The worst of the three, because every link resolves — to the documentation
+# home page, whatever it was for.
+plant rewrites-the-path <<'CASE'
+if (response.headers.get("location") == null) return response;
+const headers = new Headers(response.headers);
+headers.set("location", "https://docs.uniflowed.dev/");
+return new Response(null, { status: response.status, headers });
+CASE
+expect_fail rewrites-the-path "a redirect that rewrites the path resolves to the wrong page"
+
+# --- 4. The fallthrough stops falling through -----------------------------
+#
+# What an apex that serves a landing page and forgets it used to serve a whole
+# manual looks like from outside.
+plant no-fallthrough <<'CASE'
+const url = new URL(request.url);
+if (response.status === 308 && !url.hostname.startsWith("www.")) {
+  return new Response("not found\n", { status: 404 });
+}
+return response;
+CASE
+expect_fail no-fallthrough "rather than a 308 to the documentation host"
+
+# --- 5. `www` redirects to itself -----------------------------------------
+#
+# A loop on the front door is a site that is down, and it is one character away
+# from the line that is there.
+plant www-loop <<'CASE'
+const url = new URL(request.url);
+if (!url.hostname.startsWith("www.")) return response;
+const headers = new Headers(response.headers);
+headers.set("location", "https://www.uniflowed.dev" + url.pathname);
+return new Response(null, { status: 308, headers });
+CASE
+expect_fail www-loop "which is a loop"
+
+# --- 6. The page reaches off its own origin -------------------------------
+#
+# `default-src 'none'` with `img-src 'self'` means the browser blocks it and
+# nothing on the server says a word.
+plant off-origin-image <<'CASE'
+if (!(response.headers.get("content-type") ?? "").startsWith("text/html")) return response;
+const html = (await response.text()).replace(
+  "/brand/uniflowed-mark.svg",
+  "https://cdn.example.invalid/mark.svg",
+);
+return new Response(html, { status: response.status, headers: response.headers });
+CASE
+expect_fail off-origin-image "The browser would block it"
+
+# --- 7. The page loads a file that is not in `brand/` ---------------------
+#
+# Same-origin, allowed by the policy, and a broken image. This is the one a
+# rename produces.
+plant missing-image <<'CASE'
+if (!(response.headers.get("content-type") ?? "").startsWith("text/html")) return response;
+const html = (await response.text()).replace("/brand/uniflowed-mark.svg", "/brand/no-such-mark.svg");
+return new Response(html, { status: response.status, headers: response.headers });
+CASE
+expect_fail missing-image "is at that name"
+
+# --- 8. The stylesheet drifts away from its own hash ----------------------
+#
+# The worker derives the hash from the stylesheet at runtime so that this
+# cannot happen. If somebody ever replaces that with a literal, the failure is
+# the front door with no styles at all — so the check recomputes rather than
+# trusts.
+plant stale-style-hash <<'CASE'
+if (!(response.headers.get("content-type") ?? "").startsWith("text/html")) return response;
+const html = (await response.text()).replace("<style>", "<style>/* one more rule */");
+return new Response(html, { status: response.status, headers: response.headers });
+CASE
+expect_fail stale-style-hash "serve the front door unstyled"
+
+# --- 9. A script appears on a page whose policy forbids one ---------------
+plant a-script <<'CASE'
+if (!(response.headers.get("content-type") ?? "").startsWith("text/html")) return response;
+const html = (await response.text()).replace("</body>", "<script>void 0;</script></body>");
+return new Response(html, { status: response.status, headers: response.headers });
+CASE
+expect_fail a-script "so it would not run"
+
+# --- 10. The response headers go away on one branch -----------------------
+#
+# One branch, not all of them: a check that only looks at `/` is a check that
+# lets the redirect rot.
+plant headers-on-one-branch <<'CASE'
+if (response.status !== 308) return response;
+const headers = new Headers(response.headers);
+headers.delete("content-security-policy");
+headers.delete("referrer-policy");
+return new Response(null, { status: response.status, headers });
+CASE
+expect_fail headers-on-one-branch "sent no \`content-security-policy\`"
+
+# --- 11. The policy opens back up -----------------------------------------
+plant unsafe-inline <<'CASE'
+const headers = new Headers(response.headers);
+const policy = headers.get("content-security-policy");
+if (policy != null) {
+  headers.set("content-security-policy", policy.replace(/style-src [^;]*/, "style-src 'unsafe-inline'"));
+}
+return new Response(response.body, { status: response.status, headers });
+CASE
+expect_fail unsafe-inline "it can be named by its hash"
+
+echo "test-apex-routes: ok"

--- a/uf.config.js
+++ b/uf.config.js
@@ -606,6 +606,40 @@ export default defineConfig({
       // prints. Two files, and nothing else.
       inputs: ["infra/cloudflare/setup-assets/install.sh", "tools/ci/install-banner-fits.sh"],
     },
+    // And what `uniflowed.dev` answers. The apex used to be nine lines with one
+    // behaviour — every path 308'd to the documentation host — and now it is a
+    // landing page, a `robots.txt`, the `brand/` directory, and that same
+    // redirect for everything else. The redirect is the part worth pinning: it
+    // is a promise about `uniflowed.dev/guide`, `/og.png` and `/sitemap.xml`,
+    // which are written down in issues and in other people's pages and which
+    // nobody here can enumerate. A landing page that turned them into 404s
+    // would look perfect to whoever added it.
+    //
+    // Same shape as `docs:csp`, and the same argument for it: it imports the
+    // worker and calls its `fetch` rather than reading its source, because
+    // reading the source would be asserting the text of a file and calling it
+    // a server. Unlike `docs:csp` it needs no built site — the only assets it
+    // serves are in `brand/`, which is checked in — so it belongs here with the
+    // repository checks rather than under `docs:verify`.
+    "apex:routes": {
+      command: "tools/ci/apex-routes.sh",
+      // The worker, the directory its `ASSETS` binding answers from, and the
+      // check itself.
+      inputs: ["infra/cloudflare/workers/root.js", "brand/**", "tools/ci/apex-routes.sh"],
+    },
+    // And that the check still catches each way the apex can go wrong. Every
+    // case it covers is one change away from correct — a redirect that drops
+    // the query string is otherwise perfect — which is exactly the kind of
+    // defect a check has to be shown to catch rather than assumed to.
+    "apex:routes:test": {
+      command: "tools/ci/test-apex-routes.sh",
+      inputs: [
+        "infra/cloudflare/workers/root.js",
+        "brand/**",
+        "tools/ci/apex-routes.sh",
+        "tools/ci/test-apex-routes.sh",
+      ],
+    },
     "scripts:parse": {
       command: "tools/ci/scripts-parse.sh",
       // `git ls-files '*.sh'` minus `upstream/`, which is every tracked shell
@@ -752,6 +786,8 @@ export default defineConfig({
         "lockfile:test",
         "upstream:patches:test",
         "install:banner",
+        "apex:routes",
+        "apex:routes:test",
         "scripts:parse",
         "scripts:parse:test",
         "integrations",


### PR DESCRIPTION
## What this is

`infra/cloudflare/workers/root.js` was nine lines: set `url.hostname` to the
documentation host, return a 308. Somebody who typed `uniflowed.dev` landed
halfway down the manual with no idea what uf is or whether they should install
it. The zone does real work — `setup.` is what `curl … | sh` resolves,
`releases.` holds the archives — and the apex was the one hostname with nothing
behind it.

Now `/` is a page, and **every other path still 308s to `docs.uniflowed.dev`,
unchanged**.

## What the page says

One sentence about what uf is, the install command in the first screen, and
then one section on the thing the manual only has room for a two-line notice
about:

> **Before you spend an afternoon on it** — uf is `0.0.0-alpha`. It installs in
> seconds and scaffolds a project that builds, and it changes under you.

with four rows, each linking to the page that backs it: nothing is stable
(no version promises compatibility with the one before it), every gap has an
issue number, it does not check your types and is not a bundler, and it knows
how this shape fails (`docs/red-lines.md`). Plus: macOS and Linux only, there
is no Windows build, and the installer is readable at
`setup.uniflowed.dev/install.sh` before you run it.

It deliberately does **not** restate the documentation home page — the five
claims and the pasted `uf build` run stay there — and it carries no version
number smaller than `0.0.0-alpha`, because the README's rough-edges list is
scoped to a release on purpose and a copy here would be a second thing to keep
true on a different deploy schedule.

## How it is built

- Design is `docs/app/_design/seam.css` and `brand/tokens.css`, not a second
  visual language: warm paper, the seam with the brand spectrum over its first
  9rem and nothing else decorated, rules instead of cards, no radius, no
  shadow, no transition.
- One document, 14 KB, stylesheet inline. No script, no webfont, no CDN, no
  build step. The only subresources are files already in `brand/`.
- Dark mode is `prefers-color-scheme` alone. The manual honours a `data-theme`
  attribute because it has a toggle; this page has none, so the attribute would
  be a selector nothing can match — and that is also why it can ship
  `script-src 'none'`.
- `style-src` names the sha256 of the stylesheet, **derived at first request**
  rather than written down, so the policy and the CSS cannot drift into a front
  door served with no styles.
- `/brand/*` is served from the repository's `brand/` directory, bound as
  `ASSETS` and read in place rather than copied, which is what keeps the mark
  same-origin under `img-src 'self'`.

## What must not break, and what pins it

| Path | Before | After |
| --- | --- | --- |
| `/` | 308 → docs | **200, the page** |
| `/robots.txt` | 308 → docs | **200, the apex's own** |
| `/brand/uf.png`, `/brand/og.png`, `/brand/favicon.svg`, `/brand/tokens.css`, … | 308 → docs | **200, from `brand/`** |
| `/guide`, `/guide/install`, `/reference/cli`, `/og.png`, `/sitemap.xml`, `/setup`, anything else | 308 → docs, same path | **unchanged** |
| `/guide?from=readme` | query preserved | **unchanged** |
| `/brand/<not a file>` | 308 → docs | **308 → docs** |
| `www.<path>` | 308 → docs | 308 → **apex**, same path |

The fallthrough is the default rather than a list, because links to
`uniflowed.dev/guide` and `/og.png` live in issues and in other people's pages
and nobody here can enumerate them.

`tools/ci/apex-routes.sh` imports the worker and calls its `fetch` with an
`ASSETS` binding over `brand/` — the same shape as `tools/ci/docs-csp.sh`, and
the same argument: reading the source would be asserting the text of a file and
calling it a server. It fails when `/` stops being a page, when a redirect
rewrites the path or loses the query, when `www` loops, when the page loads
something this worker cannot answer, or when the style hash goes stale.

**It is red on `main`.** Against the nine-line worker it reports 32 findings:

```
$ tools/ci/apex-routes.sh --worker /tmp/root-old.js
  finding    / answered 308 and the apex is supposed to be a page…
  finding    /robots.txt answered 308…
  finding    www/ redirects to `https://docs.uniflowed.dev/`, wanted `https://uniflowed.dev/`
  …
32 finding(s).
```

`tools/ci/test-apex-routes.sh` plants eleven workers that are each one change
away from correct — a redirect that drops `?from=readme` is otherwise perfect —
and checks that every one is caught. Both run in the `Repository checks` job
and are in `uf run ci`.

## Verified by serving it

`wrangler dev --config infra/cloudflare/wrangler.root.jsonc` worked with no
account and no credentials. Every row of the table above was checked over HTTP
through workerd, and the page was rendered at 1280 and 390 in both colour
schemes: at 390, `scrollWidth === clientWidth === 390` — no horizontal overflow
— with only the `.command` block scrolling inside its own box, which is what
`seam.css` does too. `wrangler deploy --dry-run` reports 17.23 KiB, 5.90 KiB
gzipped, 14 asset files.

## Deploying — nothing here is deployed

`uf-root` is **not** added to the deploy job in `docs.yml`, on purpose: it is
the one Worker whose script `main.tf` owns, and two systems writing one
resource is how a `tofu apply` months later silently reverts a landing page.
`docs.yml` gains a `--dry-run` only.

To ship it, from a checkout, with `CLOUDFLARE_API_TOKEN` set:

```sh
tofu -chdir=infra/cloudflare apply -var account_id=... -var zone_id=...
```

That updates the `uf-root` script and attaches the `brand/` assets; the apex and
`www` custom domains are already declared there. If you would rather not run
Terraform, this deploys the same script and assets without touching DNS:

```sh
npx --yes wrangler@4.128.0 deploy --config infra/cloudflare/wrangler.root.jsonc
```

Pick one and stay with it. Nothing in this PR touches `workers/setup.js`,
`workers/docs.js`, npm publishing, the release workflow, or any version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
