### PR TITLE
fix(project): read package.json workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,9 @@ version = "0.0.0-alpha.20"
 dependencies = [
  "camino",
  "compact_str",
+ "globset",
  "ignore",
+ "serde_json",
  "tempfile",
  "thiserror",
  "uf_config",

--- a/crates/uf_cli/src/lib.rs
+++ b/crates/uf_cli/src/lib.rs
@@ -550,7 +550,7 @@ fn enter_workspace(cwd: &Utf8PathBuf, target: &str) -> Result<Utf8PathBuf> {
         Ok(workspace) => Ok(resolved.root.join(&workspace.path)),
         Err(available) if available.is_empty() => Err(anyhow!(
             "no workspace named {target:?}\n\n  this project has no members; a member is a \
-             directory with its own uf.config.js"
+             directory with its own uf.config.js or a package named by package.json#workspaces"
         )),
         Err(available) => {
             let names = available.iter().map(compact_str::CompactString::as_str);

--- a/crates/uf_project/Cargo.toml
+++ b/crates/uf_project/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 [dependencies]
 compact_str.workspace = true
 camino.workspace = true
+globset.workspace = true
+serde_json.workspace = true
 uf_config = { path = "../uf_config" }
 thiserror.workspace = true
 ignore.workspace = true

--- a/crates/uf_project/src/workspace.rs
+++ b/crates/uf_project/src/workspace.rs
@@ -12,13 +12,16 @@
 //!
 //! # What counts as a member
 //!
-//! A directory with its own `uf.config.js`. Nothing is declared, because a
-//! declaration would be a second list to keep in step with the first — and the
-//! first already exists, in the form of the config files themselves. The root's
-//! own config is not a member: `uf dev` already means the root.
+//! A directory with its own `uf.config.js`, or a package named by the root
+//! `package.json`'s standard `workspaces` field. The root's own config is not a
+//! member: `uf dev` already means the root.
+
+use std::fs;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::{CompactString, ToCompactString};
+use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
+use serde_json::Value;
 
 use uf_config::{CONFIG_FILES, UniflowedConfig};
 
@@ -38,7 +41,10 @@ const MAX_DEPTH: usize = 3;
 /// One uf project inside another.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Workspace {
-    /// What `uf <command>#<name>` calls it: the directory's own name.
+    /// What `uf <command>#<name>` calls it.
+    ///
+    /// Config-discovered members use the directory name; package workspaces use
+    /// `package.json#name` when present.
     pub name: CompactString,
     /// Where it is, relative to the root.
     pub path: Utf8PathBuf,
@@ -64,9 +70,21 @@ impl Workspace {
 /// member of anything.
 pub fn discover_workspaces(root: &Utf8Path, config: &UniflowedConfig) -> Vec<Workspace> {
     let mut found = Vec::new();
+
+    for workspace in package_workspaces(root, config) {
+        push_workspace(&mut found, workspace);
+    }
     visit(root, root, config, 0, &mut found);
+
     found.sort();
     found
+}
+
+fn push_workspace(found: &mut Vec<Workspace>, workspace: Workspace) {
+    if found.iter().any(|existing| existing.path == workspace.path) {
+        return;
+    }
+    found.push(workspace);
 }
 
 fn visit(
@@ -100,10 +118,13 @@ fn visit(
             && let Some(name) = path.file_name()
             && let Ok(relative) = path.strip_prefix(root)
         {
-            found.push(Workspace {
-                name: name.to_compact_string(),
-                path: relative.to_path_buf(),
-            });
+            push_workspace(
+                found,
+                Workspace {
+                    name: name.to_compact_string(),
+                    path: relative.to_path_buf(),
+                },
+            );
             // A project inside a project is that project's business, not this
             // one's: `uf dev#docs` selects `docs`, and what `docs` contains is
             // resolved from there.
@@ -112,6 +133,219 @@ fn visit(
 
         visit(root, &path, config, depth + 1, found);
     }
+}
+
+fn package_workspaces(root: &Utf8Path, config: &UniflowedConfig) -> Vec<Workspace> {
+    let Some(patterns) = package_workspace_patterns(root) else {
+        return Vec::new();
+    };
+    let Some(globs) = WorkspaceGlobs::compile(&patterns) else {
+        return Vec::new();
+    };
+
+    let mut found = Vec::new();
+    for relative in globs.walk_roots() {
+        let start = root.join(relative);
+        visit_package_workspace_root(root, &start, config, &globs, &mut found);
+    }
+    found
+}
+
+fn package_workspace_patterns(root: &Utf8Path) -> Option<Vec<String>> {
+    let source = fs::read_to_string(root.join("package.json")).ok()?;
+    let manifest = serde_json::from_str::<Value>(&source).ok()?;
+    let workspaces = manifest.get("workspaces")?;
+
+    let mut patterns = Vec::new();
+    match workspaces {
+        Value::Array(entries) => patterns.extend(workspace_pattern_strings(entries)),
+        // Yarn 1 accepts `{ "packages": [...], "nohoist": [...] }`. Only the
+        // `packages` list names members; `nohoist` is an install layout rule.
+        Value::Object(object) => {
+            if let Some(entries) = object.get("packages").and_then(Value::as_array) {
+                patterns.extend(workspace_pattern_strings(entries));
+            }
+        }
+        _ => {}
+    }
+
+    (!patterns.is_empty()).then_some(patterns)
+}
+
+fn workspace_pattern_strings(entries: &[Value]) -> impl Iterator<Item = String> + '_ {
+    entries.iter().filter_map(Value::as_str).map(str::to_owned)
+}
+
+fn visit_package_workspace_root(
+    root: &Utf8Path,
+    dir: &Utf8Path,
+    config: &UniflowedConfig,
+    globs: &WorkspaceGlobs,
+    found: &mut Vec<Workspace>,
+) {
+    if dir != root && (is_ignored(root, dir, config) || dir.join(".git").exists()) {
+        return;
+    }
+
+    if let Ok(relative) = dir.strip_prefix(root)
+        && !relative.as_str().is_empty()
+        && globs.matches(relative.as_str())
+        && dir.join("package.json").is_file()
+    {
+        push_workspace(found, package_workspace(root, relative));
+    }
+
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(path) = Utf8PathBuf::from_path_buf(entry.path()) else {
+            continue;
+        };
+        if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            visit_package_workspace_root(root, &path, config, globs, found);
+        }
+    }
+}
+
+fn package_workspace(root: &Utf8Path, relative: &Utf8Path) -> Workspace {
+    let manifest_path = root.join(relative).join("package.json");
+    let name = package_name(&manifest_path).unwrap_or_else(|| {
+        relative
+            .file_name()
+            .unwrap_or(relative.as_str())
+            .to_compact_string()
+    });
+
+    Workspace {
+        name,
+        path: relative.to_path_buf(),
+    }
+}
+
+fn package_name(path: &Utf8Path) -> Option<CompactString> {
+    let source = fs::read_to_string(path).ok()?;
+    let manifest = serde_json::from_str::<Value>(&source).ok()?;
+    manifest
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToCompactString::to_compact_string)
+}
+
+struct WorkspaceGlobs {
+    include: GlobSet,
+    exclude: GlobSet,
+    roots: Vec<Utf8PathBuf>,
+    from_root: bool,
+}
+
+impl WorkspaceGlobs {
+    fn compile(patterns: &[String]) -> Option<Self> {
+        let mut include = GlobSetBuilder::new();
+        let mut exclude = GlobSetBuilder::new();
+        let mut roots = Vec::new();
+        let mut from_root = false;
+        let mut has_include = false;
+
+        for pattern in patterns {
+            let Some(pattern) = workspace_pattern(pattern) else {
+                continue;
+            };
+            let Ok(glob) = workspace_glob(pattern.body) else {
+                continue;
+            };
+            if pattern.include {
+                has_include = true;
+                include.add(glob);
+                match workspace_walk_root(pattern.body) {
+                    Some(root) => roots.push(root),
+                    None => from_root = true,
+                }
+            } else {
+                exclude.add(glob);
+            }
+        }
+        if !has_include {
+            return None;
+        }
+
+        roots.sort();
+        roots.dedup();
+        let mut kept: Vec<Utf8PathBuf> = Vec::with_capacity(roots.len());
+        for root in roots {
+            if kept.iter().any(|existing| root.starts_with(existing)) {
+                continue;
+            }
+            kept.push(root);
+        }
+
+        Some(Self {
+            include: include.build().ok()?,
+            exclude: exclude.build().ok()?,
+            roots: kept,
+            from_root,
+        })
+    }
+
+    fn matches(&self, path: &str) -> bool {
+        self.include.is_match(path) && !self.exclude.is_match(path)
+    }
+
+    fn walk_roots(&self) -> Vec<&Utf8Path> {
+        if self.from_root {
+            return vec![Utf8Path::new("")];
+        }
+        self.roots.iter().map(Utf8PathBuf::as_path).collect()
+    }
+}
+
+struct WorkspacePattern<'a> {
+    include: bool,
+    body: &'a str,
+}
+
+fn workspace_pattern(entry: &str) -> Option<WorkspacePattern<'_>> {
+    let entry = entry.trim();
+    if entry.is_empty() {
+        return None;
+    }
+    let (include, body) = entry
+        .strip_prefix('!')
+        .map_or((true, entry), |body| (false, body));
+    let body = body
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .trim_end_matches('/');
+    if body.is_empty() || body == "." || body.split('/').any(|segment| segment == "..") {
+        return None;
+    }
+    Some(WorkspacePattern { include, body })
+}
+
+fn workspace_glob(pattern: &str) -> Result<Glob, globset::Error> {
+    GlobBuilder::new(pattern)
+        .literal_separator(true)
+        .backslash_escape(true)
+        .build()
+}
+
+fn workspace_walk_root(pattern: &str) -> Option<Utf8PathBuf> {
+    let mut root = Utf8PathBuf::new();
+    for segment in pattern.split('/') {
+        if segment.is_empty() || has_glob_syntax(segment) {
+            break;
+        }
+        root.push(segment);
+    }
+    (!root.as_str().is_empty()).then_some(root)
+}
+
+fn has_glob_syntax(pattern: &str) -> bool {
+    pattern
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '[' | '{'))
 }
 
 /// The member `selector` names, or an error naming what was available.

--- a/crates/uf_project/src/workspace/tests.rs
+++ b/crates/uf_project/src/workspace/tests.rs
@@ -34,6 +34,83 @@ fn a_directory_with_its_own_config_is_a_member() {
     assert_eq!(names(&found), vec!["docs", "site"]);
 }
 
+#[test]
+fn package_json_workspaces_are_members_without_uf_config() {
+    let (_dir, root) = tree(&[]);
+    fs::write(
+        root.join("package.json"),
+        r#"{ "workspaces": ["packages/*"] }"#,
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("packages/app")).unwrap();
+    fs::write(
+        root.join("packages/app/package.json"),
+        r#"{ "name": "@demo/app" }"#,
+    )
+    .unwrap();
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(names(&found), vec!["@demo/app"]);
+    assert_eq!(found[0].path, "packages/app");
+}
+
+#[test]
+fn yarn_object_workspaces_are_members_too() {
+    let (_dir, root) = tree(&[]);
+    fs::write(
+        root.join("package.json"),
+        r#"{ "workspaces": { "packages": ["apps/*"], "nohoist": ["**"] } }"#,
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("apps/web")).unwrap();
+    fs::write(root.join("apps/web/package.json"), "{}").unwrap();
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(names(&found), vec!["web"]);
+    assert_eq!(found[0].path, "apps/web");
+}
+
+#[test]
+fn negated_package_workspace_patterns_are_excluded() {
+    let (_dir, root) = tree(&[]);
+    fs::write(
+        root.join("package.json"),
+        r#"{ "workspaces": ["packages/*", "!packages/private"] }"#,
+    )
+    .unwrap();
+    for package in ["packages/public", "packages/private"] {
+        fs::create_dir_all(root.join(package)).unwrap();
+        fs::write(root.join(package).join("package.json"), "{}").unwrap();
+    }
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(names(&found), vec!["public"]);
+}
+
+#[test]
+fn a_package_workspace_and_config_member_are_one_member() {
+    let (_dir, root) = tree(&["packages/app"]);
+    fs::write(
+        root.join("package.json"),
+        r#"{ "workspaces": ["packages/*"] }"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("packages/app/package.json"),
+        r#"{ "name": "@demo/app" }"#,
+    )
+    .unwrap();
+
+    let found = discover_workspaces(&root, &UniflowedConfig::default());
+
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].name, "@demo/app");
+    assert_eq!(found[0].path, "packages/app");
+}
+
 /// `uf dev` already means the root, so the root is not one of its own members.
 #[test]
 fn the_root_is_not_a_member_of_itself() {


### PR DESCRIPTION
## Summary
- discover workspace members from the root package.json `workspaces` field, including Yarn object form
- allow package workspaces without `uf.config.js`, using package.json#name when present and keeping path selectors working
- keep existing config-discovered members, dedupe by path, and reject workspace patterns that try to leave the project root

Part of #736.

## Verification
- `tools/upstream/sync.sh`
- `nix develop --command cargo fmt -p uf_project -p uf_cli`
- `nix develop --command cargo test -p uf_project --lib --profile ci workspace::tests`
- `nix develop --command cargo test -p uf_project --profile ci`
- `nix develop --command cargo check -p uf_cli --profile ci`
- `nix develop --command cargo clippy -p uf_project --profile ci -- -D warnings`
- `nix develop --command cargo clippy -p uf_cli --profile ci -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791710500&installation_model_id=422833&pr_number=777&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F777&signature=082dd7ca9aaaae8e07bbbafa0c724a7207e01fc9d714e2cfc7c9cc5f6c3456b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->