### PR TITLE
env: read exact tool pins from package engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,6 +3672,7 @@ name = "uf_env"
 version = "0.0.0-alpha.19"
 dependencies = [
  "camino",
+ "compact_str",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/uf_cli/src/commands/env.rs
+++ b/crates/uf_cli/src/commands/env.rs
@@ -42,7 +42,7 @@ fn declared(cwd: &Utf8Path) -> Result<(uf_config::ResolvedConfig, Vec<uf_env::Pi
             std::env::consts::ARCH
         )
     })?;
-    let pins = uf_env::project::declared(&resolved.config, platform)?;
+    let pins = uf_env::project::declared_for_project(&resolved.root, &resolved.config, platform)?;
     Ok((resolved, pins))
 }
 
@@ -56,7 +56,8 @@ fn install(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
             renderer.status(
                 out,
                 Status::Warn,
-                "uf.config.js declares no toolchain, so nothing is pinned to this project",
+                "neither uf.config.js nor package.json engines declares an exact toolchain, so \
+                 nothing is pinned to this project",
             );
         });
         return Ok(());
@@ -149,7 +150,11 @@ fn list(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
         renderer.blank(out);
         renderer.heading(out, 2, "this project");
         if mine.is_empty() {
-            renderer.bullet_list(out, 4, &["nothing pinned in uf.config.js"]);
+            renderer.bullet_list(
+                out,
+                4,
+                &["nothing pinned in uf.config.js or package.json engines"],
+            );
         } else {
             renderer.bullet_list(out, 4, &mine);
         }

--- a/crates/uf_cli/tests/env.rs
+++ b/crates/uf_cli/tests/env.rs
@@ -70,8 +70,43 @@ fn a_project_that_pins_nothing_is_told_so_and_succeeds() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("declares no toolchain"), "{stdout}");
+    assert!(
+        stdout.contains("neither uf.config.js nor package.json engines declares"),
+        "{stdout}"
+    );
     assert!(!dir.path().join(".uniflowed/env/bin").exists());
+}
+
+/// The standard manifest field is enough to tell `uf env` what this project
+/// wants, without repeating the same pin in uf.config.js.
+#[test]
+fn env_list_reports_exact_package_json_engines() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, roots) = project(dir.path(), "{}");
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{ "engines": { "node": "24.14.0", "npm": ">=10" } }"#,
+    )
+    .unwrap();
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["env", "list"])
+        .env("UF_STORE", &store)
+        .env("UF_ROOTS", &roots)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("node@24.14.0"), "{stdout}");
+    assert!(!stdout.contains("npm@"), "{stdout}");
+    assert_plain(&stdout);
 }
 
 /// A range is refused, and the message says which tool and what was written.

--- a/crates/uf_env/Cargo.toml
+++ b/crates/uf_env/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 
 [dependencies]
 camino.workspace = true
+compact_str.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/uf_env/src/gc.rs
+++ b/crates/uf_env/src/gc.rs
@@ -74,7 +74,7 @@ pub fn plan(store: &Store, roots: &Roots) -> Result<Plan, EnvError> {
         // A half-finished unpack from an interrupted install. Nothing links
         // it and nothing ever will, because the next install stages a fresh
         // one; leaving it would be a leak that only ever grows.
-        if entry.starts_with(".staging-") || !reachable.binary_search(&entry).is_ok() {
+        if entry.starts_with(".staging-") || reachable.binary_search(&entry).is_err() {
             plan.unreachable.push(entry);
         }
     }

--- a/crates/uf_env/src/lib.rs
+++ b/crates/uf_env/src/lib.rs
@@ -82,6 +82,15 @@ pub enum EnvError {
         /// The path, as the operating system gave it.
         path: std::path::PathBuf,
     },
+    /// A project manifest could not be decoded.
+    #[error("failed to parse {path}: {source}")]
+    ManifestJson {
+        /// The manifest path.
+        path: Utf8PathBuf,
+        /// The underlying JSON error.
+        #[source]
+        source: serde_json::Error,
+    },
     /// Neither the XDG variable nor `$HOME` is set, so there is nowhere the
     /// store could mean.
     #[error("neither XDG_DATA_HOME nor HOME is set, so there is no store directory")]

--- a/crates/uf_env/src/project.rs
+++ b/crates/uf_env/src/project.rs
@@ -31,6 +31,7 @@
 use std::fs;
 
 use camino::{Utf8Path, Utf8PathBuf};
+use compact_str::CompactString;
 use sha2::{Digest, Sha256};
 use uf_config::UniflowedConfig;
 
@@ -124,13 +125,47 @@ impl Envs {
 /// are refusals rather than warnings: a typo that silently installs nothing
 /// is a project that thinks it pinned its runtime and did not.
 pub fn declared(config: &UniflowedConfig, platform: Platform) -> Result<Vec<Pin>, EnvError> {
+    declared_from(config.env.toolchain.iter(), platform)
+}
+
+/// What a repository asks for through uf's config and standard manifest fields.
+///
+/// `env.toolchain` is the explicit uf answer and wins when both places name the
+/// same tool. A package manifest's `engines` object is the standard spelling,
+/// so exact versions there are used as the fallback instead of forcing a
+/// second uf-only declaration.
+///
+/// # Errors
+///
+/// When uf's config names a tool uf installs with a version that is not exact,
+/// or when the manifest cannot be read as JSON. Non-exact manifest engines are
+/// ignored because `engines` commonly carries compatibility ranges.
+pub fn declared_for_project(
+    root: &Utf8Path,
+    config: &UniflowedConfig,
+    platform: Platform,
+) -> Result<Vec<Pin>, EnvError> {
+    let manifest = root.join("package.json");
+    let engines = engines(&manifest)?;
+    let merged = engines
+        .iter()
+        .filter(|(name, _)| !config.env.toolchain.contains_key(name))
+        .map(|(name, version)| (name, version))
+        .chain(config.env.toolchain.iter());
+    declared_from(merged, platform)
+}
+
+fn declared_from<'a>(
+    entries: impl Iterator<Item = (&'a CompactString, &'a CompactString)>,
+    platform: Platform,
+) -> Result<Vec<Pin>, EnvError> {
     let mut pins = Vec::new();
-    for (name, version) in &config.env.toolchain {
+    for (name, version) in entries {
         let tool = Tool::parse(name).ok_or_else(|| EnvError::UnknownTool {
             name: name.to_string(),
         })?;
         let version = version.trim();
-        if version.is_empty() || !version.starts_with(|c: char| c.is_ascii_digit()) {
+        if !is_exact_version(version) {
             return Err(EnvError::NotAnExactVersion {
                 tool: tool.name(),
                 version: version.to_owned(),
@@ -144,6 +179,89 @@ pub fn declared(config: &UniflowedConfig, platform: Platform) -> Result<Vec<Pin>
     }
     pins.sort();
     Ok(pins)
+}
+
+fn engines(path: &Utf8Path) -> Result<Vec<(CompactString, CompactString)>, EnvError> {
+    let source = match fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(EnvError::Read {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let value = serde_json::from_str::<serde_json::Value>(&source).map_err(|source| {
+        EnvError::ManifestJson {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+
+    let Some(engines) = value.get("engines").and_then(serde_json::Value::as_object) else {
+        return Ok(Vec::new());
+    };
+
+    Ok(engines
+        .iter()
+        .filter_map(|(name, version)| {
+            let version = version.as_str()?.trim();
+            if !is_exact_version(version) {
+                return None;
+            }
+            Tool::parse(name).map(|tool| (tool.name().into(), version.into()))
+        })
+        .collect())
+}
+
+fn is_exact_version(version: &str) -> bool {
+    let Some(separator) = version.find(['-', '+']) else {
+        return is_version_core(version);
+    };
+    is_version_core(&version[..separator]) && is_version_suffix(&version[separator..])
+}
+
+fn is_version_core(version: &str) -> bool {
+    let mut parts = version.split('.');
+    let Some(major) = parts.next() else {
+        return false;
+    };
+    let Some(minor) = parts.next() else {
+        return false;
+    };
+    let Some(patch) = parts.next() else {
+        return false;
+    };
+    parts.next().is_none() && [major, minor, patch].into_iter().all(is_digits)
+}
+
+fn is_version_suffix(suffix: &str) -> bool {
+    if let Some(rest) = suffix.strip_prefix('-') {
+        let Some((pre, build)) = rest.split_once('+') else {
+            return is_version_identifiers(rest);
+        };
+        return is_version_identifiers(pre) && is_version_identifiers(build);
+    }
+
+    let Some(build) = suffix.strip_prefix('+') else {
+        return false;
+    };
+    is_version_identifiers(build)
+}
+
+fn is_version_identifiers(value: &str) -> bool {
+    !value.is_empty()
+        && value.split('.').all(|identifier| {
+            !identifier.is_empty()
+                && identifier
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+}
+
+fn is_digits(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 /// Move what an older uf left in `.uniflowed/`, and remove the rest.

--- a/crates/uf_env/src/tests.rs
+++ b/crates/uf_env/src/tests.rs
@@ -282,6 +282,110 @@ fn a_version_that_is_not_exact_is_refused() {
     assert_eq!(pins[0].tool, Tool::Node, "runtimes are listed first");
 }
 
+/// package.json has a standard `engines` field for the same tool pins. uf's
+/// config remains the explicit override, but an exact manifest engine is
+/// enough for `uf env install`.
+#[test]
+fn package_json_engines_can_pin_the_project_toolchain() {
+    use uf_config::UniflowedConfig;
+
+    let (_guard, root) = temp();
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(
+        project.join("package.json"),
+        r#"{
+          "engines": {
+            "node": "24.14.0",
+            "pnpm": "9.15.0",
+            "npm": ">=10",
+            "cargo": "1.0.0"
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let platform = Platform {
+        os: Os::Darwin,
+        arch: Arch::Arm64,
+    };
+    let pins = project::declared_for_project(&project, &UniflowedConfig::default(), platform)
+        .expect("exact known engines become pins");
+
+    assert_eq!(pins.len(), 2);
+    assert_eq!(pins[0].tool, Tool::Node, "runtimes are listed first");
+    assert_eq!(pins[0].version, "24.14.0");
+    assert_eq!(pins[1].tool, Tool::Pnpm);
+    assert_eq!(pins[1].version, "9.15.0");
+}
+
+/// Compatibility expressions in package.json are useful for package managers,
+/// but they are not store-safe pins.
+#[test]
+fn package_json_engines_ignore_non_exact_versions() {
+    use uf_config::UniflowedConfig;
+
+    let (_guard, root) = temp();
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(
+        project.join("package.json"),
+        r#"{
+          "engines": {
+            "node": "24.x",
+            "pnpm": "24 || 25",
+            "bun": "1.2.19 - 1.2.20",
+            "deno": "1/../../escape",
+            "npm": "10.9",
+            "yarn": "4.9.2+sha.20260910"
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let platform = Platform {
+        os: Os::Darwin,
+        arch: Arch::Arm64,
+    };
+    let pins = project::declared_for_project(&project, &UniflowedConfig::default(), platform)
+        .expect("manifest ranges are ignored rather than refused");
+
+    assert_eq!(pins.len(), 1);
+    assert_eq!(pins[0].tool, Tool::Yarn);
+    assert_eq!(pins[0].version, "4.9.2+sha.20260910");
+}
+
+/// `env.toolchain` is the uf-specific escape hatch and wins over the standard
+/// manifest field when both name the same tool.
+#[test]
+fn config_toolchain_overrides_package_json_engines() {
+    use uf_config::UniflowedConfig;
+
+    let (_guard, root) = temp();
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(
+        project.join("package.json"),
+        r#"{ "engines": { "node": "22.9.0", "bun": "1.2.19" } }"#,
+    )
+    .unwrap();
+
+    let platform = Platform {
+        os: Os::Darwin,
+        arch: Arch::Arm64,
+    };
+    let mut config = UniflowedConfig::default();
+    config.env.toolchain.insert("node".into(), "24.14.0".into());
+    let pins = project::declared_for_project(&project, &config, platform)
+        .expect("config and engines merge");
+
+    assert_eq!(pins.len(), 2);
+    assert_eq!(pins[0].tool, Tool::Node);
+    assert_eq!(pins[0].version, "24.14.0");
+    assert_eq!(pins[1].tool, Tool::Bun);
+    assert_eq!(pins[1].version, "1.2.19");
+}
+
 /// Each publisher's URL is built the way that publisher names its files.
 #[test]
 fn a_source_is_where_its_publisher_puts_it() {


### PR DESCRIPTION
## Summary
- teach `uf env` to use exact known versions from `package.json#engines` as fallback tool pins
- keep `uf.config.js` as the explicit override when both sources name the same tool
- ignore engine ranges and unknown engine keys so standard package metadata can coexist with uf
- tighten exact-version validation and clear a local `uf_env` clippy warning under `-D warnings`

Part of #736.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `git -C upstream/flow diff --check`
- `cargo check -p uf_env --ignore-rust-version`
- `cargo test -p uf_env --ignore-rust-version`
- `cargo clippy -p uf_env --ignore-rust-version -- -D warnings`
- `cargo test -p uf_cli --test env --ignore-rust-version` could not complete locally because the installed stable rustc rejects a nightly-only dependency feature (`bumpalo` allocator_api); CI uses the pinned nightly toolchain
