### PR TITLE
refactor(config): split evaluated projection parsing

### DIFF
--- a/crates/uf_config/src/lib.rs
+++ b/crates/uf_config/src/lib.rs
@@ -1916,35 +1916,69 @@ pub fn load_config_file(path: &Utf8Path) -> Result<UniflowedConfig, ConfigError>
                     });
                 }
             };
-            let config: UniflowedConfig =
-                json5::from_str(&json5).map_err(|source| ConfigError::Parse {
-                    path: path.to_path_buf(),
-                    message: source.to_string(),
-                })?;
-            check_cache_switches(path, &config.app.rendering.cache)?;
-            // Which runtime this project says it is written for, checked
-            // against the table that says which runtimes have a host. Before
-            // the rendering and library checks only because it is the
-            // cheapest of the three; the three are independent. See
-            // ubugeeei-prod/uf#246.
-            runtime::check(path, &config)?;
-            // What the project says a build may produce, checked where it was
-            // written. `rendering::check` refuses the two combinations that
-            // have no build behind them; `RenderingPlan::resolve` is
-            // infallible after it, which is why every caller downstream can
-            // ask for the plan without handling an error.
-            rendering::check(path, &config)?;
-            // And what a build *is*, which is the question one level above
-            // that: `app.router.enabled: false` makes the project a library,
-            // and `build.lib` describes a build only a library has. See
-            // ubugeeei-prod/uf#268.
-            library::check(path, &config)?;
-            Ok(config)
+            parse_config_object(path, &json5)
         }
         _ => Err(ConfigError::UnreadableConfigFile {
             path: path.to_path_buf(),
         }),
     }
+}
+
+/// Parse the object literal extracted from a static `uf.config.js`.
+///
+/// This is the bootstrap path: Rust can read enough config to choose a host and
+/// builder without running user code. Once a command has a JavaScript host, the
+/// evaluated module should enter through [`parse_config_projection`] instead.
+pub fn parse_config_object(
+    path: &Utf8Path,
+    json5_object: &str,
+) -> Result<UniflowedConfig, ConfigError> {
+    let config: UniflowedConfig =
+        json5::from_str(json5_object).map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            message: source.to_string(),
+        })?;
+    validate_config(path, &config)?;
+    Ok(config)
+}
+
+/// Parse the JSON projection of an evaluated `uf.config.js`.
+///
+/// `@uniflowed/vite` already evaluates the module for commands that start a
+/// builder driver and emits plain JSON. Keeping this entry point in `uf_config`
+/// gives that evaluated path the same serde defaults and semantic validation
+/// as the static bootstrap loader.
+pub fn parse_config_projection(
+    path: &Utf8Path,
+    projection: serde_json::Value,
+) -> Result<UniflowedConfig, ConfigError> {
+    let config: UniflowedConfig =
+        serde_json::from_value(projection).map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            message: source.to_string(),
+        })?;
+    validate_config(path, &config)?;
+    Ok(config)
+}
+
+/// Validate semantic config combinations that serde alone cannot express.
+pub fn validate_config(path: &Utf8Path, config: &UniflowedConfig) -> Result<(), ConfigError> {
+    check_cache_switches(path, &config.app.rendering.cache)?;
+    // Which runtime this project says it is written for, checked against the
+    // table that says which runtimes have a host. Before the rendering and
+    // library checks only because it is the cheapest of the three; the three
+    // are independent. See ubugeeei-prod/uf#246.
+    runtime::check(path, config)?;
+    // What the project says a build may produce, checked where it was written.
+    // `rendering::check` refuses the two combinations that have no build behind
+    // them; `RenderingPlan::resolve` is infallible after it, which is why every
+    // caller downstream can ask for the plan without handling an error.
+    rendering::check(path, config)?;
+    // And what a build *is*, which is the question one level above that:
+    // `app.router.enabled: false` makes the project a library, and `build.lib`
+    // describes a build only a library has. See ubugeeei-prod/uf#268.
+    library::check(path, config)?;
+    Ok(())
 }
 
 /// Refuse a cache switch uf would read and not honour.

--- a/crates/uf_config/src/tests.rs
+++ b/crates/uf_config/src/tests.rs
@@ -472,6 +472,50 @@ fn parses_flow_config() {
     assert!(config.app.builtins.native_test_runner);
 }
 
+#[test]
+fn parses_an_evaluated_config_projection() {
+    let path = Utf8PathBuf::from("/project/uf.config.js");
+    let config = parse_config_projection(
+        &path,
+        serde_json::json!({
+            "dev": { "port": 4173 },
+            "tasks": {
+                "hello": { "command": "echo hi" }
+            }
+        }),
+    )
+    .unwrap();
+
+    assert_eq!(config.dev.port, 4173);
+    assert_eq!(config.tasks["hello"].command(), "echo hi");
+    assert_eq!(config.builder.module, "@uniflowed/vite");
+    assert_eq!(
+        config.app.runtime.capability_js_host.default,
+        CapabilityJsHost::Node
+    );
+}
+
+#[test]
+fn evaluated_config_projection_uses_the_same_validation() {
+    let path = Utf8PathBuf::from("/project/uf.config.js");
+    let error = parse_config_projection(
+        &path,
+        serde_json::json!({
+            "app": {
+                "rendering": {
+                    "cache": { "data": true }
+                }
+            }
+        }),
+    )
+    .expect_err("evaluated config still refuses unavailable caches");
+
+    assert!(matches!(
+        error,
+        ConfigError::UnimplementedCache { key: "data", .. }
+    ));
+}
+
 /// The two cache switches uf implements are read and carried.
 ///
 /// They reach `@uniflowed/vite`'s generated server entry and `uf preview`, and


### PR DESCRIPTION
Part of #698.

## Summary
- split JSON5 object parsing for the static bootstrap config path into `parse_config_object`
- add `parse_config_projection` for the JSON projection emitted by the evaluated config driver path
- share semantic validation through `validate_config` so evaluated configs get the same refusals as static configs

## Tests
- `nix develop --command cargo test -p uf_config --lib --profile ci parses_an_evaluated_config_projection`
- `nix develop --command cargo test -p uf_config --lib --profile ci evaluated_config_projection_uses_the_same_validation`
- `nix develop --command cargo test -p uf_config --lib --profile ci`
- `nix develop --command cargo test -p uf_config --profile ci`
- `nix develop --command cargo clippy -p uf_config --profile ci -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791708589&installation_model_id=422833&pr_number=776&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F776&signature=8688455fa97da0dd2af60e4ef340bf389a45e4e6c8a7e0ac462383c8aa41b7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configuration projections generated by evaluated modules can now be parsed alongside standard configuration files.
  - Shared defaults and validation are applied consistently across both configuration formats.
  - Invalid settings, including unsupported cache options, are rejected during configuration processing.

- **Tests**
  - Added coverage for parsing evaluated configuration projections, applying defaults, and enforcing validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->