### PR TITLE
upstream: silence remaining Flow deref warning

### DIFF
--- a/tools/upstream/patches/flow/0004-silence-rust-warning-noise.patch
+++ b/tools/upstream/patches/flow/0004-silence-rust-warning-noise.patch
@@ -90,6 +90,15 @@ index 16934b3cb..d7fba6ef5 100644
                              && let expression::ExpressionInner::Assignment {
                                  inner: assign,
                                  ..
+@@ -324,7 +324,7 @@ fn convert_switch_inner<M: Dupe>(
+                         && last_case
+                         && let statement::StatementInner::Expression {
+                             inner: expr_stmt, ..
+-                        } = last_stmt.deref().deref()
++                        } = (*last_stmt).deref()
+                         && let expression::ExpressionInner::Assignment {
+                             inner: assign, ..
+                         } = expr_stmt.expression.deref()
 diff --git a/rust_port/crates/flow_typing_ty_normalizer/src/env.rs b/rust_port/crates/flow_typing_ty_normalizer/src/env.rs
 index d2b3a9ff3..2e80196a9 100644
 --- a/rust_port/crates/flow_typing_ty_normalizer/src/env.rs


### PR DESCRIPTION
## Summary
- extend the existing Flow warning-noise patch to cover the remaining double-reference deref in switch_to_match
- keep the fix scoped to the upstream patch file so sync materializes the same quiet checkout everywhere

## Validation
- tools/upstream/sync.sh
- git diff --check && git -C upstream/flow diff --check
- cargo fmt --all --check
- rg check for remaining double-reference deref in upstream/flow/rust_port

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791661069&installation_model_id=422833&pr_number=764&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F764&signature=197996c3e1a5f67307ace86abdc0be02fca9b946b8034e88b1938cd3057f9264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->