### PR TITLE
ci: give npm publish tests more room

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,11 @@ jobs:
   npm:
     name: Trusted npm Publish
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # This job checks out the release tag and then runs the full workspace test
+    # suite before npm gets a package. A cold GitHub-hosted runner can still be
+    # running healthy tests after twenty minutes, so give the guardrail enough
+    # room for the release check it is meant to be.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -40,6 +44,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          cache-on-failure: true
+          key: publish-${{ inputs.version || github.ref_name }}-${{ runner.os }}-${{ runner.arch }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24


### PR DESCRIPTION
## Summary
- raise the trusted npm publish job timeout so a healthy full workspace test run can finish on a cold GitHub-hosted runner
- add the same pinned Rust cache used by CI, keyed by release version and runner architecture

## Tests
- git diff --check
- tools/ci/test-workspace-suite-runtimes.sh

## Notes
- tools/ci/test-recipes-are-runnable.sh was attempted locally, but this temporary worktree has no fresh uf binary in target/{debug,release}, so the recipe test rejected commands that CI validates after building uf.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791635735&installation_model_id=422833&pr_number=760&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F760&signature=1aad7f6bff08d424af799968b9bf3f8b816f32f8d94487fae44a7d3bc3f87fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the package publishing workflow timeout to support longer validation runs.
  * Added caching for Rust build dependencies to improve workflow performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->