### PR TITLE
ci: deny clippy warnings with all features

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ tools/upstream/sync.sh
 Pinned release toolchain (1.98.0):
 
 - [ ] `cargo fmt --all -- --check`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - [ ] `cargo test --workspace`
 - [ ] `cargo bench --workspace --no-run`
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,33 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno --version
+      # GitHub-hosted Ubuntu runners install Chromium but do not give it a
+      # usable sandbox under the AppArmor/user-namespace policy in this image.
+      # The same browser test runs sandboxed in CI on Blacksmith; this wrapper
+      # is only for the publish runner, so the release can still prove browser
+      # mode before npm receives the packages.
+      - name: Make Chromium usable on the publish runner
+        run: |
+          set -eu
+          browser=
+          for candidate in chromium google-chrome google-chrome-stable chrome; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              browser="$(command -v "$candidate")"
+              break
+            fi
+          done
+          if [ -z "$browser" ]; then
+            echo "No Chromium-family browser found" >&2
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/uf-browser"
+          wrapper="$RUNNER_TEMP/uf-browser/chromium-no-sandbox"
+          printf '%s\n' '#!/bin/sh' 'exec "$UF_REAL_BROWSER" --no-sandbox "$@"' > "$wrapper"
+          chmod +x "$wrapper"
+          {
+            echo "UF_REAL_BROWSER=$browser"
+            echo "UF_BROWSER=$wrapper"
+          } >> "$GITHUB_ENV"
       - run: cargo test --workspace
       # Only the packages in `tools/release/published-packages.txt`, which is
       # the set that is implemented.

--- a/crates/uf_cli/src/commands/task/tests.rs
+++ b/crates/uf_cli/src/commands/task/tests.rs
@@ -303,7 +303,7 @@ fn a_program_written_as_a_path_is_resolved_before_it_is_spawned() {
 #[test]
 fn a_program_written_as_a_name_is_left_to_the_path() {
     let uf_task::Command::Direct(direct) =
-        uf_task::parse("cargo clippy --workspace -- -D warnings")
+        uf_task::parse("cargo clippy --workspace --all-targets --all-features -- -D warnings")
     else {
         panic!("a program and its arguments");
     };
@@ -312,7 +312,15 @@ fn a_program_written_as_a_name_is_left_to_the_path() {
     assert_eq!(process.get_program(), "cargo");
     assert_eq!(
         process.get_args().collect::<Vec<_>>(),
-        ["clippy", "--workspace", "--", "-D", "warnings"]
+        [
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ]
     );
 }
 

--- a/crates/uf_task/src/command.rs
+++ b/crates/uf_task/src/command.rs
@@ -528,8 +528,17 @@ mod tests {
     #[test]
     fn a_backslash_before_a_newline_joins_the_lines() {
         assert_eq!(
-            words("cargo clippy --workspace \\\n  -- -D warnings"),
-            ["cargo", "clippy", "--workspace", "--", "-D", "warnings"]
+            words("cargo clippy --workspace --all-targets --all-features \\\n  -- -D warnings"),
+            [
+                "cargo",
+                "clippy",
+                "--workspace",
+                "--all-targets",
+                "--all-features",
+                "--",
+                "-D",
+                "warnings",
+            ]
         );
     }
 

--- a/tools/ci/test-workspace-suite-runtimes.sh
+++ b/tools/ci/test-workspace-suite-runtimes.sh
@@ -170,7 +170,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - run: cargo clippy --workspace
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 YAML
 expect 1 "a check that checks nothing has stopped being a check"
 names "stopped checking anything"

--- a/tools/upstream/patches/flow/0004-silence-rust-warning-noise.patch
+++ b/tools/upstream/patches/flow/0004-silence-rust-warning-noise.patch
@@ -1,0 +1,118 @@
+Subject: silence Flow Rust warning noise in uf builds
+
+Issue: ubugeeei-prod/uf#759
+Upstream: not filed with facebook/flow yet
+Submodule: 81b0c2a3dd591c66c51167aac341d851932bd9c5
+
+uf's CI and release jobs surface Rust annotations from the vendored Flow port.
+These warnings are not behavior changes, but they make warning-as-error work
+harder to read and made the release log look broken in places where the actual
+failure was elsewhere.
+
+This keeps the upstream checkout quiet on the current Rust toolchain:
+
+* name Flow's `fbcode_build` cfg in `flow_config`, matching neighboring Flow
+  crates that already declare it;
+* make double-reference dereferences explicit, instead of calling `Deref` or
+  `Clone` on the outer reference;
+* spell the normalizer context lifetime the same way the stored reference is
+  declared;
+* remove one unnecessary block expression.
+
+No Flow semantics change here; the patch only makes the existing intent
+unambiguous to rustc and clippy.
+
+diff --git a/rust_port/crates/flow_config/Cargo.toml b/rust_port/crates/flow_config/Cargo.toml
+index 8b171fe27..d504bef8f 100644
+--- a/rust_port/crates/flow_config/Cargo.toml
++++ b/rust_port/crates/flow_config/Cargo.toml
+@@ -18,3 +18,6 @@ libc = "0.2.186"
+ regex = "1.13.1"
+ serde_json = { version = "1.0.151", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+ starlark_map = "0.14.2"
++
++[lints.rust]
++unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fbcode_build)"] }
+diff --git a/rust_port/crates/flow_typing_statement/src/statement.rs b/rust_port/crates/flow_typing_statement/src/statement.rs
+index c20d52a97..0b25ac1f5 100644
+--- a/rust_port/crates/flow_typing_statement/src/statement.rs
++++ b/rust_port/crates/flow_typing_statement/src/statement.rs
+@@ -3757,9 +3757,7 @@ fn statement_<'a>(
+                 .as_ref()
+                 .map(|spec| {
+                     let export_kind = statement::ExportKind::ExportValue;
+-                    let source_ref = source
+-                        .as_ref()
+-                        .map(|(sm, sl, slit)| (sm, sl.dupe(), slit.clone()));
++                    let source_ref = source.as_ref().map(|(sm, sl, slit)| (sm, sl.dupe(), *slit));
+                     export_specifiers(cx, source_ref, export_kind, spec)
+                 })
+                 .transpose()?;
+@@ -3968,9 +3966,7 @@ fn statement_<'a>(
+                 .specifiers
+                 .as_ref()
+                 .map(|spec| {
+-                    let source_ref = source
+-                        .as_ref()
+-                        .map(|(sm, sl, slit)| (sm, sl.dupe(), slit.clone()));
++                    let source_ref = source.as_ref().map(|(sm, sl, slit)| (sm, sl.dupe(), *slit));
+                     export_specifiers(cx, source_ref, inner.export_kind, spec)
+                 })
+                 .transpose()?;
+@@ -20013,7 +20009,7 @@ pub fn mk_func_sig<'a>(
+                     VirtualReasonDesc::RType(FlowSmolStr::new("Promise")),
+                     ret_reason.loc().dupe(),
+                 );
+-                { FlowJs::get_builtin_typeapp(cx, &promise_reason, None, "Promise", vec![void_t]) }
++                FlowJs::get_builtin_typeapp(cx, &promise_reason, None, "Promise", vec![void_t])
+             } else {
+                 void_t
+             };
+diff --git a/rust_port/crates/flow_typing_statement/src/switch_to_match.rs b/rust_port/crates/flow_typing_statement/src/switch_to_match.rs
+index 16934b3cb..d7fba6ef5 100644
+--- a/rust_port/crates/flow_typing_statement/src/switch_to_match.rs
++++ b/rust_port/crates/flow_typing_statement/src/switch_to_match.rs
+@@ -280,7 +280,7 @@ fn convert_switch_inner<M: Dupe>(
+                 }
+             } else {
+                 let last_stmt = &body_stmts_vec[body_stmts_vec.len() - 1];
+-                match last_stmt.deref().deref() {
++                match (*last_stmt).deref() {
+                     // `return expr;`
+                     statement::StatementInner::Return { inner, .. }
+                         if inner.argument.is_some() && body_stmts_vec.len() == 1 =>
+@@ -303,7 +303,7 @@ fn convert_switch_inner<M: Dupe>(
+                             && let statement::StatementInner::Expression {
+                                 inner: expr_stmt,
+                                 ..
+-                            } = assignment_stmt.deref().deref()
++                            } = (*assignment_stmt).deref()
+                             && let expression::ExpressionInner::Assignment {
+                                 inner: assign,
+                                 ..
+diff --git a/rust_port/crates/flow_typing_ty_normalizer/src/env.rs b/rust_port/crates/flow_typing_ty_normalizer/src/env.rs
+index d2b3a9ff3..2e80196a9 100644
+--- a/rust_port/crates/flow_typing_ty_normalizer/src/env.rs
++++ b/rust_port/crates/flow_typing_ty_normalizer/src/env.rs
+@@ -200,7 +200,7 @@ impl<'a, 'cx> Env<'a, 'cx> {
+         CACHED.with(|c| c.clone())
+     }
+ 
+-    pub fn get_cx(&self) -> &'cx Context {
++    pub fn get_cx(&self) -> &'a Context<'cx> {
+         self.genv.cx
+     }
+ 
+diff --git a/rust_port/crates/flow_typing_utils/src/members.rs b/rust_port/crates/flow_typing_utils/src/members.rs
+index c7d49cc08..6d9a7aeed 100644
+--- a/rust_port/crates/flow_typing_utils/src/members.rs
++++ b/rust_port/crates/flow_typing_utils/src/members.rs
+@@ -1132,7 +1132,7 @@ pub fn extract_members<'cx>(
+                     // every type in the intersection
+                     let members: Vec<_> = rep
+                         .members_iter()
+-                        .filter(|t| match t.deref().deref() {
++                        .filter(|t| match (*t).deref() {
+                             TypeInner::DefT(_, d) => {
+                                 !matches!(d.deref(), DefTInner::NullT | DefTInner::VoidT)
+                             }

--- a/uf.config.js
+++ b/uf.config.js
@@ -136,7 +136,7 @@ export default defineConfig({
     // --- Rust ----------------------------------------------------------
     "rust:fmt": "cargo fmt --all",
     "rust:fmt:check": "cargo fmt --all -- --check",
-    "rust:clippy": "cargo clippy --workspace --all-targets -- -D warnings",
+    "rust:clippy": "cargo clippy --workspace --all-targets --all-features -- -D warnings",
     "rust:test": "cargo test --workspace",
     "rust:bench": "cargo bench --workspace --no-run",
     "rust:metadata": "cargo metadata --format-version 1 --locked",


### PR DESCRIPTION
## Summary
- make `uf run rust:clippy` run with `--all-targets --all-features -- -D warnings`
- align the PR checklist and runtime-suite fixture with the stricter Clippy command
- add a Flow upstream patch that removes warning noise surfaced by CI/release logs
- make the publish workflow run Chromium through a no-sandbox wrapper on GitHub-hosted runners, where the installed browser cannot use its normal sandbox

## Verification
- `tools/upstream/sync.sh`
- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path upstream/flow/rust_port/Cargo.toml --all -- --check`
- `git diff --check`
- `tools/ci/test-workspace-suite-runtimes.sh`
- attempted `cargo clippy --workspace --all-targets --all-features -- -D warnings` locally; blocked before linting because the installed rustc is 1.94.1 while this repo requires 1.98
- merge queue for PR #758 already passed direct `cargo clippy --workspace --all-targets --all-features -- -D warnings` on the same main commit
