### PR TITLE
ci: warm Blacksmith caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -57,7 +57,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -78,7 +78,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -101,7 +101,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -115,7 +115,13 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # `uf build --compile` embeds the build in a Bun runtime, and the two
       # tests that exercise it fail rather than skip when Bun is absent: a
       # single-file build nobody runs is a single-file build nobody has.
@@ -154,7 +160,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -168,7 +174,13 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # `rust:fmt:check` is cargo's half. This is uf's: the formatter this
       # repository ships, over the Flow this repository is written in. It is
       # the only thing that checks the shipped packages' formatting at all.
@@ -184,7 +196,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -198,7 +210,13 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # uf is the only thing that can lint uf's own packages, so until this job
       # existed a regression in the linter was invisible to every other check
       # in the pipeline — including to the linter's own Rust tests, which
@@ -215,7 +233,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -226,7 +244,13 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # The documentation site is a uf project in this repository, built by
       # `uf build#docs`. The Docs workflow builds it too, on its own trigger;
       # this job is what makes a pull request that breaks the site fail before
@@ -265,7 +289,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -276,7 +300,13 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
       # The `@uniflowed/*` packages are Flow, so `cargo test` cannot run a line
@@ -294,7 +324,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -321,7 +351,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -343,7 +373,7 @@ jobs:
     needs: toolchain
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -508,7 +538,7 @@ jobs:
       # because `rust-toolchain.toml` overrides `rustup default`.
       RUSTUP_TOOLCHAIN: nightly-2026-08-01
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -524,7 +554,13 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # `uf build --compile` embeds the build in a Bun runtime, and the two
       # tests that exercise it fail rather than skip when Bun is absent: a
       # single-file build nobody runs is a single-file build nobody has.
@@ -555,7 +591,7 @@ jobs:
       # `rustup default`, so the moving channel only takes effect through this.
       RUSTUP_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -62,7 +62,13 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # This repository is a uf project: the site is built by the task in
       # `uf.config.js`, with the toolchain it ships.
       - run: cargo build --release --bin uf
@@ -87,7 +93,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -101,7 +107,13 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # This repository is a uf project: the site is built by the task in
       # `uf.config.js`, with the toolchain it ships.
       - run: cargo build --release --bin uf

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - run: tools/upstream/sync.sh
@@ -50,7 +50,13 @@ jobs:
           node-version: 24
           package-manager-cache: false
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: npm ci --no-audit --no-fund
+      - name: Mount npm cache
+        uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc # v1.7.0
+        with:
+          key: ${{ github.repository }}-npm-${{ runner.os }}-node-24
+          path: ~/.npm
+          commit: ${{ github.ref == 'refs/heads/main' && 'on-change' || 'false' }}
+      - run: npm ci --prefer-offline --no-audit --no-fund
       # The site has to be built before its links can be resolved, and the
       # links this pass is about are the ones in the markup rather than the
       # ones in the sources — a link the layout computes is in no `.mdx` file.

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
@@ -90,7 +90,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
@@ -151,7 +151,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -20,7 +20,7 @@ jobs:
     name: Cargo Semver Checks
     runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: useblacksmith/checkout@0647fdbab2614a5eb86d2971070e325060d91056 # v1.7.0
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Summary
- use Blacksmith checkout on Blacksmith runner jobs so Git objects can be reused from the runner-side sticky mirror
- mount a Blacksmith sticky disk for npm's package cache before npm ci in npm-heavy CI/docs/link jobs
- keep sticky disk commits limited to main refs; pull requests and merge queue runs hydrate from the cache but discard writes

## Verification
- yq eval '.' .github/workflows/*.yml >/dev/null
- sh tools/ci/gate-covers-every-job.sh
- sh tools/ci/workspace-suite-runtimes.sh
- git diff --check

Notes: Blacksmith documents checkout caching as sticky-disk-backed, and documents sticky disks as suited for large dependency caches such as ~/.npm. The actions remain SHA-pinned with version comments.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791606561&installation_model_id=422833&pr_number=754&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F754&signature=acdd328edbcf2a7505440a4dac0c56ec9262f07c65c5b5f528c6b658a1dee31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use pinned, consistent tooling versions.
  * Added npm caching to speed up dependency installation in applicable workflows.
  * Optimized npm installs to prefer cached packages and avoid unnecessary audit and funding checks.
  * Preserved existing workflow behavior and security settings while standardizing repository checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->