### PR TITLE
release: keep untrusted packages out of the OIDC publish closure

### DIFF
--- a/tools/release/pending-packages.txt
+++ b/tools/release/pending-packages.txt
@@ -1,26 +1,29 @@
-# Implemented, and not on npm yet. One per line.
+# Implemented, and not in the OIDC publish closure yet. One per line.
 #
 # A package here has real code behind it and is not in `published-packages.txt`,
 # which is a gap rather than a decision: `@uniflowed/state` is what this project
-# offers instead of Jotai and it resolves to nothing.
+# offers instead of Jotai, but a release workflow cannot safely send it yet.
 #
 # It is a two-file list rather than one because adding a name to the published
 # list is only half the job, and the other half cannot be done from a checkout.
-# `publish.yml` publishes over OIDC and `npm trust` can only bind a name the
-# registry already has, so a name that has never been published has to be
-# published once, by a person, with an npm session and a 2FA prompt:
+# `publish.yml` publishes over OIDC and npm only lets that workflow publish a
+# name after trusted publishing has been bound. Some names here have never been
+# published and need a first local publish; some already exist on npm but still
+# need `npm trust`; some are waiting because they depend on one of those names.
+# The local bootstrap/trust sequence is still the same:
 #
 #   npm login
 #   sh tools/release/bootstrap-publish.sh
 #   sh tools/release/trust-npm.sh
 #
-# Until that has happened for a name, putting it in `published-packages.txt`
-# makes the publish job fail *after* the names before it have gone out, which
-# half-sends a release. So it waits here, where `tools/ci/publishable.sh` can
-# see it, rather than being remembered.
+# Until that has happened for a name and its internal dependencies, putting it
+# in `published-packages.txt` makes the publish job fail *after* the names
+# before it have gone out, which half-sends a release. So it waits here, where
+# `tools/ci/publishable.sh` can see it, rather than being remembered.
 #
-# Move a name to `published-packages.txt` when it is bound. Nothing else needs
-# to change: the closure check reads that file, and this one is only ever a
+# Move a name to `published-packages.txt` when it is bound and every
+# `@uniflowed/*` dependency it publishes is there too. Nothing else needs to
+# change: the closure check reads that file, and this one is only ever a
 # waiting room.
 #
 # See ubugeeei-prod/uf#210.
@@ -41,5 +44,18 @@
 # answer. `crates/uf_std`'s registry carries the same distinction per subpath,
 # and `uf inspect` reports it.
 
-temporal
+brand
+cell
+effect
+form
+i18n
+immer
+mock
+state
 std
+story
+temporal
+testing
+tui
+ui
+web

--- a/tools/release/promote-latest.sh
+++ b/tools/release/promote-latest.sh
@@ -11,10 +11,9 @@
 # `latest`, which is the right rule and stays: a prerelease must not displace a
 # stable release. These packages have no stable release, so nothing has moved
 # `latest` since the day of the first publish — with `uf@0.0.0-alpha.7` out,
-# `latest` was `0.0.0-alpha.1` on five of the seventeen names and
-# `0.0.0-alpha.2` on the other twelve, so `npm install @uniflowed/ui` gave a
-# person five releases of drift and a package set that did not agree with
-# itself. See ubugeeei-prod/uf#408.
+# `latest` was stuck on older alpha releases across the publish closure, so
+# `npm install @uniflowed/react` gave a person releases of drift and a package
+# set that did not agree with itself. See ubugeeei-prod/uf#408.
 #
 # ## Why this is a person's step and not part of the publish job
 #
@@ -74,12 +73,12 @@ check_only=false
 assume_yes=false
 # One code for the whole run.
 #
-# `npm dist-tag add` on a 2FA account asks for a one-time password per write,
-# and there are seventeen. Interactively npm handles that itself — it keeps the
-# terminal and either prompts or opens a browser — so this is for the case
-# where it cannot: a run with no terminal, and the `--otp` npm's own docs give
-# for exactly that. `UF_NPM_OTP` is the same value from the environment, so a
-# code never has to be a shell argument, where it would land in a history file.
+# `npm dist-tag add` on a 2FA account asks for a one-time password per write.
+# Interactively npm handles that itself — it keeps the terminal and either
+# prompts or opens a browser — so this is for the case where it cannot: a run
+# with no terminal, and the `--otp` npm's own docs give for exactly that.
+# `UF_NPM_OTP` is the same value from the environment, so a code never has to
+# be a shell argument, where it would land in a history file.
 otp="${UF_NPM_OTP:-}"
 for argument in "$@"; do
   case "$argument" in
@@ -268,11 +267,11 @@ failed=0
 failures=""
 while read -r name version <&3; do
   echo "promote-latest: ${name}@${version} -> latest"
-  # Not `set -e`'s business. Seventeen writes with one authentication between
-  # them: a code that expires on the ninth must not throw away the eight that
-  # worked, or the report of which they were. The command is idempotent and the
-  # plan is read from the registry, so the recovery is to run it again — and
-  # the names already moved will not be in the next plan.
+  # Not `set -e`'s business. Many writes can share one authentication between
+  # them: a code that expires mid-run must not throw away the writes that
+  # worked, or the report of which they were. The command is idempotent and
+  # the plan is read from the registry, so the recovery is to run it again —
+  # and the names already moved will not be in the next plan.
   if npm dist-tag add "${name}@${version}" latest ${otp:+--otp="$otp"}; then
     moved=$((moved + 1))
   else

--- a/tools/release/published-packages.txt
+++ b/tools/release/published-packages.txt
@@ -6,9 +6,10 @@
 # name: it squats the name, and it needs a trusted-publisher configuration of
 # its own on npmjs.com, which is a manual step per package.
 #
-# This list is the closure a real uf project needs, plus the test runner. Add a
-# package here when it is implemented, not when it is declared. `uf_lib`'s
-# registry is the source of truth for what each one is.
+# This list is the closure the publish workflow can send over npm trusted
+# publishing. Add a package here when it is implemented *and* bound to
+# `.github/workflows/publish.yml`, not merely when the name exists on npm.
+# `uf_lib`'s registry is the source of truth for what each one is.
 #
 # It has to be a *closure*: `@uniflowed/stylex` depends on `@uniflowed/core`,
 # so a release that sends one without the other produces a package that
@@ -17,39 +18,27 @@
 #
 # Adding a name here is half the job. `publish.yml` publishes over OIDC, and a
 # name that `npm trust` has not bound to that workflow fails the job *after* the
-# names before it have gone out — so a release is half-sent by adding a package
-# and tagging. Pair every addition with:
+# names before it have gone out — even if that package already has older
+# versions on npm. So a release is half-sent by adding a package and tagging.
+# Pair every addition with:
 #
 #   npm login
 #   tools/release/trust-npm.sh
 #
 # and run `uf run release:preflight` before tagging to see where things stand.
-brand
-cell
 config
 core
-effect
 fetch
-form
 graphql
 hooks
 host
-i18n
-immer
-mock
 query
 react
 react-testing
 relay
 router
 server
-state
-story
 stylex
 test
-testing
-tui
-ui
 validator
 vite
-web

--- a/tools/release/test-promote-latest.sh
+++ b/tools/release/test-promote-latest.sh
@@ -2,7 +2,7 @@
 # `promote-latest.sh` against registries that answer differently, without
 # touching npm.
 #
-# The script moves a dist-tag on seventeen published packages, by hand, once
+# The script moves a dist-tag on every package in the publish closure, by hand, once
 # per release, and every mistake in it is visible to everyone who types
 # `npm install @uniflowed/…` afterwards. Four of the ways it could be wrong
 # cannot be seen by running it against the registry as it is today:
@@ -322,7 +322,7 @@ pass "npm refusing a move fails the run"
 #     `done <"$plan"` redirected stdin for the whole loop, and `npm dist-tag
 #     add` on a 2FA account needs stdin: it asks for a one-time password, or
 #     prints a URL and waits. With the plan file there it can do neither, and
-#     `uf@0.0.0-alpha.12` failed on the first of seventeen names having moved
+#     `uf@0.0.0-alpha.12` failed on the first name, having moved
 #     nothing.
 make_registry behind
 : > "${work}/stdin.npm"
@@ -336,7 +336,7 @@ $(cat "${work}/stdin.npm")"
 pass "the plan is read on its own descriptor, so npm keeps stdin"
 
 # 13. One name refusing does not throw away the others, and the summary says
-#     which one it was. Seventeen writes with one authentication between them:
+#     which one it was. Many writes with one authentication between them:
 #     a code that expires on the ninth must not lose the eight that worked.
 : > "${work}/partial.npm"
 if NPM_LOG="${work}/partial.npm" NPM_REFUSES_ONLY=@uniflowed/config PATH="${work}/behind:$PATH" \
@@ -350,8 +350,8 @@ $(cat "${work}/partial.log")"
 grep -q '@uniflowed/config@' "${work}/partial.log" \
   || fail "partial: the failing name was not printed:
 $(cat "${work}/partial.log")"
-# And the sixteen after it still moved, which is the point.
-[ "$(grep -c '^+latest: ' "${work}/partial.log")" -ge 16 ] \
+moved_after_refusal="$(grep -c '^+latest: ' "${work}/partial.log")"
+[ "$moved_after_refusal" = "$((names - 1))" ] \
   || fail "partial: the refusal stopped the rest:
 $(cat "${work}/partial.log")"
 pass "a name that refuses is named, and does not stop the run"


### PR DESCRIPTION
## Change

Move the packages that exist on npm but are not proven publishable by the trusted-publishing workflow back to `pending-packages.txt`, and keep `ui` there too because it depends on `state`.

`published-packages.txt` now describes the closure the GitHub OIDC publish workflow can actually send, not merely every implemented name that happens to exist on the registry. The comments now call out the failure mode we hit on `uf@0.0.0-alpha.19`: registry presence is not enough, because an unbound trusted publisher still fails during `npm publish` after earlier packages may already have gone out.

## Why

The manual publish rerun for `0.0.0-alpha.19` passed the full `cargo test --workspace` suite, including the browser test that previously failed on the GitHub runner, then failed at `@uniflowed/brand@0.0.0-alpha.19` with npm 404/permission. That means the package exists on npm but this workflow is not trusted to publish the next version yet.

## Verification

- `tools/ci/publishable.sh`
- `tools/release/verify-npm.sh --closure-only`
- `tools/ci/test-publishable.sh`
- `tools/release/test-trust-npm.sh`
- `tools/release/test-bootstrap-publish.sh`
- `git diff --check`
- `tools/release/preflight.sh` reaches the existing dist-tag drift gate after confirming closure and registry presence

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791643661&installation_model_id=422833&pr_number=762&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F762&signature=3d7360ee62ea40594a95877abfb9266c1ae7233de51c1dced93628da7a31ae5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how package lists relate to OIDC trusted publishing and workflow configuration.
  - Updated explanations of package readiness, dependency requirements, and bootstrap sequencing.
  - Revised pending and published package inventories to reflect their current publishing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->