### PR TITLE
release: twelve waiting packages are on the published list

### DIFF
--- a/tools/release/pending-packages.txt
+++ b/tools/release/pending-packages.txt
@@ -36,17 +36,3 @@
 # ubugeeei-prod/uf#710's second housekeeping question, and this line is the
 # answer. `crates/uf_std`'s registry carries the same distinction per subpath,
 # and `uf inspect` reports it.
-
-brand
-cell
-effect
-form
-i18n
-immer
-mock
-state
-std
-story
-testing
-tui
-web

--- a/tools/release/pending-packages.txt
+++ b/tools/release/pending-packages.txt
@@ -36,3 +36,5 @@
 # ubugeeei-prod/uf#710's second housekeeping question, and this line is the
 # answer. `crates/uf_std`'s registry carries the same distinction per subpath,
 # and `uf inspect` reports it.
+
+std

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -24,20 +24,33 @@
 #   tools/release/trust-npm.sh
 #
 # and run `uf run release:preflight` before tagging to see where things stand.
+brand
+cell
 config
 core
+effect
 fetch
+form
 graphql
 hooks
 host
+i18n
+immer
+mock
 query
 react
 react-testing
 relay
 router
 server
+state
+std
+story
 stylex
 test
+testing
+tui
 ui
 validator
 vite
+web

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -44,7 +44,6 @@ relay
 router
 server
 state
-std
 story
 stylex
 test


### PR DESCRIPTION
## Change

`brand cell effect form i18n immer mock state story testing tui web` move from `pending-packages.txt` to `published-packages.txt`.

`std` stays in `pending-packages.txt`: `npm view @uniflowed/std` still returns nothing, so putting it in the published list would make the next publish job fail on that name after earlier names had gone out.

## Verification

- `tools/ci/publishable.sh` -> `27 implemented packages: 27 published, 1 waiting on npm trust`
- `tools/release/verify-npm.sh --closure-only` -> dependency closure holds
- `tools/release/preflight.sh` -> all 29 listed published packages are on npm; it then fails at the existing `latest` dist-tag gate because 17 names still point behind `0.0.0-alpha.18`, which requires `npm login && tools/release/promote-latest.sh`

## Release note

This PR is safe to merge once CI is green because every name it adds to the published list already exists on npm at `0.0.0-alpha.18`. A full release is still blocked on an npm-authenticated `promote-latest.sh` run, and `@uniflowed/std` still needs its first registry publish/trust setup.

Refs #210, #365, #560, #700, #710