### PR TITLE
ci: deny Rust warnings at workspace level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,9 @@ jobs:
           path: target/release
       - run: chmod +x target/release/uf
       - run: ./target/release/uf run rust:metadata
+      # And that every Rust crate inherits the workspace lint policy. Clippy
+      # warning-as-error cannot live only in a remembered command suffix.
+      - run: ./target/release/uf run rust:lints
       # Every package manifest, not just one: there are 44 of them now, and a
       # manifest that does not parse is a package that cannot be installed.
       - run: ./target/release/uf run manifests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,12 @@ repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
 version = "0.0.0-alpha.20"
 
+[workspace.lints.rust]
+warnings = "deny"
+
+[workspace.lints.clippy]
+all = "deny"
+
 [workspace.dependencies]
 # Glyph outlines and coverage rasterisation, for `uf_assets::og`. Pure Rust
 # over `ttf-parser`: it turns a glyph id into an outline and an outline into

--- a/crates/uf_assets/Cargo.toml
+++ b/crates/uf_assets/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 uf_bundle = { path = "../uf_bundle" }
 uf_infra = { path = "../uf_infra" }

--- a/crates/uf_bundle/Cargo.toml
+++ b/crates/uf_bundle/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 uf_infra = { path = "../uf_infra" }
 base64.workspace = true

--- a/crates/uf_check/Cargo.toml
+++ b/crates/uf_check/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["upstream-typecheck"]
 # Run Flow's own type inference from the `upstream/flow` submodule.

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "uf"
 path = "src/bin/uf.rs"

--- a/crates/uf_config/Cargo.toml
+++ b/crates/uf_config/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true

--- a/crates/uf_doc/Cargo.toml
+++ b/crates/uf_doc/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 serde.workspace = true

--- a/crates/uf_env/Cargo.toml
+++ b/crates/uf_env/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true

--- a/crates/uf_flow/Cargo.toml
+++ b/crates/uf_flow/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 flow_parser.workspace = true
 thiserror.workspace = true

--- a/crates/uf_fmt/Cargo.toml
+++ b/crates/uf_fmt/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 uf_config = { path = "../uf_config" }
 uf_flow = { path = "../uf_flow" }

--- a/crates/uf_i18n/Cargo.toml
+++ b/crates/uf_i18n/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 serde.workspace = true

--- a/crates/uf_infra/Cargo.toml
+++ b/crates/uf_infra/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bumpalo.workspace = true
 compact_str.workspace = true

--- a/crates/uf_lib/Cargo.toml
+++ b/crates/uf_lib/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 compact_str.workspace = true
 uf_infra = { path = "../uf_infra" }

--- a/crates/uf_lint/Cargo.toml
+++ b/crates/uf_lint/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 uf_config = { path = "../uf_config" }
 uf_flow = { path = "../uf_flow" }

--- a/crates/uf_plugin/Cargo.toml
+++ b/crates/uf_plugin/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true

--- a/crates/uf_pm/Cargo.toml
+++ b/crates/uf_pm/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 base64.workspace = true
 camino.workspace = true

--- a/crates/uf_prepare/Cargo.toml
+++ b/crates/uf_prepare/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true

--- a/crates/uf_profiler/Cargo.toml
+++ b/crates/uf_profiler/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 # No dependencies, and that is a property rather than an accident. A profiler
 # that pulls in a dependency tree measures that tree as well as the program,
 # and every crate uf profiles would then link it. `std` has an atomic, a

--- a/crates/uf_project/Cargo.toml
+++ b/crates/uf_project/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 compact_str.workspace = true
 camino.workspace = true

--- a/crates/uf_react_compiler/Cargo.toml
+++ b/crates/uf_react_compiler/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 compact_str.workspace = true
 react_compiler.workspace = true

--- a/crates/uf_rm/Cargo.toml
+++ b/crates/uf_rm/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 compact_str.workspace = true
 serde.workspace = true

--- a/crates/uf_router/Cargo.toml
+++ b/crates/uf_router/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true

--- a/crates/uf_rsc/Cargo.toml
+++ b/crates/uf_rsc/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true

--- a/crates/uf_runtime/Cargo.toml
+++ b/crates/uf_runtime/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 smallvec.workspace = true

--- a/crates/uf_std/Cargo.toml
+++ b/crates/uf_std/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 compact_str.workspace = true
 rustc-hash.workspace = true

--- a/crates/uf_stylex/Cargo.toml
+++ b/crates/uf_stylex/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 compact_str.workspace = true
 serde.workspace = true

--- a/crates/uf_task/Cargo.toml
+++ b/crates/uf_task/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 uf_config = { path = "../uf_config" }
 uf_infra = { path = "../uf_infra" }

--- a/crates/uf_term/Cargo.toml
+++ b/crates/uf_term/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 
 [dev-dependencies]

--- a/crates/uf_test/Cargo.toml
+++ b/crates/uf_test/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 uf_infra = { path = "../uf_infra" }
 uf_rsc = { path = "../uf_rsc" }

--- a/crates/uf_transform/Cargo.toml
+++ b/crates/uf_transform/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 flow_parser.workspace = true
 indexmap.workspace = true

--- a/crates/uf_tui/Cargo.toml
+++ b/crates/uf_tui/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 compact_str.workspace = true
 serde.workspace = true

--- a/tools/ci/workspace-rust-lints.sh
+++ b/tools/ci/workspace-rust-lints.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+# Every Rust crate in the workspace inherits the workspace lint policy.
+#
+# `cargo clippy -- -D warnings` already made the CI job fail on warning, but
+# the command line was the policy. A contributor who ran `cargo clippy` without
+# that suffix could still get a screen full of warnings and a zero exit code.
+# The policy now lives in `Cargo.toml`; this check keeps new crates from
+# quietly opting out by omission.
+set -eu
+
+root="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
+cd "$root"
+
+errors=0
+fail() {
+  echo "workspace-rust-lints: $1" >&2
+  errors=$((errors + 1))
+}
+
+grep -q '^\[workspace\.lints\.rust\]$' Cargo.toml \
+  || fail "Cargo.toml is missing [workspace.lints.rust]"
+grep -q '^warnings = "deny"$' Cargo.toml \
+  || fail "Cargo.toml does not deny rust warnings"
+grep -q '^\[workspace\.lints\.clippy\]$' Cargo.toml \
+  || fail "Cargo.toml is missing [workspace.lints.clippy]"
+grep -q '^all = "deny"$' Cargo.toml \
+  || fail "Cargo.toml does not deny clippy::all"
+
+for manifest in crates/*/Cargo.toml; do
+  if ! awk '
+    /^\[lints\]$/ { inside = 1; next }
+    /^\[/ { inside = 0 }
+    inside && $0 == "workspace = true" { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$manifest"; then
+    fail "$manifest does not inherit workspace lints"
+  fi
+done
+
+if [ "$errors" -ne 0 ]; then
+  exit 1
+fi
+
+echo "workspace-rust-lints: every crate inherits denied warnings"

--- a/uf.config.js
+++ b/uf.config.js
@@ -140,6 +140,10 @@ export default defineConfig({
     "rust:test": "cargo test --workspace",
     "rust:bench": "cargo bench --workspace --no-run",
     "rust:metadata": "cargo metadata --format-version 1 --locked",
+    "rust:lints": {
+      command: "tools/ci/workspace-rust-lints.sh",
+      inputs: ["Cargo.toml", "crates/*/Cargo.toml", "tools/ci/workspace-rust-lints.sh"],
+    },
 
     // The parser and the checker are vendored, and they are the thing
     // everything else reads, so they get a pass of their own.
@@ -879,6 +883,7 @@ export default defineConfig({
         "test:lib",
         "docs:build",
         "rust:metadata",
+        "rust:lints",
         "manifests",
         "lockfile",
         "lockfile:test",


### PR DESCRIPTION
## Summary
- Deny Rust warnings and Clippy's default lint group through workspace lints.
- Make every Rust workspace crate inherit the lint policy.
- Add a metadata guard so new crates cannot skip the workspace lint policy.

## Verification
- `LC_ALL=C tools/ci/workspace-rust-lints.sh`
- `LC_ALL=C cargo metadata --format-version 1 --locked`
- `LC_ALL=C cargo fmt --all -- --check`
- `LC_ALL=C sh -n tools/ci/workspace-rust-lints.sh`
- `LC_ALL=C git diff --check`
- `LC_ALL=C cargo clippy -p uf_task --all-targets --ignore-rust-version --message-format short`

Full local nightly workspace Clippy was attempted through `nix develop`, but this machine ran out of Nix store space while unpacking the pinned nightly rust-std. CI uses the pinned nightly and should be the authoritative full run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791683238&installation_model_id=422833&pr_number=767&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F767&signature=26dfacf08526c7749a08edc43115d255a144c3d3df59efddd97076aa0047b70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI & Quality**
  * Added workspace-wide Rust and Clippy lint enforcement, treating warnings and lint violations as errors.
  * Added validation to ensure all crates use the shared lint configuration.
  * CI now runs the lint-policy checks automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->