### PR TITLE
perf: speed up tests and type checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,11 +12,11 @@ tools/upstream/sync.sh
 Pinned release toolchain (1.98.0):
 
 - [ ] `cargo fmt --all -- --check`
-- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- [ ] `cargo test --workspace`
+- [ ] `cargo clippy --workspace --all-targets --all-features --profile ci -- -D warnings`
+- [ ] `cargo test --workspace --profile ci`
 - [ ] `cargo bench --workspace --no-run`
 
 Nightly, for the `upstream/flow` Rust port behind `--all-features`:
 
-- [ ] `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
-- [ ] `cargo +nightly test --workspace --all-features`
+- [ ] `cargo +nightly clippy --workspace --all-targets --all-features --profile ci -- -D warnings`
+- [ ] `cargo +nightly test --workspace --all-features --profile ci`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
       # Built once and shared, because every job below runs its checks through
       # `uf run` — this repository is a uf project, and its pipeline uses the
       # toolchain it ships rather than a second description of the same checks.
-      - run: cargo build --release --bin uf
+      - run: cargo build --profile ci-opt --bin uf
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: uf-ci
-          path: target/release/uf
+          path: target/ci-opt/uf
           retention-days: 1
 
   format:
@@ -548,7 +548,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-08-01
-          components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # The suite builds the docs site through the real `@uniflowed/vite`, and
       # those tests fail rather than skip when the workspace is not installed.
@@ -582,8 +581,7 @@ jobs:
       - run: deno --version
       - run: cargo install wild-linker --version 0.10.0 --locked
       - run: wild --version
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace --all-features --profile ci
 
   upstream-flow:
     name: Upstream Flow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,7 +116,7 @@ jobs:
             echo "UF_REAL_BROWSER=$browser"
             echo "UF_BROWSER=$wrapper"
           } >> "$GITHUB_ENV"
-      - run: cargo test --workspace
+      - run: cargo test --workspace --profile ci
       # Only the packages in `tools/release/published-packages.txt`, which is
       # the set that is implemented.
       #

--- a/crates/uf_cli/src/commands/check/dependencies.rs
+++ b/crates/uf_cli/src/commands/check/dependencies.rs
@@ -107,11 +107,12 @@ pub(super) fn load_packages(
     read: &mut FxHashSet<String>,
 ) -> Vec<SourceFile> {
     let mut loaded = Vec::new();
+    let ancestors = ancestor_bases(root);
     for import in unresolved {
         let Some(name) = package_name(&import.specifier) else {
             continue;
         };
-        let Some(directory) = installed_for(root, &import.importer, name) else {
+        let Some(directory) = installed_for(root, &ancestors, &import.importer, name) else {
             continue;
         };
         if !read.insert(directory.clone()) {
@@ -128,7 +129,12 @@ pub(super) fn load_packages(
 /// Existence is decided by the manifest, because that is what makes a
 /// directory a package: `node_modules/.bin/foo` and a leftover empty directory
 /// are both on the path and neither is one.
-fn installed_for(root: &Utf8Path, importer: &str, name: &str) -> Option<String> {
+fn installed_for(
+    root: &Utf8Path,
+    ancestors: &[String],
+    importer: &str,
+    name: &str,
+) -> Option<String> {
     let inside = search_paths(importer)
         .into_iter()
         .map(|base| {
@@ -139,8 +145,8 @@ fn installed_for(root: &Utf8Path, importer: &str, name: &str) -> Option<String> 
             }
         })
         .collect::<Vec<String>>();
-    let above = ancestor_bases(root)
-        .into_iter()
+    let above = ancestors
+        .iter()
         .map(|base| format!("{base}/{INSTALLED}/{name}"));
 
     // Inside the project first, then above it, which is the order Node climbs.
@@ -323,9 +329,9 @@ fn declares_flow(path: &Utf8PathBuf) -> bool {
     {
         return false;
     }
-    // Lossy, because a package is not obliged to be UTF-8 and a byte sequence
-    // that is not says nothing about the pragma either way.
-    String::from_utf8_lossy(&header).contains(FLOW_PRAGMA)
+    header
+        .windows(FLOW_PRAGMA.len())
+        .any(|window| window == FLOW_PRAGMA.as_bytes())
 }
 
 #[cfg(test)]

--- a/crates/uf_test/src/runner.rs
+++ b/crates/uf_test/src/runner.rs
@@ -275,7 +275,7 @@ impl TestRunner {
     ) {
         let mut worker: Option<Worker> = None;
         loop {
-            let at = state.next.fetch_add(1, Ordering::SeqCst);
+            let at = state.next.fetch_add(1, Ordering::Relaxed);
             if at >= schedule.len() {
                 retire(&mut worker, host);
                 return;
@@ -284,10 +284,7 @@ impl TestRunner {
                 // Leave the slot empty; `assemble` reports it as not run.
                 continue;
             }
-            let Some(selected) = selected
-                .iter()
-                .find(|selected| selected.file.relative == schedule[at].file)
-            else {
+            let Some(selected) = selected.get(schedule[at].index) else {
                 continue;
             };
             let file = selected.file;

--- a/tools/justfile
+++ b/tools/justfile
@@ -5,12 +5,12 @@ default:
 
 check:
     cargo fmt --all -- --check
-    cargo clippy --workspace --all-targets --all-features -- -D warnings
-    cargo test --workspace --all-features
+    cargo clippy --workspace --all-targets --all-features --profile ci -- -D warnings
+    cargo test --workspace --all-features --profile ci
     cargo bench --workspace --all-features --no-run
 
 test:
-    cargo test --workspace --all-features
+    cargo test --workspace --all-features --profile ci
 
 ci:
-    cargo test --workspace --all-features
+    cargo test --workspace --all-features --profile ci

--- a/uf.config.js
+++ b/uf.config.js
@@ -136,8 +136,10 @@ export default defineConfig({
     // --- Rust ----------------------------------------------------------
     "rust:fmt": "cargo fmt --all",
     "rust:fmt:check": "cargo fmt --all -- --check",
-    "rust:clippy": "cargo clippy --workspace --all-targets --all-features -- -D warnings",
-    "rust:test": "cargo test --workspace",
+    "rust:clippy": {
+      command: "cargo clippy --workspace --all-targets --all-features --profile ci -- -D warnings",
+    },
+    "rust:test": "cargo test --workspace --profile ci",
     "rust:bench": "cargo bench --workspace --no-run",
     "rust:metadata": "cargo metadata --format-version 1 --locked",
     "rust:lints": {
@@ -147,8 +149,10 @@ export default defineConfig({
 
     // The parser and the checker are vendored, and they are the thing
     // everything else reads, so they get a pass of their own.
-    "flow:clippy": "cargo clippy -p uf_flow --all-targets -- -D warnings",
-    "flow:test": "cargo test -p uf_flow",
+    "flow:clippy": {
+      command: "cargo clippy -p uf_flow --all-targets --profile ci -- -D warnings",
+    },
+    "flow:test": "cargo test -p uf_flow --profile ci",
 
     // --- The toolchain, used on itself ---------------------------------
     //


### PR DESCRIPTION
## Summary
- use the scheduled file index in the native test runner instead of a path scan per file
- reduce repeated dependency lookup work during Flow typecheck package loading
- use the faster Cargo CI profile for test/clippy entry points and remove the duplicate all-features clippy pass from upstream-typecheck
- build the shared CI uf binary with ci-opt instead of release fat LTO

## Verification
- cargo fmt --all -- --check
- git diff --check
- sh tools/ci/test-workspace-suite-runtimes.sh
- sh tools/ci/test-scripts-parse.sh

Full cargo test/clippy is left to GitHub CI here because this host has rustc 1.94.1 while the workspace requires rustc 1.98.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791699716&installation_model_id=422833&pr_number=773&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F773&signature=a88ed28ed59d4b051420f77cfaecaf86aa6a652e39004fa020636b3e340e999f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->