### PR TITLE
check: resolve package imports aliases

### DIFF
--- a/crates/uf_check/src/tests.rs
+++ b/crates/uf_check/src/tests.rs
@@ -1076,6 +1076,62 @@ fn a_subpath_export_still_rejects_a_value_its_type_does_not_admit() {
 }
 
 #[test]
+fn a_package_imports_map_gives_hash_specifiers_the_target_type() {
+    require_checker!();
+
+    let report = batch(&[
+        Source::new(
+            "package.json",
+            r##"{ "imports": { "#cell": "./packages/cell/index.js" } }"##,
+        ),
+        Source::new("packages/cell/index.js", CELL_INDEX),
+        Source::new(
+            "app.js",
+            "// @flow\nimport { cell } from \"#cell\";\nconst n: number = cell(\"one\");\n",
+        ),
+    ]);
+
+    assert_eq!(
+        inferred(&report),
+        ["incompatible-type"],
+        "`#cell` must resolve through package.json#imports instead of becoming `any`"
+    );
+    assert!(
+        report.untyped_modules.is_empty(),
+        "{:?}",
+        report.untyped_modules
+    );
+}
+
+#[test]
+fn a_package_imports_map_above_the_batch_root_gives_hash_specifiers_the_target_type() {
+    require_checker!();
+
+    let report = batch(&[
+        Source::new(
+            "../package.json",
+            r##"{ "imports": { "#cell": "./packages/cell/index.js" } }"##,
+        ),
+        Source::new("../packages/cell/index.js", CELL_INDEX),
+        Source::new(
+            "app.js",
+            "// @flow\nimport { cell } from \"#cell\";\nconst n: number = cell(\"one\");\n",
+        ),
+    ]);
+
+    assert_eq!(
+        inferred(&report),
+        ["incompatible-type"],
+        "`#cell` from a parent package scope must keep the target module typed"
+    );
+    assert!(
+        report.untyped_modules.is_empty(),
+        "{:?}",
+        report.untyped_modules
+    );
+}
+
+#[test]
 fn a_path_the_exports_map_does_not_publish_stays_unresolved() {
     require_checker!();
 

--- a/crates/uf_check/src/upstream/packages.rs
+++ b/crates/uf_check/src/upstream/packages.rs
@@ -98,6 +98,7 @@ pub(super) enum PackageFile {
 }
 
 /// One package: where its manifest is, and what the manifest says.
+#[derive(Clone)]
 struct Package {
     /// The manifest's own path in the batch.
     ///
@@ -124,6 +125,13 @@ struct Installed {
 /// Every package the batch declares, indexed so that a specifier can be
 /// resolved from the file that wrote it.
 pub(super) struct WorkspacePackages {
+    /// Every manifest by package scope, deepest first.
+    ///
+    /// `package.json#imports` is not reached through a package name. A
+    /// `#internal/foo` specifier belongs to the nearest parent package scope
+    /// of the file that wrote it, even when that manifest has no `name`, so it
+    /// needs a scope index separate from `project` and `installed`.
+    scopes: Vec<Package>,
     /// Manifests outside any `node_modules`, by the name they publish.
     ///
     /// The project's own packages. Visible from every file in the batch: a
@@ -158,6 +166,7 @@ impl WorkspacePackages {
     /// is the name a specifier reaches it by; two copies at one path are the
     /// same collision and the first still wins.
     pub(super) fn new(sources: &[Source<'_>], options: &Options) -> Self {
+        let mut scopes: Vec<Package> = Vec::new();
         let mut project: HashMap<CompactString, Package> = HashMap::new();
         let mut installed: HashMap<CompactString, Vec<Installed>> = HashMap::new();
         for source in sources.iter().filter(|source| is_manifest(source.path)) {
@@ -168,6 +177,7 @@ impl WorkspacePackages {
                 manifest_path: source.path.to_compact_string(),
                 manifest,
             };
+            scopes.push(package.clone());
             match installed_at(source.path) {
                 Some((enclosing, name)) => installed
                     .entry(name.to_compact_string())
@@ -186,6 +196,7 @@ impl WorkspacePackages {
                 }
             }
         }
+        scopes.sort_by_key(|package| std::cmp::Reverse(scope_specificity(&package.manifest_path)));
         // Deepest first, so the climb is a linear scan that stops at the first
         // copy the importer can see. Ties keep batch order, which only a
         // duplicated path can produce.
@@ -196,6 +207,7 @@ impl WorkspacePackages {
         }
 
         Self {
+            scopes,
             project,
             installed,
             conditions: options
@@ -221,10 +233,19 @@ impl WorkspacePackages {
         self.project.get(name)
     }
 
+    fn scope(&self, importer: &str) -> Option<&Package> {
+        self.scopes
+            .iter()
+            .find(|package| scope_encloses(package.manifest_path.as_str(), importer))
+    }
+
     /// The file `specifier` names when it is written in `importer`, or [`None`]
     /// when no package the importer can see publishes it — or publishes that
     /// subpath of it.
     pub(super) fn resolve(&self, importer: &str, specifier: &str) -> Option<PackageFile> {
+        if specifier.starts_with('#') {
+            return self.resolve_import(importer, specifier);
+        }
         let (name, subpath) = split(specifier)?;
         let package = self.lookup(importer, name)?;
 
@@ -256,6 +277,23 @@ impl WorkspacePackages {
         }
     }
 
+    fn resolve_import(&self, importer: &str, specifier: &str) -> Option<PackageFile> {
+        let package = self.scope(importer)?;
+        let imports = package.manifest.imports()?;
+        let target = imports.resolve_package(specifier, &self.conditions)?;
+
+        if resolve::is_relative(target.as_str()) {
+            return resolve::join(&package.manifest_path, target.as_str()).map(PackageFile::Exact);
+        }
+
+        // Node's `imports` can point at another package. Reuse the ordinary
+        // package resolver for that half, while leaving recursive `#` aliases
+        // unresolved until there is a concrete need for them.
+        (!target.starts_with('#'))
+            .then(|| self.resolve(package.manifest_path.as_str(), target.as_str()))
+            .flatten()
+    }
+
     /// The manifest that publishes `specifier`'s package, if the batch holds
     /// one.
     ///
@@ -266,6 +304,9 @@ impl WorkspacePackages {
     /// package's file into a batch has to pull the manifest that named it in
     /// alongside. See [`super::closure`].
     pub(super) fn manifest_of(&self, importer: &str, specifier: &str) -> Option<&str> {
+        if specifier.starts_with('#') {
+            return Some(self.scope(importer)?.manifest_path.as_str());
+        }
         let (name, _) = split(specifier)?;
         Some(self.lookup(importer, name)?.manifest_path.as_str())
     }
@@ -294,6 +335,37 @@ fn installed_at(manifest_path: &str) -> Option<(&str, &str)> {
     Some((enclosing.strip_suffix('/').unwrap_or(enclosing), name))
 }
 
+fn scope_directory(manifest_path: &str) -> &str {
+    manifest_path
+        .strip_suffix(MANIFEST)
+        .and_then(|path| path.strip_suffix('/'))
+        .unwrap_or("")
+}
+
+fn scope_encloses(manifest_path: &str, importer: &str) -> bool {
+    let scope = scope_directory(manifest_path);
+    if scope.is_empty() {
+        return leading_parent_segments(importer) == 0;
+    }
+    if is_above_root(scope) {
+        return leading_parent_segments(importer) <= scope.split('/').count();
+    }
+    path_encloses(scope, importer)
+}
+
+fn scope_specificity(manifest_path: &str) -> isize {
+    let scope = scope_directory(manifest_path);
+    if scope.is_empty() {
+        return 0;
+    }
+    let segments = scope.split('/').count() as isize;
+    if is_above_root(scope) {
+        -segments
+    } else {
+        segments
+    }
+}
+
 /// Whether a file at `importer` is inside `enclosing`, so that Node's climb
 /// from it reaches that directory's `node_modules`.
 ///
@@ -315,6 +387,22 @@ fn encloses(enclosing: &str, importer: &str) -> bool {
 /// Whether a base names a directory above the batch root.
 fn is_above_root(enclosing: &str) -> bool {
     !enclosing.is_empty() && enclosing.split('/').all(|segment| segment == "..")
+}
+
+fn leading_parent_segments(path: &str) -> usize {
+    path.split('/')
+        .take_while(|segment| *segment == "..")
+        .count()
+}
+
+fn path_encloses(scope: &str, importer: &str) -> bool {
+    let mut importer_segments = importer.split('/');
+    for scope_segment in scope.split('/') {
+        if Some(scope_segment) != importer_segments.next() {
+            return false;
+        }
+    }
+    importer_segments.next().is_some()
 }
 
 /// How specific a base is, so the nearest copy answers first.
@@ -546,6 +634,101 @@ mod tests {
             packages.resolve("app.js", "legacy/lib/util"),
             Some(PackageFile::Implied("vendor/legacy/lib/util".into()))
         );
+    }
+
+    #[test]
+    fn a_package_imports_map_resolves_a_hash_specifier_from_its_scope() {
+        let packages = packages(&[Source::new(
+            "package.json",
+            r##"{ "imports": { "#cell": "./packages/cell/index.js" } }"##,
+        )]);
+
+        assert_eq!(exact(&packages, "#cell"), "packages/cell/index.js");
+    }
+
+    #[test]
+    fn a_package_imports_map_above_the_batch_root_is_visible() {
+        let packages = packages(&[Source::new(
+            "../package.json",
+            r##"{ "imports": { "#cell": "./packages/cell/index.js" } }"##,
+        )]);
+
+        assert_eq!(exact(&packages, "#cell"), "../packages/cell/index.js");
+    }
+
+    #[test]
+    fn a_nearer_package_scope_wins_over_one_above_the_batch_root() {
+        let packages = packages(&[
+            Source::new(
+                "../package.json",
+                r##"{ "imports": { "#mode": "./above.js" } }"##,
+            ),
+            Source::new(
+                "package.json",
+                r##"{ "imports": { "#mode": "./root.js" } }"##,
+            ),
+        ]);
+
+        assert_eq!(exact(&packages, "#mode"), "root.js");
+    }
+
+    #[test]
+    fn a_parent_package_scope_answers_files_above_the_batch_root() {
+        let packages = packages(&[
+            Source::new(
+                "package.json",
+                r##"{ "imports": { "#mode": "./root.js" } }"##,
+            ),
+            Source::new(
+                "../package.json",
+                r##"{ "imports": { "#mode": "./parent.js" } }"##,
+            ),
+        ]);
+
+        assert_eq!(exact_from(&packages, "../app.js", "#mode"), "../parent.js");
+    }
+
+    #[test]
+    fn a_grandparent_package_scope_beats_parent_for_grandparent_files() {
+        let packages = packages(&[
+            Source::new(
+                "package.json",
+                r##"{ "imports": { "#mode": "./root.js" } }"##,
+            ),
+            Source::new(
+                "../package.json",
+                r##"{ "imports": { "#mode": "./parent.js" } }"##,
+            ),
+            Source::new(
+                "../../package.json",
+                r##"{ "imports": { "#mode": "./grandparent.js" } }"##,
+            ),
+        ]);
+
+        assert_eq!(
+            exact_from(&packages, "../../app.js", "#mode"),
+            "../../grandparent.js"
+        );
+    }
+
+    #[test]
+    fn the_nearest_package_scope_answers_a_hash_specifier() {
+        let packages = packages(&[
+            Source::new(
+                "package.json",
+                r##"{ "imports": { "#mode": "./root.js" } }"##,
+            ),
+            Source::new(
+                "packages/app/package.json",
+                r##"{ "name": "app", "imports": { "#mode": "./local.js" } }"##,
+            ),
+        ]);
+
+        assert_eq!(
+            exact_from(&packages, "packages/app/index.js", "#mode"),
+            "packages/app/local.js"
+        );
+        assert_eq!(exact_from(&packages, "other.js", "#mode"), "root.js");
     }
 
     #[test]

--- a/tools/upstream/patches/flow/0005-expose-package-json-imports.patch
+++ b/tools/upstream/patches/flow/0005-expose-package-json-imports.patch
@@ -1,0 +1,118 @@
+Subject: expose package.json imports in the Flow Rust port
+
+Issue: ubugeeei-prod/uf#736
+Upstream: not filed with facebook/flow yet
+Submodule: 81b0c2a3dd591c66c51167aac341d851932bd9c5
+
+`package.json#imports` is the standard map for package-private `#...`
+specifier aliases. uf needs to read it when resolving the module graph it hands
+to Flow; otherwise a local `#internal/foo` import falls through as an untyped
+bare package named `#internal`.
+
+The existing `PackageExports` resolver already has the exact condition and
+wildcard machinery `imports` needs. This patch stores an object-form imports
+map on `PackageJson` and deliberately skips `exports`' conditional-main sugar,
+because an `imports` object is keyed by `#...`, not by `"."` subpaths.
+
+diff --git a/rust_port/crates/flow_parser_utils/src/package_exports.rs b/rust_port/crates/flow_parser_utils/src/package_exports.rs
+index 200b7026f0..a9c6341c23 100644
+--- a/rust_port/crates/flow_parser_utils/src/package_exports.rs
++++ b/rust_port/crates/flow_parser_utils/src/package_exports.rs
+@@ -80,6 +80,15 @@ impl PackageExports {
+             _ => None,
+         }
+     }
++
++    pub fn parse_imports(expr: &ast::expression::Expression<Loc, Loc>) -> Option<Self> {
++        match expr.deref() {
++            ExpressionInner::Object { inner, .. } => {
++                Some(parse_package_exports_obj(&inner.properties))
++            }
++            _ => None,
++        }
++    }
+ }
+ 
+ fn pattern_key_compare(a: &str, b: &str) -> std::cmp::Ordering {
+diff --git a/rust_port/crates/flow_parser_utils/src/package_json.rs b/rust_port/crates/flow_parser_utils/src/package_json.rs
+index f9b72b767d..6f00486e09 100644
+--- a/rust_port/crates/flow_parser_utils/src/package_json.rs
++++ b/rust_port/crates/flow_parser_utils/src/package_json.rs
+@@ -23,6 +23,7 @@ use crate::package_exports::PackageExports;
+ //   types: string option;
+ //   haste_commonjs: bool;
+ //   exports: Package_exports.t option;
++//   imports: Package_exports.t option;
+ // }
+ #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+ pub struct PackageJson {
+@@ -31,6 +32,8 @@ pub struct PackageJson {
+     types: Option<FlowSmolStr>,
+     haste_commonjs: bool,
+     exports: Option<PackageExports>,
++    #[serde(default)]
++    imports: Option<PackageExports>,
+ }
+ 
+ impl PackageJson {
+@@ -42,11 +45,12 @@ impl PackageJson {
+             types: None,
+             haste_commonjs: false,
+             exports: None,
++            imports: None,
+         }
+     }
+ 
+     // let create ~name ~main ~types ~haste_commonjs ~exports =
+-    //   { name; main; types; haste_commonjs; exports }
++    //   { name; main; types; haste_commonjs; exports; imports = None }
+     pub fn create(
+         name: Option<FlowSmolStr>,
+         main: Option<FlowSmolStr>,
+@@ -60,6 +64,7 @@ impl PackageJson {
+             types,
+             haste_commonjs,
+             exports,
++            imports: None,
+         }
+     }
+ 
+@@ -84,6 +89,10 @@ impl PackageJson {
+         self.exports.as_ref()
+     }
+ 
++    pub fn imports(&self) -> Option<&PackageExports> {
++        self.imports.as_ref()
++    }
++
+     pub fn parse(node_main_fields: &[FlowSmolStr], object: &Object<Loc, Loc>) -> Self {
+         let mut prop_map = HashMap::new();
+         for property in object.properties.iter() {
+@@ -102,12 +111,14 @@ impl PackageJson {
+         };
+         let haste_commonjs = bool_opt(prop_map.get("haste_commonjs")).unwrap_or(false);
+         let exports = package_exports_opt(prop_map.get("exports"));
++        let imports = package_imports_opt(prop_map.get("imports"));
+         Self {
+             name,
+             main,
+             types,
+             haste_commonjs,
+             exports,
++            imports,
+         }
+     }
+ }
+@@ -138,6 +149,12 @@ fn package_exports_opt(
+     expr.and_then(PackageExports::parse)
+ }
+ 
++fn package_imports_opt(
++    expr: Option<&ast::expression::Expression<Loc, Loc>>,
++) -> Option<PackageExports> {
++    expr.and_then(PackageExports::parse_imports)
++}
++
+ /// Given a list of JSON properties, loosely extract the properties and turn it into a
+ /// [Expression.t SMap.t]. We aren't looking to validate the file, and don't currently
+ /// care about any non-literal properties, so we skip over everything else.


### PR DESCRIPTION
## Summary
- expose package.json `imports` from the vendored Flow Rust `PackageJson` parser
- resolve `#...` package-private imports from the nearest package scope during `uf check`
- add package resolver and checker regressions so `#cell` resolves to the target type instead of becoming `any`

Partially addresses #736 (`imports`).

## Verification
- `tools/upstream/sync.sh`
- `tools/upstream/test-patches.sh`
- `git diff --check`
- `cargo fmt --all --check`

Not run locally: `cargo test -p uf_check ...` because this host cargo is rustc 1.94 while the workspace requires rustc 1.98/nightly, and `nix develop` ran out of disk while fetching the nightly shell. CI should run this with the pinned toolchain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791653589&installation_model_id=422833&pr_number=763&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F763&signature=39d295ac9bcf7afc07b198f0d3bcc40c74b411b27b146e5a53dc1b4ee75dc244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving `package.json` `imports` maps, including scoped hash specifiers such as `#internal/foo`.
  * Imports resolve to declared files or package targets while preserving exported type information.
  * Added support for nested and parent package scopes, using the nearest applicable manifest.
  * Added support for reading and exposing object-form `imports` maps in package metadata.

* **Bug Fixes**
  * Prevented values imported through valid `imports` mappings from being incorrectly treated as untyped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->