### PR TITLE
feat(router, vite, lint): a slot is a route into a named place, and the layout that receives it

### DIFF
--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -828,8 +828,10 @@ pub(crate) enum RoutesCommand {
     /// The path is a URL path in the spelling the directories already use —
     /// `/articles/[slug]`, `/docs/[...path]`, `/(marketing)/about` — so what
     /// is typed is what appears in `RoutePath`. A spelling uf reserves without
-    /// serving (`@team`, `(.)photo`) is refused here with the same sentence
-    /// `uf build` and `uf lint` give, rather than written and reported later.
+    /// serving (`(.)photo`) is refused here with the same sentence `uf build`
+    /// and `uf lint` give, rather than written and reported later. A `@slot`
+    /// is refused too, for the opposite reason: uf serves parallel routes, and
+    /// a slot is not a URL — this command's argument is one.
     ///
     /// Nothing is overwritten: a route whose page exists is an error, and a
     /// run that stops has written none of its files.

--- a/crates/uf_lint/src/rules/framework.rs
+++ b/crates/uf_lint/src/rules/framework.rs
@@ -196,7 +196,7 @@ pub(crate) static OWN_RULES: &[RuleDescriptor] = &[
         category: RuleCategory::Router,
         default_level: RuleLevel::Error,
         requirement: SourceText,
-        description: "`@slot` and `(.)segment` directories are not routes uf can serve",
+        description: "`(.)segment` directories are not routes uf can serve",
     },
     RuleDescriptor {
         id: "package/no-npm-scripts",

--- a/crates/uf_lint/src/runner/router.rs
+++ b/crates/uf_lint/src/runner/router.rs
@@ -57,7 +57,11 @@ fn grammar() -> String {
     format!("reserved file names are _uf.<{roles}>[.<{variants}>].js")
 }
 
-/// `router/unsupported-segment`: `@slot` and `(.)segment` directories.
+/// `router/unsupported-segment`: `(.)segment` directories.
+///
+/// `@slot` was reported here too, until slots became routes. What is left is
+/// interception, which needs a navigation to carry where it came from — a
+/// change to what a navigation is rather than to this grammar.
 ///
 /// A file-scan rule for something that is not about the file, and that is the
 /// shape the linter has: a directory is only ever seen through the files under

--- a/crates/uf_lint/src/tests/router.rs
+++ b/crates/uf_lint/src/tests/router.rs
@@ -94,18 +94,19 @@ fn router_reserved_files_leaves_project_owned_names_alone() {
     }
 }
 
-/// `router/unsupported-segment`: the two directory spellings uf reserves
-/// without serving.
+/// `router/unsupported-segment`: the directory spelling uf reserves without
+/// serving.
 ///
 /// The diagnostic lands on a file because a file is what `uf lint` can point
 /// at; what is wrong is the directory the file is in. Before this, `@team` and
 /// `(.)photo` were literal URL segments in both routers and nothing said so.
+/// `@team` is a slot uf serves now, and this rule is what is left: interception
+/// needs a navigation to carry where it came from.
 #[test]
-fn router_unsupported_segment_reports_a_slot_and_an_interception() {
+fn router_unsupported_segment_reports_an_interception() {
     for path in [
-        "app/dashboard/@team/_uf.page.js",
-        "app/@team/_uf.layout.js",
         "app/feed/(.)photo/_uf.page.js",
+        "app/feed/(..)photo/_uf.layout.js",
         "app/feed/(..)(..)photo/_uf.page.js",
     ] {
         let diagnostics = lint_one("router/unsupported-segment", path, "// @flow\n");
@@ -123,7 +124,7 @@ fn router_unsupported_segment_reports_a_slot_and_an_interception() {
 fn router_unsupported_segment_says_what_the_spelling_is_and_that_it_is_refused() {
     let diagnostics = lint_one(
         "router/unsupported-segment",
-        "app/dashboard/@team/_uf.page.js",
+        "app/feed/(.)photo/_uf.page.js",
         "// @flow\n",
     );
     let message = &diagnostics
@@ -132,8 +133,8 @@ fn router_unsupported_segment_says_what_the_spelling_is_and_that_it_is_refused()
         .expect("a diagnostic")
         .message;
 
-    assert!(message.contains("@team"), "{message}");
-    assert!(message.contains("parallel route"), "{message}");
+    assert!(message.contains("(.)photo"), "{message}");
+    assert!(message.contains("intercepting route"), "{message}");
     assert!(message.contains("refused"), "{message}");
     assert!(message.contains("267"), "{message}");
 }
@@ -145,9 +146,14 @@ fn router_unsupported_segment_leaves_the_segments_uf_serves_alone() {
         "app/(marketing)/about/_uf.page.js",
         "app/posts/[slug]/_uf.page.js",
         "app/docs/[...path]/_uf.page.js",
-        // A private subtree: neither router walks into it, so a slot there is
-        // not a route uf would have served.
-        "app/_drafts/@team/notes.js",
+        // A slot is a route uf serves: it renders into the layout of the
+        // segment that declares it, at that segment's own paths.
+        "app/dashboard/@team/_uf.page.js",
+        "app/@team/_uf.layout.js",
+        "app/dashboard/@team/_uf.default.js",
+        // A private subtree: neither router walks into it, so an interception
+        // there is not a route uf would have served.
+        "app/_drafts/(.)photo/notes.js",
         // Outside the router root entirely. `@scope` is a directory, not a
         // route, and a rule that reported it would report every workspace.
         "packages/@uniflowed/router/index.js",

--- a/crates/uf_router/src/lib.rs
+++ b/crates/uf_router/src/lib.rs
@@ -27,6 +27,8 @@ pub const RESERVED_LAYOUT_STEM: &str = "_uf.layout";
 pub const RESERVED_MIDDLEWARE_STEM: &str = "_uf.middleware";
 /// The stem every reserved route handler is spelled with.
 pub const RESERVED_ROUTE_STEM: &str = "_uf.route";
+/// The stem a slot's stand-in page is spelled with.
+pub const RESERVED_DEFAULT_STEM: &str = "_uf.default";
 
 /// What a page may be written in, in the order a directory holding two is
 /// resolved.
@@ -256,17 +258,19 @@ pub enum RouterError {
         /// The catch-all's parameter name, for the suggested spelling.
         parameter: String,
     },
-    /// A directory spelled the way a parallel route or an intercepting route
-    /// is: `@team`, `(.)photo`. uf has neither.
+    /// A directory spelled the way an intercepting route is: `(.)photo`.
     ///
     /// Refused rather than served, and the refusal is the whole of what
-    /// ubugeeei-prod/uf#267 asks for first. Neither spelling was one this
-    /// grammar had an opinion about, so both fell through to a literal
-    /// segment: `@team` became the URL `/@team`, and `(.)photo` became
+    /// ubugeeei-prod/uf#267 asks for first. Neither this spelling nor `@team`
+    /// was one this grammar had an opinion about, so both fell through to a
+    /// literal segment: `@team` became the URL `/@team`, and `(.)photo` became
     /// `/(.)photo`, because the test for a `(group)` is that the segment
     /// *ends* in `)`. Both then appeared in the generated `RoutePath` union
     /// and in `uf inspect`, so a project migrating from Next.js got output
     /// that looked like it worked.
+    ///
+    /// `@team` is a slot uf serves now. Interception is not, and this is what
+    /// is left of the refusal.
     ///
     /// `reason` comes from [`RouteSegment::unsupported_reason`], so this and
     /// `uf lint`'s `router/unsupported-segment` say the same sentence about
@@ -278,7 +282,134 @@ pub enum RouterError {
         /// What is wrong with it and what to do instead.
         reason: String,
     },
+    /// A `@slot` whose segment declares no layout of its own.
+    ///
+    /// A slot renders *into* a layout — that is the whole of what a parallel
+    /// route is — so the segment that declares one has to have a layout to
+    /// render it into. Inheriting the layout above would put the slot in a
+    /// frame that knows nothing about it, and every route under that frame
+    /// would be asked to position a prop it never declared.
+    ///
+    /// Refused rather than dropped, for the reason the spelling itself is:
+    /// a slot that renders nowhere is a directory of pages nothing reaches,
+    /// and the project looks like it works.
+    #[error(
+        "{directory}: `{slot}` is a parallel-route slot and `{segment}` declares no layout of its \
+         own, so there is nothing to render the slot into — a slot is a prop the segment's own \
+         layout receives beside `children`. Add `{layout}`, or move the slot to a segment that \
+         has one."
+    )]
+    SlotWithoutLayout {
+        /// The slot directory, as it is written on disk.
+        directory: Utf8PathBuf,
+        /// The slot directory's name, as it is written.
+        slot: String,
+        /// The route path of the segment that declares it.
+        segment: String,
+        /// The layout file that would receive it.
+        layout: Utf8PathBuf,
+    },
+    /// A `_uf.default.js` that is not directly inside a `@slot` directory.
+    ///
+    /// A default answers one question — what a slot renders when the URL
+    /// addresses the other one — so it is asked once, at the slot, and is
+    /// meaningful in exactly one place. uf has no `children` default the way
+    /// Next.js does: `children` is the page the URL matched, and a URL that
+    /// matches no page is a 404 rather than a segment with a hole in it.
+    ///
+    /// Refused rather than ignored, because a file the router never opens is
+    /// the failure this whole issue is about.
+    #[error(
+        "{file}: `_uf.default.js` is what a `@slot` renders when the URL says nothing about it, \
+         and it belongs directly inside the slot directory — one per slot, beside that slot's own \
+         pages. Nothing would ever render this one. uf has no `default` for `children`: a URL \
+         that matches no page is a 404."
+    )]
+    DefaultOutsideSlot {
+        /// The file, as it is written on disk.
+        file: Utf8PathBuf,
+    },
+    /// A `_uf.route.js` or `_uf.middleware.js` inside a `@slot`.
+    ///
+    /// A slot is matched and rendered as part of the page at a URL; it never
+    /// answers a request of its own and never guards one. A handler or a guard
+    /// under a slot is a file with no request to see — and worse than useless,
+    /// because the directory contributes no URL segment, so the path it would
+    /// appear to claim is the *declaring* segment's, which is somebody else's.
+    #[error(
+        "{file}: a `@slot` renders inside the page at a URL and answers no request of its own, so \
+         `_uf.{role}.js` here would never run. A slot directory contributes no URL segment, so \
+         this would claim `{path}` — which belongs to the segment that declares the slot. Move it \
+         out of `{slot}`."
+    )]
+    ServerModuleInsideSlot {
+        /// The file, as it is written on disk.
+        file: Utf8PathBuf,
+        /// Which of the two roles it is, as it is written in the name.
+        role: &'static str,
+        /// The route path the directory would otherwise contribute to.
+        path: String,
+        /// The slot directory it is under, as it is written.
+        slot: String,
+    },
+    /// A boundary or a template inside a `@slot`.
+    ///
+    /// A slot renders a page and the layouts under the slot, and nothing else
+    /// yet: it has no `<Suspense>` of its own, no error boundary of its own and
+    /// no 404 of its own. Next.js gives a slot all three, and that is the part
+    /// of parallel routes uf has not built.
+    ///
+    /// Refused rather than ignored, because the whole of ubugeeei-prod/uf#267
+    /// is that a file the router never opens must not look like one it does.
+    /// This is also the list of what is left to implement, stated where
+    /// somebody writing the file will read it.
+    #[error(
+        "{file}: a `@slot` renders a page and the layouts inside the slot, and has no `{role}` of \
+         its own — uf's parallel routes do not carry per-slot boundaries yet, so this file would \
+         never be opened. Put it outside `{slot}`, where it covers the whole segment. \
+         https://github.com/ubugeeei-prod/uf/issues/267"
+    )]
+    BoundaryInsideSlot {
+        /// The file, as it is written on disk.
+        file: Utf8PathBuf,
+        /// The role, as it is written in the name.
+        role: &'static str,
+        /// The slot directory it is under, as it is written.
+        slot: String,
+    },
+    /// A slot named after a prop every layout already receives.
+    ///
+    /// A slot arrives as a prop named after the directory, so `@children` and
+    /// `@params` are the two names that would land on top of something the
+    /// layout already has. `@children` is the likelier of the two by a long
+    /// way: `children` is what Next.js calls its *implicit* slot, so it is the
+    /// first thing somebody migrating writes down.
+    ///
+    /// Refused rather than resolved by precedence. Whichever way the tie were
+    /// broken, one of the two would be silently missing — the page, or the
+    /// slot — and a page that quietly does not render is the failure this whole
+    /// issue is about.
+    #[error(
+        "{directory}: a slot arrives as a prop named after its directory, and `{name}` is a prop \
+         every layout already receives, so one of the two would silently go missing. Rename the \
+         slot. The page a URL matches is always `children` — uf has no `@children` slot, which is \
+         the name Next.js gives that page."
+    )]
+    SlotNameIsALayoutProp {
+        /// The slot directory, as it is written on disk.
+        directory: Utf8PathBuf,
+        /// The slot's name, without the `@`.
+        name: String,
+    },
 }
+
+/// The prop names a layout already receives, which a slot may therefore not
+/// take.
+///
+/// Two, and both are `RouteView`'s: `children` is what the layout wraps and
+/// `params` is the route's. Kept here rather than at the check so that
+/// `packages/vite/internal/routes.js` has one list to mirror.
+pub const LAYOUT_PROP_NAMES: [&str; 2] = ["children", "params"];
 
 pub fn discover_routes(
     root: &Utf8Path,
@@ -289,9 +420,14 @@ pub fn discover_routes(
         return Ok(Vec::new());
     }
 
-    // Before any route is built, because the point is that none is: a slot or
-    // an interception used to become a literal URL segment and a live route.
+    // Before any route is built, because the point is that none is: an
+    // interception used to become a literal URL segment and a live route, and
+    // so did a slot before slots were served.
     refuse_unsupported_directories(&app_root)?;
+    // And before any route is built for the opposite reason: a slot's pages are
+    // routes uf renders, so what is wrong with a slot has to be said here
+    // rather than discovered as a missing prop at render time.
+    check_slots(&app_root)?;
 
     let mut routes = Vec::new();
     for entry in WalkDir::new(&app_root) {
@@ -325,6 +461,23 @@ pub fn discover_routes(
             continue;
         }
         let relative = directory.strip_prefix(&app_root).unwrap_or(&directory);
+        // A page inside a `@slot` is not a URL, and this is the line that says
+        // so. A slot never *adds* a path: it renders into the layout of the
+        // segment that declares it, matched against the URL that segment's own
+        // routes are matched against. So `app/dashboard/@team/members/
+        // _uf.page.js` is what `/dashboard/members` puts in the `team` slot,
+        // and it is not a second page at that path — which is what it would be
+        // if it fell through to here, since the slot segment contributes
+        // nothing to `route_path_and_params`.
+        //
+        // The consequence is worth stating rather than discovering: a slot
+        // decorates URLs that already exist. `/dashboard/members` with no
+        // `app/dashboard/members/_uf.page.js` is a 404 whatever the slots hold,
+        // and that is uf's answer to the question Next.js answers with a
+        // `default.js` for `children`.
+        if slot_in(relative).is_some() {
+            continue;
+        }
         // Before the path is built, because the path is where the evidence
         // goes missing: `/docs/:slug*/edit` reads like a route, and only the
         // directory names say which `[...param]` the author wrote.
@@ -454,14 +607,15 @@ pub fn discover_server_modules(
 /// Refuse the directory spellings uf reserves without serving.
 ///
 /// A pass of its own rather than a check inside the page walk above, and the
-/// difference is what gets caught: `app/@team/` may hold a layout, a loading
-/// file and no page at all, and it is still a directory the author wrote
-/// expecting a parallel route. The walk above only ever sees `_uf.page.js`.
+/// difference is what gets caught: `app/feed/(.)photo/` may hold a layout, a
+/// loading file and no page at all, and it is still a directory the author
+/// wrote expecting an intercepting route. The walk above only ever sees
+/// `_uf.page.js`.
 ///
 /// Private directories are pruned, because the build's router prunes them: a
 /// leading `.` or `_` means the directory is a place to put things rather than
-/// a route, so `app/_drafts/@team/` is not a route uf would have served and is
-/// not one it should refuse.
+/// a route, so `app/_drafts/(.)photo/` is not a route uf would have served and
+/// is not one it should refuse.
 ///
 /// The first offender wins, sorted by name so the message does not depend on
 /// the order the filesystem hands entries back.
@@ -490,6 +644,146 @@ fn refuse_unsupported_directories(app_root: &Utf8Path) -> Result<(), RouterError
         let directory = Utf8PathBuf::from_path_buf(entry.path().to_path_buf())
             .map_err(|path| RouterError::NonUtf8(path.display().to_string()))?;
         return Err(RouterError::UnsupportedRouteDirectory { directory, reason });
+    }
+    Ok(())
+}
+
+/// The first `@slot` segment of a path relative to the router root, if it has
+/// one.
+///
+/// One question asked in three places — discovery skips a page under a slot,
+/// [`check_slots`] decides which files are inside one, and the path builder
+/// drops the segment — so it is one function. A slot inside a slot answers with
+/// the outermost, which is the one that decides whether a file is "in a slot"
+/// at all.
+fn slot_in(relative: &Utf8Path) -> Option<&str> {
+    relative
+        .as_str()
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .find_map(|segment| classify_route_segment(segment).slot().map(|_| segment))
+}
+
+/// What a `@slot` needs to be a slot, checked before any route is built.
+///
+/// Four rules, and each is a file that would otherwise be opened by nobody. A
+/// slot needs a layout at the segment that declares it, because a slot *is* a
+/// prop that layout receives, and it needs a name that is not one of the props
+/// the layout already has. A `_uf.default.js` needs to be directly inside a
+/// slot, because that is the only question it answers. A `_uf.route.js` or
+/// `_uf.middleware.js` inside a slot has no request to see, and the path it
+/// would appear to claim belongs to the segment above.
+///
+/// Private directories are pruned for the reason
+/// [`refuse_unsupported_directories`] prunes them: a leading `.` or `_` is a
+/// subtree neither router walks into, so nothing in it is a route uf would
+/// have served.
+///
+/// Sorted by name so the first offender does not depend on the order the
+/// filesystem hands entries back.
+fn check_slots(app_root: &Utf8Path) -> Result<(), RouterError> {
+    let walk = WalkDir::new(app_root)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_entry(|entry| {
+            entry.depth() == 0
+                || !entry.file_type().is_dir()
+                || !entry.file_name().to_string_lossy().starts_with(['.', '_'])
+        });
+
+    for entry in walk {
+        let entry = entry.map_err(|source| RouterError::Walk {
+            path: app_root.to_path_buf(),
+            source,
+        })?;
+        let path = Utf8PathBuf::from_path_buf(entry.path().to_path_buf())
+            .map_err(|path| RouterError::NonUtf8(path.display().to_string()))?;
+        let relative = path.strip_prefix(app_root).unwrap_or(&path);
+
+        if entry.file_type().is_dir() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some(slot_name) = classify_route_segment(&name).slot().map(str::to_owned) else {
+                continue;
+            };
+            if LAYOUT_PROP_NAMES.contains(&slot_name.as_str()) {
+                return Err(RouterError::SlotNameIsALayoutProp {
+                    directory: path,
+                    name: slot_name,
+                });
+            }
+            // The *own* layout of the segment above, not the layouts in scope
+            // there. A slot rendered into an inherited layout would be a prop
+            // that layout never declared, on every route below it.
+            let declaring = path.parent().unwrap_or(app_root);
+            if find_module(declaring, RESERVED_LAYOUT_STEM, &MODULE_EXTENSIONS).is_none() {
+                let (segment_path, _) =
+                    route_path_and_params(declaring.strip_prefix(app_root).unwrap_or(declaring));
+                return Err(RouterError::SlotWithoutLayout {
+                    layout: declaring.join(RESERVED_LAYOUT),
+                    directory: path,
+                    slot: name,
+                    segment: segment_path,
+                });
+            }
+            continue;
+        }
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        let Some(role) = classify_reserved_file(&file_name)
+            .recognized()
+            .filter(|file| file.variant.is_route_entry())
+            .map(|file| file.role)
+        else {
+            continue;
+        };
+        // The slot's *own* directory, not any slot above: one default per slot,
+        // beside that slot's own pages. A deeper one would be a second answer
+        // to a question that is asked once, at the slot.
+        let inside_a_slot_root = path
+            .parent()
+            .and_then(Utf8Path::file_name)
+            .is_some_and(|name| classify_route_segment(name).slot().is_some());
+
+        match role {
+            ReservedRole::Default if !inside_a_slot_root => {
+                return Err(RouterError::DefaultOutsideSlot { file: path });
+            }
+            ReservedRole::Route | ReservedRole::Middleware => {
+                if let Some(slot) = slot_in(relative) {
+                    let directory = path.parent().unwrap_or(app_root);
+                    let (claimed, _) = route_path_and_params(
+                        directory.strip_prefix(app_root).unwrap_or(directory),
+                    );
+                    return Err(RouterError::ServerModuleInsideSlot {
+                        role: role.as_str(),
+                        slot: slot.to_owned(),
+                        path: claimed,
+                        file: path,
+                    });
+                }
+            }
+            // What a slot does not have yet. `layout`, `page` and `default` are
+            // what it does have, and a `story` is not the router's at all.
+            ReservedRole::NotFound
+            | ReservedRole::Error
+            | ReservedRole::Loading
+            | ReservedRole::Template => {
+                if let Some(slot) = slot_in(relative) {
+                    return Err(RouterError::BoundaryInsideSlot {
+                        role: role.as_str(),
+                        slot: slot.to_owned(),
+                        file: path,
+                    });
+                }
+            }
+            ReservedRole::Layout
+            | ReservedRole::Page
+            | ReservedRole::Default
+            | ReservedRole::Story => {}
+        }
     }
     Ok(())
 }
@@ -668,7 +962,8 @@ pub fn write_router_manifest(
 ///
 /// A `(group)` is not a routing directory — it contributes no segment to the
 /// path — so `app/files/[...path]/(internal)/` leaves the catch-all last and
-/// is fine.
+/// is fine. A `@slot` contributes none either, for a different reason and with
+/// the same consequence here.
 fn non_terminal_catch_all(relative: &Utf8Path) -> Option<(String, String)> {
     let mut catch_all: Option<&str> = None;
     for segment in relative
@@ -676,7 +971,8 @@ fn non_terminal_catch_all(relative: &Utf8Path) -> Option<(String, String)> {
         .split('/')
         .filter(|segment| !segment.is_empty())
     {
-        if classify_route_segment(segment) == RouteSegment::Group {
+        let classified = classify_route_segment(segment);
+        if classified == RouteSegment::Group || classified.slot().is_some() {
             continue;
         }
         if let Some(found) = catch_all {
@@ -714,12 +1010,19 @@ fn route_path_and_params(relative: &Utf8Path) -> (String, Vec<RouteParam>) {
                 });
                 segments.push(format!(":{name}"));
             }
-            // A slot or an interception cannot reach here: `discover_routes`
-            // refuses the directory before it builds a path. Spelled out
-            // rather than folded into the literal arm so that a third
-            // unsupported spelling has to be decided about here too.
+            // A slot contributes no URL segment, exactly as a group does: it
+            // is a named place a route renders *into*, and the URL it is
+            // matched against is the declaring segment's. The two arms are
+            // separate because they are separate decisions — a group organises
+            // files and a slot organises rendering — and folding them together
+            // is how the next spelling gets one of the two answers by accident.
+            RouteSegment::Slot(_) => {}
             RouteSegment::Literal(name) => segments.push(name.to_string()),
-            RouteSegment::Slot(_) | RouteSegment::Interception { .. } => {
+            // An interception cannot reach here: `discover_routes` refuses the
+            // directory before it builds a path. Spelled out rather than
+            // folded into the literal arm so that a second unsupported
+            // spelling has to be decided about here too.
+            RouteSegment::Interception { .. } => {
                 segments.push(segment.to_string());
             }
         }

--- a/crates/uf_router/src/reserved.rs
+++ b/crates/uf_router/src/reserved.rs
@@ -52,10 +52,22 @@
 //! checked. A convention silently served as a URL is worse than one that is
 //! not supported: the project looks like it works.
 //!
-//! So [`RouteSegment::Slot`] and [`RouteSegment::Interception`] are names in
-//! this grammar without being routes. Both routers refuse them, `uf lint`
-//! reports them, and the refusal says which feature the spelling belongs to.
-//! See ubugeeei-prod/uf#267.
+//! So [`RouteSegment::Slot`] and [`RouteSegment::Interception`] became names in
+//! this grammar, and both routers refused them by name rather than serving
+//! them.
+//!
+//! A slot is a route now. [`RouteSegment::Slot`] contributes no URL segment —
+//! it is a `(group)` in that one respect — and everything under it is a route
+//! *into a named place* rather than into the one page a URL has: the layout of
+//! the segment that declares the slot receives it as a prop beside `children`.
+//! [`ReservedRole::Default`] is the other half, and it is the reason a slot
+//! can be a route at all: a URL that says nothing about a slot still has to
+//! leave something in it.
+//!
+//! [`RouteSegment::Interception`] is still a name without a route. It needs a
+//! navigation to carry where it came from, which is a change to what a
+//! navigation *is* rather than a change to this grammar, so it stays refused
+//! by name. See ubugeeei-prod/uf#267.
 
 use std::str::FromStr;
 
@@ -81,6 +93,27 @@ pub enum ReservedRole {
     Template,
     /// Renders a route.
     Page,
+    /// Renders in a slot the URL says nothing about.
+    ///
+    /// A slot — `app/dashboard/@team/` — is matched against the same URL its
+    /// segment is, and a URL is free to address one slot and not another:
+    /// `/dashboard/members` has a page for `@team` and nothing at all for
+    /// `@analytics`. Without this file the second slot would be empty, so a
+    /// link into one half of a two-slot layout would produce half a page, and
+    /// arriving at that URL directly would produce it too.
+    ///
+    /// It is a page in every way that matters — it is a component and it may
+    /// be Markdown — except that no path leads to it, which is why it is not
+    /// one of [`route_parts`](ReservedRole::route_parts) for the same reason
+    /// [`NotFound`](ReservedRole::NotFound) is not.
+    ///
+    /// Only inside a slot. Next.js also reads a `default.js` beside an
+    /// ordinary page, for the `children` slot on a hard navigation; uf's
+    /// `children` is the page the URL matched and there is no case where it is
+    /// missing, so a `_uf.default.js` outside a slot would be a file the
+    /// router never reaches. `discover_routes` refuses it rather than leaving
+    /// it there to be wondered about.
+    Default,
     /// Runs before a route resolves.
     Middleware,
     /// Renders a path no route matched.
@@ -130,6 +163,7 @@ impl ReservedRole {
             Self::Layout => "layout",
             Self::Template => "template",
             Self::Page => "page",
+            Self::Default => "default",
             Self::Middleware => "middleware",
             Self::NotFound => "not-found",
             Self::Error => "error",
@@ -147,11 +181,12 @@ impl ReservedRole {
     /// Two `all` in one module meaning two different things is the drift this
     /// module exists to prevent, one level up.
     #[must_use]
-    pub const fn all() -> [Self; 9] {
+    pub const fn all() -> [Self; 10] {
         [
             Self::Layout,
             Self::Template,
             Self::Page,
+            Self::Default,
             Self::Middleware,
             Self::NotFound,
             Self::Error,
@@ -164,10 +199,11 @@ impl ReservedRole {
     /// The roles a rendered route is built from.
     ///
     /// A `route` answers a request rather than rendering, a `story` names a
-    /// state of a component, a `not-found` is reached by no path, an `error`
-    /// renders instead of the route rather than as part of it, and a `loading`
-    /// renders while it is not there yet — so none of the five composes a
-    /// route, though all five are reserved names.
+    /// state of a component, a `not-found` is reached by no path, a `default`
+    /// stands in for a slot the URL did not address, an `error` renders
+    /// instead of the route rather than as part of it, and a `loading` renders
+    /// while it is not there yet — so none of the six composes a route, though
+    /// all six are reserved names.
     ///
     /// A `template` does compose one. It is a layout that remounts, and the
     /// rendered route contains it exactly the way it contains a layout.
@@ -185,6 +221,7 @@ impl FromStr for ReservedRole {
             "layout" => Ok(Self::Layout),
             "template" => Ok(Self::Template),
             "page" => Ok(Self::Page),
+            "default" => Ok(Self::Default),
             "middleware" => Ok(Self::Middleware),
             "not-found" => Ok(Self::NotFound),
             "error" => Ok(Self::Error),
@@ -328,8 +365,9 @@ impl ReservedRole {
     pub const fn extensions(self) -> &'static [&'static str] {
         match self {
             // A `not-found` is a page in every way that matters, so it is one
-            // here too.
-            Self::Page | Self::NotFound => &crate::PAGE_EXTENSIONS,
+            // here too, and so is a `default`: both render in place of a page
+            // and neither is handed anything Markdown cannot receive.
+            Self::Page | Self::NotFound | Self::Default => &crate::PAGE_EXTENSIONS,
             // A story names a rendered state of a component, so it is code
             // for the same reason a layout is.
             // A template is a layout that remounts, and a story names a
@@ -416,13 +454,18 @@ pub enum RouteSegment<'a> {
     CatchAll(&'a str),
     /// An ordinary URL segment, spelled exactly as the directory is.
     Literal(&'a str),
-    /// `@team` — a parallel-route slot. Not a route uf can serve.
+    /// `@team` — a parallel-route slot, under the borrowed name.
     ///
     /// A slot is a route that matches into a *named place* rather than into
-    /// the one page a URL has, and a layout renders several of them at once,
-    /// each with its own loading and error state. uf's `RouteRecord` is one
-    /// page and a list of layouts and `RouteView` composes exactly that, so
-    /// there is no second child to give a layout and no place to put one.
+    /// the one page a URL has: the segment holding `@team` gives its layout a
+    /// `team` prop beside `children`, and the two are matched against the same
+    /// URL independently. So the directory contributes no URL segment, exactly
+    /// as a [`Group`](RouteSegment::Group) does — `app/dashboard/@team/
+    /// members/_uf.page.js` is what `/dashboard/members` puts in the `team`
+    /// slot, and it is not a second page at that path.
+    ///
+    /// A URL is free to address one slot and not another, which is what
+    /// [`ReservedRole::Default`] answers.
     Slot(&'a str),
     /// `(.)photo`, `(..)photo`, `(...)photo`, `(..)(..)photo` — an intercepting
     /// route. Not a route uf can serve.
@@ -439,28 +482,39 @@ pub enum RouteSegment<'a> {
     },
 }
 
-impl RouteSegment<'_> {
+impl<'a> RouteSegment<'a> {
     /// One directory name per spelling uf refuses.
     ///
     /// Here so that `tests/reserved_names.rs` can hold the build router to the
     /// same list, the way it already holds it to [`ReservedRole`]. A spelling
     /// one router refuses and the other serves is the disagreement this module
     /// exists to prevent, and the two are separate implementations.
-    pub const UNSUPPORTED_EXAMPLES: &'static [&'static str] = &[
-        "@team",
-        "(.)photo",
-        "(..)photo",
-        "(...)photo",
-        "(..)(..)photo",
-    ];
+    pub const UNSUPPORTED_EXAMPLES: &'static [&'static str] =
+        &["(.)photo", "(..)photo", "(...)photo", "(..)(..)photo"];
 
     /// Whether uf serves a segment spelled this way.
     ///
-    /// False for the two Next.js conventions uf has reserved without
-    /// implementing. Refusing is the point: they used to be literals.
+    /// False for interception alone. `@team` was here too until slots became
+    /// routes; refusing is still the point for what is left, because a literal
+    /// is what these used to be.
     #[must_use]
     pub const fn is_supported(&self) -> bool {
-        !matches!(self, Self::Slot(_) | Self::Interception { .. })
+        !matches!(self, Self::Interception { .. })
+    }
+
+    /// The slot this segment names, if it names one.
+    ///
+    /// Here rather than at each `matches!` site because three callers ask the
+    /// same question — discovery skips the segment, the path builder drops it,
+    /// and the refusal below needs to know a slot from a literal — and a slot
+    /// that one of them read differently from the others is a page rendered in
+    /// a place no other part of uf agrees about.
+    #[must_use]
+    pub const fn slot(&self) -> Option<&'a str> {
+        match self {
+            Self::Slot(name) => Some(name),
+            _ => None,
+        }
     }
 
     /// Why uf refuses a directory spelled this way, or [`None`] when it
@@ -478,14 +532,6 @@ impl RouteSegment<'_> {
     #[must_use]
     pub fn unsupported_reason(&self, segment: &str) -> Option<String> {
         match self {
-            Self::Slot(_) => Some(format!(
-                "`{segment}` is a parallel-route slot, and uf does not have parallel routes — a \
-                 route here renders in one place, so there is nothing for a slot to render into. \
-                 It is refused rather than served as the URL segment `/{segment}`, which is what \
-                 it used to become. Rename the directory; a URL segment that really starts with \
-                 `@` has no spelling in this grammar, so capture it with a `[param]`. \
-                 https://github.com/ubugeeei-prod/uf/issues/267"
-            )),
             Self::Interception { route, .. } => Some(format!(
                 "`{segment}` is an intercepting route, and uf does not have interception — a \
                  navigation carries where it is going and not where it came from, so nothing here \
@@ -494,7 +540,9 @@ impl RouteSegment<'_> {
                  belongs at, or rename the directory. \
                  https://github.com/ubugeeei-prod/uf/issues/267"
             )),
-            Self::Group | Self::Param(_) | Self::CatchAll(_) | Self::Literal(_) => None,
+            Self::Group | Self::Param(_) | Self::CatchAll(_) | Self::Literal(_) | Self::Slot(_) => {
+                None
+            }
         }
     }
 }
@@ -848,16 +896,36 @@ mod tests {
     }
 
     #[test]
-    fn a_slot_is_named_rather_than_served_as_a_url() {
+    fn a_slot_is_a_route_that_contributes_no_url_segment() {
         // `@team` used to be the literal URL segment `/@team`, in both routers
-        // and in the generated `RoutePath`. See ubugeeei-prod/uf#267.
+        // and in the generated `RoutePath`; then it was refused by name; now it
+        // is a slot uf serves. See ubugeeei-prod/uf#267.
         assert_eq!(classify_route_segment("@team"), RouteSegment::Slot("team"));
-        assert!(!classify_route_segment("@team").is_supported());
+        assert!(classify_route_segment("@team").is_supported());
+        assert_eq!(classify_route_segment("@team").slot(), Some("team"));
         // Not a slot: the `@` has to start the segment, so a scoped-looking
         // name in the middle is an ordinary literal.
         assert_eq!(
             classify_route_segment("mail@example"),
             RouteSegment::Literal("mail@example")
+        );
+        assert_eq!(classify_route_segment("mail@example").slot(), None);
+    }
+
+    #[test]
+    fn a_default_file_is_reserved_and_is_not_part_of_a_route() {
+        // What a slot renders when the URL addresses the other one. A page in
+        // every way but the path that leads to it, which is why it takes the
+        // page extensions and is not one of `route_parts`.
+        assert_eq!(recognized("_uf.default.js").role, ReservedRole::Default);
+        assert_eq!(
+            recognized("_uf.default.native.js").variant,
+            ReservedVariant::Native
+        );
+        assert!(!classify_reserved_file("_uf.default.mdx").is_unknown());
+        assert!(
+            !ReservedRole::route_parts().contains(&ReservedRole::Default),
+            "a default stands in for a slot's page rather than composing a route"
         );
     }
 
@@ -894,7 +962,7 @@ mod tests {
     }
 
     #[test]
-    fn every_unsupported_example_is_one_of_the_two_kinds() {
+    fn every_unsupported_example_is_an_interception() {
         for segment in RouteSegment::UNSUPPORTED_EXAMPLES {
             let classified = classify_route_segment(segment);
             assert!(
@@ -913,7 +981,7 @@ mod tests {
 
     #[test]
     fn a_segment_uf_serves_has_no_reason_to_refuse_it() {
-        for segment in ["(marketing)", "[slug]", "[...path]", "posts"] {
+        for segment in ["(marketing)", "[slug]", "[...path]", "posts", "@team"] {
             assert_eq!(
                 classify_route_segment(segment).unsupported_reason(segment),
                 None,

--- a/crates/uf_router/src/scaffold.rs
+++ b/crates/uf_router/src/scaffold.rs
@@ -16,10 +16,13 @@
 //! disagreeing is what ubugeeei-prod/uf#224, #291, #386 and #437 all are.
 //!
 //! It is also why this refuses more than a scaffold usually would. A path with
-//! `@team` or `(.)photo` in it, and a `[...rest]` with a segment after it, are
-//! rejected here rather than written and then reported by the next `uf build`:
-//! the point of one grammar is that the answer does not depend on which tool
-//! you ask.
+//! `(.)photo` in it, and a `[...rest]` with a segment after it, are rejected
+//! here rather than written and then reported by the next `uf build`: the point
+//! of one grammar is that the answer does not depend on which tool you ask.
+//!
+//! `@team` is refused for a different reason, and the difference is worth
+//! keeping: a slot is a route uf serves, but it is not a *URL*, and this
+//! command's argument is a URL. See [`ScaffoldError::SlotSegment`].
 //!
 //! [`discover_routes`]: crate::discover_routes
 
@@ -66,16 +69,34 @@ pub struct ScaffoldFile {
 /// Why a path is not one `uf routes add` can write.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ScaffoldError {
-    /// A directory spelled the way a parallel route or an intercepting route
-    /// is. The sentence is [`RouteSegment::unsupported_reason`]'s, so this and
-    /// `uf build` and `uf lint` all say the same thing about the same
-    /// spelling.
+    /// A directory spelled the way an intercepting route is. The sentence is
+    /// [`RouteSegment::unsupported_reason`]'s, so this and `uf build` and
+    /// `uf lint` all say the same thing about the same spelling.
     #[error("{segment}: {reason}")]
     UnsupportedSegment {
         /// The segment, as it was written.
         segment: String,
         /// What is wrong with it and what to do instead.
         reason: String,
+    },
+    /// A `@slot` in the path this command was given.
+    ///
+    /// Not a refusal of the feature — uf serves parallel routes — but of the
+    /// argument. `uf routes add` takes a URL and writes the page that answers
+    /// it, and a slot has no URL: it renders into the layout of the segment
+    /// that declares it, at that segment's own paths. So there is nothing here
+    /// for this command to do that a reader would recognise as "adding a
+    /// route", and writing the directory alone would leave a slot with no
+    /// layout to render into, which the next `uf build` refuses.
+    #[error(
+        "`{segment}` is a parallel-route slot, and `uf routes add` takes a URL — a slot has none. \
+         It renders into the layout of the segment that declares it, at that segment's own paths. \
+         Create the directory beside that layout and put the slot's pages in it; \
+         `uf routes add` writes the pages the URL names."
+    )]
+    SlotSegment {
+        /// The segment, as it was written.
+        segment: String,
     },
     /// A `[...param]` with another routing segment after it, which is a page
     /// no URL can reach — see [`crate::RouterError::NonTerminalCatchAll`].
@@ -130,6 +151,11 @@ fn route_directory(path: &str) -> Result<Utf8PathBuf, ScaffoldError> {
             return Err(ScaffoldError::UnsupportedSegment {
                 segment: segment.to_owned(),
                 reason,
+            });
+        }
+        if classified.slot().is_some() {
+            return Err(ScaffoldError::SlotSegment {
+                segment: segment.to_owned(),
             });
         }
         if matches!(
@@ -437,21 +463,37 @@ mod tests {
         // that the next `uf build` reports. The sentence is the one
         // `RouteSegment::unsupported_reason` gives, so a reader gets the same
         // answer whichever tool told them.
-        let error = directory("/@team").unwrap_err();
+        let error = directory("/feed/(.)photo").unwrap_err();
         let ScaffoldError::UnsupportedSegment { reason, .. } = &error else {
             panic!("expected an unsupported segment, got {error:?}");
         };
         assert_eq!(
             reason.as_str(),
-            classify_route_segment("@team")
-                .unsupported_reason("@team")
+            classify_route_segment("(.)photo")
+                .unsupported_reason("(.)photo")
                 .unwrap()
                 .as_str()
         );
-        assert!(matches!(
-            directory("/feed/(.)photo"),
-            Err(ScaffoldError::UnsupportedSegment { .. })
-        ));
+    }
+
+    /// A slot is refused by this command and not by the router, and the message
+    /// has to be about the command: uf serves parallel routes, and what it does
+    /// not have is a URL for one to be added at.
+    #[test]
+    fn a_slot_is_refused_because_this_command_takes_a_url() {
+        let error = directory("/dashboard/@team/members").unwrap_err();
+        let ScaffoldError::SlotSegment { segment } = &error else {
+            panic!("expected a slot segment, got {error:?}");
+        };
+        assert_eq!(segment, "@team");
+        let message = error.to_string();
+        assert!(message.contains("takes a URL"), "{message}");
+        // And not the sentence the router uses for what it refuses: there is
+        // no such sentence for a slot any more.
+        assert_eq!(
+            classify_route_segment("@team").unsupported_reason("@team"),
+            None
+        );
     }
 
     #[test]

--- a/crates/uf_router/src/tests.rs
+++ b/crates/uf_router/src/tests.rs
@@ -697,47 +697,165 @@ fn a_layout_and_a_middleware_are_found_in_either_spelling() {
     }
 }
 
-/// A slot directory is refused rather than served as the URL segment `/@team`.
+/// A slot's page is not a URL.
 ///
-/// The whole of ubugeeei-prod/uf#267's first piece. `@team` was not a spelling
-/// this grammar had an opinion about, so it fell through to a literal: the
-/// route was discovered, `/@team` went into the generated `RoutePath`, and
-/// `route("/@team", …)` type checked. A project migrating from Next.js got
-/// output that looked like it worked.
+/// The whole of ubugeeei-prod/uf#267's first piece, arrived at from the other
+/// side. `@team` was not a spelling this grammar had an opinion about, so it
+/// fell through to a literal: the route was discovered, `/@team` went into the
+/// generated `RoutePath`, and `route("/@team", …)` type checked. Then it was a
+/// name both routers refused. It is a route now — and still not a path: the
+/// slot's page renders into the declaring segment's layout, at the URL that
+/// segment's own routes answer.
 #[test]
-fn a_parallel_route_slot_is_refused() {
+fn a_parallel_route_slot_contributes_no_url() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app/dashboard/@team/members")).unwrap();
+    fs::create_dir_all(root.join("app/dashboard/members")).unwrap();
+    fs::write(root.join("app/dashboard/_uf.layout.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/dashboard/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/dashboard/members/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(
+        root.join("app/dashboard/@team/members/_uf.page.js"),
+        "// @flow\n",
+    )
+    .unwrap();
+
+    let routes = discover_routes(&root, &UniflowedConfig::default()).unwrap();
+
+    // Two, not three and not four: the slot's page is what `/dashboard/members`
+    // puts in the `team` slot, so it is neither a path of its own nor a second
+    // page at a path that already has one.
+    assert_eq!(
+        routes
+            .iter()
+            .map(|route| route.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["/dashboard", "/dashboard/members"]
+    );
+    // And the generated union says the same thing: `RoutePath` is what a
+    // caller may pass to `route()`, and `/dashboard/@team/members` is not a
+    // path this project serves.
+    let generated = generate_router_flow(&routes);
+    assert!(!generated.contains("@team"), "{generated}");
+}
+
+/// A slot is a prop the declaring segment's own layout receives, so a segment
+/// with no layout of its own has nothing to render it into.
+///
+/// Refused rather than dropped: a slot that renders nowhere is a directory of
+/// pages nothing reaches, which is the failure this whole issue is about.
+#[test]
+fn a_slot_on_a_segment_with_no_layout_is_refused() {
     let dir = tempfile::tempdir().unwrap();
     let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
     fs::create_dir_all(root.join("app/dashboard/@team")).unwrap();
+    fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/dashboard/_uf.page.js"), "// @flow\n").unwrap();
     fs::write(root.join("app/dashboard/@team/_uf.page.js"), "// @flow\n").unwrap();
 
     let error = discover_routes(&root, &UniflowedConfig::default()).unwrap_err();
 
     let message = error.to_string();
-    assert!(message.contains("app/dashboard/@team"), "{message}");
-    assert!(message.contains("parallel route"), "{message}");
-    // It has to say it is refused. "Not supported" reads as "ignored", and
-    // being quietly ignored is what this replaced.
-    assert!(message.contains("refused"), "{message}");
+    assert!(message.contains("@team"), "{message}");
+    // The layout above is not the answer: inheriting one would hand a prop to
+    // a layout that never declared it, on every route below.
+    assert!(message.contains("no layout of its own"), "{message}");
 }
 
-/// A slot with no page at all is still refused.
+/// A `_uf.default.js` outside a slot is a file the router never opens.
 ///
-/// The reason the check is a directory pass rather than a line in the page
-/// walk: `app/@team/` may hold a layout, a loading file and a `default.js` and
-/// no page, and it is still a directory somebody wrote expecting a parallel
-/// route. The page walk only ever sees `_uf.page.js`.
+/// uf has no `default` for `children` the way Next.js does: `children` is the
+/// page the URL matched, and a URL that matches no page is a 404.
 #[test]
-fn a_slot_holding_no_page_is_refused_too() {
+fn a_default_outside_a_slot_is_refused() {
     let dir = tempfile::tempdir().unwrap();
     let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-    fs::create_dir_all(root.join("app/@team")).unwrap();
-    fs::write(root.join("app/@team/_uf.layout.js"), "// @flow\n").unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
     fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/_uf.default.js"), "// @flow\n").unwrap();
 
     let error = discover_routes(&root, &UniflowedConfig::default()).unwrap_err();
 
-    assert!(error.to_string().contains("@team"), "{error}");
+    let message = error.to_string();
+    assert!(message.contains("_uf.default.js"), "{message}");
+    assert!(message.contains("404"), "{message}");
+}
+
+/// A default beside a slot's own pages is what the file is for, so it is not
+/// refused — and neither is the slot around it.
+#[test]
+fn a_slot_with_a_default_and_a_layout_is_discovered() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+    fs::create_dir_all(root.join("app/@team")).unwrap();
+    fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/@team/_uf.default.js"), "// @flow\n").unwrap();
+    fs::write(root.join("app/@team/_uf.page.js"), "// @flow\n").unwrap();
+
+    let routes = discover_routes(&root, &UniflowedConfig::default()).unwrap();
+
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].path, "/");
+}
+
+/// A slot arrives as a prop named after its directory, so it may not be named
+/// after a prop the layout already has.
+///
+/// `@children` is the one somebody actually writes: `children` is what Next.js
+/// calls its implicit slot, so it is the first name a person migrating reaches
+/// for. Resolving the collision by precedence either way would leave one of the
+/// two silently missing.
+#[test]
+fn a_slot_named_after_a_layout_prop_is_refused() {
+    for name in LAYOUT_PROP_NAMES {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        let slot = format!("app/@{name}");
+        fs::create_dir_all(root.join(&slot)).unwrap();
+        fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
+        fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+        fs::write(root.join(&slot).join("_uf.page.js"), "// @flow\n").unwrap();
+
+        let error = discover_routes(&root, &UniflowedConfig::default()).unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains(name), "{name}: {message}");
+        assert!(message.contains("silently"), "{name}: {message}");
+    }
+}
+
+/// What a slot does not have yet, said where somebody writing the file reads
+/// it.
+///
+/// Per-slot boundaries are the part of parallel routes uf has not built, and
+/// these files would otherwise be opened by nobody — which is exactly the
+/// failure the issue is about, one level down.
+#[test]
+fn a_boundary_or_a_handler_inside_a_slot_is_refused() {
+    for (name, expected) in [
+        ("_uf.loading.js", "loading"),
+        ("_uf.error.js", "error"),
+        ("_uf.not-found.js", "not-found"),
+        ("_uf.template.js", "template"),
+        ("_uf.route.js", "@team"),
+        ("_uf.middleware.js", "@team"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        fs::create_dir_all(root.join("app/@team")).unwrap();
+        fs::write(root.join("app/_uf.layout.js"), "// @flow\n").unwrap();
+        fs::write(root.join("app/_uf.page.js"), "// @flow\n").unwrap();
+        fs::write(root.join("app/@team/_uf.page.js"), "// @flow\n").unwrap();
+        fs::write(root.join("app/@team").join(name), "// @flow\n").unwrap();
+
+        let error = discover_routes(&root, &UniflowedConfig::default()).unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains(expected), "{name}: {message}");
+    }
 }
 
 /// Every interception spelling Next.js defines, refused by the same rule.
@@ -781,11 +899,12 @@ fn a_route_group_is_still_discovered() {
     assert_eq!(routes[0].path, "/about");
 }
 
-/// A private directory is not a route, so a slot inside one is not refused.
+/// A private directory is not a route, so what is in one is neither refused
+/// nor scanned.
 ///
 /// Both routers skip a directory whose name starts with `.` or `_`, so
-/// `app/_drafts/@team/` was never going to be served — refusing it would be
-/// the linter inventing a rule about a place the router does not look.
+/// `app/_drafts/@team/` was never going to be served — refusing it, or reading
+/// a slot out of it, would be a rule about a place the router does not look.
 #[test]
 fn a_slot_inside_a_private_directory_is_left_alone() {
     let dir = tempfile::tempdir().unwrap();
@@ -802,20 +921,20 @@ fn a_slot_inside_a_private_directory_is_left_alone() {
 
 /// The generated types are the reason the refusal matters at all.
 ///
-/// `RoutePath` is a closed union built from what discovery found, so a slot
-/// that discovery accepted became a path a caller could pass to `route()` and
-/// Flow would agree with them. Refusing the directory is what keeps the union
-/// honest — there is no route, so there is no type for one.
+/// `RoutePath` is a closed union built from what discovery found, so a
+/// directory that discovery accepted became a path a caller could pass to
+/// `route()` and Flow would agree with them. Refusing the directory is what
+/// keeps the union honest — there is no route, so there is no type for one.
 #[test]
 fn a_refused_directory_never_reaches_the_generated_types() {
     let dir = tempfile::tempdir().unwrap();
     let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-    fs::create_dir_all(root.join("app/@team")).unwrap();
-    fs::write(root.join("app/@team/_uf.page.js"), "// @flow\n").unwrap();
+    fs::create_dir_all(root.join("app/feed/(.)photo")).unwrap();
+    fs::write(root.join("app/feed/(.)photo/_uf.page.js"), "// @flow\n").unwrap();
 
     let error = write_router_manifest(&root, &UniflowedConfig::default()).unwrap_err();
 
-    assert!(error.to_string().contains("@team"), "{error}");
+    assert!(error.to_string().contains("(.)photo"), "{error}");
     assert!(
         !root.join("router.js").exists(),
         "a manifest was written for a project the router refuses"

--- a/crates/uf_router/tests/reserved_names.rs
+++ b/crates/uf_router/tests/reserved_names.rs
@@ -19,16 +19,17 @@
 //! makes adding a second one a decision somebody has to write down.
 //!
 //! The directory names are the second half. `@team` and `(.)photo` are Next.js
-//! conventions uf does not implement, and until ubugeeei-prod/uf#267 *neither*
-//! router had an opinion about them: both fell through to a literal URL
-//! segment, so a project that wrote one got `/@team` and no error. They agree
-//! about that now, and the tests at the bottom are what keeps them agreeing —
-//! a spelling one refuses and the other serves is worse than the hole was.
+//! conventions, and until ubugeeei-prod/uf#267 *neither* router had an opinion
+//! about them: both fell through to a literal URL segment, so a project that
+//! wrote one got `/@team` and no error. `@team` is a parallel route both
+//! routers serve now and `(.)photo` is one both refuse, and the tests at the
+//! bottom are what keeps them agreeing about which is which — a spelling one
+//! refuses and the other serves is worse than the hole was.
 
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use uf_router::{ReservedRole, RouteSegment, classify_route_segment};
+use uf_router::{LAYOUT_PROP_NAMES, ReservedRole, RouteSegment, classify_route_segment};
 
 /// Roles that are reserved names without being anything the router resolves.
 ///
@@ -158,6 +159,44 @@ fn both_routers_refuse_the_same_directory_spellings() {
         "`RouteSegment::UNSUPPORTED_EXAMPLES` and `UNSUPPORTED_SEGMENTS` in \
          `packages/vite/internal/routes.js` name different directory spellings, so one router \
          refuses a directory the other serves as a URL"
+    );
+}
+
+/// The names a slot may not take, on both sides.
+///
+/// A slot arrives as a prop named after its directory, so a name the layout
+/// already uses is a collision — and a list one router refuses and the other
+/// accepts is a slot that builds and renders nothing, which is the third way
+/// this pair of files has drifted.
+#[test]
+fn both_routers_reserve_the_same_layout_prop_names() {
+    let source = build_router_source();
+
+    let table = source
+        .split_once("export const LAYOUT_PROP_NAMES = Object.freeze([")
+        .expect(
+            "`LAYOUT_PROP_NAMES` is a frozen array literal; if it is not, this test is out of date",
+        )
+        .1
+        .split_once("]);")
+        .expect("the literal is closed")
+        .0;
+
+    let build_router: BTreeSet<String> = table
+        .split('"')
+        .filter(|value| !value.trim().is_empty() && !value.contains(','))
+        .map(str::to_owned)
+        .collect();
+    let grammar: BTreeSet<String> = LAYOUT_PROP_NAMES
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect();
+
+    assert_eq!(
+        grammar, build_router,
+        "`uf_router::LAYOUT_PROP_NAMES` and `LAYOUT_PROP_NAMES` in \
+         `packages/vite/internal/routes.js` name different props, so one router refuses a slot \
+         the other scans into a prop that overwrites something"
     );
 }
 

--- a/docs/app/guide/migrate/_uf.page.mdx
+++ b/docs/app/guide/migrate/_uf.page.mdx
@@ -185,9 +185,9 @@ The conventions line up more closely than the capabilities do:
 | `app/api/x/route.ts` | `app/api/x/_uf.route.js` — `Request` in, `Response` out, **`uf dev` only** |
 | `not-found.tsx` | `_uf.not-found.js`, a segment file resolved by the nearest one above the path; a project that declares none gets uf's page inside the root's layouts |
 | `template.tsx` | `_uf.template.js` — a layout that remounts, keyed on the pathname |
-| `@slot/` | **refused by name.** uf has no parallel routes, so there is no second place for a route to render ([#267](https://github.com/ubugeeei-prod/uf/issues/267)) |
+| `@slot/` | `@slot/` — a parallel route: the segment's own layout receives it as a prop beside `children`, and the slot's pages are matched against the same URL. No per-slot `loading`, `error` or `template` yet ([#267](https://github.com/ubugeeei-prod/uf/issues/267)) |
 | `(.)folder/` | **refused by name.** uf has no intercepting routes: a navigation carries where it is going and not where it came from ([#267](https://github.com/ubugeeei-prod/uf/issues/267)) |
-| `default.tsx` | nothing — it exists to resolve a slot a URL says nothing about, and there are no slots |
+| `default.tsx` | `_uf.default.js`, directly inside the `@slot` it belongs to. There is no `default` for `children`: a URL that matches no page is a 404 |
 | `middleware.ts` | `_uf.middleware.js`, never called |
 | `generateStaticParams` | `generateStaticParams` |
 | `export const metadata` | `metadata` on a page or layout, merged along the path with the page last |

--- a/docs/app/guide/routing/_uf.page.mdx
+++ b/docs/app/guide/routing/_uf.page.mdx
@@ -60,25 +60,27 @@ app/posts/[slug]/_uf.page.js      →  /posts/anything
 app/docs/[...path]/_uf.page.js    →  /docs/a/b/c
 ```
 
-### Two spellings that are refused
+A directory named `@team` is a [parallel-route slot](#parallel-routes): it is
+not a URL segment at all. There is no escape hatch for a URL segment that
+really begins with `@`; capture it with a `[param]` instead.
 
-A directory named `@team` is a **parallel-route slot** and one named
-`(.)photo`, `(..)photo`, `(...)photo` or `(..)(..)photo` is an **intercepting
-route**. uf has neither feature, and both are refused by name — by `uf build`,
-by `uf dev` and by `uf lint`.
+### One spelling that is refused
 
-They are refused rather than ignored, and the difference is the point. Until
-[#267](https://github.com/ubugeeei-prod/uf/issues/267) neither name meant
-anything to the router, so both fell through to "an ordinary URL segment":
-`app/@team/_uf.page.js` served `/@team`, `app/feed/(.)photo/_uf.page.js` served
-`/feed/(.)photo` — a `(group)` is a segment that *ends* in `)`, which
-`(.)photo` does not — and both went into the generated `RoutePath`, so
-`route("/@team", …)` type checked. A person migrating from Next.js got a
-project that looked like it worked.
+A directory named `(.)photo`, `(..)photo`, `(...)photo` or `(..)(..)photo` is
+an **intercepting route**. uf does not have interception — a navigation carries
+where it is going and not where it came from — so the directory is refused by
+name, by `uf build`, by `uf dev` and by `uf lint`.
 
-There is no escape hatch for a URL segment that really begins with `@`;
-capture it with a `[param]` instead. A `(group)` is untouched: it ends in `)`
-and always did.
+It is refused rather than ignored, and the difference is the point. Until
+[#267](https://github.com/ubugeeei-prod/uf/issues/267) neither this name nor
+`@team` meant anything to the router, so both fell through to "an ordinary URL
+segment": `app/@team/_uf.page.js` served `/@team`,
+`app/feed/(.)photo/_uf.page.js` served `/feed/(.)photo` — a `(group)` is a
+segment that *ends* in `)`, which `(.)photo` does not — and both went into the
+generated `RoutePath`, so `route("/@team", …)` type checked. A person migrating
+from Next.js got a project that looked like it worked.
+
+A `(group)` is untouched: it ends in `)` and always did.
 
 "The rest" is the whole rest, so a spread is the last routing directory on the
 way to a page. `app/docs/[...path]/edit/_uf.page.js` would be a page no URL can
@@ -143,6 +145,67 @@ segment with no `_uf.template.js` gets no wrapper at all.
 
 The key is the **pathname**, so a navigation that changes only the query string
 does not remount. A filter written into the URL keeps the page it filters.
+
+## Parallel routes
+
+A directory whose name starts with `@` is a **slot**: a second thing a layout
+renders, beside its `children`.
+
+```
+app/dashboard/_uf.layout.js            the frame, which renders both
+app/dashboard/_uf.page.js              →  /dashboard          as `children`
+app/dashboard/members/_uf.page.js      →  /dashboard/members  as `children`
+app/dashboard/@team/_uf.default.js     the team slot when the URL says nothing
+app/dashboard/@team/members/_uf.page.js  /dashboard/members   as `team`
+```
+
+The layout receives the slot under the directory's name without its `@`:
+
+```js
+// @flow
+// app/dashboard/_uf.layout.js
+import * as React from "react";
+
+export default component Dashboard(children: React.Node, team: React.Node) {
+  return (
+    <div className="dashboard">
+      <main>{children}</main>
+      <aside>{team}</aside>
+    </div>
+  );
+}
+```
+
+**A slot adds no URL.** `@team` contributes nothing to the path, the way a
+`(group)` does not, and the slot's pages are matched against the *same* URL the
+page is — so `/dashboard/members` renders `app/dashboard/members/_uf.page.js`
+as `children` and `app/dashboard/@team/members/_uf.page.js` as `team`, at once,
+each inside its own layouts. A URL no ordinary page matches is a 404 whatever
+the slots hold, which is why uf has no `default` for `children` the way Next.js
+does.
+
+`_uf.default.js` is what a slot renders when the URL matches none of *its*
+routes. A slot with none renders nothing, and the layout is handed `null` — so
+`{team ?? <Empty />}` is a thing you can write and rely on.
+
+Four rules, each refused by name rather than by silence:
+
+- the segment that declares a slot must have a layout of its own, because the
+  slot is a prop that layout receives;
+- a slot may not be named `children` or `params`, which are the props every
+  layout already receives — `@children` is the tempting one, because `children`
+  is what Next.js calls the page, and here the page always is `children`;
+- `_uf.default.js` belongs directly inside a slot directory, and nowhere else;
+- a slot holds pages, layouts, nested slots and one default — a `_uf.loading.js`,
+  `_uf.error.js`, `_uf.not-found.js`, `_uf.template.js`, `_uf.route.js` or
+  `_uf.middleware.js` inside one is refused, because uf's slots do not carry
+  boundaries of their own yet
+  ([#267](https://github.com/ubugeeei-prod/uf/issues/267)).
+
+A slot page's `loader` is not run — a slot's data has nowhere to be embedded for
+hydration — and a slot page that exports one says so rather than being handed
+`undefined`. Fetch inside the component, or put the data on the page the URL
+names.
 
 ## Not found nests too
 

--- a/docs/app/reference/cli/_uf.page.mdx
+++ b/docs/app/reference/cli/_uf.page.mdx
@@ -136,8 +136,10 @@ teaching that the rule is noise.
 
 The file names come from the same grammar `uf build` discovers routes with, so
 a scaffold uf writes is a route uf finds. A spelling uf reserves without
-serving — `@team`, `(.)photo` — is refused here with the sentence `uf build`
-and `uf lint` give for it, rather than written now and reported later. Nothing
+serving — `(.)photo` — is refused here with the sentence `uf build` and
+`uf lint` give for it, rather than written now and reported later. A `@team` is
+refused for the opposite reason: uf serves parallel routes, and a slot is not a
+URL — which is what this command's argument is. Nothing
 is overwritten: a route whose page already exists is an error, and a run that
 stops has written none of its files.
 

--- a/packages/router/index.js
+++ b/packages/router/index.js
@@ -15,6 +15,13 @@
 //
 // `_uf.template.js` is a layout that remounts on every navigation, for the
 // cases where a layout's persistence is the wrong default.
+//
+// A directory named `@team` is a parallel-route slot: it contributes no URL
+// segment, and the layout of the segment that holds it receives the slot as a
+// `team` prop beside `children`. The slot's pages are matched against the same
+// URL the page is, so one URL renders two subtrees at once, and
+// `_uf.default.js` is what a slot renders when the URL matched none of its
+// routes. See ubugeeei-prod/uf#267.
 
 import * as React from "react";
 
@@ -43,7 +50,10 @@ export type {
   RouteRecord,
   RouteTable,
   Router,
+  ResolvedSlot,
   SearchParams,
+  SlotRecord,
+  SlotRouteRecord,
   TemplateModule,
   TwitterCard,
 } from "./internal/runtime.js";
@@ -93,7 +103,20 @@ export type ErrorProps = {|
   readonly reset: () => void,
 |};
 
-/** Props a layout receives. */
+/**
+ * Props a layout receives.
+ *
+ * A layout on a segment that declares parallel-route slots receives one more
+ * prop per slot, named after the directory without its `@`, and this exact
+ * type does not describe those — the names are the project's. Declare them: a
+ * layout beside `@team` and `@analytics` is
+ *
+ *     component Dashboard(children: React.Node, team: React.Node, analytics: React.Node)
+ *
+ * and the router passes `null` for a slot the URL addressed by neither a route
+ * of its own nor a `_uf.default.js`, so `{team ?? <Empty />}` is a thing that
+ * can be written and relied on.
+ */
 export type LayoutProps<
   TParams extends { readonly [string]: string | $ReadOnlyArray<string> } = {},
 > = {|

--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -105,11 +105,24 @@ type PageRenderProps = {|
   readonly data: mixed,
 |};
 
-/** The props `RouteView` gives each layout, outermost first. */
-type LayoutRenderProps = {|
+/**
+ * The props `RouteView` gives each layout, outermost first.
+ *
+ * Inexact, and that is the parallel routes reaching the type: a layout on a
+ * segment that declares `@team` is handed a `team` prop beside `children`, and
+ * the names are the project's rather than this file's. Every extra prop is a
+ * `React.Node` — a rendered slot, or `null` when the URL addressed neither the
+ * slot's routes nor a `_uf.default.js`.
+ *
+ * The exactness is not lost so much as moved: what a layout may be *given* is
+ * open, and what it *declares* is still its own exact props type, which is
+ * where a typo in a slot name shows up.
+ */
+type LayoutRenderProps = {
   readonly params: RouteParams,
   readonly children: React.Node,
-|};
+  ...
+};
 
 /** What a page module may export. The component is `default` or `Page`. */
 export type PageModule = {
@@ -434,6 +447,81 @@ export type RouteRecord = {|
    * template renders exactly the tree it did before.
    */
   readonly templates?: $ReadOnlyArray<TemplateRecord>,
+  /**
+   * The parallel-route slots in scope on this route, outermost first.
+   *
+   * Optional for the reason `templates` is. A route with no slot renders
+   * exactly the tree it did before slots existed, which is most routes.
+   */
+  readonly slots?: $ReadOnlyArray<SlotRecord>,
+|};
+
+/**
+ * One parallel-route slot, as the route table carries it.
+ *
+ * A slot is a second thing a layout renders. `app/dashboard/@team/` gives
+ * `app/dashboard/_uf.layout.js` a `team` prop beside `children`, and the slot's
+ * pages are matched against the same URL the page is: `/dashboard/members`
+ * renders `app/dashboard/members/_uf.page.js` as `children` and
+ * `app/dashboard/@team/members/_uf.page.js` as `team`, at once, each inside its
+ * own layouts.
+ *
+ * A slot never adds a URL — the directory contributes no path segment — so
+ * `routes` here is a second table matched against paths the main table already
+ * defines. That is uf's answer to the question Next.js answers with a
+ * `default.js` for `children`: there is no such thing, because `children` is
+ * the page the URL matched and a URL that matches no page is a 404.
+ *
+ * `above` is how many of the route's `layouts` are outside the slot, so
+ * `layouts[above - 1]` is the one that receives it — the same number, spelled
+ * the same way, as [`TemplateRecord`]'s and [`LoadingRecord`]'s.
+ */
+export type SlotRecord = {|
+  readonly name: string,
+  readonly above: number,
+  /**
+   * `_uf.default.js`: what this slot renders when the URL matches none of its
+   * routes.
+   *
+   * `null` for a slot that declares none, and then the slot renders nothing at
+   * all. That is what an unaddressed slot does on a soft navigation in Next.js
+   * too, and it is the honest answer for a slot that only some URLs have
+   * something to put in — a modal, a detail pane.
+   */
+  readonly defaultPage: ?() => Promise<PageModule>,
+  /** The default's source path, for diagnostics; absent when there is none. */
+  readonly defaultFile?: string,
+  /** Whether that default is MDX content. */
+  readonly defaultMdx?: boolean,
+  readonly routes: $ReadOnlyArray<SlotRouteRecord>,
+|};
+
+/**
+ * One page inside a slot.
+ *
+ * A [`RouteRecord`] without the parts a slot does not have. No `loading` and no
+ * `templates`: those belong to the segment, and they already wrap the layout
+ * the slot renders into. Per-slot boundaries are the part of parallel routes uf
+ * has not built, and `@uniflowed/vite`'s scan refuses the files rather than
+ * leaving them unopened — see ubugeeei-prod/uf#267.
+ *
+ * `page` is required, unlike a `RouteRecord`'s: a slot route that ships no
+ * client page has no URL of its own to hand the browser, so there would be
+ * nothing to do with the entry. The client table drops the whole route when its
+ * page is dropped, slots and all.
+ *
+ * `layouts` are the layouts *inside* the slot, and `slots` are the slots a
+ * layout inside this one declares — the recursion is the feature rather than a
+ * special case.
+ */
+export type SlotRouteRecord = {|
+  readonly path: string,
+  readonly params: $ReadOnlyArray<RouteParamSpec>,
+  readonly mdx: boolean,
+  readonly file: string,
+  readonly page: () => Promise<PageModule>,
+  readonly layouts: $ReadOnlyArray<() => Promise<LayoutModule>>,
+  readonly slots: $ReadOnlyArray<SlotRecord>,
 |};
 
 /**
@@ -638,6 +726,36 @@ export type ResolvedRoute = {|
     readonly above: number,
     readonly module: TemplateModule,
   |}>,
+  /**
+   * The slots this route renders, outermost first, already imported.
+   *
+   * Empty for a route with no slot above it, and empty on a resolution that
+   * *is* a boundary — a not-found or an error page — for the reason its
+   * `templates` is: a boundary is matched rather than walked to, and a slot
+   * belongs to the segment the walk went through.
+   */
+  readonly slots: $ReadOnlyArray<ResolvedSlot>,
+|};
+
+/**
+ * One slot, matched against the URL and imported.
+ *
+ * `page` is `null` for a slot the URL addressed and that declares no
+ * `_uf.default.js`, and the layout receives `null` rather than nothing at all:
+ * a layout that declares a slot always gets that prop, so a project can write
+ * `{team ?? <Empty />}` and mean it.
+ *
+ * `params` are the slot's own. A slot matches the same URL by its own patterns,
+ * so `@team/[member]` captures `member` while the page beside it captures
+ * nothing — which is the point of matching twice rather than sharing one match.
+ */
+export type ResolvedSlot = {|
+  readonly name: string,
+  readonly above: number,
+  readonly page: ?PageModule,
+  readonly params: RouteParams,
+  readonly layouts: $ReadOnlyArray<LayoutModule>,
+  readonly slots: $ReadOnlyArray<ResolvedSlot>,
 |};
 
 /** Thrown by `notFound()`; the renderer answers with the not-found page. */
@@ -833,8 +951,25 @@ export function hasClientPage(route: RouteRecord): boolean {
  * Match a pathname against the table, preferring the most specific route.
  */
 export function matchRoute(routes: $ReadOnlyArray<RouteRecord>, pathname: string): ?RouteMatch {
+  return matchIn(routes, pathname);
+}
+
+/**
+ * The same match, over anything that has a route path.
+ *
+ * A slot is a second table matched against the same URL — see [`SlotRecord`] —
+ * and it has to be matched by *this* function rather than by one of its own:
+ * two matchers would be two answers to "which of these paths does this URL
+ * name", and the one that disagreed would show up as a slot holding somebody
+ * else's page. The generic is only about the record type; the ranking, the
+ * parameters and the tie-break are the route table's.
+ */
+function matchIn<TRecord: { +path: string, ... }>(
+  routes: $ReadOnlyArray<TRecord>,
+  pathname: string,
+): ?{| readonly route: TRecord, readonly params: RouteParams |} {
   const parts = pathname.split("/").filter((part) => part !== "");
-  let best: ?RouteMatch = null;
+  let best: ?{| readonly route: TRecord, readonly params: RouteParams |} = null;
   let bestScore = -1;
   for (const route of routes) {
     const segments = compile(route.path);
@@ -1074,6 +1209,11 @@ async function resolveRoute(
   // depends on nothing the loader produces.
   const loading = resolveLoading(matched.route, matched.route.layouts.length);
   const templates = resolveTemplates(matched.route, matched.route.layouts.length);
+  // Started alongside and awaited at the end, for the reason the boundaries
+  // are: a slot is matched against the URL and depends on nothing the loader
+  // produces, so the second match and its imports overlap the first page's
+  // loader rather than following it.
+  const slots = resolveSlots(matched.route.slots ?? [], pathname, matched.route.layouts.length);
 
   // The loader, run here and awaited below — or not awaited at all.
   //
@@ -1135,7 +1275,139 @@ async function resolveRoute(
     errorBoundary: await boundary,
     loading: await loading,
     templates: await templates,
+    slots: await slots,
   };
+}
+
+/**
+ * The route's slots, matched against the URL and imported.
+ *
+ * The second matching pass parallel routes are, and it is a pass rather than a
+ * branch of the first: a slot has its own patterns over the same path, so
+ * `/dashboard/members` can be `[member]` to one slot, a static segment to
+ * another and nothing at all to a third, at once.
+ *
+ * A slot that will not load renders nothing rather than taking the page with
+ * it, which is the judgement `resolveTemplates` and `resolveLoading` already
+ * make: a slot is a second thing beside the page, and a broken second thing
+ * must not become a broken route. The entry stays in the list with `page:
+ * null`, so the layout still receives the prop it declares.
+ */
+async function resolveSlots(
+  records: $ReadOnlyArray<SlotRecord>,
+  pathname: string,
+  layoutCount: number,
+): Promise<$ReadOnlyArray<ResolvedSlot>> {
+  if (records.length === 0) {
+    return [];
+  }
+  return Promise.all(records.map((record) => resolveSlot(record, pathname, layoutCount)));
+}
+
+async function resolveSlot(
+  record: SlotRecord,
+  pathname: string,
+  layoutCount: number,
+): Promise<ResolvedSlot> {
+  // Clamped exactly as a template's `above` is, and for the same reason: a
+  // hand-written table, or a `(group)` between the layout and the route, can
+  // leave a route with fewer layouts than the slot was declared above.
+  const above = Math.min(record.above, layoutCount);
+  const empty: ResolvedSlot = {
+    name: record.name,
+    above,
+    page: null,
+    params: {},
+    layouts: [],
+    slots: [],
+  };
+
+  const matched = matchIn(record.routes, pathname);
+  if (matched == null) {
+    // The URL says nothing about this slot. `_uf.default.js` is what it says
+    // instead, and a slot that declares none renders nothing at all.
+    const load = record.defaultPage;
+    if (load == null) {
+      return empty;
+    }
+    const module = await loadOrNull(load);
+    if (module == null) {
+      return empty;
+    }
+    return { ...empty, page: withoutLoader(module, record.defaultFile ?? record.name) };
+  }
+
+  const route = matched.route;
+  // Started together and awaited apart, so the two `await`s are not a
+  // waterfall and each keeps the type its loader had.
+  const pending = loadOrNull(route.page);
+  const pendingLayouts = Promise.all(route.layouts.map((layout) => loadOrNull(layout)));
+  const page = await pending;
+  const layouts = await pendingLayouts;
+  if (page == null) {
+    return empty;
+  }
+  const loaded = layouts.filter(Boolean);
+  if (loaded.length !== layouts.length) {
+    return empty;
+  }
+  return {
+    name: record.name,
+    above,
+    page: withoutLoader(page, route.file),
+    params: matched.params,
+    layouts: loaded,
+    // The slot's own layouts are what a nested slot is measured against, so
+    // the count handed down is this slot's rather than the route's.
+    slots: await resolveSlots(route.slots, pathname, loaded.length),
+  };
+}
+
+/**
+ * A module, or `null` when it would not import.
+ *
+ * The judgement [`resolveTemplates`] and [`resolveLoading`] already make, at
+ * the granularity a slot needs it: a slot is a second thing beside the page, so
+ * a slot whose module is missing renders nothing rather than taking the route
+ * down with it — and the import error surfaces where it belongs, the next time
+ * the module is asked for.
+ */
+async function loadOrNull<TModule>(load: () => Promise<TModule>): Promise<?TModule> {
+  try {
+    return await loadOnce(load);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The same page module, having said out loud that a slot's loader does not run.
+ *
+ * A slot page is a component. It is *not* handed data, and this throws rather
+ * than passing `undefined` to a page that asked for some, because a slot whose
+ * loader is quietly skipped is exactly the failure ubugeeei-prod/uf#267 is
+ * about — a file written to a convention, and nothing that reads it.
+ *
+ * Why not run it. A page's loader answer is embedded in the document for the
+ * browser to hydrate from, once, under one id; a slot's would have nowhere to
+ * go, so it would run on the server and again in the browser on the way in.
+ * That is not merely two fetches: a loader that reads `cookies()` succeeds on
+ * the server and throws in the browser, and the slot would render on one side
+ * and not the other — a hydration mismatch produced by the router. So the rule
+ * is the narrow one, and lifting it means embedding per-slot data, which is
+ * named in the issue as what is left.
+ */
+function withoutLoader(module: PageModule, file: string): PageModule {
+  if (typeof module.loader === "function") {
+    throw new Error(
+      `@uniflowed/router: ${file} is inside a \`@slot\` and exports a \`loader\`, which the ` +
+        "router does not run — a slot's data has nowhere to be embedded for hydration, so it " +
+        "would be fetched again in the browser and a server-only loader would render one tree " +
+        "on the server and another in the page. Fetch inside the component, or move the data to " +
+        "the page the URL names. https://github.com/ubugeeei-prod/uf/issues/267",
+    );
+  }
+  return module;
 }
 
 /**
@@ -1367,6 +1639,11 @@ async function resolveError(
     // show, which is worse than none.
     loading: [],
     templates: [],
+    // And slots for the third time: a slot belongs to the segment the walk went
+    // through, and an error page is matched rather than walked to. A layout
+    // that declares one is still mounted above the boundary, holding the slot
+    // it was rendered with — the boundary replaces what is under it.
+    slots: [],
   };
 }
 
@@ -1438,6 +1715,8 @@ async function resolveNotFound(
     loading: [],
     // Templates are accumulated on that same walk, and for the same reason.
     templates: [],
+    // Slots too: a URL that matched no route addressed no slot either.
+    slots: [],
   };
 }
 
@@ -2371,7 +2650,22 @@ export component RouteView() {
     element = insideTemplates(element, resolved, depth);
     if (depth > 0) {
       const Layout = layoutComponent(resolved.layouts[depth - 1]);
-      element = <Layout params={resolved.params}>{element}</Layout>;
+      // The slots declared on this layout's own segment, beside `children`.
+      // Spread rather than passed as one `slots` object, because a slot is a
+      // prop a layout declares by name — `component Dashboard(children, team)`
+      // — and a bag would make every layout destructure a map to find out
+      // whether the router had anything for it.
+      // The spread first and `params` after it, so that a slot named after a
+      // prop the layout already has loses rather than wins. `@params` and
+      // `@children` are refused by the scan, and this is the second line of
+      // that defence for a table written by hand: losing a slot is a hole in
+      // the page, and overwriting `params` is every route in the segment
+      // rendering against the wrong parameters.
+      element = (
+        <Layout {...slotsAt(resolved.slots, depth)} params={resolved.params}>
+          {element}
+        </Layout>
+      );
     }
   }
   return (
@@ -2531,6 +2825,79 @@ function insideTemplates(element: React.Node, resolved: ResolvedRoute, depth: nu
     );
   }
   return out;
+}
+
+/**
+ * The slots declared at `depth`, as the props the layout there receives.
+ *
+ * One object per layout rather than one lookup per slot, so the common case —
+ * a project with no slots at all — allocates nothing and spreads nothing.
+ *
+ * A slot the URL addressed and that has no `_uf.default.js` is `null` rather
+ * than absent: a layout that declares `team` receives `team` on every route,
+ * so `{team ?? <Empty />}` is a thing a project can write and rely on.
+ */
+function slotsAt(
+  slots: $ReadOnlyArray<ResolvedSlot>,
+  depth: number,
+): { readonly [string]: React.Node } {
+  if (slots.length === 0) {
+    return EMPTY_SLOTS;
+  }
+  const props: { [string]: React.Node } = {};
+  for (const slot of slots) {
+    if (slot.above === depth) {
+      // `null` rather than an element that renders nothing, and the difference
+      // is the whole of what the prop is for: `{team ?? <Empty />}` has to be
+      // able to tell "this slot has nothing in it" from "this slot rendered
+      // something empty", and an element is never `null`.
+      props[slot.name] = slot.page == null ? null : <SlotView slot={slot} />;
+    }
+  }
+  return props;
+}
+
+/** One object for every layout on a project that declares no slot. */
+const EMPTY_SLOTS: { readonly [string]: React.Node } = Object.freeze({});
+
+/**
+ * One slot's tree: its page, inside the layouts declared under the slot, with
+ * the slots those layouts declare in turn.
+ *
+ * The same composition [`RouteView`] does and deliberately not the same
+ * function. A route's tree carries the things a slot does not have — the error
+ * boundary, the `<Suspense>` fallbacks, the templates, the head — and folding
+ * a second, simpler case into that loop would be four `if`s asking which of the
+ * two this is. What the two share is the *order*, page innermost and layouts
+ * backwards over a root-first list, and that is short enough to be right twice.
+ *
+ * A slot with no page is never rendered through this component at all —
+ * [`slotsAt`] hands the layout `null` instead, so the layout can tell an empty
+ * slot from one that rendered something empty. The guard below is what makes
+ * that a fact about one place rather than a convention two places share.
+ */
+component SlotView(slot: ResolvedSlot) {
+  // Before the early return, because a hook after one is a hook that runs on
+  // some renders and not others. The search string is the route's — a slot
+  // matches the path and the query belongs to the URL, not to either match.
+  const { resolved } = useRouterState();
+  const page = slot.page;
+  if (page == null) {
+    return null;
+  }
+  const Page = pageComponent(page);
+  let element: React.Node = (
+    <Page params={slot.params} searchParams={resolved.searchParams} data={undefined} />
+  );
+  for (let depth = slot.layouts.length; depth > 0; depth -= 1) {
+    const Layout = layoutComponent(slot.layouts[depth - 1]);
+    element = (
+      <Layout {...slotsAt(slot.slots, depth)} params={slot.params}>
+        {element}
+      </Layout>
+    );
+  }
+  return element;
 }
 
 /**

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -22,6 +22,7 @@ export const RESERVED = Object.freeze({
   layout: "_uf.layout",
   template: "_uf.template",
   page: "_uf.page",
+  default: "_uf.default",
   middleware: "_uf.middleware",
   notFound: "_uf.not-found",
   error: "_uf.error",
@@ -38,21 +39,40 @@ export const RESERVED = Object.freeze({
  * spelling one router refuses and the other serves as a URL is exactly the
  * disagreement that made this necessary.
  *
- * `@team` is Next.js's parallel-route slot and `(.)photo` its intercepting
- * route. uf has neither, and until #267 both fell through to "a literal URL
- * segment": `@team` became `/@team`, `(.)photo` became `/(.)photo` — the test
- * for a `(group)` is that the segment *ends* in `)` — and the generated
+ * `(.)photo` is Next.js's intercepting route. `@team`, its parallel-route
+ * slot, was on this list too: until #267 both fell through to "a literal URL
+ * segment", so `@team` became `/@team`, `(.)photo` became `/(.)photo` — the
+ * test for a `(group)` is that the segment *ends* in `)` — and the generated
  * `RoutePath` union contained them, so `route("/@team", …)` type checked. A
  * convention served as nonsense is worse than one that is refused, because the
  * project looks like it works.
+ *
+ * A slot is a route this router serves now; see {@link scanRoutes}. An
+ * interception is not: it needs a navigation to carry where it came from,
+ * which is a change to what a navigation is rather than to this scan.
  */
 export const UNSUPPORTED_SEGMENTS = Object.freeze([
-  "@team",
   "(.)photo",
   "(..)photo",
   "(...)photo",
   "(..)(..)photo",
 ]);
+
+/**
+ * The prop names a layout already receives, which a slot may therefore not
+ * take.
+ *
+ * A slot arrives as a prop named after its directory, so `@children` and
+ * `@params` are the two names that would land on top of something the layout
+ * already has. `@children` is the one somebody actually writes: `children` is
+ * what Next.js calls its implicit slot, so it is the first name a person
+ * migrating reaches for — and here the page the URL matched always is
+ * `children`.
+ *
+ * The same list as `uf_router::LAYOUT_PROP_NAMES`; see that file for why the
+ * collision is refused rather than resolved by precedence.
+ */
+export const LAYOUT_PROP_NAMES = Object.freeze(["children", "params"]);
 
 /** Extensions a page or layout may use; `.mdx` is a page written as content. */
 const PAGE_EXTENSIONS = [".js", ".jsx", ".mdx"];
@@ -75,6 +95,61 @@ const MAX_DEPTH = 32;
  *   `layouts` are outside each one
  * @property {ReadonlyArray<{above: number, module: string}>} templates the
  *   `_uf.template.js` wrappers in scope, root first, with the same `above`
+ * @property {ReadonlyArray<Slot>} slots the parallel-route slots in scope,
+ *   outermost first
+ * @property {boolean} mdx whether the page is MDX content
+ */
+
+/**
+ * One parallel-route slot — a second thing a layout renders, beside its page.
+ *
+ * A directory named `@team` contributes no URL segment. It declares a slot on
+ * the segment that holds it, and that segment's own layout receives the
+ * rendered slot as a `team` prop beside `children`. The slot's pages are
+ * matched against the same URL the page is, so `app/dashboard/@team/members/
+ * _uf.page.js` is what `/dashboard/members` puts in the slot — not a second
+ * page at that path.
+ *
+ * `above` is how many of the route's `layouts` are outside the slot, counted
+ * after the declaring segment's own layout is added — so `layouts[above - 1]`
+ * is the layout that receives it. It is the same number, spelled the same way,
+ * as a template's and a loading boundary's. The layout has to be the segment's
+ * *own*: a slot rendered into an inherited layout would be a prop that layout
+ * never declared, on every route below it, so {@link scanRoutes} refuses a slot
+ * whose segment has no layout of its own.
+ *
+ * `defaultPage` is the slot's `_uf.default.js`: what it renders when the URL
+ * matches none of its routes. A slot with neither a match nor a default
+ * renders nothing, which is what an unaddressed slot on a soft navigation does
+ * in Next.js too.
+ *
+ * @typedef {object} Slot
+ * @property {string} name the slot's name, without the `@`
+ * @property {number} above how many of the route's layouts are outside it
+ * @property {?string} defaultPage absolute path of `_uf.default.*`, or `null`
+ * @property {boolean} defaultMdx whether that default is MDX content
+ * @property {ReadonlyArray<SlotRoute>} routes what the slot may render, by URL
+ */
+
+/**
+ * One page inside a slot.
+ *
+ * A `Route` without the parts a slot does not have: no `loading`, no
+ * `templates`, and no boundary of its own. Those are the segment's, and they
+ * already wrap the layout the slot renders into. Per-slot boundaries are the
+ * part of parallel routes uf has not built — see
+ * https://github.com/ubugeeei-prod/uf/issues/267 — and {@link scanRoutes}
+ * refuses the files rather than leaving them unopened.
+ *
+ * `layouts` are the layouts *inside* the slot, root first; the ones above it
+ * are already rendering, since the slot renders into one of them.
+ *
+ * @typedef {object} SlotRoute
+ * @property {string} path route path such as `/dashboard/members`
+ * @property {ReadonlyArray<{name: string, catchAll: boolean}>} params
+ * @property {string} page absolute path of the page module
+ * @property {ReadonlyArray<string>} layouts absolute paths, slot root first
+ * @property {ReadonlyArray<Slot>} slots slots declared inside this slot
  * @property {boolean} mdx whether the page is MDX content
  */
 
@@ -167,9 +242,16 @@ const MAX_DEPTH = 32;
  * Directories that do not exist yield an empty table rather than an error: a
  * library project has no router root, and that is not a mistake.
  *
- * Throws for a directory named the way a parallel route or an intercepting
- * route is spelled: uf has neither, and both used to become literal URL
- * segments. See {@link UNSUPPORTED_SEGMENTS}.
+ * Throws for a directory named the way an intercepting route is spelled: uf
+ * does not have interception, and the spelling used to become a literal URL
+ * segment. See {@link UNSUPPORTED_SEGMENTS}.
+ *
+ * A `@slot` directory is a parallel route and is scanned; see {@link Slot}. It
+ * throws for the three ways one can be written without being renderable: a
+ * slot on a segment with no layout of its own, a `_uf.default.js` that is not
+ * directly inside a slot, and a boundary or a handler inside a slot. Each is a
+ * file the router would otherwise never open, which is the failure #267 is
+ * about.
  *
  * @param {string} appRoot absolute path of the router root (`app/`)
  * @returns {{
@@ -192,11 +274,24 @@ export function scanRoutes(appRoot) {
   // records below are made of them. See the note beside them.
   let rootLayouts = [];
 
-  const walk = (directory, segments, layouts, loading, templates, depth) => {
+  const walk = (directory, segments, layouts, loading, templates, slots, depth) => {
     if (depth > MAX_DEPTH) return;
     const entries = readdirSync(directory, { withFileTypes: true }).sort((a, b) =>
       a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
     );
+
+    // A `_uf.default.js` answers one question — what a slot renders when the
+    // URL says nothing about it — and this walk is everywhere a slot is not,
+    // so one found here is a file nothing would ever open.
+    const strayDefault = findModule(directory, RESERVED.default, PAGE_EXTENSIONS);
+    if (strayDefault != null) {
+      throw new Error(
+        `${strayDefault}: \`_uf.default.js\` is what a \`@slot\` renders when the URL says ` +
+          "nothing about it, and it belongs directly inside the slot directory — one per slot, " +
+          "beside that slot's own pages. Nothing would ever render this one. uf has no " +
+          "`default` for `children`: a URL that matches no page is a 404.",
+      );
+    }
 
     const ownLayout = findModule(directory, RESERVED.layout, MODULE_EXTENSIONS);
     const nextLayouts = ownLayout ? [...layouts, ownLayout] : layouts;
@@ -226,6 +321,29 @@ export function scanRoutes(appRoot) {
       ? [...templates, { above: nextLayouts.length, module: ownTemplate }]
       : templates;
 
+    // Slots before this directory's own page, because the page renders inside
+    // the layout that holds them: a slot declared here belongs to every route
+    // at or below this segment, the way a template does.
+    let nextSlots = slots;
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+      const classified = classifyRouteSegment(entry.name);
+      if (classified.kind !== "slot") continue;
+      nextSlots = [
+        ...nextSlots,
+        scanSlot(
+          directory,
+          entry.name,
+          classified.name,
+          segments,
+          ownLayout,
+          nextLayouts.length,
+          depth,
+        ),
+      ];
+    }
+
     // A middleware guards this directory and everything below it, whether or
     // not this directory is itself a route: `app/dashboard/_uf.middleware.js`
     // with no `_uf.page.js` beside it still guards `/dashboard/settings`.
@@ -245,6 +363,7 @@ export function scanRoutes(appRoot) {
         layouts: nextLayouts,
         loading: nextLoading,
         templates: nextTemplates,
+        slots: nextSlots,
         mdx: page.endsWith(".mdx"),
       });
     }
@@ -287,9 +406,11 @@ export function scanRoutes(appRoot) {
       // A leading dot or underscore is private to the author: `_components/`
       // beside a page is a place to put things, not a route.
       if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+      // Already walked, above, into a table of its own.
+      if (classifyRouteSegment(entry.name).kind === "slot") continue;
       // Checked before descending, and after the private-directory test for
-      // the same reason `uf_router` prunes them: `app/_drafts/@team/` is not a
-      // route uf would have served, so it is not one to refuse.
+      // the same reason `uf_router` prunes them: `app/_drafts/(.)photo/` is not
+      // a route uf would have served, so it is not one to refuse.
       const refused = unsupportedSegmentReason(entry.name);
       if (refused != null) {
         throw new Error(`${path.join(directory, entry.name)}: ${refused}`);
@@ -300,12 +421,13 @@ export function scanRoutes(appRoot) {
         nextLayouts,
         nextLoading,
         nextTemplates,
+        nextSlots,
         depth + 1,
       );
     }
   };
 
-  walk(appRoot, [], [], [], [], 0);
+  walk(appRoot, [], [], [], [], [], 0);
 
   // A boundary at the router root for a project that declared none, carrying
   // the root's layouts and no module of its own.
@@ -351,6 +473,170 @@ export function scanRoutes(appRoot) {
   notFound.sort(byPath);
   errors.sort(byPath);
   return { routes, handlers, middleware, notFound, errors };
+}
+
+/**
+ * One `@slot` directory, scanned into a {@link Slot}.
+ *
+ * Separate from `walk` rather than a mode of it, because the two build
+ * different things out of the same tree. `walk` builds URLs and the boundaries
+ * around them; this builds what one named place may hold, matched against URLs
+ * somebody else's directories define. Folding them together would mean a
+ * `loading` accumulator that is dead in half the calls and a route table that
+ * is dead in the other half.
+ *
+ * Nested slots are ordinary: a slot's own layout may declare slots of its own,
+ * and they are collected here the same way, so the recursion is the shape of
+ * the feature rather than a special case.
+ *
+ * @param {string} parent the directory that declares the slot
+ * @param {string} directoryName the slot directory, `@team` as written
+ * @param {string} name the slot's name, `team`
+ * @param {ReadonlyArray<string>} segments the declaring segments, for the URL
+ * @param {?string} ownLayout the declaring segment's own layout, or `null`
+ * @param {number} above how many layouts are outside the slot
+ * @param {number} depth nesting depth, against `MAX_DEPTH`
+ * @returns {Slot}
+ */
+function scanSlot(parent, directoryName, name, segments, ownLayout, above, depth) {
+  const directory = path.join(parent, directoryName);
+  if (LAYOUT_PROP_NAMES.includes(name)) {
+    throw new Error(
+      `${directory}: a slot arrives as a prop named after its directory, and \`${name}\` is a ` +
+        "prop every layout already receives, so one of the two would silently go missing. " +
+        "Rename the slot. The page a URL matches is always `children` — uf has no `@children` " +
+        "slot, which is the name Next.js gives that page.",
+    );
+  }
+  // The declaring segment's *own* layout, not the layouts in scope there. A
+  // slot is a prop that layout receives beside `children`, so a slot on a
+  // segment with no layout has nothing to render into — and rendering it into
+  // an inherited one would hand a prop to a layout that never declared it, on
+  // every route below.
+  if (ownLayout == null) {
+    const routePath = routeFromSegments(segments).path;
+    throw new Error(
+      `${directory}: \`${directoryName}\` is a parallel-route slot and \`${routePath}\` declares ` +
+        "no layout of its own, so there is nothing to render the slot into — a slot is a prop " +
+        "the segment's own layout receives beside `children`. Add " +
+        `\`${path.join(parent, `${RESERVED.layout}.js`)}\`, or move the slot to a segment that ` +
+        "has one.",
+    );
+  }
+
+  const routes = [];
+  const defaultPage = findModule(directory, RESERVED.default, PAGE_EXTENSIONS);
+
+  const walkSlot = (current, currentSegments, layouts, atSlotRoot, currentDepth) => {
+    if (currentDepth > MAX_DEPTH) return;
+    // What a slot does not have, said where somebody writing the file will
+    // read it rather than by never opening it. This is also the list of what
+    // is left of parallel routes; see the issue.
+    for (const role of [RESERVED.notFound, RESERVED.error, RESERVED.loading, RESERVED.template]) {
+      const found =
+        findModule(current, role, MODULE_EXTENSIONS) ?? findModule(current, role, PAGE_EXTENSIONS);
+      if (found != null) {
+        throw new Error(
+          `${found}: a \`@slot\` renders a page and the layouts inside the slot, and has no ` +
+            `\`${role.slice("_uf.".length)}\` of its own — uf's parallel routes do not carry ` +
+            "per-slot boundaries yet, so this file would never be opened. Put it outside " +
+            `\`${directoryName}\`, where it covers the whole segment. ` +
+            "https://github.com/ubugeeei-prod/uf/issues/267",
+        );
+      }
+    }
+    for (const role of [RESERVED.route, RESERVED.middleware]) {
+      const found = findModule(current, role, MODULE_EXTENSIONS);
+      if (found != null) {
+        throw new Error(
+          `${found}: a \`@slot\` renders inside the page at a URL and answers no request of its ` +
+            `own, so \`${role}.js\` here would never run. A slot directory contributes no URL ` +
+            `segment, so this would claim \`${routeFromSegments(currentSegments).path}\` — which ` +
+            `belongs to the segment that declares the slot. Move it out of \`${directoryName}\`.`,
+        );
+      }
+    }
+    // One default per slot, at the slot. A deeper one would be a second answer
+    // to a question that is asked once — the URL either addressed this slot or
+    // it did not.
+    if (!atSlotRoot && findModule(current, RESERVED.default, PAGE_EXTENSIONS) != null) {
+      throw new Error(
+        `${findModule(current, RESERVED.default, PAGE_EXTENSIONS)}: a \`@slot\` has one ` +
+          `\`_uf.default.js\`, directly inside \`${directoryName}\`, and this one is deeper, so ` +
+          "nothing would ever render it.",
+      );
+    }
+
+    const layoutHere = findModule(current, RESERVED.layout, MODULE_EXTENSIONS);
+    const nextLayouts = layoutHere ? [...layouts, layoutHere] : layouts;
+
+    const entries = readdirSync(current, { withFileTypes: true }).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
+
+    let nestedSlots = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+      const classified = classifyRouteSegment(entry.name);
+      if (classified.kind !== "slot") continue;
+      nestedSlots = [
+        ...nestedSlots,
+        scanSlot(
+          current,
+          entry.name,
+          classified.name,
+          currentSegments,
+          layoutHere,
+          nextLayouts.length,
+          currentDepth,
+        ),
+      ];
+    }
+
+    const page = findModule(current, RESERVED.page, PAGE_EXTENSIONS);
+    if (page) {
+      const { path: routePath, params } = routeFromSegments(currentSegments);
+      routes.push({
+        path: routePath,
+        params,
+        page,
+        layouts: nextLayouts,
+        slots: nestedSlots,
+        mdx: page.endsWith(".mdx"),
+      });
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+      const classified = classifyRouteSegment(entry.name);
+      if (classified.kind === "slot") continue;
+      const refused = unsupportedSegmentReason(entry.name);
+      if (refused != null) {
+        throw new Error(`${path.join(current, entry.name)}: ${refused}`);
+      }
+      walkSlot(
+        path.join(current, entry.name),
+        [...currentSegments, entry.name],
+        nextLayouts,
+        false,
+        currentDepth + 1,
+      );
+    }
+  };
+
+  walkSlot(directory, segments, [], true, depth + 1);
+
+  const byPath = (a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+  routes.sort(byPath);
+  return {
+    name,
+    above,
+    defaultPage,
+    defaultMdx: defaultPage != null && defaultPage.endsWith(".mdx"),
+    routes,
+  };
 }
 
 function isDirectory(candidate) {
@@ -436,15 +722,6 @@ function interceptionMarker(segment) {
  */
 export function unsupportedSegmentReason(segment) {
   const classified = classifyRouteSegment(segment);
-  if (classified.kind === "slot") {
-    return (
-      `\`${segment}\` is a parallel-route slot, and uf does not have parallel routes — a route ` +
-      "here renders in one place, so there is nothing for a slot to render into. It is refused " +
-      `rather than served as the URL segment \`/${segment}\`, which is what it used to become. ` +
-      "Rename the directory; a URL segment that really starts with `@` has no spelling in this " +
-      "grammar, so capture it with a `[param]`. https://github.com/ubugeeei-prod/uf/issues/267"
-    );
-  }
   if (classified.kind === "interception") {
     return (
       `\`${segment}\` is an intercepting route, and uf does not have interception — a navigation ` +
@@ -461,16 +738,19 @@ export function unsupportedSegmentReason(segment) {
  * Turn directory segments into a route path and its parameters.
  *
  * `(group)` segments organise files without appearing in the URL, `[name]`
- * captures one segment, and `[...name]` captures the rest of the path. A slot
- * or an interception never reaches here: {@link scanRoutes} refuses the
- * directory before it walks into it.
+ * captures one segment, and `[...name]` captures the rest of the path. A
+ * `@slot` contributes nothing either — it is a named place a route renders
+ * into, matched against the URL of the segment that declares it — so a slot's
+ * pages are matched against ordinary paths and add none of their own. An
+ * interception never reaches here: {@link scanRoutes} refuses the directory
+ * before it walks into it.
  */
 export function routeFromSegments(segments) {
   const params = [];
   const out = [];
   for (const segment of segments) {
     const classified = classifyRouteSegment(segment);
-    if (classified.kind === "group") continue;
+    if (classified.kind === "group" || classified.kind === "slot") continue;
     if (classified.kind === "catchAll") {
       params.push({ name: classified.name, catchAll: true });
       out.push(`:${classified.name}*`);
@@ -648,6 +928,59 @@ export function routesModuleSource(table, options = {}) {
     return id;
   };
 
+  // Slots are hoisted like layouts and deduplicated by identity rather than by
+  // file: one `scanRoutes` slot record is shared by every route at or below the
+  // segment that declares it, so the object is the key. A slot holds a whole
+  // route table of its own, and emitting it once per route below it would be
+  // that table copied into the bundle once per route.
+  //
+  // Nested slots are emitted before the slot that holds them, because a `const`
+  // cannot read one declared after it.
+  const slotIds = new Map();
+  const slotDefinitions = [];
+  const slotFiles = new Set();
+  const slotId = (slot) => {
+    let id = slotIds.get(slot);
+    if (id !== undefined) {
+      return id;
+    }
+    const routes = slot.routes.map((route) => {
+      slotFiles.add(route.page);
+      for (const file of route.layouts) slotFiles.add(file);
+      const nested = route.slots.map(slotId);
+      return `    {
+      path: ${JSON.stringify(route.path)},
+      params: ${JSON.stringify(route.params)},
+      mdx: ${route.mdx},
+      file: ${JSON.stringify(displayFile(route.page))},
+      page: () => import(${JSON.stringify(route.page)}),
+      layouts: [${route.layouts.map(layoutId).join(", ")}],
+      slots: [${nested.join(", ")}],
+    }`;
+    });
+    // After the routes, so a nested slot's `const` is already emitted.
+    id = `slot${slotIds.size}`;
+    slotIds.set(slot, id);
+    if (slot.defaultPage != null) {
+      slotFiles.add(slot.defaultPage);
+    }
+    const fallback =
+      slot.defaultPage == null
+        ? "    defaultPage: null,"
+        : `    defaultPage: () => import(${JSON.stringify(slot.defaultPage)}),
+    defaultFile: ${JSON.stringify(displayFile(slot.defaultPage))},`;
+    slotDefinitions.push(`const ${id} = {
+    name: ${JSON.stringify(slot.name)},
+    above: ${slot.above},
+${fallback}
+    defaultMdx: ${slot.defaultMdx},
+    routes: [
+${routes.join(",\n")}
+    ],
+  };`);
+    return id;
+  };
+
   const entries = table.routes.map((route) => {
     if (!shipsPage(route)) {
       return `  {
@@ -658,6 +991,7 @@ export function routesModuleSource(table, options = {}) {
     layouts: [],
     loading: [],
     templates: [],
+    slots: [],
   }`;
     }
     const layouts = route.layouts.map(layoutId);
@@ -667,6 +1001,7 @@ export function routesModuleSource(table, options = {}) {
     const templates = (route.templates ?? []).map(
       (entry) => `{ above: ${entry.above}, module: ${templateId(entry.module)} }`,
     );
+    const slots = (route.slots ?? []).map(slotId);
     return `  {
     path: ${JSON.stringify(route.path)},
     params: ${JSON.stringify(route.params)},
@@ -676,6 +1011,7 @@ export function routesModuleSource(table, options = {}) {
     layouts: [${layouts.join(", ")}],
     loading: [${loading.join(", ")}],
     templates: [${templates.join(", ")}],
+    slots: [${slots.join(", ")}],
   }`;
   });
 
@@ -743,7 +1079,12 @@ export function routesModuleSource(table, options = {}) {
   // Last, because it is defined by what everything above did *not* import: a
   // layout a kept route also uses is already in the graph as a lazy chunk, and
   // importing it here as well would pull it into the entry chunk instead.
-  const carried = new Set([...layoutIds.keys(), ...loadingIds.keys(), ...templateIds.keys()]);
+  const carried = new Set([
+    ...layoutIds.keys(),
+    ...loadingIds.keys(),
+    ...templateIds.keys(),
+    ...slotFiles,
+  ]);
   const styleOnlyImports = [];
   for (const route of table.routes) {
     if (shipsPage(route)) {
@@ -754,6 +1095,7 @@ export function routesModuleSource(table, options = {}) {
       ...route.layouts,
       ...(route.loading ?? []).map((it) => it.module),
       ...(route.templates ?? []).map((it) => it.module),
+      ...slotModuleFiles(route.slots ?? []),
     ];
     for (const file of files) {
       if (carried.has(file)) {
@@ -764,7 +1106,7 @@ export function routesModuleSource(table, options = {}) {
     }
   }
 
-  return `${[...styleOnlyImports, ...layoutImports, ...loadingImports, ...templateImports].join("\n")}
+  return `${[...styleOnlyImports, ...layoutImports, ...loadingImports, ...templateImports, ...slotDefinitions].join("\n")}
 export const routes = [
 ${entries.join(",\n")}
 ];
@@ -782,6 +1124,27 @@ ${errorEntries.join(",\n")}
 ];
 export default routes;
 `;
+}
+
+/**
+ * Every module a slot tree holds, flattened.
+ *
+ * For the side-effect imports a dropped route needs: a slot's pages, its
+ * layouts and its default are as much a part of that route's stylesheets as
+ * its own page is, and a slot nested inside one is too.
+ *
+ * @param {ReadonlyArray<Slot>} slots
+ * @returns {Array<string>}
+ */
+function slotModuleFiles(slots) {
+  const files = [];
+  for (const slot of slots) {
+    if (slot.defaultPage != null) files.push(slot.defaultPage);
+    for (const route of slot.routes) {
+      files.push(route.page, ...route.layouts, ...slotModuleFiles(route.slots));
+    }
+  }
+  return files;
 }
 
 /**

--- a/packages/vite/internal/rsc.js
+++ b/packages/vite/internal/rsc.js
@@ -141,6 +141,12 @@ export function clientRouteFilter(manifest, root, boundaries = {}) {
     if (route.layouts.some(needed)) return true;
     if ((route.loading ?? []).some((entry) => needed(entry.module))) return true;
     if ((route.templates ?? []).some((entry) => needed(entry.module))) return true;
+    // A slot renders inside this route, so a `"use client"` anywhere in one is
+    // this route's reason to ship. Without this line a page whose only
+    // interactive part is in a slot would be dropped from the client bundle
+    // and served as a document — rendered correctly and never hydrated, which
+    // is the quietest way a feature can be half-implemented.
+    if (slotNeeds(route.slots ?? [], needed)) return true;
     // A boundary with no module of its own is the record the scan synthesises
     // at the router root, and what renders there is the framework's own page —
     // already in `@uniflowed/router`, reaching nothing this project wrote. It
@@ -159,6 +165,31 @@ export function clientRouteFilter(manifest, root, boundaries = {}) {
     }
     return false;
   };
+}
+
+/**
+ * Whether anything in a slot tree has to reach the browser.
+ *
+ * Recursive because slots nest: a slot's own layout may declare slots of its
+ * own, and a `"use client"` at any depth is still inside the page this route
+ * renders.
+ *
+ * @param {ReadonlyArray<{
+ *   defaultPage: ?string,
+ *   routes: ReadonlyArray<{page: string, layouts: ReadonlyArray<string>, slots: ReadonlyArray<*>}>,
+ * }>} slots
+ * @param {(file: ?string) => boolean} needed
+ */
+function slotNeeds(slots, needed) {
+  for (const slot of slots) {
+    if (slot.defaultPage != null && needed(slot.defaultPage)) return true;
+    for (const route of slot.routes) {
+      if (needed(route.page)) return true;
+      if (route.layouts.some(needed)) return true;
+      if (slotNeeds(route.slots, needed)) return true;
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/library/parallel-routes.test.js
+++ b/tests/library/parallel-routes.test.js
@@ -1,0 +1,451 @@
+// @flow
+//
+// Parallel routes: `@slot` directories, and the `_uf.default.js` that fills one
+// the URL said nothing about.
+//
+// uf's route tree had exactly one page per URL, so there was no way to render a
+// route somewhere other than where its path said. A directory named `@team` was
+// the second of the two Next.js spellings that fell through to "an ordinary URL
+// segment" — `app/@team/_uf.page.js` served `/@team` — and then, with #472, a
+// name refused by both routers. It is a route now, and this file is what says
+// so: the segment contributes no URL, its pages are matched against the same
+// path the page is, and the layout of the segment that declares it receives the
+// result as a prop beside `children`. See ubugeeei-prod/uf#267.
+//
+// Four things have to be true and there is a section for each: the scan finds
+// slots and keeps them out of the URL, it refuses the ways one can be written
+// without being renderable, the composed tree hands each slot to the right
+// layout, and a navigation moves the slots with the page.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as React from "@uniflowed/react";
+import { render, screen, userEvent } from "@uniflowed/react-testing";
+import { RouteView, RouterProvider, resolveMatch, routerView, useRouter } from "@uniflowed/router";
+import { createRenderer } from "@uniflowed/router/server";
+import { afterAll, describe, expect, it } from "@uniflowed/test";
+
+import {
+  LAYOUT_PROP_NAMES,
+  routesModuleSource,
+  scanRoutes,
+} from "../../packages/vite/internal/routes.js";
+
+const roots: Array<string> = [];
+
+afterAll(() => {
+  for (const root of roots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+/** A router root holding each named file. */
+function appRoot(files: $ReadOnlyArray<string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "uf-slots-"));
+  roots.push(root);
+  for (const relative of files) {
+    const file = path.join(root, relative);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "// @flow\nexport default function Part() {}\n");
+  }
+  return root;
+}
+
+/** What `scanRoutes` threw for this tree, or `null` when it did not. */
+function refusal(files: $ReadOnlyArray<string>): ?string {
+  try {
+    scanRoutes(appRoot(files));
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+/** A dashboard with two slots, which is the shape the whole feature is for. */
+const DASHBOARD = [
+  "_uf.layout.js",
+  "dashboard/_uf.layout.js",
+  "dashboard/_uf.page.js",
+  "dashboard/members/_uf.page.js",
+  "dashboard/@team/_uf.default.js",
+  "dashboard/@team/_uf.layout.js",
+  "dashboard/@team/members/_uf.page.js",
+  "dashboard/@analytics/_uf.page.js",
+];
+
+describe("scanning a router root that holds slots", () => {
+  it("gives a slot no URL of its own", () => {
+    // The whole of the first half. `@team` used to be the literal segment
+    // `/@team`; now it is not a path at all, and the paths in the table are
+    // exactly the ones the ordinary directories name.
+    const { routes } = scanRoutes(appRoot(DASHBOARD));
+
+    expect(routes.map((route) => route.path)).toEqual(["/dashboard", "/dashboard/members"]);
+  });
+
+  it("matches a slot's pages against the URL the segment is matched against", () => {
+    // `app/dashboard/@team/members/_uf.page.js` is what `/dashboard/members`
+    // puts in the `team` slot — the same path, not `/dashboard/@team/members`
+    // and not a second route at `/dashboard/members`.
+    const root = appRoot(DASHBOARD);
+    const { routes } = scanRoutes(root);
+    const team = routes[0].slots.find((slot) => slot.name === "team");
+
+    expect(team?.routes.map((route) => route.path)).toEqual(["/dashboard/members"]);
+    expect(team?.routes[0].layouts.map((file) => path.relative(root, file))).toEqual([
+      path.join("dashboard", "@team", "_uf.layout.js"),
+    ]);
+  });
+
+  it("puts the slot on the layout of the segment that declares it", () => {
+    // `above` counts the layouts outside the slot, taken after the declaring
+    // segment's own layout is added — so `layouts[above - 1]` is the layout
+    // that receives the prop. The same number, spelled the same way, as a
+    // template's.
+    const { routes } = scanRoutes(appRoot(DASHBOARD));
+
+    expect(routes[0].layouts.length).toBe(2);
+    expect(routes[0].slots.map((slot) => ({ name: slot.name, above: slot.above }))).toEqual([
+      { name: "analytics", above: 2 },
+      { name: "team", above: 2 },
+    ]);
+  });
+
+  it("carries a slot down to every route under the segment", () => {
+    // A slot belongs to the layout, and the layout wraps everything below it,
+    // so `/dashboard/members` has both slots too — the way a template does.
+    const { routes } = scanRoutes(appRoot(DASHBOARD));
+
+    expect(routes[1].path).toBe("/dashboard/members");
+    expect(routes[1].slots.map((slot) => slot.name)).toEqual(["analytics", "team"]);
+  });
+
+  it("finds the slot's default and says when it has none", () => {
+    const root = appRoot(DASHBOARD);
+    const { routes } = scanRoutes(root);
+    const [analytics, team] = routes[0].slots;
+
+    expect(team.defaultPage == null ? null : path.relative(root, team.defaultPage)).toBe(
+      path.join("dashboard", "@team", "_uf.default.js"),
+    );
+    expect(analytics.defaultPage).toBe(null);
+  });
+
+  it("gives a project with no slot the empty list it had before", () => {
+    const { routes } = scanRoutes(appRoot(["_uf.layout.js", "_uf.page.js"]));
+
+    expect(routes[0].slots).toEqual([]);
+  });
+
+  it("carries them into the generated module, once each", () => {
+    // Deduplicated by identity rather than by file, for the reason layouts are
+    // deduplicated: one slot record is shared by every route below the segment
+    // that declares it, and emitting it per route would put the slot's whole
+    // table in the bundle once per route.
+    const source = routesModuleSource(scanRoutes(appRoot(DASHBOARD)));
+
+    expect(source.match(/const slot\d = \{/g)?.length).toBe(2);
+    expect(source).toContain("slots: [slot0, slot1]");
+    expect(source).toContain('name: "team"');
+    expect(source).toContain("defaultPage: () => import(");
+  });
+
+  it("nests a slot inside a slot", () => {
+    // The recursion is the shape of the feature rather than a special case: a
+    // slot's own layout may declare slots, measured against the slot's layouts.
+    const root = appRoot([
+      "_uf.layout.js",
+      "_uf.page.js",
+      "@aside/_uf.layout.js",
+      "@aside/_uf.page.js",
+      "@aside/@inner/_uf.page.js",
+    ]);
+
+    const { routes } = scanRoutes(root);
+    const aside = routes[0].slots[0];
+
+    expect(aside.name).toBe("aside");
+    expect(aside.routes[0].slots.map((slot) => ({ name: slot.name, above: slot.above }))).toEqual([
+      { name: "inner", above: 1 },
+    ]);
+  });
+});
+
+describe("what a slot may not be written as", () => {
+  it("refuses a slot on a segment with no layout of its own", () => {
+    // A slot *is* a prop the segment's own layout receives. Rendering it into
+    // an inherited layout would hand a prop to a layout that never declared
+    // it, on every route below.
+    const message = refusal([
+      "_uf.layout.js",
+      "dashboard/_uf.page.js",
+      "dashboard/@team/_uf.page.js",
+    ]);
+
+    expect(message).not.toBe(null);
+    expect(message ?? "").toContain("@team");
+    expect(message ?? "").toContain("no layout of its own");
+  });
+
+  it("refuses a slot named after a prop the layout already has", () => {
+    // `@children` is the one somebody actually writes: `children` is what
+    // Next.js calls its implicit slot. Whichever way the collision were
+    // resolved, one of the two would silently go missing.
+    for (const name of LAYOUT_PROP_NAMES) {
+      const message = refusal([
+        "_uf.layout.js",
+        "_uf.page.js",
+        path.join(`@${name}`, "_uf.page.js"),
+      ]);
+
+      expect(message).not.toBe(null);
+      expect(message ?? "").toContain(name);
+      expect(message ?? "").toContain("silently");
+    }
+  });
+
+  it("refuses a default that is not inside a slot", () => {
+    // uf has no `default` for `children`: `children` is the page the URL
+    // matched, and a URL that matches no page is a 404. A `_uf.default.js`
+    // outside a slot is a file nothing would ever open.
+    const message = refusal(["_uf.layout.js", "_uf.page.js", "_uf.default.js"]);
+
+    expect(message).not.toBe(null);
+    expect(message ?? "").toContain("_uf.default.js");
+    expect(message ?? "").toContain("404");
+  });
+
+  it("refuses a second default deeper inside a slot", () => {
+    const message = refusal([
+      "_uf.layout.js",
+      "_uf.page.js",
+      "@aside/_uf.page.js",
+      "@aside/deep/_uf.default.js",
+    ]);
+
+    expect(message).not.toBe(null);
+    expect(message ?? "").toContain("deeper");
+  });
+
+  it("refuses a boundary inside a slot, naming what is missing", () => {
+    // Per-slot boundaries are the part of parallel routes uf has not built.
+    // The refusal is where somebody writing the file finds that out.
+    for (const [file, role] of [
+      ["@aside/_uf.loading.js", "loading"],
+      ["@aside/_uf.error.js", "error"],
+      ["@aside/_uf.not-found.js", "not-found"],
+      ["@aside/_uf.template.js", "template"],
+    ]) {
+      const message = refusal(["_uf.layout.js", "_uf.page.js", "@aside/_uf.page.js", file]);
+
+      expect(message).not.toBe(null);
+      expect(message ?? "").toContain(role);
+      expect(message ?? "").toContain("267");
+    }
+  });
+
+  it("refuses a handler or a guard inside a slot", () => {
+    // A slot directory contributes no URL segment, so either would claim the
+    // declaring segment's path — which belongs to somebody else.
+    for (const file of ["@aside/_uf.route.js", "@aside/_uf.middleware.js"]) {
+      const message = refusal(["_uf.layout.js", "_uf.page.js", file]);
+
+      expect(message).not.toBe(null);
+      expect(message ?? "").toContain("@aside");
+    }
+  });
+
+  it("still refuses an intercepting route", () => {
+    // The other half of #267, and it is still a name without a route:
+    // interception needs a navigation to carry where it came from.
+    const message = refusal(["_uf.layout.js", "feed/(.)photo/_uf.page.js"]);
+
+    expect(message).not.toBe(null);
+    expect(message ?? "").toContain("intercepting route");
+  });
+});
+
+// --- Composition -------------------------------------------------------
+
+component Frame(children: React.Node, team: React.Node) {
+  return (
+    <div>
+      <nav>the sidebar</nav>
+      <aside data-testid="team">{team ?? "nothing in the slot"}</aside>
+      <main>{children}</main>
+    </div>
+  );
+}
+
+const loadFrame = () => Promise.resolve({ default: Frame });
+const pageOf = (text: string) => () => Promise.resolve({ default: () => <p>{text}</p> });
+
+const slot = {
+  name: "team",
+  above: 1,
+  defaultPage: pageOf("the team default"),
+  defaultMdx: false,
+  routes: [
+    {
+      path: "/dashboard/members",
+      params: [],
+      mdx: false,
+      file: "app/dashboard/@team/members/_uf.page.js",
+      page: pageOf("the team members"),
+      layouts: [],
+      slots: [],
+    },
+  ],
+};
+
+const page = (routePath: string, text: string) => ({
+  path: routePath,
+  params: [],
+  mdx: false,
+  file: `app${routePath}/_uf.page.js`,
+  page: pageOf(text),
+  layouts: [loadFrame],
+  loading: [],
+  templates: [],
+  slots: [slot],
+});
+
+const table = {
+  routes: [page("/dashboard", "the dashboard"), page("/dashboard/members", "the members page")],
+  notFound: [],
+  errors: [],
+};
+
+const assets = { scripts: [], styles: [], preloads: [] };
+
+describe("rendering a route that has one", () => {
+  it("gives the layout the slot beside its children", async () => {
+    // One URL, two subtrees: the page the path names as `children`, and the
+    // slot's page for the same path as `team`. This is the whole feature.
+    const { prerender } = createRenderer({ App: routerView("./app"), ...table });
+
+    const result = await prerender("/dashboard/members", assets);
+
+    expect(result.html).toContain("the members page");
+    expect(result.html).toContain("the team members");
+    // Inside the layout, in the place the layout put it: before `children`,
+    // because that is where the `<aside>` is written.
+    expect(result.html.indexOf("the team members")).toBeLessThan(
+      result.html.indexOf("the members page"),
+    );
+  });
+
+  it("renders the slot's default when the URL says nothing about it", async () => {
+    // `/dashboard` matches no route in the slot's table, and the slot has a
+    // `_uf.default.js`. Without one there would be a hole in the page, which
+    // is the reason the file exists.
+    const { prerender } = createRenderer({ App: routerView("./app"), ...table });
+
+    const result = await prerender("/dashboard", assets);
+
+    expect(result.html).toContain("the dashboard");
+    expect(result.html).toContain("the team default");
+  });
+
+  it("renders nothing for an unaddressed slot with no default", async () => {
+    // The layout still receives the prop — as `null` — so a project can write
+    // `{team ?? <Empty />}` and rely on it.
+    const withoutDefault = {
+      ...table,
+      routes: [
+        {
+          ...page("/dashboard", "the dashboard"),
+          slots: [{ ...slot, defaultPage: null }],
+        },
+      ],
+    };
+    const { prerender } = createRenderer({ App: routerView("./app"), ...withoutDefault });
+
+    const result = await prerender("/dashboard", assets);
+
+    expect(result.html).toContain("nothing in the slot");
+    expect(result.html).not.toContain("the team default");
+  });
+
+  it("renders the same tree as before for a route with no slot", async () => {
+    const { prerender } = createRenderer({
+      App: routerView("./app"),
+      routes: [{ ...page("/dashboard", "the dashboard"), slots: [] }],
+      notFound: [],
+      errors: [],
+    });
+
+    const result = await prerender("/dashboard", assets);
+
+    expect(result.html).toContain("the dashboard");
+    expect(result.html).toContain("nothing in the slot");
+  });
+
+  it("refuses a slot page that exports a loader, rather than dropping it", async () => {
+    // A slot's data has nowhere to be embedded for hydration, so running the
+    // loader would fetch again in the browser — and a server-only loader would
+    // render one tree on the server and another in the page. Saying so is the
+    // point: a convention quietly ignored is what #267 is about.
+    const withLoader = {
+      ...table,
+      routes: [
+        {
+          ...page("/dashboard", "the dashboard"),
+          slots: [
+            {
+              ...slot,
+              defaultPage: () =>
+                Promise.resolve({ default: () => <p>x</p>, loader: () => ({ a: 1 }) }),
+            },
+          ],
+        },
+      ],
+    };
+
+    const resolved = await resolveMatch(withLoader, "/dashboard");
+
+    expect(resolved.status).toBe(500);
+    expect(resolved.error?.kind).toBe("thrown");
+  });
+});
+
+// --- Navigation --------------------------------------------------------
+
+component Go() {
+  const router = useRouter();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        router.push("/dashboard/members", { scroll: false }).catch(() => {});
+      }}
+    >
+      go
+    </button>
+  );
+}
+
+describe("navigating between two routes that share a slot", () => {
+  it("matches the slot again and swaps what it holds", async () => {
+    // The slot is matched against the URL, so a navigation moves it: the
+    // default gives way to the slot's own page for the new path, while the
+    // layout holding both is never unmounted.
+    createRenderer({ App: routerView("./app"), ...table });
+    const resolved = await resolveMatch(table, "/dashboard");
+
+    render(
+      <RouterProvider url="/dashboard" initial={resolved}>
+        <RouteView />
+        <Go />
+      </RouterProvider>,
+    );
+    expect(screen.getByTestId("team").textContent).toContain("the team default");
+
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+
+    expect(screen.getByText("the members page")).not.toBe(null);
+    expect(screen.getByTestId("team").textContent).toContain("the team members");
+  });
+});

--- a/tests/library/route-segments.test.js
+++ b/tests/library/route-segments.test.js
@@ -1,22 +1,24 @@
 // @flow
 //
-// The directory names uf reserves inside the router root without serving.
+// What a directory name means to the route path, and the one spelling uf
+// reserves inside the router root without serving.
 //
 // Next.js spells a parallel route `@team` and an intercepting route
-// `(.)photo`. uf has neither, and until now neither router had an opinion
-// about the spellings: both fell through to "an ordinary URL segment", so
-// `app/@team/_uf.page.js` served `/@team`, `app/feed/(.)photo/_uf.page.js`
-// served `/feed/(.)photo` — the test for a `(group)` is that the segment
-// *ends* in `)` — and the generated `RoutePath` union contained both, so
-// `route("/@team", …)` type checked. A person who wrote one got no route and
-// no error, which is worse than not supporting it: the project looks like it
-// works. See ubugeeei-prod/uf#267.
+// `(.)photo`. Neither router had an opinion about either, so both fell through
+// to "an ordinary URL segment": `app/@team/_uf.page.js` served `/@team`,
+// `app/feed/(.)photo/_uf.page.js` served `/feed/(.)photo` — the test for a
+// `(group)` is that the segment *ends* in `)` — and the generated `RoutePath`
+// union contained both, so `route("/@team", …)` type checked. A person who
+// wrote one got no route and no error, which is worse than not supporting it:
+// the project looks like it works. See ubugeeei-prod/uf#267.
 //
-// Both routers refuse them now. `crates/uf_router/tests/reserved_names.rs`
-// holds the two to the same list of spellings; this file is the build router's
-// half of the behaviour, over real directories, because `scanRoutes` is
-// `readdirSync` and `statSync` and a fake tree would prove nothing about which
-// directory is walked into.
+// `@team` is a parallel route both routers serve now, and what it does is
+// `parallel-routes.test.js`; what this file keeps is that it is not a URL.
+// `(.)photo` is still refused by both. `crates/uf_router/tests/
+// reserved_names.rs` holds the two to the same list of refused spellings; this
+// file is the build router's half of the behaviour, over real directories,
+// because `scanRoutes` is `readdirSync` and `statSync` and a fake tree would
+// prove nothing about which directory is walked into.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -60,6 +62,8 @@ describe("classifying a directory name", () => {
   });
 
   it("names a slot rather than reading it as a URL segment", () => {
+    // A slot is a route now — `parallel-routes.test.js` is what it does — and
+    // the thing that has not changed is that it is not a *URL* segment.
     expect(classifyRouteSegment("@team")).toEqual({ kind: "slot", name: "team" });
     // The `@` has to start the segment: a name that merely contains one is an
     // ordinary literal, and a rule that read it otherwise would refuse it.
@@ -99,6 +103,12 @@ describe("classifying a directory name", () => {
     expect(routeFromSegments(["docs", "[...path]"]).path).toBe("/docs/:path*");
     expect(routeFromSegments([]).path).toBe("/");
   });
+
+  it("drops a slot from the path the way it drops a group", () => {
+    // The two are different decisions with one consequence here: a group
+    // organises files and a slot organises rendering, and neither is a URL.
+    expect(routeFromSegments(["dashboard", "@team", "members"]).path).toBe("/dashboard/members");
+  });
 });
 
 describe("scanning a router root that holds one", () => {
@@ -106,8 +116,8 @@ describe("scanning a router root that holds one", () => {
     for (const segment of UNSUPPORTED_SEGMENTS) {
       const root = appRoot([path.join("feed", segment, "_uf.page.js")]);
 
-      // The build serving `/feed/@team` is the bug. Throwing is the fix, and
-      // the message has to say the directory is *refused* — "unsupported"
+      // The build serving `/feed/(.)photo` is the bug. Throwing is the fix,
+      // and the message has to say the directory is *refused* — "unsupported"
       // reads as "ignored", and ignored is what it used to be.
       let thrown = null;
       try {
@@ -123,17 +133,17 @@ describe("scanning a router root that holds one", () => {
     }
   });
 
-  it("refuses a slot that holds no page, because it is still a slot", () => {
-    const root = appRoot(["_uf.page.js", path.join("@team", "_uf.layout.js")]);
+  it("refuses an interception that holds no page, because it is still one", () => {
+    const root = appRoot(["_uf.page.js", path.join("feed", "(.)photo", "_uf.layout.js")]);
 
-    expect(() => scanRoutes(root)).toThrow("@team");
+    expect(() => scanRoutes(root)).toThrow("(.)photo");
   });
 
   it("leaves a private directory alone, because no router walks into it", () => {
     // A leading `.` or `_` means the directory is a place to put things rather
-    // than a route, so `app/_drafts/@team/` was never going to be served and
-    // refusing it would be a rule about a place the router does not look.
-    const root = appRoot(["_uf.page.js", path.join("_drafts", "@team", "notes.js")]);
+    // than a route, so `app/_drafts/(.)photo/` was never going to be served
+    // and refusing it would be a rule about a place the router does not look.
+    const root = appRoot(["_uf.page.js", path.join("_drafts", "(.)photo", "notes.js")]);
 
     expect(scanRoutes(root).routes.map((route) => route.path)).toEqual(["/"]);
   });


### PR DESCRIPTION
`app/@team/` was a URL segment, then — with #472 — a name both routers refused. Neither of those is what a parallel route is. This makes it a route.

## What a slot is here

A `@slot` directory contributes no path segment, the way a `(group)` does not, and its pages are matched against the **same URL the page is**. The layout of the segment that declares the slot receives it as a prop named after the directory, beside `children`:

```
app/dashboard/_uf.layout.js              the frame, which renders both
app/dashboard/_uf.page.js                →  /dashboard          as `children`
app/dashboard/members/_uf.page.js        →  /dashboard/members  as `children`
app/dashboard/@team/_uf.default.js       the team slot when the URL says nothing
app/dashboard/@team/members/_uf.page.js  /dashboard/members     as `team`
```

```js
export default component Dashboard(children: React.Node, team: React.Node) {
  return <div><main>{children}</main><aside>{team ?? <Empty />}</aside></div>;
}
```

`_uf.default.js` is the other half and a tenth `ReservedRole`: what a slot renders when the URL matched none of *its* routes. A slot with none renders nothing, and the layout is handed `null` rather than nothing at all, so `{team ?? …}` is a thing a project can rely on.

Slots nest — a slot's own layout may declare slots — and the recursion is the shape of the feature rather than a special case.

## The design decision, rather than the copy

**A slot never adds a URL.** A path no ordinary page matches is a 404 whatever the slots hold. That is why there is no `default` for `children` here, which is one file fewer than Next.js needs and the thing #267 asked for: "a design that arrives at fewer files than Next has".

## Refused rather than ignored

Six ways a slot can be written without being renderable, each of them otherwise a file the router opens never — which is the failure #267 is about, one level down. Both routers say the same sentence:

| written | refused because |
| --- | --- |
| `@team` on a segment with no layout of its own | a slot *is* a prop that layout receives; an inherited layout never declared it |
| `@children`, `@params` | one of the two props would silently go missing — and `@children` is the first name somebody migrating writes |
| `_uf.default.js` outside a slot, or deeper than its root | the question is asked once, at the slot |
| `_uf.loading.js`, `_uf.error.js`, `_uf.not-found.js`, `_uf.template.js` inside a slot | uf's slots carry no boundaries of their own yet |
| `_uf.route.js`, `_uf.middleware.js` inside a slot | a slot answers no request, and the path it would appear to claim is the declaring segment's |
| a slot page exporting a `loader` | a slot's data has nowhere to be embedded for hydration (see below) |

## Interception is still refused

A navigation carries where it is going and not where it came from, which is a change to what a navigation *is* rather than to this grammar. `RouteSegment::UNSUPPORTED_EXAMPLES` and `UNSUPPORTED_SEGMENTS` keep the four interception spellings and lose `@team`, held together by `both_routers_refuse_the_same_directory_spellings` — the test that already existed to keep the two routers agreeing. `router/unsupported-segment` is now about interception alone.

`uf routes add /@team` is refused too, and its message says the opposite thing from the old one: uf serves parallel routes, and what *this command* takes is a URL.

## The bundle

`clientRouteFilter` now reads the slot tree. Without that line, a page whose only interactive part lives in a slot would be dropped from the client bundle and served as a document — rendered correctly and never hydrated, which is the quietest way a feature can be half-implemented.

## What remains, and why

Named in an issue comment as well.

- **Per-slot `loading`, `error` and `not-found`.** A slot renders a page and the layouts inside it. The four files are refused by name rather than left unopened, and the refusal links the issue.
- **A slot page's `loader`.** Not run, and refused rather than handed `undefined`. A page's loader answer is embedded in the document under one id; a slot's has nowhere to go, so running it would fetch again in the browser — and a loader that reads `cookies()` would succeed on the server and throw in the page, so the slot would render on one side and not the other. Lifting it means per-slot hydration data.
- **Independent navigation per slot.** One URL, one history entry. Slots re-match on every navigation; they do not each keep their own.
- **Metadata from a slot page.** The document's title belongs to the page the URL names.
- **Intercepting routes**, which is what the modal-over-a-feed pattern still needs.

## Tests that fail without this

Verified by reverting and watching them fail, then restoring.

- `crates/uf_router/src/lib.rs` reverted to `main`, tests kept: **5 fail** — `a_parallel_route_slot_contributes_no_url`, `a_slot_on_a_segment_with_no_layout_is_refused`, `a_default_outside_a_slot_is_refused`, `a_slot_with_a_default_and_a_layout_is_discovered`, `a_boundary_or_a_handler_inside_a_slot_is_refused` — and the output shows the regression by name, `Route { path: "/@team", … }` back in the table. (The sixth, `a_slot_named_after_a_layout_prop_is_refused`, asserts over a constant that lives in the reverted file, so it does not compile rather than failing.)
- `packages/vite/internal/routes.js` and `packages/router/internal/runtime.js` reverted: `parallel-routes.test.js` will not load, and `route-segments.test.js`'s "drops a slot from the path the way it drops a group" fails.
- `runtime.js` alone reverted: **4 of 21** fail — the composition and navigation sections.

## What was run

| | |
| --- | --- |
| `cargo fmt --all --check` | clean |
| `cargo clippy -p uf_router -p uf_lint --all-targets -- -D warnings` | clean |
| `cargo test -p uf_router` | 76 + 5 + 0 passed |
| `cargo test -p uf_lint` | 316 passed |
| `cargo test -p uf_cli` | 493 + 66 + … passed; `--test vite` 56 passed |
| `uf test#library` | 2886 passed, 1 skipped |
| `uf lint` | 0 errors, 14 pre-existing warnings |
| `uf fmt --check` | clean |

`cargo test -p uf_cli --test vite` had to be run with `--test-threads=1` on this machine. In parallel, five of its cases fail with missing build output — `Cannot find module …/.uf/build/server/server.js`, `static/index.html` absent — which is several tests building in place and racing each other rather than anything about routing; all 56 pass serially. I did not re-run the parallel case on `main` to confirm it fails there too, so that is an inference from the failure mode rather than a measurement.

Refs #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791548706&installation_model_id=422833&pr_number=749&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F749&signature=c199888ac3067bb1c2d99d768373672f6d544998e90cd21e8cba9391773933e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->