### PR TITLE
fix(deno): scope package imports in loader map

### DIFF
--- a/crates/uf_cli/src/commands/deno_loader.rs
+++ b/crates/uf_cli/src/commands/deno_loader.rs
@@ -29,6 +29,10 @@
 //!   `index.js` under [`OUTPUT`], `@uniflowed/host/transform` → the compiled
 //!   `transform.js`, and a trailing-slash key per package so a deep path
 //!   nobody declared still lands in the right tree.
+//! * **one scoped table per `@uniflowed/*` package with `imports`.** A package's
+//!   `#internal` names belong to that package, not to the whole run. Import
+//!   map scopes keep two packages that both say `#runtime` from overwriting each
+//!   other while still pointing at the compiled copies under [`OUTPUT`].
 //! * **the project root, as a prefix.** `file:///<root>/` → `file:///<out>/`,
 //!   which is what makes the worker's own `import(pathToFileURL(file))` reach
 //!   the compiled copy. It has to be a prefix key rather than one key per
@@ -88,7 +92,7 @@ const STAMP: &str = ".uf-deno-build";
 /// stamp — but what this pass puts around a transform: the layout under
 /// [`OUTPUT`], the shape of the import map. A change to either makes every
 /// tree already on disk wrong in a way no source edit would reveal.
-const FRAMING: &str = "1";
+const FRAMING: &str = "2";
 
 /// The scope every package this pass mirrors belongs to.
 const SCOPE: &str = "@uniflowed";
@@ -456,6 +460,7 @@ fn import_map(
     packages: &BTreeMap<String, Utf8PathBuf>,
 ) -> String {
     let mut imports: BTreeMap<String, String> = BTreeMap::new();
+    let mut scopes: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for (name, real) in packages {
         let into = directory.join(PACKAGES).join(SCOPE).join(name.as_str());
@@ -467,6 +472,10 @@ fn import_map(
                 format!("{SCOPE}/{name}/{}", subpath.trim_start_matches("./"))
             };
             imports.insert(key, file_url(&into.join(target.trim_start_matches("./"))));
+        }
+        let local = package_imports(real, &into);
+        if !local.is_empty() {
+            scopes.insert(directory_url(&into), local);
         }
     }
 
@@ -482,6 +491,17 @@ fn import_map(
         table.insert(key, serde_json::Value::String(value));
     }
     document.insert("imports".to_string(), serde_json::Value::Object(table));
+    if !scopes.is_empty() {
+        let mut all = serde_json::Map::new();
+        for (scope, entries) in scopes {
+            let mut table = serde_json::Map::new();
+            for (key, value) in entries {
+                table.insert(key, serde_json::Value::String(value));
+            }
+            all.insert(scope, serde_json::Value::Object(table));
+        }
+        document.insert("scopes".to_string(), serde_json::Value::Object(all));
+    }
     let mut text = serde_json::to_string_pretty(&serde_json::Value::Object(document))
         .unwrap_or_else(|_| String::from("{\"imports\":{}}"));
     text.push('\n');
@@ -516,6 +536,49 @@ fn exports(directory: &Utf8Path) -> Vec<(String, String)> {
         .filter(|(key, _)| key.starts_with('.') && !key.contains('*'))
         .filter_map(|(key, value)| condition(value).map(|target| (key.clone(), target)))
         .collect()
+}
+
+/// One package's private `#` specifiers, scoped to the compiled package tree.
+///
+/// Exact entries map to exact files. Pattern entries map to import-map prefixes
+/// when both sides are the package-imports shape Node specifies:
+/// `"#x/*": "./internal/*"` becomes `"#x/" -> ".../internal/"`.
+fn package_imports(directory: &Utf8Path, into: &Utf8Path) -> BTreeMap<String, String> {
+    let Some(manifest) = manifest(directory) else {
+        return BTreeMap::new();
+    };
+    let Some(table) = manifest.get("imports").and_then(|value| value.as_object()) else {
+        return BTreeMap::new();
+    };
+
+    table
+        .iter()
+        .filter(|(key, _)| key.starts_with('#'))
+        .filter_map(|(key, value)| {
+            let target = condition(value)?;
+            scoped_import_entry(key, &target, into)
+        })
+        .collect()
+}
+
+fn scoped_import_entry(key: &str, target: &str, into: &Utf8Path) -> Option<(String, String)> {
+    if !target.starts_with("./") {
+        return None;
+    }
+    if let Some(key_prefix) = key.strip_suffix("/*") {
+        let target_prefix = target.strip_suffix("/*")?;
+        return Some((
+            format!("{key_prefix}/"),
+            directory_url(&into.join(target_prefix.trim_start_matches("./"))),
+        ));
+    }
+    if key.contains('*') || target.contains('*') {
+        return None;
+    }
+    Some((
+        key.to_owned(),
+        file_url(&into.join(target.trim_start_matches("./"))),
+    ))
 }
 
 /// The file one export entry resolves to, following conditions.

--- a/crates/uf_cli/src/commands/deno_loader/tests.rs
+++ b/crates/uf_cli/src/commands/deno_loader/tests.rs
@@ -136,6 +136,46 @@ fn the_map_names_every_uniflowed_export() {
     assert_eq!(imports["@uniflowed/test/"], directory_url(&into));
 }
 
+#[test]
+fn package_imports_are_scoped_to_the_package_that_declares_them() {
+    let fixture = Fixture::new();
+    fixture.package(
+        "test",
+        r##"{
+          "name": "@uniflowed/test",
+          "type": "module",
+          "imports": {
+            "#worker": "./worker.js",
+            "#internal/*": "./internal/*",
+            "#external": "@uniflowed/host"
+          },
+          "exports": { ".": "./index.js", "./worker": "./worker.js" }
+        }"##,
+    );
+    fixture.write(
+        &fixture.scope.join("test/internal/log.js"),
+        "// @flow\nexport const label: string = \"log\";\n",
+    );
+    let sources = vec![fixture.source("src/a.test.js", "// @flow\nimport \"@uniflowed/test\";\n")];
+
+    let loader = fixture.build(&sources);
+    let map = fixture.map(&loader);
+    let into = loader.directory.join("packages/@uniflowed/test");
+    let scope = directory_url(&into);
+    let entries = &map["scopes"][scope.as_str()];
+
+    assert_eq!(entries["#worker"], file_url(&into.join("worker.js")));
+    assert_eq!(entries["#internal/"], directory_url(&into.join("internal")));
+    assert!(
+        entries["#external"].is_null(),
+        "bare package targets are omitted rather than written as invalid import-map addresses"
+    );
+    assert!(
+        map["imports"]["#worker"].is_null(),
+        "package-local imports must not become process-wide import-map entries"
+    );
+}
+
 /// The entry a reader stops at, and the one whose absence breaks everything.
 ///
 /// `.uf/deno` is under the project root, so the prefix that redirects the


### PR DESCRIPTION
## Summary
- emits package-local `package.json#imports` entries into Deno import-map `scopes`
- keeps `#` specifiers local to the compiled package URL instead of process-wide
- bumps the Deno loader framing stamp so stale import maps are rebuilt

Part of #736.

## Tests
- `nix develop --command cargo fmt -p uf_cli`
- `nix develop --command cargo test -p uf_cli --lib --profile ci package_imports_are_scoped_to_the_package_that_declares_them`
- `nix develop --command cargo test -p uf_cli --lib --profile ci deno_loader`
- `nix develop --command cargo test -p uf_check --lib --profile ci a_package_with_no_exports_map_prefers_module_to_main`
- `git diff --check`
- `nix develop --command cargo clippy -p uf_cli --lib --profile ci -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791704782&installation_model_id=422833&pr_number=774&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F774&signature=4c41c827bfd0e92ef6ce24ce62c1c4553927e50ea672e39b11248354b4bfee21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deno import maps now support package-scoped `#internal` imports for reachable packages.
  - Relative file and directory targets are resolved correctly within their declaring package.
- **Bug Fixes**
  - Prevented package-local import keys from leaking into global import-map entries.
  - Bare package targets are excluded from scoped mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->