### PR TITLE
perf(check, upstream): the set an SSA normal form costs, once instead of once per node

### DIFF
--- a/crates/uf_check/examples/alloc_report.rs
+++ b/crates/uf_check/examples/alloc_report.rs
@@ -25,7 +25,12 @@
 //! environment is separated from what a module costs to infer. The spans are
 //! uf's own — the vendored port is a submodule and carries none — so the row
 //! that ends up largest is the boundary uf hands work across, not a line
-//! inside inference.
+//! inside inference. That boundary is `check::infer_ast`, the single call into
+//! `flow_typing::type_inference`, and on `packages/router/internal/runtime.js`
+//! it is 89% of every allocation the check makes. What sits on either side of
+//! it inside `check::infer_one` — the parse and the diagnostics — is 2.2%
+//! between them, and the graph, the options and the project modules are 70
+//! allocations for the whole run.
 //!
 //! Debug and release give identical allocation counts — the counter is in the
 //! allocator, not in the optimiser — so this can be run without a release

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -457,9 +457,25 @@ fn check_one(
     source: &Source<'_>,
     modules: &Rc<ProjectModules>,
 ) -> Result<Vec<TypeDiagnostic>, CheckError> {
+    // Three spans inside this one, and they partition it: on
+    // `packages/router/internal/runtime.js` they account for 1,951,920 of the
+    // 1,951,944 allocations `check::infer_one` reads, and the two dozen left
+    // over are this function's own bookkeeping. That is the point of them —
+    // ubugeeei-prod/uf#713 could say the checker spends 91.6% of its
+    // allocations here and not what *here* was, and the answer turned out to be
+    // one call: `check::infer_ast`, 89.4% of the whole check. Everything else
+    // this function does — the parse, the diagnostics, the context, the
+    // signature table — is the remaining 2.2%.
     profile_span!("check::infer_one");
     let file_key = FileKey::new(FileKeyInner::SourceFile(source.path.to_owned()));
-    let parsed = parse::parse_file(file_key.dupe(), source.source, options, false);
+    // The second parse of this file in a cold batch: `ProjectModules::facts`
+    // parsed it too, in the pass that describes the batch before anything is
+    // checked. Spanned so the duplicate has a number — 35,914 allocations on
+    // that module, 1.7% — rather than being an unmeasured line in a comment.
+    let parsed = {
+        profile_span!("check::infer_parse");
+        parse::parse_file(file_key.dupe(), source.source, options, false)
+    };
     if !parsed.is_parseable() {
         // A file that does not parse is broken whatever its docblock says, so
         // it is reported. Whether it also *counts* as checked is
@@ -498,17 +514,27 @@ fn check_one(
 
     let ast::Program { all_comments, .. } = parsed.ast.as_ref();
     let aloc_ast = flow_aloc::loc_to_aloc_ast(parsed.ast.as_ref());
-    type_inference::infer_ast(
-        &lint_severities,
-        &cx,
-        &parsed.file_key,
-        parsed.file_sig.dupe(),
-        &metadata,
-        all_comments,
-        aloc_ast,
-    )
-    .map_err(|error| job_error(source.path, error))?;
+    // The one call, and the only span here that is not uf's own code. It is
+    // where a cold `uf check` spends nine allocations in ten, so it is the row
+    // a reader should reach for first and the one a change to the port has to
+    // move.
+    {
+        profile_span!("check::infer_ast");
+        type_inference::infer_ast(
+            &lint_severities,
+            &cx,
+            &parsed.file_key,
+            parsed.file_sig.dupe(),
+            &metadata,
+            all_comments,
+            aloc_ast,
+        )
+        .map_err(|error| job_error(source.path, error))?;
+    }
 
+    // Suppression filtering and the translation into uf's diagnostics, together
+    // because they are one phase from outside: what the check has to say.
+    profile_span!("check::infer_diagnostics");
     let (errors, warnings) = suppressed(&cx, &parsed, cx.errors(), modules);
     Ok(convert::diagnostics(&errors, &warnings, source.path))
 }

--- a/crates/uf_check/tests/upstream_patch_allocations.rs
+++ b/crates/uf_check/tests/upstream_patch_allocations.rs
@@ -1,0 +1,149 @@
+//! What patch 0003 buys, counted rather than described.
+//!
+//! `tools/upstream/patches/flow/0003-ssa-normal-forms-cost-one-set.patch` is a
+//! performance patch, so its other half cannot be a diagnostic: it changes no
+//! answer, and every test in `upstream_patches.rs`, `typecheck.rs` and the rest
+//! of this directory says so by continuing to pass. What it changes is how many
+//! times the SSA builder allocates to compute a normal form, and the only test
+//! that can fail without it is one that counts.
+//!
+//! # Why this is its own binary
+//!
+//! The counters are in the allocator, so they are process-wide: a second test
+//! running on another thread of the same binary would have its allocations
+//! added to this one's. `uf_profiler::Window` makes measurement *windows*
+//! exclusive, which stops two measurements from rebasing each other's peaks —
+//! it cannot stop a neighbouring test from allocating. One test per binary can.
+//!
+//! ```sh
+//! cargo test -p uf_check --test upstream_patch_allocations
+//! ```
+
+#![cfg(feature = "upstream-typecheck")]
+
+use uf_check::{CheckLimits, Source, check_source};
+use uf_profiler::{AllocSnapshot, CountingAllocator, Window};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator::new();
+
+/// How many `if`/`if`/`while` blocks the module below is made of.
+///
+/// Enough that the per-call cost of forcing a builtin environment — 136,236
+/// allocations, and the same whatever is being checked — is a sixth of the
+/// figure rather than most of it, and small enough that the module checks
+/// twice in a couple of seconds in a debug build.
+const BLOCKS: usize = 80;
+
+/// The ceiling this test defends, in allocations.
+///
+/// What this test itself measures over exactly the module
+/// [`merge_heavy_module`] builds: **810,800** allocations with the patch
+/// reverted, **697,196** with it applied. The same module through
+/// `ubugeeei-prod/uf#678`'s harness — `cargo run --example alloc_report -p
+/// uf_check` — reads 810,137 and 696,533; the few hundred between them are the
+/// test harness's own, inside the window.
+///
+/// The ceiling sits between the two with room on both sides — 8% above what the
+/// patch costs, 7% below what its absence costs — so it is neither a
+/// transcription of today's number nor close enough to the old one to pass by
+/// accident.
+///
+/// It is a ceiling and not an equality on purpose. Anything that makes the
+/// checker allocate less keeps this green; the thing it is here to catch is the
+/// patch going missing, which puts the figure back above it.
+const CEILING: u64 = 750_000;
+
+/// A module whose every statement merges the same four bindings.
+///
+/// The patch is about `Val::normalize`, which turns a PHI — the SSA builder's
+/// word for "this binding was written in more than one place" — into the set of
+/// writes that reach it. So the module is written to make PHIs: three control
+/// flow joins per block, over four bindings that each read what the others
+/// wrote, so the set of writes reaching any one of them grows with the block
+/// count rather than staying at two.
+///
+/// It type checks clean, which the test also asserts. A module that had errors
+/// in it would be measuring the error path.
+fn merge_heavy_module() -> String {
+    let mut source = String::from(concat!(
+        "// @flow\n",
+        "export function fold(n: number): number {\n",
+        "  let a = 0;\n",
+        "  let b = 0;\n",
+        "  let c = 0;\n",
+        "  let d = 0;\n",
+    ));
+    for block in 0..BLOCKS {
+        source.push_str(&format!(
+            "  if (n > {}) {{ a = b; }} else {{ b = a; }}\n",
+            block
+        ));
+        source.push_str(&format!(
+            "  if (n > {}) {{ c = a + b; }} else {{ d = c + a; }}\n",
+            block + 1
+        ));
+        source.push_str(&format!(
+            "  while (n > {}) {{ a = c; c = d; d = b; b = a; }}\n",
+            block + 2
+        ));
+    }
+    source.push_str("  return a + b + c + d;\n}\n");
+    source
+}
+
+fn check(source: &str) -> Vec<uf_check::TypeDiagnostic> {
+    check_source(
+        Source::new("merge_heavy.js", source),
+        &[],
+        // Tests must not race the wall clock; a loaded CI box is not a type
+        // error, and a check that gave up early would allocate less than one
+        // that finished.
+        &CheckLimits::default().without_timeout(),
+    )
+    .expect("the checker runs")
+}
+
+#[test]
+fn a_normal_form_costs_one_set_and_not_one_per_node() {
+    let source = merge_heavy_module();
+
+    // The builtin environment and the master context are memoized for the
+    // process and built on first use. Forcing them here keeps a cost that is
+    // paid once out of a figure that is about this module.
+    let warm = check(&source);
+    assert!(
+        warm.is_empty(),
+        "the module under measurement must type check clean, got {warm:#?}"
+    );
+
+    // Exclusive, so nothing else can rebase the peaks mid-measurement, and
+    // taken before the baseline snapshot for the same reason.
+    let _window = Window::open();
+    CountingAllocator::enable();
+    let before = AllocSnapshot::capture();
+    let diagnostics = check(&source);
+    let after = AllocSnapshot::capture();
+    CountingAllocator::disable();
+
+    assert!(
+        diagnostics.is_empty(),
+        "the module under measurement must type check clean, got {diagnostics:#?}"
+    );
+
+    let delta = after.delta_from(&before);
+    assert!(
+        delta.allocations > 0,
+        "the counting allocator recorded nothing, so this test measured nothing"
+    );
+    assert!(
+        delta.allocations <= CEILING,
+        "checking a {} byte module of {BLOCKS} merge blocks took {} allocations, over the \
+         {CEILING} ceiling. Either `tools/upstream/patches/flow/0003-*.patch` is not applied — \
+         run `tools/upstream/sync.sh` — or something else in the checker started allocating per \
+         node. `cargo run --example alloc_report -p uf_check -- <file> --phases` says which \
+         phase.",
+        source.len(),
+        delta.allocations,
+    );
+}

--- a/crates/uf_check/tests/upstream_patches.rs
+++ b/crates/uf_check/tests/upstream_patches.rs
@@ -87,6 +87,16 @@
 //! Measured against `flow` itself before it was written, the same way 0001
 //! was: `flow-bin@0.330.0` reports `unknown` for every leading `infer` below
 //! through `flow check`, in the same words as an unpatched `uf check`.
+//!
+//! # 0003: an SSA normal form costs one set, not one per node
+//!
+//! ubugeeei-prod/uf#678, and the only patch here whose test is not in this
+//! file. It changes no answer — it is why `uf check` allocates a fifth less to
+//! reach the same one — so there is no diagnostic to assert and nothing to add
+//! below. Every test in this file passing *is* its correctness evidence, and
+//! what would fail without it is a count: `tests/upstream_patch_allocations.rs`,
+//! which is its own binary because the counters are in the allocator and a
+//! neighbouring test's allocations would land in the figure.
 
 #![cfg(feature = "upstream-typecheck")]
 

--- a/tools/upstream/patches/flow/0003-ssa-normal-forms-cost-one-set.patch
+++ b/tools/upstream/patches/flow/0003-ssa-normal-forms-cost-one-set.patch
@@ -1,0 +1,176 @@
+Subject: an SSA normal form costs one set, not one per node
+
+Issue: ubugeeei-prod/uf#678
+Upstream: not filed with facebook/flow yet
+Submodule: 81b0c2a3dd591c66c51167aac341d851932bd9c5
+
+`uf check` allocated 2,130,342 times to type check one 123 KB module, and 89%
+of that was the single call into `flow_typing::type_inference::infer_ast`.
+Sampling the stack at allocation sites put a third of every allocation the
+whole command makes -- not of inference, of `uf check` -- in one function:
+`ssa_builder::val::Val::normalize`, with `Val::join` next at 13%.
+
+`normalize` turns a write state into the set of atomic writes that reach it,
+and it built a fresh `BTreeSet` at every node of the term:
+
+    WriteState::Uninitialized | WriteState::Loc(_) => {
+        let mut set = BTreeSet::new();
+        set.insert(t.dupe());
+        set
+    }
+    ...
+    WriteState::Phi(ts) => ts.iter().flat_map(|t| Self::normalize(t).into_iter()).collect(),
+
+A PHI is a tree of PHIs, so a term of n nodes built n sets -- a singleton at
+every leaf, a union at every branch -- and dropped all of them into the
+parent's, to produce a result with at most n elements in it. Every one of those
+sets is an allocation. `Val::merge`, which is what runs at each control flow
+join for each binding in scope, then built two more and a third for the union.
+
+This threads the destination down instead. `normalize_into(t, atoms)` adds a
+term's atoms to a set the caller owns; `normalize` is the wrapper that starts
+one. A set is still built in the one place a *subterm's* own normal form is
+needed rather than the traversal's -- a resolved REF, whose contents are
+rewritten to the joined form -- and `merge` normalizes both of its terms into
+one set, because a set holding the atoms of both is exactly the union it used
+to build two sets to take. `join` then walks a set rather than a
+`btree_set::Union`, so its `size_hint` is exact and the vector it fills is
+allocated once instead of doubling its way up to the width of the PHI.
+
+The result of every one of these is the same set it was, and the writes back
+into resolved REFs happen in the same order over the same terms, so no
+diagnostic moves. `cargo test -p uf_check` is the evidence: every test over the
+checker, the fixtures and the two patches above this one included, unchanged
+and green.
+
+Its own half is `crates/uf_check/tests/upstream_patch_allocations.rs`, which
+counts rather than compares diagnostics -- a patch that changes no answer
+cannot have a test that reads one.
+
+Measured with `cargo run --example alloc_report -p uf_check`, the harness
+ubugeeei-prod/uf#678 was filed with:
+
+    packages/router/internal/runtime.js, 123,056 bytes
+                        before        after
+    allocations      2,130,342    1,703,582   -20.0%
+    bytes           358.74 MiB   265.71 MiB   -25.9%
+
+    the same module twice (`--batch 2`), so the marginal per-module cost:
+    allocations      1,847,531    1,420,770   -23.1%
+
+It is a stopgap and belongs upstream: nothing here is uf-specific, and Flow's
+own checker pays the same cost on the same terms.
+
+diff --git a/rust_port/crates/flow_analysis/src/ssa_builder.rs b/rust_port/crates/flow_analysis/src/ssa_builder.rs
+index 7e1ecac09..274d34d7b 100644
+--- a/rust_port/crates/flow_analysis/src/ssa_builder.rs
++++ b/rust_port/crates/flow_analysis/src/ssa_builder.rs
+@@ -116,45 +116,69 @@ mod val {
+             let Some(first) = iter.next() else {
+                 return WriteState::Phi(Rc::from([]));
+             };
+-            if let Some(second) = iter.next() {
+-                let mut states = vec![first.dupe(), second.dupe()];
+-                states.extend(iter.duped());
+-                WriteState::Phi(Rc::from(states))
+-            } else {
+-                first.dupe()
+-            }
++            let Some(second) = iter.next() else {
++                return first.dupe();
++            };
++            // Sized from the iterator rather than grown from two. Every caller
++            // hands this the elements of a set, so the hint is exact and the
++            // vector is allocated once instead of doubling its way up to the
++            // width of the PHI.
++            let mut states = Vec::with_capacity(iter.size_hint().0 + 2);
++            states.push(first.dupe());
++            states.push(second.dupe());
++            states.extend(iter.duped());
++            WriteState::Phi(Rc::from(states))
+         }
+ 
+         fn normalize(t: &WriteState<L>) -> BTreeSet<WriteState<L>> {
++            let mut atoms = BTreeSet::new();
++            Self::normalize_into(t, &mut atoms);
++            atoms
++        }
++
++        /// The atoms of `t`, added to `atoms`.
++        ///
++        /// One set for the whole traversal rather than one per node. A PHI is a
++        /// tree of PHIs and the recursion used to build a fresh `BTreeSet` at
++        /// every node of it — a singleton at each leaf, a union at each
++        /// branch — and then drop all of them into the parent's. Every one of
++        /// those sets is an allocation, so a term of n nodes cost n of them to
++        /// produce a result of at most n elements. Threading the destination
++        /// down makes it one.
++        ///
++        /// The sets are still built in the one place a subterm's own normal
++        /// form is needed rather than the traversal's: a resolved REF, whose
++        /// contents are rewritten to the joined form below.
++        fn normalize_into(t: &WriteState<L>, atoms: &mut BTreeSet<WriteState<L>>) {
+             match t {
+                 WriteState::Uninitialized | WriteState::Loc(_) => {
+-                    let mut set = BTreeSet::new();
+-                    set.insert(t.dupe());
+-                    set
++                    atoms.insert(t.dupe());
+                 }
+                 WriteState::Ref(r) => {
+                     let borrowed = r.borrow();
+                     match &*borrowed {
+                         RefState::Unresolved(_) => {
+                             drop(borrowed);
+-                            let mut set = BTreeSet::new();
+-                            set.insert(t.dupe());
+-                            set
++                            atoms.insert(t.dupe());
+                         }
+                         RefState::Resolved(resolved) => {
+                             let resolved = resolved.dupe();
+                             drop(borrowed);
+-                            let vals = Self::normalize(&resolved);
++                            let mut vals = Self::normalize(&resolved);
+                             let joined = Self::join(&vals);
+                             *r.borrow_mut() = RefState::Resolved(joined);
+-                            vals
++                            // `append` rather than `extend`: it moves the nodes
++                            // this set already owns instead of inserting its
++                            // elements one at a time, and leaves `vals` empty.
++                            atoms.append(&mut vals);
+                         }
+                     }
+                 }
+-                WriteState::Phi(ts) => ts
+-                    .iter()
+-                    .flat_map(|t| Self::normalize(t).into_iter())
+-                    .collect(),
++                WriteState::Phi(ts) => {
++                    for t in ts.iter() {
++                        Self::normalize_into(t, atoms);
++                    }
++                }
+             }
+         }
+ 
+@@ -168,9 +192,16 @@ mod val {
+                 // (Atomic terms include Uninitialized, Loc _, and REF { contents = Unresolved _ }.)
+                 // Note that normal forms might change over time, as unresolved refs become resolved;
+                 // thus, we do not shortcut normalization of previously normalized terms.
+-                let vals1 = Self::normalize(&t1.write_state);
+-                let vals2 = Self::normalize(&t2.write_state);
+-                Self::mk_with_write_state(Self::join(vals1.union(&vals2)))
++                //
++                // The union is taken by normalizing both terms into the same
++                // set, in the order they would have been normalized in
++                // separately. A set holding the atoms of both is what the union
++                // of the two sets is, so this is one set where it was three —
++                // and what `join` then walks knows its own length.
++                let mut vals = BTreeSet::new();
++                Self::normalize_into(&t1.write_state, &mut vals);
++                Self::normalize_into(&t2.write_state, &mut vals);
++                Self::mk_with_write_state(Self::join(&vals))
+             }
+         }
+ 


### PR DESCRIPTION
`uf check` allocated **2,130,342 times and 358.74 MiB** to type check one 123 KB
module. It now allocates **1,703,582 times and 265.71 MiB** — 20.0% and 25.9%
less — and reports exactly the same diagnostics.

Refs #678

## The measurement, and that it is not stale

#678's headline is 2,001,094 allocations and 333.63 MiB over
`packages/router/internal/runtime.js` at 113,734 bytes. That file is 123,056
bytes today, and re-run on the harness the issue was filed with the figure is
**2,130,342 allocations and 358.74 MiB** — the same cost per source byte, on a
file that grew 8%. Nothing about the issue had gone away, so this is a fix
rather than a correction.

Everything below is `cargo run --example alloc_report -p uf_check`, the harness
from #682/#713, on the pinned nightly in a debug build. Allocation counts are
identical in release — the counter is in the allocator — so the before/after
pairs come from one method and one machine.

## Where the two million go — the half #713 could not reach

#713 put 91.6% of them inside `check::infer_one` and could not say what inside
it, on the grounds that the rest is the vendored port. Three more spans in
`check_one` — its parse, its one call into the port, its diagnostics — say
otherwise: they partition the span, 1,951,920 of the 1,951,944 allocations it
reads, the two dozen left over being the function's own bookkeeping.

| phase | allocations / run | share of the check |
| --- | ---: | ---: |
| `check::infer_ast` | 1,905,184 | **89.4%** |
| `check::environment` | 136,236 | 6.4% |
| `check::module_facts` | 42,069 | 2.0% |
| `check::infer_parse` | 35,914 | 1.7% |
| `check::infer_diagnostics` | 10,822 | 0.5% |
| everything else uf owns | 117 | — |

So it is **one line**, and everything uf wrote around it is already free: the
context, the resolver and the signature table are 57 allocations between them.

Sampling the stack at allocation sites (1 in 500, backtrace at the site) then
named the function inside it. A third of every allocation `uf check` makes —
not of inference, of the command — was
`flow_analysis::ssa_builder::val::Val::normalize`, with `Val::join` next at
13%. Two functions, 47% of the whole thing.

## What they were doing

`normalize` turns a write state into the set of atomic writes that reach it,
and built a fresh `BTreeSet` at every node of the term:

```rust
WriteState::Uninitialized | WriteState::Loc(_) => {
    let mut set = BTreeSet::new();
    set.insert(t.dupe());
    set
}
...
WriteState::Phi(ts) => ts.iter().flat_map(|t| Self::normalize(t).into_iter()).collect(),
```

A PHI is a tree of PHIs, so a term of *n* nodes built *n* sets — a singleton at
each leaf, a union at each branch — and dropped all of them into the parent's,
to produce a result with at most *n* elements in it. `Val::merge`, which runs at
every control flow join for every binding in scope, then built two of those and
a third for the union.

`tools/upstream/patches/flow/0003-ssa-normal-forms-cost-one-set.patch` threads
the destination down instead: one set for the traversal, one set in `merge`
rather than three, and a `join` that walks a set rather than a
`btree_set::Union` so its `size_hint` is exact and its vector is allocated once
instead of doubling its way up to the width of the PHI.

The sets it produces are the same sets, and the write-backs into resolved refs
happen in the same order over the same terms. Nothing else in the file moves.

## Before and after

| `packages/router/internal/runtime.js`, 123,056 bytes | before | after | |
| --- | ---: | ---: | ---: |
| allocations | 2,130,342 | 1,703,582 | **−20.0%** |
| bytes | 358.74 MiB | 265.71 MiB | **−25.9%** |
| allocations, marginal per module (`--batch 2`) | 1,847,531 | 1,420,770 | **−23.1%** |
| bytes, marginal per module | 340.60 MiB | 247.58 MiB | **−27.3%** |

`check::infer_ast` itself goes from 1,905,184 allocations per run to 1,478,424,
and the sampled profile that had `normalize` at 32.8% has `normalize_into` at
10.0%.

No release timing was taken and no wall-clock claim is made: this machine is
disk constrained and runs several builds at once, so the same binary measured
1.17 s and 1.65 s median on the same input an hour apart. #678 is a question
about allocations and bytes, the counter for those is in the allocator, and
both numbers above are identical in a release build for that reason.

## Correctness

`cargo test -p uf_check`: **222 passed, 1 ignored, 0 failed**, including the
24 typed-AST fixtures and the eight tests that pin patches 0001 and 0002. A
speed-up that changed a diagnostic would land there first.

The patch's own half cannot be a diagnostic, because it changes none. It is
`crates/uf_check/tests/upstream_patch_allocations.rs`: it checks a module built
to make PHIs — three control flow joins per block over four bindings that each
read what the others wrote — and fails if that costs more than 750,000
allocations.

* with the patch reverted: **810,800** — the test fails
* with it applied: **697,196** — the test passes

Its own test binary, because the counters are in the allocator and a
neighbouring test's allocations would land in the figure.

`tools/upstream/test-patches.sh` still passes all fifteen cases, and the sync
applies 0003 from the pinned commit and then leaves it alone.

## What this does not do

* **`check::environment`, 136,236 allocations per call.** #713 measured it and
  the correction under it says there is no caller that would notice: `uf check`
  runs it once per process, `uf check --watch` does not exist and the language
  server does not type check. Unchanged, and still worth doing the day
  something re-checks in a live process.
* **The second parse of every file in a cold batch.** `ProjectModules::facts`
  parses to describe the batch and `check_one` parses to check it. That now has
  a number — `check::infer_parse`, 35,914 allocations, 1.7% — rather than a
  comment saying it happens.
* **`Val::join`, now the largest single row at 18.5%.** What is left of it is
  structural: a PHI *is* an `Rc<[WriteState]>`, so building one costs the `Rc`,
  and the vector it is copied from cannot be skipped — `btree_set::Iter` is not
  `TrustedLen`, so `Rc<[T]>: FromIterator` collects into a vector anyway. This
  change makes that vector one allocation instead of `log2(width)`; removing it
  entirely means changing what a PHI is.
* **The rest of `infer_ast`.** After `join` at 18.5% and `normalize_into` at
  10.0% the profile has no third hot spot — the next row is 3.3% and it is
  `Type::new`. Going further is the type representation itself, which is a
  different size of change.

Not `Closes`, because #678 also asks what the checker costs relative to `uf fmt`
and `uf lint`, and those two figures were taken on the older file and would need
re-taking before the comparison in the issue body is true again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
