### PR TITLE
build: warn when library exports are not published

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3599,6 +3599,7 @@ dependencies = [
  "camino",
  "clap",
  "compact_str",
+ "globset",
  "image",
  "mimalloc",
  "serde",

--- a/crates/uf_cli/Cargo.toml
+++ b/crates/uf_cli/Cargo.toml
@@ -50,6 +50,7 @@ uf_pm = { path = "../uf_pm" }
 uf_prepare = { path = "../uf_prepare" }
 uf_project = { path = "../uf_project" }
 walkdir.workspace = true
+globset.workspace = true
 uf_rm = { path = "../uf_rm" }
 uf_router = { path = "../uf_router" }
 uf_rsc = { path = "../uf_rsc" }

--- a/crates/uf_cli/src/commands/build/library.rs
+++ b/crates/uf_cli/src/commands/build/library.rs
@@ -490,24 +490,25 @@ fn export_target(target: &str) -> Option<&str> {
 fn always_published_targets(manifest: &serde_json::Value) -> BTreeSet<String> {
     let mut targets = BTreeSet::from([String::from("package.json")]);
 
-    if let Some(main) = manifest.get("main").and_then(serde_json::Value::as_str) {
-        if let Some(target) = manifest_path(main) {
-            targets.insert(target);
-        }
+    if let Some(target) = manifest
+        .get("main")
+        .and_then(serde_json::Value::as_str)
+        .and_then(manifest_path)
+    {
+        targets.insert(target);
     }
     if let Some(bin) = manifest.get("bin") {
         match bin {
             serde_json::Value::String(path) => {
-                if let Some(target) = manifest_path(path) {
-                    targets.insert(target);
-                }
+                targets.extend(manifest_path(path));
             }
             serde_json::Value::Object(commands) => {
-                for path in commands.values().filter_map(serde_json::Value::as_str) {
-                    if let Some(target) = manifest_path(path) {
-                        targets.insert(target);
-                    }
-                }
+                targets.extend(
+                    commands
+                        .values()
+                        .filter_map(serde_json::Value::as_str)
+                        .filter_map(manifest_path),
+                );
             }
             _ => {}
         }

--- a/crates/uf_cli/src/commands/build/library.rs
+++ b/crates/uf_cli/src/commands/build/library.rs
@@ -448,16 +448,14 @@ fn unpublished_exports(root: &Utf8Path) -> Vec<String> {
         return Vec::new();
     };
 
-    let files = manifest
-        .get("files")
-        .and_then(serde_json::Value::as_array)
-        .map(|entries| {
-            entries
-                .iter()
-                .filter_map(serde_json::Value::as_str)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+    let Some(files) = manifest.get("files").and_then(serde_json::Value::as_array) else {
+        return Vec::new();
+    };
+    let files = files
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    let always_published = always_published_targets(&manifest);
 
     let mut missing = Vec::new();
     let mut targets = Vec::new();
@@ -466,7 +464,7 @@ fn unpublished_exports(root: &Utf8Path) -> Vec<String> {
         let Some(relative) = export_target(&target) else {
             continue;
         };
-        if npm_always_publishes(relative) || files_publish(relative, &files) {
+        if always_published.contains(relative) || files_publish(relative, &files) {
             continue;
         }
         missing.push(target);
@@ -483,26 +481,83 @@ fn unpublished_exports(root: &Utf8Path) -> Vec<String> {
     )]
 }
 
+/// A relative target out of `exports`, or nothing for package specifiers.
 fn export_target(target: &str) -> Option<&str> {
     target.strip_prefix("./")
 }
 
-fn npm_always_publishes(path: &str) -> bool {
-    path == "package.json"
-        || path.eq_ignore_ascii_case("readme")
-        || path
-            .rsplit('/')
-            .next()
-            .is_some_and(|name| name.eq_ignore_ascii_case("license"))
+/// Targets npm publishes even when `files` does not name them.
+fn always_published_targets(manifest: &serde_json::Value) -> BTreeSet<String> {
+    let mut targets = BTreeSet::from([String::from("package.json")]);
+
+    if let Some(main) = manifest.get("main").and_then(serde_json::Value::as_str) {
+        if let Some(target) = manifest_path(main) {
+            targets.insert(target);
+        }
+    }
+    if let Some(bin) = manifest.get("bin") {
+        match bin {
+            serde_json::Value::String(path) => {
+                if let Some(target) = manifest_path(path) {
+                    targets.insert(target);
+                }
+            }
+            serde_json::Value::Object(commands) => {
+                for path in commands.values().filter_map(serde_json::Value::as_str) {
+                    if let Some(target) = manifest_path(path) {
+                        targets.insert(target);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    targets
 }
 
+/// A manifest path in the same relative spelling `exports` targets use here.
+fn manifest_path(path: &str) -> Option<String> {
+    let path = path.trim().trim_start_matches("./").trim_start_matches('/');
+    if path.is_empty() || path.starts_with("../") {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+/// Whether `path` is a root metadata file npm publishes regardless of `files`.
+fn is_always_published_root_file(path: &str) -> bool {
+    if path.contains('/') {
+        return false;
+    }
+    let lower = path.to_ascii_lowercase();
+    lower == "package.json"
+        || has_optional_extension(&lower, "readme")
+        || has_optional_extension(&lower, "license")
+        || has_optional_extension(&lower, "licence")
+}
+
+/// Whether `name` is exactly `stem`, or `stem` followed by an extension.
+fn has_optional_extension(name: &str, stem: &str) -> bool {
+    name == stem
+        || name
+            .strip_prefix(stem)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+/// Apply the `files` allowlist in order, including negations.
 fn files_publish(path: &str, files: &[&str]) -> bool {
+    if is_always_published_root_file(path) {
+        return true;
+    }
     let mut published = false;
     for entry in files {
         let Some(pattern) = file_pattern(entry) else {
             continue;
         };
-        if !file_pattern_matches(pattern.body, path) {
+        if !file_pattern_matches(pattern.body, path)
+            && (pattern.include || !file_negation_matches_anywhere(pattern.body, path))
+        {
             continue;
         }
         published = pattern.include;
@@ -510,11 +565,13 @@ fn files_publish(path: &str, files: &[&str]) -> bool {
     published
 }
 
+/// One parsed `files` entry.
 struct FilePattern<'a> {
     include: bool,
     body: &'a str,
 }
 
+/// Parse a `files` entry into its include/exclude direction and pattern body.
 fn file_pattern(entry: &str) -> Option<FilePattern<'_>> {
     let entry = entry.trim();
     if entry.is_empty() {
@@ -533,6 +590,7 @@ fn file_pattern(entry: &str) -> Option<FilePattern<'_>> {
     Some(FilePattern { include, body })
 }
 
+/// Whether a single `files` pattern selects `path`.
 fn file_pattern_matches(pattern: &str, path: &str) -> bool {
     if !has_glob_syntax(pattern) {
         return path == pattern
@@ -543,20 +601,37 @@ fn file_pattern_matches(pattern: &str, path: &str) -> bool {
     if glob_matches(pattern, path) {
         return true;
     }
+    let mut rest = path;
+    while let Some((ancestor, _)) = rest.rsplit_once('/') {
+        if glob_matches(pattern, ancestor) {
+            return true;
+        }
+        rest = ancestor;
+    }
+    false
+}
+
+/// Slashless negations behave like ignore rules and subtract matching names at any depth.
+fn file_negation_matches_anywhere(pattern: &str, path: &str) -> bool {
     if pattern.contains('/') {
         return false;
     }
-    path.rsplit('/')
-        .next()
-        .is_some_and(|name| glob_matches(pattern, name))
+    let name = path.rsplit('/').next().unwrap_or(path);
+    if has_glob_syntax(pattern) {
+        glob_matches(pattern, name)
+    } else {
+        pattern == name
+    }
 }
 
+/// Whether `pattern` needs glob matching rather than literal path matching.
 fn has_glob_syntax(pattern: &str) -> bool {
     pattern
         .chars()
         .any(|character| matches!(character, '*' | '?' | '[' | '{'))
 }
 
+/// Match one root-relative glob pattern against one root-relative path.
 fn glob_matches(pattern: &str, path: &str) -> bool {
     GlobBuilder::new(pattern)
         .literal_separator(true)

--- a/crates/uf_cli/src/commands/build/library.rs
+++ b/crates/uf_cli/src/commands/build/library.rs
@@ -80,6 +80,7 @@ use std::fs;
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use globset::GlobBuilder;
 use serde_json::json;
 use uf_bundle::{
     BudgetMetric, BundleReport, ReportOptions, build_report, collect_assets, write_report,
@@ -201,6 +202,7 @@ pub(crate) fn build(
     // imported, and every existing check would pass it: the manifest is
     // well-formed, the build succeeded, and the two disagree.
     let unresolved = timer.measure("exports", || unresolved_exports(&root, &out_dir));
+    let unpublished = timer.measure("files", || unpublished_exports(&root));
 
     let build_manifest = meta_dir.join("uf-build-manifest.json");
     let payload = json!({
@@ -323,7 +325,7 @@ pub(crate) fn build(
         );
         renderer.blank(out);
 
-        for warning in warnings.iter().chain(&unresolved) {
+        for warning in warnings.iter().chain(&unresolved).chain(&unpublished) {
             renderer.status(out, Status::Warn, warning);
         }
         renderer.status(out, Status::Success, &summary);
@@ -425,6 +427,143 @@ fn unresolved_exports(root: &Utf8Path, out_dir: &Utf8Path) -> Vec<String> {
         plural(missing.len(), "file"),
         missing.join(", "),
     )]
+}
+
+/// Subpaths whose `exports` target is not included by `package.json#files`.
+///
+/// `files` is a publish-time allowlist, which makes it the other half of the
+/// same contract [`unresolved_exports`] checks: one asks whether the build wrote
+/// the target, the other asks whether npm will put that target in the tarball.
+/// Without this, a library can build cleanly and publish a package that has an
+/// `exports` map pointing at files npm omitted — especially the scaffold's
+/// `dist/`, which `.gitignore` intentionally ignores unless `files` names it.
+fn unpublished_exports(root: &Utf8Path) -> Vec<String> {
+    let Ok(text) = fs::read_to_string(root.join("package.json")) else {
+        return Vec::new();
+    };
+    let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Vec::new();
+    };
+    let Some(exports) = manifest.get("exports") else {
+        return Vec::new();
+    };
+
+    let files = manifest
+        .get("files")
+        .and_then(serde_json::Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut missing = Vec::new();
+    let mut targets = Vec::new();
+    collect_targets(exports, &mut targets);
+    for target in targets {
+        let Some(relative) = export_target(&target) else {
+            continue;
+        };
+        if npm_always_publishes(relative) || files_publish(relative, &files) {
+            continue;
+        }
+        missing.push(target);
+    }
+    missing.sort();
+    missing.dedup();
+    if missing.is_empty() {
+        return Vec::new();
+    }
+    vec![format!(
+        "package.json exports {} not covered by files: {}",
+        plural(missing.len(), "file"),
+        missing.join(", "),
+    )]
+}
+
+fn export_target(target: &str) -> Option<&str> {
+    target.strip_prefix("./")
+}
+
+fn npm_always_publishes(path: &str) -> bool {
+    path == "package.json"
+        || path.eq_ignore_ascii_case("readme")
+        || path
+            .rsplit('/')
+            .next()
+            .is_some_and(|name| name.eq_ignore_ascii_case("license"))
+}
+
+fn files_publish(path: &str, files: &[&str]) -> bool {
+    let mut published = false;
+    for entry in files {
+        let Some(pattern) = file_pattern(entry) else {
+            continue;
+        };
+        if !file_pattern_matches(pattern.body, path) {
+            continue;
+        }
+        published = pattern.include;
+    }
+    published
+}
+
+struct FilePattern<'a> {
+    include: bool,
+    body: &'a str,
+}
+
+fn file_pattern(entry: &str) -> Option<FilePattern<'_>> {
+    let entry = entry.trim();
+    if entry.is_empty() {
+        return None;
+    }
+    let (include, body) = entry
+        .strip_prefix('!')
+        .map_or((true, entry), |body| (false, body));
+    let body = body
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .trim_end_matches('/');
+    if body.is_empty() {
+        return None;
+    }
+    Some(FilePattern { include, body })
+}
+
+fn file_pattern_matches(pattern: &str, path: &str) -> bool {
+    if !has_glob_syntax(pattern) {
+        return path == pattern
+            || path
+                .strip_prefix(pattern)
+                .is_some_and(|rest| rest.starts_with('/'));
+    }
+    if glob_matches(pattern, path) {
+        return true;
+    }
+    if pattern.contains('/') {
+        return false;
+    }
+    path.rsplit('/')
+        .next()
+        .is_some_and(|name| glob_matches(pattern, name))
+}
+
+fn has_glob_syntax(pattern: &str) -> bool {
+    pattern
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '[' | '{'))
+}
+
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    GlobBuilder::new(pattern)
+        .literal_separator(true)
+        .backslash_escape(true)
+        .build()
+        .map(|glob| glob.compile_matcher().is_match(path))
+        .unwrap_or(false)
 }
 
 /// Every string an `exports` value can reach, however it is nested.

--- a/crates/uf_cli/src/commands/build/library/tests.rs
+++ b/crates/uf_cli/src/commands/build/library/tests.rs
@@ -220,6 +220,27 @@ fn files_globs_cover_manifest_exports() {
 }
 
 #[test]
+fn files_globs_are_root_relative_and_directory_matches_include_children() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": {
+    ".": "./index.js",
+    "./private": "./internal/private.js",
+    "./deep": "./dist/sub/index.js"
+  },
+  "files": ["*.js", "dist/*", "!*.test.js"]
+}"#,
+    );
+
+    let found = unpublished_exports(&root);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(found[0].contains("./internal/private.js"), "{found:?}");
+    assert!(!found[0].contains("./index.js"), "{found:?}");
+    assert!(!found[0].contains("./dist/sub/index.js"), "{found:?}");
+}
+
+#[test]
 fn package_json_exports_are_always_publishable() {
     let (_dir, root) = project(
         r#"{
@@ -236,7 +257,49 @@ fn package_json_exports_are_always_publishable() {
 }
 
 #[test]
-fn a_manifest_with_no_files_warns_for_exported_targets() {
+fn npm_always_published_manifest_targets_are_not_reported() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "main": "./dist/index.js",
+  "bin": {
+    "lib": "./dist/cli.js"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./cli": "./dist/cli.js"
+  },
+  "files": ["index.js", "!*.test.js"]
+}"#,
+    );
+
+    assert!(unpublished_exports(&root).is_empty());
+}
+
+#[test]
+fn root_metadata_files_are_always_publishable_but_nested_ones_are_not() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": {
+    ".": "./index.js",
+    "./readme": "./README.md",
+    "./license": "./LICENSE.txt",
+    "./nested-license": "./docs/LICENSE.txt"
+  },
+  "files": ["index.js", "!*.test.js"]
+}"#,
+    );
+
+    let found = unpublished_exports(&root);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(found[0].contains("./docs/LICENSE.txt"), "{found:?}");
+    assert!(!found[0].contains("./README.md"), "{found:?}");
+    assert!(!found[0].contains("./LICENSE.txt"), "{found:?}");
+}
+
+#[test]
+fn a_manifest_with_no_files_has_no_files_allowlist_warning() {
     let (_dir, root) = project(
         r#"{
   "name": "lib",
@@ -244,8 +307,5 @@ fn a_manifest_with_no_files_warns_for_exported_targets() {
 }"#,
     );
 
-    let found = unpublished_exports(&root);
-    assert_eq!(found.len(), 1, "{found:?}");
-    assert!(found[0].contains("./index.js"), "{found:?}");
-    assert!(found[0].contains("./dist/index.js"), "{found:?}");
+    assert!(unpublished_exports(&root).is_empty());
 }

--- a/crates/uf_cli/src/commands/build/library/tests.rs
+++ b/crates/uf_cli/src/commands/build/library/tests.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 use uf_config::{LibraryConfig, LibraryFormat, LibraryPlan, UniflowedConfig};
 
-use super::{arguments, declared_dependencies, unresolved_exports};
+use super::{arguments, declared_dependencies, unpublished_exports, unresolved_exports};
 
 /// A project directory holding `package.json` with `manifest` in it.
 fn project(manifest: &str) -> (tempfile::TempDir, Utf8PathBuf) {
@@ -153,4 +153,99 @@ fn a_source_target_outside_the_output_directory_is_never_reported() {
 fn a_manifest_with_no_exports_reports_nothing() {
     let (_dir, root) = project(r#"{ "name": "lib", "main": "./dist/index.js" }"#);
     assert!(unresolved_exports(&root, &root.join("dist")).is_empty());
+}
+
+#[test]
+fn exports_targets_covered_by_files_report_nothing() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": { ".": { "flow": "./index.js", "default": "./dist/index.js" } },
+  "files": ["index.js", "dist", "!*.test.js"]
+}"#,
+    );
+
+    assert!(unpublished_exports(&root).is_empty());
+}
+
+#[test]
+fn an_exports_target_not_covered_by_files_is_reported() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": { ".": { "flow": "./index.js", "default": "./dist/index.js" } },
+  "files": ["index.js", "!*.test.js"]
+}"#,
+    );
+
+    let found = unpublished_exports(&root);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(found[0].contains("./dist/index.js"), "{found:?}");
+    assert!(!found[0].contains("./index.js"), "{found:?}");
+}
+
+#[test]
+fn files_are_applied_in_order_so_negations_can_subtract_exports() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": {
+    ".": "./index.js",
+    "./fixture": "./internal/fixture.test.js"
+  },
+  "files": ["index.js", "internal", "!*.test.js"]
+}"#,
+    );
+
+    let found = unpublished_exports(&root);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(found[0].contains("./internal/fixture.test.js"), "{found:?}");
+    assert!(!found[0].contains("./index.js"), "{found:?}");
+}
+
+#[test]
+fn files_globs_cover_manifest_exports() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": {
+    ".": "./index.js",
+    "./native": "./internal/native-runtime.js"
+  },
+  "files": ["*.js", "internal/*.js", "!*.test.js"]
+}"#,
+    );
+
+    assert!(unpublished_exports(&root).is_empty());
+}
+
+#[test]
+fn package_json_exports_are_always_publishable() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "files": ["index.js", "!*.test.js"]
+}"#,
+    );
+
+    assert!(unpublished_exports(&root).is_empty());
+}
+
+#[test]
+fn a_manifest_with_no_files_warns_for_exported_targets() {
+    let (_dir, root) = project(
+        r#"{
+  "name": "lib",
+  "exports": { ".": { "flow": "./index.js", "default": "./dist/index.js" } }
+}"#,
+    );
+
+    let found = unpublished_exports(&root);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(found[0].contains("./index.js"), "{found:?}");
+    assert!(found[0].contains("./dist/index.js"), "{found:?}");
 }


### PR DESCRIPTION
## Summary
- warn during library builds when package.json exports target files that package.json#files would not publish
- apply files entries in order, including negations, directory entries, and glob entries
- cover package.json as npm always-published and add focused unit tests

Refs #736

## Verification
- cargo fmt --all --check
- git diff --check
- not run locally: cargo test/clippy need the pinned nightly; rustup is unavailable here and nix develop ran out of disk while materializing the toolchain

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791688402&installation_model_id=422833&pr_number=768&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F768&signature=dacb37f658bfe020584b92066cd7428636e929508ec395107e82afea2175bf94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-time warnings when package export targets are excluded by publish file rules.
  * Corrected handling of packages without a `files` field so they no longer produce file-coverage warnings.
  * Improved matching for negations, directory globs, manifest targets, and always-published files.
* **Tests**
  * Added coverage for export and publish-rule combinations, including missing files, ordered exclusions, glob patterns, always-published files, and packages without file rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->