### PR TITLE
fix(check): prefer module package entry over main

### DIFF
--- a/crates/uf_check/src/upstream/options.rs
+++ b/crates/uf_check/src/upstream/options.rs
@@ -32,13 +32,17 @@ const REACT_RULES: [ReactRule; 4] = [
 /// How many tokens of a file's header are scanned for a docblock.
 const MAX_HEADER_TOKENS: i32 = 10;
 
-/// The `package.json` field a package with no `exports` map is entered through.
+/// The `package.json` fields a package with no `exports` map is entered through.
 ///
-/// Flow's own default, and Node's. Stated rather than left to
-/// `Options::default()`, whose list is empty — with an empty list `main` is
-/// never read, and a package that has no `exports` map would resolve to
-/// nothing at all.
-const NODE_MAIN_FIELDS: [&str; 1] = ["main"];
+/// Prefer `module` to `main` because uf checks the ESM graph. A legacy dual
+/// package with no `exports` map commonly leaves its CommonJS entry in `main`
+/// and its ESM entry in `module`; checking the CommonJS file is the same kind
+/// of wrong graph as choosing the `require` condition below.
+///
+/// Stated rather than left to `Options::default()`, whose list is empty — with
+/// an empty list neither field is ever read, and a package that has no
+/// `exports` map would resolve to nothing at all.
+const NODE_MAIN_FIELDS: [&str; 2] = ["module", "main"];
 
 /// The `exports` conditions a package subpath is resolved under.
 ///
@@ -169,9 +173,9 @@ mod tests {
         let options = options(&CheckLimits::default());
 
         assert_eq!(&*options.node_package_export_conditions, ["import"]);
-        // Without this the `main` of a package with no `exports` map is never
-        // read, and such a package resolves to nothing.
-        assert_eq!(&*options.node_main_fields, ["main"]);
+        // Without this the entry fields of a package with no `exports` map are
+        // never read, and such a package resolves to nothing.
+        assert_eq!(&*options.node_main_fields, ["module", "main"]);
     }
 
     #[test]

--- a/crates/uf_check/src/upstream/packages.rs
+++ b/crates/uf_check/src/upstream/packages.rs
@@ -508,6 +508,19 @@ mod tests {
     }
 
     #[test]
+    fn a_package_with_no_exports_map_prefers_module_to_main() {
+        let packages = packages(&[Source::new(
+            "vendor/dual/package.json",
+            r#"{ "name": "dual", "main": "./cjs.js", "module": "./esm.js" }"#,
+        )]);
+
+        assert_eq!(
+            packages.resolve("app.js", "dual"),
+            Some(PackageFile::Implied("vendor/dual/esm.js".into()))
+        );
+    }
+
+    #[test]
     fn a_package_with_neither_exports_nor_main_falls_back_to_its_directory() {
         let packages = packages(&[Source::new(
             "vendor/bare/package.json",


### PR DESCRIPTION
## Summary
- prefer `module` before `main` when resolving packages with no `exports` map
- cover legacy dual packages whose CommonJS entry is in `main` and ESM entry is in `module`

Refs #736

## Tests
- `nix develop . --command cargo fmt --all -- --check`
- `nix develop . --command cargo test -p uf_check no_exports_map -- --nocapture`
- `nix develop . --command cargo test -p uf_check a_package_is_entered_the_way_an_es_module_import_enters_it -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791602665&installation_model_id=422833&pr_number=751&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F751&signature=1ceda1328574bb7549a3ed14d90596e293bf6d7a15f98622e0e95e05fce0873e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Packages without an `exports` map now prefer the ESM `module` entry when both `module` and `main` fields are available.
* **Tests**
  * Added coverage confirming that package resolution selects the ESM entry over the CommonJS `main` entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->