### PR TITLE
fix(check): report host-conditional package exports

### DIFF
--- a/crates/uf_check/src/report.rs
+++ b/crates/uf_check/src/report.rs
@@ -129,6 +129,14 @@ pub struct CheckReport {
     /// `any` and carry on, which is what happens here — and this list is how a
     /// caller says so out loud instead of letting the hole be silent.
     pub untyped_modules: Vec<CompactString>,
+    /// Untyped package imports whose `exports` map only resolved for a
+    /// concrete host condition such as `node`, `bun`, `deno` or `browser`.
+    ///
+    /// These are also present in [`Self::untyped_modules`], because the import
+    /// is still typed as `any`. This list says why: the package was visible,
+    /// but `uf check` deliberately did not pick one host's branch for a graph
+    /// it has to share across hosts.
+    pub host_conditional_modules: Vec<CompactString>,
     /// What the shared builtin environment cost.
     pub builtins: BuiltinsTiming,
     /// Wall time spent in inference, excluding the builtin merge.

--- a/crates/uf_check/src/tests.rs
+++ b/crates/uf_check/src/tests.rs
@@ -107,6 +107,7 @@ fn a_report_counts_by_severity() {
         files_skipped: 0,
         files_from_cache: 0,
         untyped_modules: Vec::new(),
+        host_conditional_modules: Vec::new(),
         builtins: BuiltinsTiming {
             elapsed: std::time::Duration::ZERO,
             cold_elapsed: std::time::Duration::ZERO,
@@ -129,6 +130,7 @@ fn throughput_is_unknown_when_no_time_passed() {
         files_skipped: 0,
         files_from_cache: 0,
         untyped_modules: Vec::new(),
+        host_conditional_modules: Vec::new(),
         builtins: BuiltinsTiming {
             elapsed: std::time::Duration::ZERO,
             cold_elapsed: std::time::Duration::ZERO,
@@ -1153,6 +1155,41 @@ fn a_path_the_exports_map_does_not_publish_stays_unresolved() {
         report.untyped_modules,
         ["@uniflowed/cell/internal/schedule.js"]
     );
+}
+
+#[test]
+fn host_only_package_exports_are_reported_separately_from_missing_packages() {
+    require_checker!();
+
+    let report = batch(&[
+        Source::new(
+            "packages/hosted/package.json",
+            r#"{
+              "name": "hosted",
+              "exports": {
+                ".": { "node": "./node.js", "bun": "./bun.js" }
+              }
+            }"#,
+        ),
+        Source::new(
+            "packages/hosted/node.js",
+            "// @flow\nexport type Mode = \"node\";\n",
+        ),
+        Source::new(
+            "packages/hosted/bun.js",
+            "// @flow\nexport type Mode = \"bun\";\n",
+        ),
+        Source::new(
+            "app.js",
+            "// @flow\nimport type { Mode } from \"hosted\";\n\
+             import type { Missing } from \"not-installed\";\n\
+             export const mode: Mode = \"node\";\n\
+             export const missing: Missing = 1;\n",
+        ),
+    ]);
+
+    assert_eq!(report.untyped_modules, ["hosted", "not-installed"]);
+    assert_eq!(report.host_conditional_modules, ["hosted"]);
 }
 
 #[test]

--- a/crates/uf_check/src/upstream/graph.rs
+++ b/crates/uf_check/src/upstream/graph.rs
@@ -62,6 +62,8 @@ enum Resolution {
     Module(usize),
     /// A module Flow's own library definitions declare.
     Declared,
+    /// A package export that would resolve after choosing a concrete host.
+    HostConditional,
     /// Nothing typed: the import is `any`, and the specifier is reported.
     Untyped,
 }
@@ -76,6 +78,7 @@ impl Resolution {
         match self {
             Self::Module(_) => "@",
             Self::Declared => "~",
+            Self::HostConditional => "!",
             Self::Untyped => "?",
         }
     }
@@ -175,7 +178,27 @@ impl<'a> Graph<'a> {
             .requires
             .iter()
             .zip(&self.resolutions[index])
-            .filter(|(_, resolution)| **resolution == Resolution::Untyped)
+            .filter(|(_, resolution)| {
+                matches!(
+                    **resolution,
+                    Resolution::HostConditional | Resolution::Untyped
+                )
+            })
+            .map(|(require, _)| require.specifier.clone())
+            .collect()
+    }
+
+    /// The specifiers that stayed untyped because their `exports` map only
+    /// resolved for a concrete host.
+    pub(super) fn host_conditional(&self, index: usize) -> Vec<CompactString> {
+        if self.facts[index].signature.is_none() {
+            return Vec::new();
+        }
+        self.facts[index]
+            .requires
+            .iter()
+            .zip(&self.resolutions[index])
+            .filter(|(_, resolution)| **resolution == Resolution::HostConditional)
             .map(|(require, _)| require.specifier.clone())
             .collect()
     }
@@ -200,6 +223,9 @@ fn resolve(
         // the cache exists not to do.
         Some(index) if facts[index].signature.is_some() => Resolution::Module(index),
         _ if require.declared => Resolution::Declared,
+        _ if modules.host_conditional_exports(importer, &require.specifier) => {
+            Resolution::HostConditional
+        }
         _ => Resolution::Untyped,
     }
 }

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -287,6 +287,7 @@ fn check_batch(
 
     let mut diagnostics = Vec::new();
     let mut untyped = BTreeSet::new();
+    let mut host_conditional = BTreeSet::new();
     let mut skipped = 0usize;
     let mut from_cache = 0usize;
     let mut result = Ok(());
@@ -295,6 +296,7 @@ fn check_batch(
             skipped += 1;
         }
         untyped.extend(graph.untyped(index));
+        host_conditional.extend(graph.host_conditional(index));
 
         let dependencies = graph.dependency_digest(index);
         // The record is about this file; the digest says whether it is still
@@ -359,6 +361,7 @@ fn check_batch(
         files_skipped: skipped,
         files_from_cache: from_cache,
         untyped_modules: untyped.into_iter().collect(),
+        host_conditional_modules: host_conditional.into_iter().collect(),
         builtins,
         elapsed: started.elapsed(),
     })

--- a/crates/uf_check/src/upstream/packages.rs
+++ b/crates/uf_check/src/upstream/packages.rs
@@ -74,6 +74,10 @@ const MANIFEST: &str = "package.json";
 /// The directory an installed package sits under, with its separator.
 const INSTALLED_PREFIX: &str = "node_modules/";
 
+/// Host-specific `exports` conditions that are intentionally not part of the
+/// checker graph.
+const HOST_EXPORT_CONDITIONS: [&str; 4] = ["node", "bun", "deno", "browser"];
+
 /// The path a bare specifier named, and how much of a path it is.
 ///
 /// The two cases resolve differently on purpose, and the difference is Node's
@@ -148,6 +152,11 @@ pub(super) struct WorkspacePackages {
     installed: HashMap<CompactString, Vec<Installed>>,
     /// The `exports` conditions a subpath is resolved under, from [`Options`].
     conditions: Vec<FlowSmolStr>,
+    /// The condition sets that would resolve for one concrete host.
+    ///
+    /// These do not decide the checker graph. They only explain a miss after
+    /// the graph has already refused to pick one host.
+    host_condition_sets: Vec<Vec<FlowSmolStr>>,
 }
 
 impl WorkspacePackages {
@@ -206,15 +215,19 @@ impl WorkspacePackages {
             copies.sort_by_key(|copy| std::cmp::Reverse(specificity(&copy.enclosing)));
         }
 
+        let conditions: Vec<FlowSmolStr> = options
+            .node_package_export_conditions
+            .iter()
+            .map(|condition| FlowSmolStr::new(condition.as_str()))
+            .collect();
+        let host_condition_sets = host_condition_sets(&conditions);
+
         Self {
             scopes,
             project,
             installed,
-            conditions: options
-                .node_package_export_conditions
-                .iter()
-                .map(|condition| FlowSmolStr::new(condition.as_str()))
-                .collect(),
+            conditions,
+            host_condition_sets,
         }
     }
 
@@ -277,6 +290,27 @@ impl WorkspacePackages {
         }
     }
 
+    /// Whether `specifier` names a package subpath that only resolves after a
+    /// concrete host condition is added.
+    pub(super) fn host_conditional_exports(&self, importer: &str, specifier: &str) -> bool {
+        if specifier.starts_with('#') {
+            return false;
+        }
+        let Some((name, subpath)) = split(specifier) else {
+            return false;
+        };
+        let Some(package) = self.lookup(importer, name) else {
+            return false;
+        };
+        let Some(exports) = package.manifest.exports() else {
+            return false;
+        };
+        exports
+            .resolve_package(&subpath, &self.conditions)
+            .is_none()
+            && exports.resolves_package_with_any_condition_set(&subpath, &self.host_condition_sets)
+    }
+
     fn resolve_import(&self, importer: &str, specifier: &str) -> Option<PackageFile> {
         let package = self.scope(importer)?;
         let imports = package.manifest.imports()?;
@@ -310,6 +344,19 @@ impl WorkspacePackages {
         let (name, _) = split(specifier)?;
         Some(self.lookup(importer, name)?.manifest_path.as_str())
     }
+}
+
+fn host_condition_sets(conditions: &[FlowSmolStr]) -> Vec<Vec<FlowSmolStr>> {
+    HOST_EXPORT_CONDITIONS
+        .iter()
+        .map(|host| {
+            let mut set = conditions.to_vec();
+            if !set.iter().any(|condition| condition.as_str() == *host) {
+                set.push(FlowSmolStr::new(host));
+            }
+            set
+        })
+        .collect()
 }
 
 /// Where an installed package is installed, and under what name.
@@ -554,6 +601,22 @@ mod tests {
             exact(&packages, "@uniflowed/host/transform"),
             "packages/host/transform.js"
         );
+    }
+
+    #[test]
+    fn host_only_exports_are_classified_without_resolving_the_checker_graph() {
+        let packages = packages(&[Source::new(
+            "packages/hosted/package.json",
+            r#"{
+              "name": "hosted",
+              "exports": { ".": { "bun": "./bun.js", "node": "./node.js" } }
+            }"#,
+        )]);
+
+        assert!(packages.resolve("app.js", "hosted").is_none());
+        assert!(packages.host_conditional_exports("app.js", "hosted"));
+        assert!(!packages.host_conditional_exports("app.js", "missing"));
+        assert!(!packages.host_conditional_exports("app.js", "hosted/private"));
     }
 
     #[test]

--- a/crates/uf_check/src/upstream/project.rs
+++ b/crates/uf_check/src/upstream/project.rs
@@ -466,6 +466,12 @@ impl ProjectModules {
         }
     }
 
+    /// Whether a package specifier missed because `exports` only offered
+    /// concrete host branches.
+    pub(super) fn host_conditional_exports(&self, importer: &str, specifier: &str) -> bool {
+        self.packages.host_conditional_exports(importer, specifier)
+    }
+
     /// Type the import as `any`, and say so.
     ///
     /// Exactly `flow_services_inference`'s `unchecked_module_t`: the module

--- a/crates/uf_cli/src/commands/check.rs
+++ b/crates/uf_cli/src/commands/check.rs
@@ -414,6 +414,7 @@ fn type_check_payload(types: &TypeCheck) -> Value {
                 .map_or(report.builtins.cold, |batch| batch.builtins.cold)
         );
         value["untypedModules"] = json!(report.untyped_modules);
+        value["hostConditionalModules"] = json!(report.host_conditional_modules);
     }
     if let TypeCheck::Failed(error) = types {
         value["error"] = json!(error.to_string());
@@ -641,6 +642,7 @@ fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
                 rows.insert(1, KeyValue::toned("libdefs", &libdefs, Tone::Muted));
             }
             let untyped = untyped_module_list(report);
+            let host_conditional = host_conditional_module_list(report);
             ui.render(|renderer, out| {
                 renderer.blank(out);
                 renderer.key_values(out, 2, &rows);
@@ -655,6 +657,17 @@ fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
                     let items: Vec<&str> = untyped.iter().map(String::as_str).collect();
                     renderer.bullet_list(out, 4, &items);
                 }
+                if !host_conditional.is_empty() {
+                    renderer.blank(out);
+                    push_spaces(out, 2);
+                    renderer.status(
+                        out,
+                        Status::Info,
+                        "these packages only publish host-specific exports; uf check typed them as any instead of guessing a host",
+                    );
+                    let items: Vec<&str> = host_conditional.iter().map(String::as_str).collect();
+                    renderer.bullet_list(out, 4, &items);
+                }
             });
         }
     }
@@ -666,16 +679,22 @@ fn render_type_footer(ui: &mut Ui, types: &TypeCheck) {
 /// set is always in `--json`.
 #[cfg(feature = "upstream-typecheck")]
 fn untyped_module_list(report: &CheckReport) -> Vec<String> {
-    let mut named: Vec<String> = report
-        .untyped_modules
+    limited_module_list(&report.untyped_modules)
+}
+
+#[cfg(feature = "upstream-typecheck")]
+fn host_conditional_module_list(report: &CheckReport) -> Vec<String> {
+    limited_module_list(&report.host_conditional_modules)
+}
+
+#[cfg(feature = "upstream-typecheck")]
+fn limited_module_list<T: std::fmt::Display>(modules: &[T]) -> Vec<String> {
+    let mut named: Vec<String> = modules
         .iter()
         .take(UNTYPED_MODULES_SHOWN)
         .map(ToString::to_string)
         .collect();
-    let overflow = report
-        .untyped_modules
-        .len()
-        .saturating_sub(UNTYPED_MODULES_SHOWN);
+    let overflow = modules.len().saturating_sub(UNTYPED_MODULES_SHOWN);
     if overflow > 0 {
         named.push(format!("and {overflow} more"));
     }

--- a/crates/uf_cli/tests/typecheck.rs
+++ b/crates/uf_cli/tests/typecheck.rs
@@ -164,6 +164,7 @@ fn a_second_run_is_answered_from_the_cache_under_the_project_root() {
         "filesChecked",
         "filesSkipped",
         "untypedModules",
+        "hostConditionalModules",
     ] {
         assert_eq!(
             first["typeCheck"][field], second["typeCheck"][field],
@@ -320,6 +321,54 @@ fn imports_that_uf_cannot_type_yet_are_named_rather_than_hidden() {
         untyped.iter().any(|name| name == "./generated/table.js"),
         "{untyped:?}"
     );
+}
+
+#[test]
+fn host_conditional_package_exports_are_reported_apart_from_missing_packages() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    let package = dir.path().join("packages/hosted");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&package).unwrap();
+    fs::write(
+        package.join("package.json"),
+        r#"{
+          "name": "hosted",
+          "exports": { ".": { "node": "./node.js", "bun": "./bun.js" } }
+        }"#,
+    )
+    .unwrap();
+    fs::write(
+        package.join("node.js"),
+        "// @flow\nexport type Mode = \"node\";\n",
+    )
+    .unwrap();
+    fs::write(
+        package.join("bun.js"),
+        "// @flow\nexport type Mode = \"bun\";\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("app.js"),
+        "// @flow\nimport type { Mode } from \"hosted\";\n\
+         import type { Missing } from \"not-installed\";\n\
+         export const mode: Mode = \"node\";\n\
+         export const missing: Missing = 1;\n",
+    )
+    .unwrap();
+
+    let value = check_json(dir.path());
+    let untyped = value["typeCheck"]["untypedModules"].as_array().unwrap();
+    let host_conditional = value["typeCheck"]["hostConditionalModules"]
+        .as_array()
+        .unwrap();
+
+    assert!(untyped.iter().any(|name| name == "hosted"), "{untyped:?}");
+    assert!(
+        untyped.iter().any(|name| name == "not-installed"),
+        "{untyped:?}"
+    );
+    assert_eq!(host_conditional, [serde_json::json!("hosted")].as_slice());
 }
 
 /// A hand-written library definition is full of `any`, and that is what one is

--- a/tools/upstream/patches/flow/0007-expose-package-exports-condition-probe.patch
+++ b/tools/upstream/patches/flow/0007-expose-package-exports-condition-probe.patch
@@ -1,0 +1,35 @@
+Subject: expose a package exports condition-set probe
+
+Issue: ubugeeei-prod/uf#735
+Upstream: not filed with facebook/flow yet
+Submodule: 81b0c2a3dd591c66c51167aac341d851932bd9c5
+
+uf needs to tell apart a package that is not present from a package whose
+`exports` map is present but publishes a subpath only behind host-specific
+conditions. The answer has to come from the same matcher Flow uses for package
+exports, otherwise the diagnostic would drift from the graph the checker
+actually types.
+
+This patch exposes a small probe that reuses `resolve_package` across several
+candidate condition sets and reports whether any of them would resolve.
+
+diff --git a/rust_port/crates/flow_parser_utils/src/package_exports.rs b/rust_port/crates/flow_parser_utils/src/package_exports.rs
+--- a/rust_port/crates/flow_parser_utils/src/package_exports.rs
++++ b/rust_port/crates/flow_parser_utils/src/package_exports.rs
+@@ -65,6 +65,15 @@ impl PackageExports {
+         }
+     }
+-
++    pub fn resolves_package_with_any_condition_set(
++        &self,
++        subpath: &str,
++        condition_sets: &[Vec<FlowSmolStr>],
++    ) -> bool {
++        condition_sets
++            .iter()
++            .any(|conditions| self.resolve_package(subpath, conditions).is_some())
++    }
++
+     pub fn parse(expr: &ast::expression::Expression<Loc, Loc>) -> Option<Self> {
+         match expr.deref() {
+             ExpressionInner::StringLiteral { inner, .. } => Some(


### PR DESCRIPTION
## Summary
- classify package imports whose package.json exports only resolve after choosing a concrete JS host condition
- expose the classification as typeCheck.hostConditionalModules while keeping the imports in untypedModules
- add the small Flow parser-utils patch needed to probe alternate condition sets through Flow's own exports matcher

Part of #735.

## Tests
- tools/upstream/sync.sh
- nix develop --command cargo test -p uf_check --lib --profile ci
- nix develop --command cargo test -p uf_cli --test typecheck --profile ci
- nix develop --command cargo clippy -p uf_check -p uf_cli --profile ci -- -D warnings
- nix develop --command cargo test -p uf_check --test upstream_patches --profile ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791707048&installation_model_id=422833&pr_number=775&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F775&signature=be9c83626def4815e67e7f5f1d92b5d30fbcdae237658fc800f59d35a85b5998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->