### PR TITLE
feat(router): resolve routes for native targets

### DIFF
--- a/crates/uf_cli/src/cli.rs
+++ b/crates/uf_cli/src/cli.rs
@@ -141,8 +141,11 @@ pub(crate) enum Commands {
         /// 25.5 and newer; the file itself needs nothing.
         #[arg(long)]
         compile: bool,
-        /// Compile for this platform rather than for this machine, as a
-        /// target triple: `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`.
+        /// Build this application target: `web`, `native`, `ios` or `android`.
+        ///
+        /// With `--compile`, this remains the standalone binary's platform
+        /// triple instead: `x86_64-unknown-linux-gnu`,
+        /// `aarch64-apple-darwin`.
         ///
         /// Cross-compiling downloads that platform's runtime, so the first
         /// build for a target needs the network. Bun's backend only; Node
@@ -153,7 +156,7 @@ pub(crate) enum Commands {
         // a triple is not accepted, and "uf has never built for this" and
         // "your Bun is too old for this" are different sentences that a reader
         // has to be able to tell apart. `compile::parse_target` says both.
-        #[arg(long, value_name = "TRIPLE", requires = "compile")]
+        #[arg(long, value_name = "TARGET")]
         target: Option<String>,
         /// Also write a directory that can be copied to a host with a
         /// JavaScript runtime and nothing else. Overrides

--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -155,6 +155,7 @@ pub(crate) fn build(
             &plan,
             standalone,
             requested_adapter.or(resolved.config.app.runtime.deploy.adapter),
+            requested_target,
         )?;
         return library::build(ui, timer, &resolved, &plan, requested_mode, size_report);
     }
@@ -936,16 +937,17 @@ fn refuse_unanswerable_actions(
     )
 }
 
-/// Refuse `--compile` or `--adapter` on a project that is a library.
+/// Refuse application-only build flags on a project that is a library.
 ///
-/// Both flags produce a **deployment**: an executable that serves the
-/// application, or a directory a host runs it from. A library has no
-/// application to serve — no route table, no server entry, no request to
-/// answer — so each would have to invent one, and what it invented would be an
-/// empty server that starts and 404s everything.
+/// `--compile` and `--adapter` produce a **deployment**: an executable that
+/// serves the application, or a directory a host runs it from. `--target`
+/// without `--compile` chooses the application surface whose routes uf should
+/// discover. A library has no application to serve or route table to narrow, so
+/// each would have to invent one, and what it invented would be an empty server
+/// that starts and 404s everything.
 ///
 /// Refused by name and before anything is built, which is the rule
-/// ubugeeei-prod/uf#638 applied to the same two flags: a target uf cannot
+/// ubugeeei-prod/uf#638 applied to the same class of flags: a target uf cannot
 /// produce is a sentence, and a sentence is cheaper before the bundle than
 /// after it.
 /// The adapter is whichever of `--adapter` and `app.runtime.deploy.adapter`
@@ -956,11 +958,13 @@ fn refuse_an_application_artefact(
     plan: &LibraryPlan,
     standalone: bool,
     adapter: Option<DeployAdapter>,
+    requested_target: Option<&str>,
 ) -> Result<()> {
-    let asked = match (standalone, adapter) {
-        (true, _) => "`uf build --compile` writes an executable that serves an application",
-        (_, Some(_)) => "a deploy adapter writes a directory a host serves an application from",
-        (false, None) => return Ok(()),
+    let asked = match (standalone, adapter, requested_target) {
+        (true, _, _) => "`uf build --compile` writes an executable that serves an application",
+        (_, Some(_), _) => "a deploy adapter writes a directory a host serves an application from",
+        (false, None, Some(_)) => "`uf build --target` chooses which application routes to build",
+        (false, None, None) => return Ok(()),
     };
     bail!(
         "{asked}, and {}. A library is imported rather than served: `uf build` writes its \

--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -28,8 +28,14 @@ use uf_bundle::{
     BudgetMetric, BundleBudgets, BundleReport, ByteSize, ReportOptions, build_report,
     collect_assets, evaluate, write_report,
 };
-use uf_config::{DeployAdapter, LibraryPlan, Navigation, Prerender, RenderingPlan, load_config};
-use uf_router::{Route, discover_routes, discover_server_modules, write_router_manifest};
+use uf_config::{
+    DeployAdapter, FrameworkPreset, LibraryPlan, Navigation, Prerender, RenderingPlan,
+    RuntimeTarget, UniflowedConfig, load_config,
+};
+use uf_router::{
+    Route, RouteTarget, discover_routes_for_target, discover_server_modules_for_target,
+    write_router_manifest_for_target,
+};
 use uf_rsc::{
     BuildId, ProjectScanOptions, RSC_MANIFEST_BUILD_DIR, RSC_MANIFEST_ENV, RscAnalysis,
     RscDiagnostic, RscSeverity, analyze_project,
@@ -154,6 +160,7 @@ pub(crate) fn build(
     }
 
     let root = resolved.root.clone();
+    let app_target = application_target(&resolved.config, requested_target, standalone)?;
     // What this project said a build may produce, resolved once. Two settings
     // decide it — `app.rendering.modes` and `build.staticBuild` — and reading
     // them apart at the four places below is how they would come to disagree;
@@ -162,10 +169,10 @@ pub(crate) fn build(
 
     progress.tick("discovering routes");
     let routes = timer.measure("routes", || {
-        discover_routes(&resolved.root, &resolved.config)
+        discover_routes_for_target(&resolved.root, &resolved.config, app_target)
     })?;
     let router_manifest = timer.measure("router types", || {
-        write_router_manifest(&resolved.root, &resolved.config)
+        write_router_manifest_for_target(&resolved.root, &resolved.config, app_target)
     })?;
     // The other half of the same tree: the route handlers and middleware,
     // which have no page and so appear in no `Route`. Only `--adapter static`
@@ -173,7 +180,7 @@ pub(crate) fn build(
     // refuse by name — and the walk is one pass over a directory that was just
     // walked, so it is done here rather than made conditional on a flag.
     let server_modules = timer.measure("server modules", || {
-        discover_server_modules(&resolved.root, &resolved.config)
+        discover_server_modules_for_target(&resolved.root, &resolved.config, app_target)
     })?;
 
     let out_dir = resolved.root.join(resolved.config.build.out_dir.as_str());
@@ -321,7 +328,7 @@ pub(crate) fn build(
             &builder,
             &root,
             "build",
-            &build_arguments(&resolved.config.build.out_dir, plan),
+            &build_arguments(&resolved.config.build.out_dir, plan, app_target),
             &env,
             &[(RSC_MANIFEST_ENV, rsc_input.as_str())],
         )?;
@@ -389,6 +396,7 @@ pub(crate) fn build(
         "engine": "vite",
         "transform": "uf transform",
         "host": host.name(),
+        "target": app_target.as_str(),
         "entries": resolved.config.build.entries,
         "routes": routes.iter().map(|route| json!({
             "path": route.path,
@@ -708,6 +716,7 @@ pub(crate) fn build(
         let mut summary_rows = vec![
             KeyValue::new("engine", "vite"),
             KeyValue::toned("host", host_name, Tone::Muted),
+            KeyValue::toned("target", app_target.as_str(), Tone::Muted),
             KeyValue::new("entries", &entries),
             KeyValue::toned("routes", &route_count, Tone::Number),
             KeyValue::toned("prerendered pages", &page_count, Tone::Number),
@@ -960,26 +969,110 @@ fn refuse_an_application_artefact(
     )
 }
 
+/// Which application target this ordinary build resolves.
+///
+/// `--target` used to mean only the standalone binary's platform triple, so
+/// `standalone` leaves that meaning with [`compile::runtimes`]. Without
+/// `--compile`, it names the app surface instead: web, native, iOS or Android.
+fn application_target(
+    config: &UniflowedConfig,
+    requested: Option<&str>,
+    standalone: bool,
+) -> Result<RouteTarget> {
+    let target = match requested.filter(|_| !standalone) {
+        Some(requested) => parse_application_target(requested)?,
+        None => default_application_target(config),
+    };
+    let needed = runtime_target_for_route_target(target);
+    if config.app.targets.contains(&needed) {
+        return Ok(target);
+    }
+    let declared = config
+        .app
+        .targets
+        .iter()
+        .map(runtime_target_name)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let declared = if declared.is_empty() {
+        String::from("nothing")
+    } else {
+        declared
+    };
+    bail!(
+        "`uf build --target {}` needs `app.targets` to include `{}`; this project declares {}",
+        target.as_str(),
+        runtime_target_name(&needed),
+        declared,
+    )
+}
+
+fn default_application_target(config: &UniflowedConfig) -> RouteTarget {
+    match config.app.framework {
+        FrameworkPreset::ReactNative => RouteTarget::Native,
+        FrameworkPreset::Uniflowed | FrameworkPreset::React => RouteTarget::Web,
+    }
+}
+
+fn parse_application_target(requested: &str) -> Result<RouteTarget> {
+    if let Ok(target) = requested.parse() {
+        return Ok(target);
+    }
+    if compile::TARGETS
+        .iter()
+        .any(|target| target.triple == requested)
+    {
+        bail!(
+            "`--target {requested}` is a platform target for `uf build --compile`; add \
+             `--compile`, or choose an application target: web, native, ios or android"
+        );
+    }
+    bail!(
+        "`--target {requested}` is not an application target uf builds.\n  \
+         accepted application targets: web, native, ios, android\n  \
+         platform targets are accepted with `uf build --compile --target <triple>`"
+    )
+}
+
+fn runtime_target_for_route_target(target: RouteTarget) -> RuntimeTarget {
+    match target {
+        RouteTarget::Web => RuntimeTarget::Web,
+        RouteTarget::Native | RouteTarget::Ios | RouteTarget::Android => RuntimeTarget::ReactNative,
+    }
+}
+
+fn runtime_target_name(target: &RuntimeTarget) -> &'static str {
+    match target {
+        RuntimeTarget::Web => "web",
+        RuntimeTarget::ReactNative => "react-native",
+        RuntimeTarget::Server => "server",
+        RuntimeTarget::Hermes => "hermes",
+    }
+}
+
 /// What `driver.js build` is told, beyond where to put the output.
 ///
-/// Three arguments, and the third is the interesting one. `--prerender` and
-/// `--static-build` are the decision; `--because` is the *sentence* the
-/// decision came from, so a refusal in the builder quotes the same config key
-/// a refusal in `uf` does. Without it the driver would have to reconstruct
-/// "which setting made this a static build" from a flag that no longer says,
-/// and the two halves of one rule would tell a reader to look in two places.
+/// `--target` is the application platform whose reserved files the builder
+/// should resolve; `--prerender` and `--static-build` are the rendering
+/// decision; `--because` is the *sentence* that decision came from, so a
+/// refusal in the builder quotes the same config key a refusal in `uf` does.
+/// Without it the driver would have to reconstruct "which setting made this a
+/// static build" from a flag that no longer says, and the two halves of one
+/// rule would tell a reader to look in two places.
 ///
-/// `app.rendering.navigation` is deliberately **not** a fourth. It is not a
+/// `app.rendering.navigation` is deliberately **not** a fifth. It is not a
 /// decision about this build — it is the same answer for `uf dev`, `uf build`
 /// and `uf preview`, and neither of the first two is handed a rendering plan
 /// at all — so a builder reads it out of `uf.config.js` the way it reads
 /// `app.react.strictMode`. Passing it here as well would make the client entry
 /// a function of two sources that agree until one of them is a flag somebody
 /// forgot to forward.
-fn build_arguments(out_dir: &str, plan: RenderingPlan) -> Vec<String> {
+fn build_arguments(out_dir: &str, plan: RenderingPlan, target: RouteTarget) -> Vec<String> {
     let mut args = vec![
         String::from("--out-dir"),
         out_dir.to_string(),
+        String::from("--target"),
+        target.as_str().to_string(),
         String::from("--prerender"),
         plan.prerender().as_str().to_string(),
         String::from("--because"),

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -6633,13 +6633,13 @@ fn a_library_reports_an_exports_target_it_did_not_build() {
     assert!(!said.contains("./index.js"), "{said}");
 }
 
-/// `--compile` and `--adapter` write a deployment that serves an application.
+/// `--compile`, `--adapter`, and bare `--target` need an application.
 ///
 /// Refused by name and before anything is built, which is the rule
-/// ubugeeei-prod/uf#638 applied to the same two flags. `--compile` needs no
-/// Bun here for the same reason: nothing is resolved before the refusal.
+/// ubugeeei-prod/uf#638 applied to the same family of flags. `--compile` needs
+/// no Bun here for the same reason: nothing is resolved before the refusal.
 #[test]
-fn a_library_refuses_the_two_flags_that_write_a_deployment() {
+fn a_library_refuses_application_only_build_flags() {
     if !fixture_ready() {
         return;
     }
@@ -6649,6 +6649,7 @@ fn a_library_refuses_the_two_flags_that_write_a_deployment() {
     for (flags, expected) in [
         (vec!["build", "--compile"], "executable"),
         (vec!["build", "--adapter", "node"], "directory"),
+        (vec!["build", "--target", "ios"], "application routes"),
     ] {
         let output = uf()
             .arg("--cwd")

--- a/crates/uf_router/src/lib.rs
+++ b/crates/uf_router/src/lib.rs
@@ -2,6 +2,7 @@ pub mod reserved;
 pub mod scaffold;
 
 use std::fs;
+use std::str::FromStr;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::{CompactString, ToCompactString};
@@ -55,24 +56,106 @@ pub const PAGE_EXTENSIONS: [&str; 3] = [".js", ".jsx", ".mdx"];
 /// and neither is something Markdown can be.
 pub const MODULE_EXTENSIONS: [&str; 2] = [".js", ".jsx"];
 
-/// The first spelling of `stem` that exists in `directory`.
+/// Which application target the file-system router is resolving.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RouteTarget {
+    /// A React DOM application.
+    #[default]
+    Web,
+    /// A React Native application, before it has been narrowed to a platform.
+    Native,
+    /// A React Native application on iOS.
+    Ios,
+    /// A React Native application on Android.
+    Android,
+}
+
+impl RouteTarget {
+    /// The spelling `uf build --target` accepts.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Web => "web",
+            Self::Native => "native",
+            Self::Ios => "ios",
+            Self::Android => "android",
+        }
+    }
+
+    /// The reserved-file variants this target checks, most specific first.
+    #[must_use]
+    pub const fn variants(self) -> &'static [ReservedVariant] {
+        match self {
+            Self::Web => &[ReservedVariant::Web, ReservedVariant::Default],
+            Self::Native => &[ReservedVariant::Native, ReservedVariant::Default],
+            Self::Ios => &[
+                ReservedVariant::Ios,
+                ReservedVariant::Native,
+                ReservedVariant::Default,
+            ],
+            Self::Android => &[
+                ReservedVariant::Android,
+                ReservedVariant::Native,
+                ReservedVariant::Default,
+            ],
+        }
+    }
+}
+
+impl FromStr for RouteTarget {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "web" => Ok(Self::Web),
+            "native" | "react-native" => Ok(Self::Native),
+            "ios" => Ok(Self::Ios),
+            "android" => Ok(Self::Android),
+            _ => Err(()),
+        }
+    }
+}
+
+/// The first spelling of `stem` this target would load from `directory`.
 ///
-/// First rather than "the only one", mirroring `findModule` in
-/// `packages/vite/internal/routes.js`: a directory holding both `$page.js`
-/// and `$page.mdx` resolves to the same one on both sides, which matters
-/// more than which one it is.
-fn find_module(directory: &Utf8Path, stem: &str, extensions: &[&str]) -> Option<Utf8PathBuf> {
-    extensions.iter().find_map(|extension| {
-        let candidate = directory.join(format!("{stem}{extension}"));
-        candidate.is_file().then_some(candidate)
+/// Platform before extension: `$page.native.mdx` is more specific to the
+/// target than `$page.js`, and a directory that wrote both has made the
+/// native one the route for a native build.
+fn find_module_for_target(
+    directory: &Utf8Path,
+    stem: &str,
+    extensions: &[&str],
+    target: RouteTarget,
+) -> Option<Utf8PathBuf> {
+    for variant in target.variants() {
+        for extension in extensions {
+            let file = match variant.as_str() {
+                Some(variant) => format!("{stem}.{variant}{extension}"),
+                None => format!("{stem}{extension}"),
+            };
+            let candidate = directory.join(file);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Whether `name` is the page this target might resolve.
+fn is_reserved_page_for_target(name: &str, target: RouteTarget) -> bool {
+    target.variants().iter().any(|variant| {
+        PAGE_EXTENSIONS
+            .iter()
+            .any(|extension| match variant.as_str() {
+                Some(variant) => name == format!("{RESERVED_PAGE_STEM}.{variant}{extension}"),
+                None => name == format!("{RESERVED_PAGE_STEM}{extension}"),
+            })
     })
 }
 
-/// Whether `name` is a reserved page in any of its spellings.
-fn is_reserved_page(name: &str) -> bool {
-    PAGE_EXTENSIONS
-        .iter()
-        .any(|extension| name == format!("{RESERVED_PAGE_STEM}{extension}"))
+fn reserved_file_applies_to_target(file: ReservedFile, target: RouteTarget) -> bool {
+    file.variant.is_route_entry() && target.variants().contains(&file.variant)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,9 +190,8 @@ pub struct Route {
     /// which prerendered files a guard never sees — got `false` from the
     /// per-directory form for every route below the one that declared it.
     ///
-    /// Kept in the `.js` grammar `reserved` documents. The build's router also
-    /// accepts `.jsx`, which this discovery does not, for pages as much as for
-    /// middleware; see ubugeeei-prod/uf#386.
+    /// Resolved through the same extension and target ordering as the build
+    /// router, because `uf build` reads this before it asks Vite to bundle.
     pub middleware: Vec<Utf8PathBuf>,
 }
 
@@ -415,6 +497,14 @@ pub fn discover_routes(
     root: &Utf8Path,
     config: &UniflowedConfig,
 ) -> Result<Vec<Route>, RouterError> {
+    discover_routes_for_target(root, config, RouteTarget::Web)
+}
+
+pub fn discover_routes_for_target(
+    root: &Utf8Path,
+    config: &UniflowedConfig,
+    target: RouteTarget,
+) -> Result<Vec<Route>, RouterError> {
     let app_root = root.join(config.app.router.root.as_str());
     if !app_root.exists() {
         return Ok(Vec::new());
@@ -427,7 +517,7 @@ pub fn discover_routes(
     // And before any route is built for the opposite reason: a slot's pages are
     // routes uf renders, so what is wrong with a slot has to be said here
     // rather than discovered as a missing prop at render time.
-    check_slots(&app_root)?;
+    check_slots(&app_root, target)?;
 
     let mut routes = Vec::new();
     for entry in WalkDir::new(&app_root) {
@@ -435,7 +525,11 @@ pub fn discover_routes(
             path: app_root.clone(),
             source,
         })?;
-        if !entry.file_type().is_file() || !entry.file_name().to_str().is_some_and(is_reserved_page)
+        if !entry.file_type().is_file()
+            || !entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| is_reserved_page_for_target(name, target))
         {
             continue;
         }
@@ -455,7 +549,7 @@ pub fn discover_routes(
         // so the precedence is written once, in `PAGE_EXTENSIONS`, and both
         // routers read the same order. File names rather than whole paths,
         // because the two are built from different halves of the walk.
-        if find_module(&directory, RESERVED_PAGE_STEM, &PAGE_EXTENSIONS)
+        if find_module_for_target(&directory, RESERVED_PAGE_STEM, &PAGE_EXTENSIONS, target)
             .is_none_or(|resolved| resolved.file_name() != page.file_name())
         {
             continue;
@@ -496,8 +590,14 @@ pub fn discover_routes(
 
         routes.push(Route {
             path: path.to_compact_string(),
-            has_layout: find_module(&directory, RESERVED_LAYOUT_STEM, &MODULE_EXTENSIONS).is_some(),
-            middleware: middleware_chain(&app_root, &directory),
+            has_layout: find_module_for_target(
+                &directory,
+                RESERVED_LAYOUT_STEM,
+                &MODULE_EXTENSIONS,
+                target,
+            )
+            .is_some(),
+            middleware: middleware_chain(&app_root, &directory, target),
             directory,
             page,
             params,
@@ -568,6 +668,14 @@ pub fn discover_server_modules(
     root: &Utf8Path,
     config: &UniflowedConfig,
 ) -> Result<Vec<ServerModule>, RouterError> {
+    discover_server_modules_for_target(root, config, RouteTarget::Web)
+}
+
+pub fn discover_server_modules_for_target(
+    root: &Utf8Path,
+    config: &UniflowedConfig,
+    target: RouteTarget,
+) -> Result<Vec<ServerModule>, RouterError> {
     let app_root = root.join(config.app.router.root.as_str());
     if !app_root.exists() {
         return Ok(Vec::new());
@@ -590,7 +698,8 @@ pub fn discover_server_modules(
             (RESERVED_ROUTE_STEM, ServerModuleKind::RouteHandler),
             (RESERVED_MIDDLEWARE_STEM, ServerModuleKind::Middleware),
         ] {
-            if let Some(file) = find_module(&directory, stem, &MODULE_EXTENSIONS) {
+            if let Some(file) = find_module_for_target(&directory, stem, &MODULE_EXTENSIONS, target)
+            {
                 found.push(ServerModule {
                     path: path.to_compact_string(),
                     file,
@@ -681,7 +790,7 @@ fn slot_in(relative: &Utf8Path) -> Option<&str> {
 ///
 /// Sorted by name so the first offender does not depend on the order the
 /// filesystem hands entries back.
-fn check_slots(app_root: &Utf8Path) -> Result<(), RouterError> {
+fn check_slots(app_root: &Utf8Path, target: RouteTarget) -> Result<(), RouterError> {
     let walk = WalkDir::new(app_root)
         .sort_by_file_name()
         .into_iter()
@@ -715,7 +824,9 @@ fn check_slots(app_root: &Utf8Path) -> Result<(), RouterError> {
             // there. A slot rendered into an inherited layout would be a prop
             // that layout never declared, on every route below it.
             let declaring = path.parent().unwrap_or(app_root);
-            if find_module(declaring, RESERVED_LAYOUT_STEM, &MODULE_EXTENSIONS).is_none() {
+            if find_module_for_target(declaring, RESERVED_LAYOUT_STEM, &MODULE_EXTENSIONS, target)
+                .is_none()
+            {
                 let (segment_path, _) =
                     route_path_and_params(declaring.strip_prefix(app_root).unwrap_or(declaring));
                 return Err(RouterError::SlotWithoutLayout {
@@ -734,7 +845,7 @@ fn check_slots(app_root: &Utf8Path) -> Result<(), RouterError> {
         let file_name = entry.file_name().to_string_lossy().into_owned();
         let Some(role) = classify_reserved_file(&file_name)
             .recognized()
-            .filter(|file| file.variant.is_route_entry())
+            .filter(|file| reserved_file_applies_to_target(*file, target))
             .map(|file| file.role)
         else {
             continue;
@@ -797,11 +908,17 @@ fn check_slots(app_root: &Utf8Path) -> Result<(), RouterError> {
 /// `packages/vite/internal/routes.js` builds on its descent, and it has to be:
 /// one of the two decides what runs, and the other decides what `uf build`
 /// says about it.
-fn middleware_chain(app_root: &Utf8Path, directory: &Utf8Path) -> Vec<Utf8PathBuf> {
+fn middleware_chain(
+    app_root: &Utf8Path,
+    directory: &Utf8Path,
+    target: RouteTarget,
+) -> Vec<Utf8PathBuf> {
     let mut chain = Vec::new();
     let mut current = Some(directory);
     while let Some(dir) = current {
-        if let Some(file) = find_module(dir, RESERVED_MIDDLEWARE_STEM, &MODULE_EXTENSIONS) {
+        if let Some(file) =
+            find_module_for_target(dir, RESERVED_MIDDLEWARE_STEM, &MODULE_EXTENSIONS, target)
+        {
             chain.push(file);
         }
         if dir == app_root {
@@ -928,10 +1045,18 @@ pub fn write_router_manifest(
     root: &Utf8Path,
     config: &UniflowedConfig,
 ) -> Result<Option<Utf8PathBuf>, RouterError> {
+    write_router_manifest_for_target(root, config, RouteTarget::Web)
+}
+
+pub fn write_router_manifest_for_target(
+    root: &Utf8Path,
+    config: &UniflowedConfig,
+    target: RouteTarget,
+) -> Result<Option<Utf8PathBuf>, RouterError> {
     if !config.app.router.enabled {
         return Ok(None);
     }
-    let routes = discover_routes(root, config)?;
+    let routes = discover_routes_for_target(root, config, target)?;
     let manifest = root.join(config.app.router.manifest.as_str());
     // Through the formatter uf ships, with this project's own `fmt` settings.
     //

--- a/crates/uf_router/src/reserved.rs
+++ b/crates/uf_router/src/reserved.rs
@@ -265,14 +265,13 @@ impl ReservedVariant {
         }
     }
 
-    /// Whether this variant is the one the router resolves as the route itself.
+    /// Whether this variant can be the file the router resolves for a target.
     ///
-    /// Platform variants and colocated tests are companions to a route, never
-    /// routes of their own, which is why `discover_routes` only matches the
-    /// default variant.
+    /// A platform variant is a route for the target that selects it; a
+    /// colocated test is a companion to a route and never is.
     #[must_use]
     pub const fn is_route_entry(self) -> bool {
-        matches!(self, Self::Default)
+        !matches!(self, Self::Test)
     }
 
     /// Every variant, in declaration order.
@@ -772,13 +771,13 @@ mod tests {
     }
 
     #[test]
-    fn only_the_default_variant_is_a_route_entry() {
-        assert!(ReservedVariant::Default.is_route_entry());
-        for variant in ReservedVariant::all()
-            .into_iter()
-            .filter(|variant| *variant != ReservedVariant::Default)
-        {
-            assert!(!variant.is_route_entry(), "{variant:?}");
+    fn every_variant_but_a_colocated_test_can_be_a_route_entry() {
+        for variant in ReservedVariant::all() {
+            assert_eq!(
+                variant.is_route_entry(),
+                variant != ReservedVariant::Test,
+                "{variant:?}"
+            );
         }
     }
 

--- a/crates/uf_router/src/tests.rs
+++ b/crates/uf_router/src/tests.rs
@@ -658,6 +658,86 @@ fn a_directory_with_two_page_spellings_is_one_route() {
     }
 }
 
+/// Platform variants are route entries for the target that asks for them.
+///
+/// A native build should never silently ship the web page just because the
+/// unqualified `$page.js` exists, and iOS/Android should be able to narrow a
+/// shared `$page.native.js` the same way Metro resolves platform modules.
+#[test]
+fn route_targets_choose_the_most_specific_reserved_page() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = camino::Utf8Path::from_path(dir.path()).expect("a UTF-8 path");
+    let app = root.join("app/guide");
+    std::fs::create_dir_all(&app).expect("a directory");
+    for name in [
+        "$page.js",
+        "$page.web.jsx",
+        "$page.native.mdx",
+        "$page.ios.js",
+        "$page.android.jsx",
+    ] {
+        std::fs::write(app.join(name), "// @flow\n").expect("a page");
+    }
+
+    for (target, expected) in [
+        (RouteTarget::Web, "$page.web.jsx"),
+        (RouteTarget::Native, "$page.native.mdx"),
+        (RouteTarget::Ios, "$page.ios.js"),
+        (RouteTarget::Android, "$page.android.jsx"),
+    ] {
+        let routes =
+            discover_routes_for_target(root, &uf_config::UniflowedConfig::default(), target)
+                .expect("discovery");
+
+        assert_eq!(
+            routes
+                .iter()
+                .map(|route| route.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/guide"],
+            "{target:?} sees one route"
+        );
+        assert_eq!(
+            routes[0].page.file_name(),
+            Some(expected),
+            "{target:?} chose the wrong page"
+        );
+    }
+}
+
+/// Server modules resolve through the same target-aware path as pages.
+#[test]
+fn route_targets_choose_the_most_specific_server_module() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = camino::Utf8Path::from_path(dir.path()).expect("a UTF-8 path");
+    let app = root.join("app/api");
+    std::fs::create_dir_all(&app).expect("a directory");
+    for name in ["$route.js", "$route.native.jsx", "$route.ios.js"] {
+        std::fs::write(app.join(name), "// @flow\n").expect("a route handler");
+    }
+
+    for (target, expected) in [
+        (RouteTarget::Web, "$route.js"),
+        (RouteTarget::Native, "$route.native.jsx"),
+        (RouteTarget::Ios, "$route.ios.js"),
+        (RouteTarget::Android, "$route.native.jsx"),
+    ] {
+        let modules = discover_server_modules_for_target(
+            root,
+            &uf_config::UniflowedConfig::default(),
+            target,
+        )
+        .expect("server module discovery");
+
+        assert_eq!(modules.len(), 1, "{target:?}: {modules:?}");
+        assert_eq!(
+            modules[0].file.file_name(),
+            Some(expected),
+            "{target:?} chose the wrong handler"
+        );
+    }
+}
+
 /// And a layout or a middleware beside it is found in either of its two.
 #[test]
 fn a_layout_and_a_middleware_are_found_in_either_spelling() {

--- a/packages/vite/driver.js
+++ b/packages/vite/driver.js
@@ -7,7 +7,7 @@
 //
 //   <host> driver.js dev     --root <dir> [--mode <m>] [--host <h>] [--port <n>] [--strict-port]
 //                            [--uf-env-file <file>]...
-//   <host> driver.js build   --root <dir> [--mode <m>] [--out-dir <dir>]
+//   <host> driver.js build   --root <dir> [--mode <m>] [--out-dir <dir>] [--target <target>]
 //                            [--prerender everything|possible|nothing]
 //                            [--static-build] [--because <sentence>]
 //   <host> driver.js library --root <dir> [--mode <m>] [--out-dir <dir>]
@@ -51,7 +51,7 @@ import { emit, errorEvent, eventLogger } from "./internal/events.js";
 import { loadUfConfig, projectConfig } from "./internal/config.js";
 import { send, toRequest } from "./internal/http.js";
 import { withProjectConfig } from "./merge.js";
-import { VIRTUAL, scanRoutes } from "./internal/routes.js";
+import { VIRTUAL, resolveRouteTarget, scanRoutes } from "./internal/routes.js";
 import {
   BUILD_ID_FILE,
   assetsFromManifest,
@@ -161,6 +161,7 @@ async function viteConfig(config, mode) {
   const port = Number(argument("--port") ?? dev.port ?? 5173);
   const allowedHosts =
     Array.isArray(dev.allowedHosts) && dev.allowedHosts.length > 0 ? dev.allowedHosts : undefined;
+  const routeTarget = resolveRouteTarget(config, argument("--target"));
 
   // What uf generates from the semantics it owns: where the project is, which
   // plugins make Flow compile, and the few settings uf enforces rather than
@@ -191,7 +192,7 @@ async function viteConfig(config, mode) {
     mode,
     clearScreen: false,
     customLogger: eventLogger(argument("--log-level") ?? "info"),
-    plugins: [uniflowed({ root, config })],
+    plugins: [uniflowed({ root, config, target: routeTarget })],
     server: {
       host,
       port,
@@ -255,6 +256,7 @@ async function viteConfig(config, mode) {
 async function dev() {
   const { createServer } = await import("vite");
   const config = await loadConfig();
+  const routeTarget = resolveRouteTarget(config, argument("--target"));
   // The mode is uf's to decide, not this file's: `uf dev` resolves `--mode`,
   // the profile `uf env use` wrote and `env.active` before it starts anything,
   // and always passes the answer. The fallback is for a driver started by hand.
@@ -266,9 +268,9 @@ async function dev() {
   emit("listening", {
     local: urls.local,
     network: urls.network,
-    routes: scanRoutes(path.resolve(root, config.app?.router?.root ?? "app")).routes.map(
-      (route) => route.path,
-    ),
+    routes: scanRoutes(path.resolve(root, config.app?.router?.root ?? "app"), {
+      target: routeTarget,
+    }).routes.map((route) => route.path),
   });
   watchSources(server);
   watchEnvFiles(server);
@@ -390,6 +392,7 @@ function watchEnvFiles(server) {
 async function preview() {
   const { preview: startPreview } = await import("vite");
   const config = await loadConfig();
+  const routeTarget = resolveRouteTarget(config, argument("--target"));
   const inline = await viteConfig(config, argument("--mode") ?? "production");
   // A build that declared it emits no server has none to mount. `uf` refuses
   // `uf start` for such a project and lets this one through, because a preview
@@ -489,9 +492,9 @@ async function preview() {
     // be the report being wrong about the thing it exists to report.
     routes:
       build == null
-        ? scanRoutes(path.resolve(root, config.app?.router?.root ?? "app")).routes.map(
-            (route) => route.path,
-          )
+        ? scanRoutes(path.resolve(root, config.app?.router?.root ?? "app"), {
+            target: routeTarget,
+          }).routes.map((route) => route.path)
         : build.entry.routes.map((route) => route.path),
     handlers: build == null ? [] : build.entry.handlers.map((handler) => handler.path),
   });

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -80,6 +80,7 @@ import {
   RESERVED,
   VIRTUAL,
   clientModuleSource,
+  resolveRouteTarget,
   routesModuleSource,
   scanRoutes,
   serverModuleSource,
@@ -115,6 +116,7 @@ export function devUrlFor(id) {
  * @typedef {object} UniflowedOptions
  * @property {string} [root] absolute project root; Vite's root by default
  * @property {object} [config] the loaded `uf.config.js` object
+ * @property {"web" | "native" | "ios" | "android"} [target] app target
  * @property {string} [command] the `uf` binary to transform through
  */
 
@@ -126,6 +128,7 @@ export function devUrlFor(id) {
 export default function uniflowed(options = {}) {
   const ufConfig = options.config ?? {};
   const app = ufConfig.app ?? {};
+  const routeTarget = resolveRouteTarget(ufConfig, options.target);
   const routerRoot = app.router?.root ?? "app";
   const appEntry = app.router?.entry ?? ufConfig.build?.entries?.[0] ?? "app.js";
   const markdown = app.builtins?.markdown ?? {};
@@ -156,6 +159,7 @@ export default function uniflowed(options = {}) {
     flowPlugin({
       routerRoot,
       appEntry,
+      routeTarget,
       strictMode,
       navigation,
       mount,
@@ -176,6 +180,7 @@ export default function uniflowed(options = {}) {
 function flowPlugin({
   routerRoot,
   appEntry,
+  routeTarget,
   strictMode,
   navigation,
   mount,
@@ -373,7 +378,7 @@ function flowPlugin({
       if (id === RUNTIME_RESOLVED_ID) return refreshRuntimeSource();
       if (id === AUDIT_RESOLVED_ID) return auditRuntimeSource(accessibility?.axe);
       if (id === resolved(VIRTUAL.routes)) {
-        const table = scanRoutes(appRoot);
+        const table = scanRoutes(appRoot, { target: routeTarget });
         // The server renders every route, so the server's table is the whole
         // one and is generated with no filter at all. Only the browser's copy
         // is split.

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -78,6 +78,52 @@ export const LAYOUT_PROP_NAMES = Object.freeze(["children", "params"]);
 const PAGE_EXTENSIONS = [".js", ".jsx", ".mdx"];
 const MODULE_EXTENSIONS = [".js", ".jsx"];
 
+/** Application targets the route scanner knows how to select files for. */
+export const ROUTE_TARGETS = Object.freeze(["web", "native", "ios", "android"]);
+
+const TARGET_VARIANTS = Object.freeze({
+  web: ["web", null],
+  native: ["native", null],
+  ios: ["ios", "native", null],
+  android: ["android", "native", null],
+});
+
+/**
+ * The route target a loaded `uf.config.js` and an optional CLI flag describe.
+ *
+ * `react-native` is accepted as the config-shaped spelling of the same target
+ * `uf build --target native` selects. The default follows the framework
+ * preset rather than the target list: uf's default list names both web and
+ * React Native, so the list is a promise the project should keep satisfying,
+ * not the one build to run when none was requested.
+ */
+export function resolveRouteTarget(config = {}, requested = null) {
+  const app = config.app ?? {};
+  const named =
+    requested == null || requested === ""
+      ? app.framework === "react-native"
+        ? "native"
+        : "web"
+      : requested === "react-native"
+        ? "native"
+        : requested;
+  if (!ROUTE_TARGETS.includes(named)) {
+    throw new Error(
+      `uf: ${JSON.stringify(named)} is not an application target; choose web, native, ios or android`,
+    );
+  }
+  const declared = app.targets;
+  if (Array.isArray(declared)) {
+    const needs = named === "web" ? "web" : "react-native";
+    if (!declared.includes(needs)) {
+      throw new Error(
+        `uf: --target ${named} needs app.targets to include ${JSON.stringify(needs)}`,
+      );
+    }
+  }
+  return named;
+}
+
 /** Deepest directory nesting the scan will follow. */
 const MAX_DEPTH = 32;
 
@@ -254,6 +300,7 @@ const MAX_DEPTH = 32;
  * about.
  *
  * @param {string} appRoot absolute path of the router root (`app/`)
+ * @param {{target?: "web" | "native" | "ios" | "android"}} [options]
  * @returns {{
  *   routes: Route[],
  *   handlers: Handler[],
@@ -262,7 +309,8 @@ const MAX_DEPTH = 32;
  *   errors: ErrorBoundary[],
  * }}
  */
-export function scanRoutes(appRoot) {
+export function scanRoutes(appRoot, options = {}) {
+  const target = resolveRouteTarget({}, options.target ?? "web");
   const routes = [];
   const handlers = [];
   const middleware = [];
@@ -283,7 +331,7 @@ export function scanRoutes(appRoot) {
     // A `$default.js` answers one question — what a slot renders when the
     // URL says nothing about it — and this walk is everywhere a slot is not,
     // so one found here is a file nothing would ever open.
-    const strayDefault = findModule(directory, RESERVED.default, PAGE_EXTENSIONS);
+    const strayDefault = findModule(directory, RESERVED.default, PAGE_EXTENSIONS, target);
     if (strayDefault != null) {
       throw new Error(
         `${strayDefault}: \`$default.js\` is what a \`@slot\` renders when the URL says ` +
@@ -293,7 +341,7 @@ export function scanRoutes(appRoot) {
       );
     }
 
-    const ownLayout = findModule(directory, RESERVED.layout, MODULE_EXTENSIONS);
+    const ownLayout = findModule(directory, RESERVED.layout, MODULE_EXTENSIONS, target);
     const nextLayouts = ownLayout ? [...layouts, ownLayout] : layouts;
     if (depth === 0) {
       rootLayouts = nextLayouts;
@@ -305,7 +353,7 @@ export function scanRoutes(appRoot) {
     // `nextLayouts.length` is therefore the count taken after the own layout is
     // added, not before. A segment with a loading file and no layout of its own
     // still gets a boundary — it just shares its parent's frame.
-    const ownLoading = findModule(directory, RESERVED.loading, MODULE_EXTENSIONS);
+    const ownLoading = findModule(directory, RESERVED.loading, MODULE_EXTENSIONS, target);
     const nextLoading = ownLoading
       ? [...loading, { above: nextLayouts.length, module: ownLoading }]
       : loading;
@@ -316,7 +364,7 @@ export function scanRoutes(appRoot) {
     // Every template above a route is on that route, one inside the next, for
     // the reason every layout is — the difference between the two is a `key`,
     // not a shape.
-    const ownTemplate = findModule(directory, RESERVED.template, MODULE_EXTENSIONS);
+    const ownTemplate = findModule(directory, RESERVED.template, MODULE_EXTENSIONS, target);
     const nextTemplates = ownTemplate
       ? [...templates, { above: nextLayouts.length, module: ownTemplate }]
       : templates;
@@ -339,6 +387,7 @@ export function scanRoutes(appRoot) {
           segments,
           ownLayout,
           nextLayouts.length,
+          target,
           depth,
         ),
       ];
@@ -347,12 +396,12 @@ export function scanRoutes(appRoot) {
     // A middleware guards this directory and everything below it, whether or
     // not this directory is itself a route: `app/dashboard/$middleware.js`
     // with no `$page.js` beside it still guards `/dashboard/settings`.
-    const ownMiddleware = findModule(directory, RESERVED.middleware, MODULE_EXTENSIONS);
+    const ownMiddleware = findModule(directory, RESERVED.middleware, MODULE_EXTENSIONS, target);
     if (ownMiddleware) {
       middleware.push({ path: routeFromSegments(segments).path, module: ownMiddleware });
     }
 
-    const page = findModule(directory, RESERVED.page, PAGE_EXTENSIONS);
+    const page = findModule(directory, RESERVED.page, PAGE_EXTENSIONS, target);
     if (page) {
       const { path: routePath, pattern, params } = routeFromSegments(segments);
       routes.push({
@@ -370,7 +419,7 @@ export function scanRoutes(appRoot) {
     // A handler answers the request itself, so it takes no layouts and is not
     // MDX. It may sit beside a page: `/feed` can render for a browser and
     // `/feed.xml` answer for a reader, and both are the same directory tree.
-    const handler = findModule(directory, RESERVED.route, MODULE_EXTENSIONS);
+    const handler = findModule(directory, RESERVED.route, MODULE_EXTENSIONS, target);
     if (handler) {
       const { path: routePath, pattern, params } = routeFromSegments(segments);
       handlers.push({ path: routePath, pattern, params, module: handler });
@@ -380,7 +429,7 @@ export function scanRoutes(appRoot) {
     // `app/guide/$not-found.js` was never looked for and a reader who
     // followed a stale link into the manual was answered by the site's root
     // 404, outside the manual's own layout. See ubugeeei-prod/uf#263.
-    const ownNotFound = findModule(directory, RESERVED.notFound, PAGE_EXTENSIONS);
+    const ownNotFound = findModule(directory, RESERVED.notFound, PAGE_EXTENSIONS, target);
     if (ownNotFound) {
       notFound.push({
         path: routeFromSegments(segments).path,
@@ -392,7 +441,7 @@ export function scanRoutes(appRoot) {
 
     // `errors` is the boundaries a project declares, not failures that
     // happened: one entry per directory holding an `$error.js`.
-    const ownError = findModule(directory, RESERVED.error, MODULE_EXTENSIONS);
+    const ownError = findModule(directory, RESERVED.error, MODULE_EXTENSIONS, target);
     if (ownError) {
       errors.push({
         path: routeFromSegments(segments).path,
@@ -495,10 +544,11 @@ export function scanRoutes(appRoot) {
  * @param {ReadonlyArray<string>} segments the declaring segments, for the URL
  * @param {?string} ownLayout the declaring segment's own layout, or `null`
  * @param {number} above how many layouts are outside the slot
+ * @param {"web" | "native" | "ios" | "android"} target application target
  * @param {number} depth nesting depth, against `MAX_DEPTH`
  * @returns {Slot}
  */
-function scanSlot(parent, directoryName, name, segments, ownLayout, above, depth) {
+function scanSlot(parent, directoryName, name, segments, ownLayout, above, target, depth) {
   const directory = path.join(parent, directoryName);
   if (LAYOUT_PROP_NAMES.includes(name)) {
     throw new Error(
@@ -525,7 +575,7 @@ function scanSlot(parent, directoryName, name, segments, ownLayout, above, depth
   }
 
   const routes = [];
-  const defaultPage = findModule(directory, RESERVED.default, PAGE_EXTENSIONS);
+  const defaultPage = findModule(directory, RESERVED.default, PAGE_EXTENSIONS, target);
 
   const walkSlot = (current, currentSegments, layouts, atSlotRoot, currentDepth) => {
     if (currentDepth > MAX_DEPTH) return;
@@ -534,7 +584,8 @@ function scanSlot(parent, directoryName, name, segments, ownLayout, above, depth
     // is left of parallel routes; see the issue.
     for (const role of [RESERVED.notFound, RESERVED.error, RESERVED.loading, RESERVED.template]) {
       const found =
-        findModule(current, role, MODULE_EXTENSIONS) ?? findModule(current, role, PAGE_EXTENSIONS);
+        findModule(current, role, MODULE_EXTENSIONS, target) ??
+        findModule(current, role, PAGE_EXTENSIONS, target);
       if (found != null) {
         throw new Error(
           `${found}: a \`@slot\` renders a page and the layouts inside the slot, and has no ` +
@@ -546,7 +597,7 @@ function scanSlot(parent, directoryName, name, segments, ownLayout, above, depth
       }
     }
     for (const role of [RESERVED.route, RESERVED.middleware]) {
-      const found = findModule(current, role, MODULE_EXTENSIONS);
+      const found = findModule(current, role, MODULE_EXTENSIONS, target);
       if (found != null) {
         throw new Error(
           `${found}: a \`@slot\` renders inside the page at a URL and answers no request of its ` +
@@ -559,15 +610,16 @@ function scanSlot(parent, directoryName, name, segments, ownLayout, above, depth
     // One default per slot, at the slot. A deeper one would be a second answer
     // to a question that is asked once — the URL either addressed this slot or
     // it did not.
-    if (!atSlotRoot && findModule(current, RESERVED.default, PAGE_EXTENSIONS) != null) {
+    const nestedDefault = findModule(current, RESERVED.default, PAGE_EXTENSIONS, target);
+    if (!atSlotRoot && nestedDefault != null) {
       throw new Error(
-        `${findModule(current, RESERVED.default, PAGE_EXTENSIONS)}: a \`@slot\` has one ` +
+        `${nestedDefault}: a \`@slot\` has one ` +
           `\`$default.js\`, directly inside \`${directoryName}\`, and this one is deeper, so ` +
           "nothing would ever render it.",
       );
     }
 
-    const layoutHere = findModule(current, RESERVED.layout, MODULE_EXTENSIONS);
+    const layoutHere = findModule(current, RESERVED.layout, MODULE_EXTENSIONS, target);
     const nextLayouts = layoutHere ? [...layouts, layoutHere] : layouts;
 
     const entries = readdirSync(current, { withFileTypes: true }).sort((a, b) =>
@@ -589,12 +641,13 @@ function scanSlot(parent, directoryName, name, segments, ownLayout, above, depth
           currentSegments,
           layoutHere,
           nextLayouts.length,
+          target,
           currentDepth,
         ),
       ];
     }
 
-    const page = findModule(current, RESERVED.page, PAGE_EXTENSIONS);
+    const page = findModule(current, RESERVED.page, PAGE_EXTENSIONS, target);
     if (page) {
       const { path: routePath, params } = routeFromSegments(currentSegments);
       routes.push({
@@ -647,13 +700,16 @@ function isDirectory(candidate) {
   }
 }
 
-function findModule(directory, stem, extensions) {
-  for (const extension of extensions) {
-    const candidate = path.join(directory, stem + extension);
-    try {
-      if (statSync(candidate).isFile()) return candidate;
-    } catch {
-      // keep looking
+function findModule(directory, stem, extensions, target = "web") {
+  for (const variant of TARGET_VARIANTS[target] ?? TARGET_VARIANTS.web) {
+    for (const extension of extensions) {
+      const fileName = variant == null ? `${stem}${extension}` : `${stem}.${variant}${extension}`;
+      const candidate = path.join(directory, fileName);
+      try {
+        if (statSync(candidate).isFile()) return candidate;
+      } catch {
+        // keep looking
+      }
     }
   }
   return null;

--- a/packages/vite/route-segments.test.js
+++ b/packages/vite/route-segments.test.js
@@ -29,6 +29,7 @@ import { afterAll, describe, expect, it } from "@uniflowed/test";
 import {
   UNSUPPORTED_SEGMENTS,
   classifyRouteSegment,
+  resolveRouteTarget,
   routeFromSegments,
   scanRoutes,
 } from "./internal/routes.js";
@@ -152,5 +153,36 @@ describe("scanning a router root that holds one", () => {
     const root = appRoot([path.join("(marketing)", "about", "$page.js")]);
 
     expect(scanRoutes(root).routes.map((route) => route.path)).toEqual(["/about"]);
+  });
+
+  it("selects the route files for the requested application target", () => {
+    const root = appRoot([
+      path.join("guide", "$page.js"),
+      path.join("guide", "$page.web.jsx"),
+      path.join("guide", "$page.native.mdx"),
+      path.join("guide", "$page.ios.js"),
+      path.join("guide", "$page.android.jsx"),
+    ]);
+
+    expect(scanRoutes(root, { target: "web" }).routes[0].page).toBe(
+      path.join(root, "guide", "$page.web.jsx"),
+    );
+    expect(scanRoutes(root, { target: "native" }).routes[0].page).toBe(
+      path.join(root, "guide", "$page.native.mdx"),
+    );
+    expect(scanRoutes(root, { target: "ios" }).routes[0].page).toBe(
+      path.join(root, "guide", "$page.ios.js"),
+    );
+    expect(scanRoutes(root, { target: "android" }).routes[0].page).toBe(
+      path.join(root, "guide", "$page.android.jsx"),
+    );
+  });
+
+  it("defaults a React Native config to the native route target", () => {
+    expect(resolveRouteTarget({ app: { framework: "react-native" } })).toBe("native");
+    expect(resolveRouteTarget({ app: { targets: ["react-native"] } }, "ios")).toBe("ios");
+    expect(() => resolveRouteTarget({ app: { targets: ["web"] } }, "native")).toThrow(
+      "react-native",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a RouteTarget model for web, native, ios, and android route resolution
- teach Rust and Vite routers to prefer target-specific reserved files before generic files
- pass the target through uf build, the Vite driver, and the generated build manifest

Refs #501

## Verification
- cargo fmt --all --check
- git diff --check
- RUSTC_BOOTSTRAP=1 cargo test -p uf_router --ignore-rust-version -j1

## Notes
- pnpm is not installed in this environment, so the Vite test could not run through package tooling
- raw bun test does not apply this repo's Flow transform and fails parsing existing Flow syntax before exercising the test
- cargo check -p uf_cli is blocked on the local Rust toolchain: rustc 1.94.1 cannot compile oxc_data_structures 0.147.0's std::hint::cold_path usage; nix develop attempted to fetch the pinned toolchain but the disk filled up

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791693759&installation_model_id=422833&pr_number=769&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F769&signature=c2b8bdc124166bab51cd9fe25fe4b5f0c1b2bff841691aee926af91ea4138b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added application-target support for web, native, iOS, and Android builds.
  - Use `--target` to select the application target without requiring `--compile`.
  - Routes and server modules now automatically use target-specific files, with fallback to default files.
  - Build manifests and summaries now record the resolved application target.
  - Added support for `react-native` as an alias for the native target.

- **Bug Fixes**
  - Invalid or unsupported application targets are now rejected with clear validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->