### PR TITLE
ci: harden publish browser wrapper

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,8 +81,11 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno --version
-      # GitHub-hosted Ubuntu runners install Chromium but do not give it a
-      # usable sandbox under the AppArmor/user-namespace policy in this image.
+      # GitHub-hosted Ubuntu runners install Chromium-family browsers but do
+      # not give Chromium a usable sandbox under the AppArmor/user-namespace
+      # policy in this image, and the distro `chromium` shim can spend the
+      # browser worker's start budget talking to a broken DBus session before
+      # it ever opens the test page.
       # The same browser test runs sandboxed in CI on Blacksmith; this wrapper
       # is only for the publish runner, so the release can still prove browser
       # mode before npm receives the packages.
@@ -90,7 +93,7 @@ jobs:
         run: |
           set -eu
           browser=
-          for candidate in chromium google-chrome google-chrome-stable chrome; do
+          for candidate in google-chrome-stable google-chrome chrome chromium; do
             if command -v "$candidate" >/dev/null 2>&1; then
               browser="$(command -v "$candidate")"
               break
@@ -101,9 +104,14 @@ jobs:
             exit 1
           fi
           mkdir -p "$RUNNER_TEMP/uf-browser"
-          wrapper="$RUNNER_TEMP/uf-browser/chromium-no-sandbox"
-          printf '%s\n' '#!/bin/sh' 'exec "$UF_REAL_BROWSER" --no-sandbox "$@"' > "$wrapper"
+          wrapper="$RUNNER_TEMP/uf-browser/chromium-publish"
+          printf '%s\n' \
+            '#!/bin/sh' \
+            'unset DBUS_SESSION_BUS_ADDRESS' \
+            'exec "$UF_REAL_BROWSER" --no-sandbox --disable-setuid-sandbox --no-zygote "$@"' \
+            > "$wrapper"
           chmod +x "$wrapper"
+          echo "Using $browser for UF_BROWSER"
           {
             echo "UF_REAL_BROWSER=$browser"
             echo "UF_BROWSER=$wrapper"


### PR DESCRIPTION
## Summary
- prefer stable Chrome before the Ubuntu chromium shim in the trusted npm publish workflow
- harden the publish-only browser wrapper with no-sandbox companion flags and a cleared DBus session env
- print the selected browser path so failed publish logs name what was driven

## Tests
- git diff --check
- tools/ci/test-workspace-suite-runtimes.sh

## Context
The alpha.19 publish rerun now gets past setup and into the browser host test, but Chromium never opens the page within the browser worker's 20s startup budget on the GitHub-hosted runner. This keeps the production CI behavior unchanged and only adjusts the publish runner shim.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791638015&installation_model_id=422833&pr_number=761&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F761&signature=11a90a36e34b8bcbfbd89f76ce5104571cbf57e573026353c70d9546a9df1bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->