### PR TITLE
fix(check): prefer libdef declarations over package manifests

### DIFF
--- a/crates/uf_check/src/upstream/closure.rs
+++ b/crates/uf_check/src/upstream/closure.rs
@@ -45,11 +45,10 @@
 //! own library definitions do not describe. The second half of that matters as
 //! much as the first, because it is what the caller is expected to do about it:
 //! `uf check` reads `node_modules` for a bare specifier left here and adds what
-//! it finds to the batch. A file in the batch outranks a `declare module` —
-//! [`super::project::ProjectModules::resolve`] says why — so offering it
-//! `react` would replace Flow's own description of React with whatever
-//! JavaScript happens to be installed, and the answer would get worse rather
-//! than better. A package Flow describes is Flow's to describe.
+//! it finds to the batch. A package Flow describes is Flow's to describe: the
+//! walk must not add `react`, or a package a project's `flow-typed/` declares,
+//! because doing so would replace the declaration with whatever JavaScript
+//! happens to be installed and make the answer worse rather than better.
 
 use std::collections::BTreeSet;
 
@@ -115,8 +114,12 @@ pub(super) fn closure(
     while let Some(module) = frontier.pop() {
         let source = available[module];
         for specifier in requires(&source, options) {
-            let resolved = if resolve::is_relative(&specifier) {
+            let declared = declared(&specifier);
+            let relative = resolve::is_relative(&specifier);
+            let resolved = if relative {
                 index.resolve(source.path, &specifier)
+            } else if declared {
+                None
             } else {
                 // The manifest first, and whether or not the file it names is
                 // in the batch: a package that publishes a subpath this batch
@@ -136,7 +139,7 @@ pub(super) fn closure(
             };
             match resolved {
                 Some(target) => reach(target, &mut seen, &mut frontier),
-                None if !declared(&specifier) => {
+                None if !declared => {
                     unresolved.insert(UnresolvedImport {
                         specifier,
                         importer: source.path.to_compact_string(),
@@ -329,9 +332,8 @@ mod tests {
 
     #[test]
     fn a_specifier_a_libdef_declares_is_not_left_for_the_caller() {
-        // A file in the batch outranks a `declare module`, so a caller that
-        // went and found `react` on disk would replace Flow's description of
-        // it with whatever is installed.
+        // A caller that went and found `react` on disk would replace Flow's
+        // description of it with whatever is installed.
         let available = [Source::new("app.js", "import 'react';\nimport 'nope';\n")];
         let found = closure(
             &["app.js"],
@@ -347,6 +349,30 @@ mod tests {
                 importer: "app.js".into(),
             }]
         );
+    }
+
+    #[test]
+    fn a_declared_package_is_not_shadowed_by_a_manifest_in_the_batch() {
+        // `flow-typed` is how a project describes an untyped package. A
+        // vendored copy or workspace wrapper with the same package name must
+        // not change what a bare import means once the declaration exists.
+        let available = [
+            Source::new("app.js", "import 'editor-pkg';\n"),
+            Source::new("vendor/editor-pkg/index.js", "export const anything = 1;\n"),
+            Source::new(
+                "vendor/editor-pkg/package.json",
+                r#"{ "name": "editor-pkg", "main": "index.js" }"#,
+            ),
+        ];
+        let found = closure(
+            &["app.js"],
+            &available,
+            &options::options(&CheckLimits::default()),
+            &|specifier| specifier == "editor-pkg",
+        );
+
+        assert_eq!(found.reached, [0]);
+        assert!(found.unresolved.is_empty());
     }
 
     #[test]

--- a/crates/uf_check/src/upstream/graph.rs
+++ b/crates/uf_check/src/upstream/graph.rs
@@ -37,6 +37,7 @@ use compact_str::CompactString;
 use uf_profiler::profile_span;
 
 use super::project::ProjectModules;
+use super::resolve;
 use crate::cache::{CachedRequire, Digest, Fields, hex};
 
 /// What a check needs to know about one file before it checks anything.
@@ -206,16 +207,19 @@ impl<'a> Graph<'a> {
 
 /// What one specifier resolves to, by [`ProjectModules::resolve`]'s own order.
 ///
-/// A file in the batch outranks a `declare module`, and a file in the batch
-/// that cannot contribute a signature is not a resolution at all — both are
-/// upstream's rules, mirrored here rather than reimplemented, and the mirror is
-/// what a test would break if `project`'s order ever changed.
+/// A bare `declare module` outranks the package manifests in the batch, while
+/// relative modules still resolve to the batch before asset declarations. The
+/// order mirrors [`ProjectModules::resolve`] rather than reimplementing a
+/// separate answer to what one specifier means.
 fn resolve(
     modules: &ProjectModules,
     facts: &[ModuleFacts],
     importer: &str,
     require: &CachedRequire,
 ) -> Resolution {
+    if !resolve::is_relative(&require.specifier) && require.declared {
+        return Resolution::Declared;
+    }
     match modules.locate(importer, &require.specifier) {
         // Whether the target has a signature is read from the batch's facts
         // rather than asked of `ProjectModules`, which would pack one to find

--- a/crates/uf_check/src/upstream/project.rs
+++ b/crates/uf_check/src/upstream/project.rs
@@ -26,8 +26,8 @@
 //! | relative, names a source in the batch | that module's signature, as a typed module |
 //! | relative, names a source that cannot contribute a signature | an unchecked module, recorded |
 //! | relative, names nothing in the batch | an unchecked module, recorded |
-//! | bare, published by a `package.json` in the batch | that module's signature, as a typed module |
 //! | bare, declared by Flow's libdefs | that `declare module` block |
+//! | bare, published by a `package.json` in the batch | that module's signature, as a typed module |
 //! | bare, anything else | an unchecked module, recorded |
 //!
 //! A bare specifier is never resolved against the batch's *paths*, even when a
@@ -38,10 +38,11 @@
 //!
 //! # What is not resolved
 //!
-//! * **A package with no manifest in the batch.** `react` and everything else
+//! * **A package with no declaration and no manifest in the batch.** Anything
 //!   under `node_modules` is not a source `uf check` collects, so it stays
-//!   unchecked unless Flow's own library definitions declare it — and stays in
-//!   [`crate::CheckReport::untyped_modules`] when they do not.
+//!   unchecked unless Flow's own or the project's library definitions declare
+//!   it — and stays in [`crate::CheckReport::untyped_modules`] when they do
+//!   not.
 //! * **A directory's `package.json` `main`.** A *relative* specifier naming a
 //!   directory finds `./internal/index.js` and nothing else; only a specifier
 //!   that names a package goes through that package's manifest.
@@ -407,13 +408,11 @@ impl ProjectModules {
 
     /// What `specifier`, imported from `importer`, resolves to.
     ///
-    /// A file in the batch outranks a `declare module`, which is upstream's own
-    /// order: `check_service`'s `dep_module_t` only reaches for
-    /// `typed_builtin_module_opt` once the module system has failed to resolve
-    /// the specifier to a file. A workspace package that this project actually
-    /// contains is the module the runtime loads, so it is the module the
-    /// checker must type — a libdef that happened to share its name would be a
-    /// description of something else.
+    /// A bare package declared by Flow's or the project's library definitions
+    /// wins before the batch's package manifests. That is what makes a
+    /// hand-written `flow-typed/` libdef a description of an untyped
+    /// dependency rather than a hint that can be shadowed by a vendored copy
+    /// whose `package.json` publishes the same name.
     fn resolve(
         self: &Rc<Self>,
         cx: &Context<'static>,
@@ -441,15 +440,15 @@ impl ProjectModules {
             }
             return self.unchecked(cx, name);
         }
+        if let Some(module) = typed_builtin_module(cx, specifier) {
+            return ResolvedRequire::TypedModule(module);
+        }
         if let Some(index) = self.resolve_package(importer, name)
             && let Some(signature) = self.signature(index)
         {
             return ResolvedRequire::TypedModule(self.module_thunk(index, &signature));
         }
-        match typed_builtin_module(cx, specifier) {
-            Some(module) => ResolvedRequire::TypedModule(module),
-            None => self.unchecked(cx, name),
-        }
+        self.unchecked(cx, name)
     }
 
     /// The batch's source for a package specifier, through the manifest that

--- a/crates/uf_check/tests/libdefs.rs
+++ b/crates/uf_check/tests/libdefs.rs
@@ -57,6 +57,16 @@ fn codes(sources: &[Source<'_>], libs: &[Source<'_>]) -> Vec<String> {
         .collect()
 }
 
+fn inferred_codes(sources: &[Source<'_>], libs: &[Source<'_>]) -> Vec<String> {
+    check_sources(sources, libs, &limits())
+        .expect("the checker runs")
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.kind != uf_check::DiagnosticKind::Parse)
+        .map(|diagnostic| diagnostic.code.unwrap_or("<none>").to_owned())
+        .collect()
+}
+
 #[test]
 fn a_type_a_libdef_declares_is_a_type_and_not_an_any_typed_value() {
     let sources = [Source::new("src/Edge.js", USES_A_LIBDEF_TYPE)];
@@ -108,6 +118,42 @@ fn a_module_a_libdef_declares_is_not_reported_as_untyped() {
         "a module the project declared is not a hole: {:?}",
         with.untyped_modules
     );
+}
+
+#[test]
+fn a_libdef_declare_module_wins_over_a_project_manifest_with_the_same_name() {
+    // A vendored package or wrapper can publish the same name a libdef
+    // declares. In that case the declaration is the type surface the project
+    // asked for; the manifest should not shadow it and turn namespace members
+    // back into missing properties or any-typed values.
+    let sources = [
+        Source::new(
+            "src/probe.js",
+            "// @flow\nimport * as Editor from \"editor-pkg\";\n\
+             export const provider: Editor.languages.FoldingRangeProvider = { kind: \"x\" };\n",
+        ),
+        Source::new(
+            "vendor/editor-pkg/index.js",
+            "// @flow\nexport const anything: string = \"runtime\";\n",
+        ),
+        Source::new(
+            "vendor/editor-pkg/package.json",
+            r#"{ "name": "editor-pkg", "main": "index.js" }"#,
+        ),
+    ];
+    let libs = [Source::new(
+        "flow-typed/editor.js",
+        "// @flow\ndeclare module \"editor-pkg\" {\n  declare export namespace languages {\n    declare type FoldingRangeProvider = { kind: string };\n  }\n}\n",
+    )];
+
+    let without = inferred_codes(&sources, &[]);
+    assert!(
+        without.iter().any(|code| code == "prop-missing")
+            && without.iter().any(|code| code == "value-as-type"),
+        "the fixture must reproduce the manifest shadow before the libdef wins: {without:?}"
+    );
+
+    assert_eq!(inferred_codes(&sources, &libs), Vec::<String>::new());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make bare specifiers declared by Flow/project libdefs resolve to the declared module before package manifests in the batch
- keep closure and dependency graph resolution in the same order so scoped checks and cache keys agree
- add a regression for a `declare export namespace` libdef shadowed by a project package manifest

Fixes #699.

## Verification
- `tools/upstream/sync.sh`
- `nix develop --command cargo fmt -p uf_check`
- `nix develop --command cargo test -p uf_check --test libdefs --profile ci a_libdef_declare_module_wins_over_a_project_manifest_with_the_same_name -- --nocapture`
- `nix develop --command cargo test -p uf_check --lib --profile ci upstream::closure::tests::a_declared_package_is_not_shadowed_by_a_manifest_in_the_batch`
- `nix develop --command cargo test -p uf_check --profile ci`
- `nix develop --command cargo clippy -p uf_check --profile ci -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791712094&installation_model_id=422833&pr_number=778&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F778&signature=f6e8dbcee6848b06c5c046b6cef5787c46d5ccbdb84ed2b91f18bd5ad2384d39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->