### PR TITLE
feat(std): ship slice search helpers

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -243,13 +243,15 @@ pub fn std_modules() -> StdModuleList {
         // that one to the file.
         StdModule::declared("@uniflowed/std", StdCategory::Types),
         // ---------------------------------------------------------------
-        // What ships. ubugeeei-prod/uf#711, the first tranche.
+        // What ships. ubugeeei-prod/uf#711, the first tranche, plus the first
+        // slice-search piece of #710's next tranche.
         // ---------------------------------------------------------------
         //
         // Every list below is exactly what the file exports, and a test reads
-        // the file rather than trusting that. All six are pure Flow over
-        // `Uint8Array`, `TextEncoder`, `AbortController`, `Promise` and
-        // `setTimeout`: no `node:` import, no `Buffer`, no binding.
+        // the file rather than trusting that. The shipped modules are pure
+        // Flow over platform values such as `Uint8Array`, `TextEncoder`,
+        // `AbortController`, `Promise` and `setTimeout`: no `node:` import, no
+        // `Buffer`, no binding.
         StdModule::ships(
             "@uniflowed/std/errors",
             StdCategory::Diagnostics,
@@ -315,13 +317,18 @@ pub fn std_modules() -> StdModuleList {
                 "isValid",
             ],
         ),
+        StdModule::ships(
+            "@uniflowed/std/slices",
+            StdCategory::Data,
+            &["binarySearch", "binarySearchBy", "search"],
+        ),
         // ---------------------------------------------------------------
         // Planned: nobody has written it.
         // ---------------------------------------------------------------
         //
         // Read [`StdStatus::Planned`] before reading any of these. The exports
         // are the shape somebody imagined, they are checked by nothing, and
-        // being here is not a commitment that the module will exist. Four of
+        // being here is not a commitment that the module will exist. Three of
         // them are named in #710's next tranche and say so.
         StdModule::planned(
             "@uniflowed/std/vfs",

--- a/crates/uf_std/src/tests.rs
+++ b/crates/uf_std/src/tests.rs
@@ -51,7 +51,8 @@ fn std_registry_covers_requested_modules() {
     assert!(specifiers.contains(&"@uniflowed/std/zip"));
     assert!(specifiers.contains(&"@uniflowed/std/import-meta"));
     assert!(specifiers.contains(&"@uniflowed/std/defer"));
-    // The six of ubugeeei-prod/uf#711, named here as well as held to
+    // The six of ubugeeei-prod/uf#711 plus the first search helper from #710's
+    // next tranche, named here as well as held to
     // `packages/std` by `crates/uf_lib`: this list is what a reader checks
     // first, and a shipped module missing from it is the drift #710 is about.
     for shipped in [
@@ -61,6 +62,7 @@ fn std_registry_covers_requested_modules() {
         "@uniflowed/std/bytes",
         "@uniflowed/std/heap",
         "@uniflowed/std/hex",
+        "@uniflowed/std/slices",
     ] {
         let module = modules
             .iter()

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Six modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Seven modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -45,9 +45,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/bytes` | `bytes` | Searching, splitting and joining `Uint8Array`, plus `Builder` |
 | `@uniflowed/std/heap` | `container/heap` | A binary heap with a comparator |
 | `@uniflowed/std/hex` | `encoding/hex` | `encode`, `decode`, `isValid`, `dump` |
+| `@uniflowed/std/slices` | `sort.Search`, `slices.BinarySearch` | Lower-bound search and insertion points for sorted arrays |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these six are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these seven are.
 Everything above runs.
 
 ## The types are the point

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -21,9 +21,10 @@ export type StdCategory =
 /**
  * What a `@uniflowed/std` specifier is today.
  *
- * `"ships"` is the six subpaths of ubugeeei-prod/uf#711 — `errors`, `sync`,
- * `context`, `bytes`, `heap`, `hex` — each of which is real code behind its own
- * export path. `"declared"` is this module: functions that raise
+ * `"ships"` is the subpaths that have real code behind their own export paths:
+ * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
+ * `heap`, `hex` — and the `slices` search helper from #710's next tranche.
+ * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another
  * `@uniflowed/*` already answers it, or that no runtime-agnostic module can.

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -18,6 +18,7 @@
     "./errors": "./errors.js",
     "./heap": "./heap.js",
     "./hex": "./hex.js",
+    "./slices": "./slices.js",
     "./sync": "./sync.js",
     "./package.json": "./package.json"
   },
@@ -28,6 +29,7 @@
     "heap.js",
     "hex.js",
     "index.js",
+    "slices.js",
     "sync.js",
     "!*.test.js"
   ],

--- a/packages/std/slices.js
+++ b/packages/std/slices.js
@@ -1,0 +1,109 @@
+// @flow
+//
+// `@uniflowed/std/slices`: Go's `sort.Search` and `slices.BinarySearch`.
+//
+// JavaScript has a stable full sort and no binary search primitive. That gap is
+// small enough that people rewrite it at the call site, and large enough that
+// the rewritten version is often off by one at the insertion point, misses the
+// first duplicate, or silently overflows through `>> 1` on a large array.
+//
+// This module keeps the three useful facts together:
+//
+// * [`search`] is the generic monotone-predicate primitive from Go's
+//   `sort.Search`: first true index, or `length` when none is true.
+// * [`binarySearchBy`] is the lower-bound form: the comparator says how the
+//   item at `index` relates to the target value the caller has in mind.
+// * [`binarySearch`] is the ordinary "sorted array plus target" wrapper.
+//
+// All three return insertion points rather than `-1`. That is the useful
+// answer for sorted data: when a value is absent, the returned index is where it
+// belongs if the caller wants to insert it and keep the array sorted.
+
+/**
+ * Where a value is, or where it belongs.
+ *
+ * `found` is true when `index` names an existing item equal to the target. When
+ * it is false, `index` is the insertion point in the half-open range
+ * `[0, items.length]`.
+ */
+export type SearchResult = {
+  readonly index: number,
+  readonly found: boolean,
+};
+
+/**
+ * Compare two values for sorted order.
+ *
+ * Same contract as `Array.prototype.sort`: negative means `left` comes before
+ * `right`, positive means after, zero means equal.
+ */
+export type Compare<T> = (left: T, right: T) => number;
+
+/**
+ * Return the first index in `[0, length)` whose predicate is true.
+ *
+ * If the predicate is false everywhere, the answer is `length`. The predicate
+ * must be monotone — false for some prefix and true for the rest — which is the
+ * same precondition Go documents and the same precondition every binary search
+ * has. A non-monotone predicate still terminates, but the answer only describes
+ * the partition the predicate claimed to have.
+ */
+export function search(length: number, predicate: (index: number) => boolean): number {
+  assertSearchLength(length);
+
+  let low = 0;
+  let high = length;
+  while (low < high) {
+    // `Math.floor` rather than `>> 1`: bitwise operators coerce through signed
+    // 32-bit integers, which is exactly the overflow this helper exists to keep
+    // out of call sites.
+    const middle = low + Math.floor((high - low) / 2);
+    if (predicate(middle)) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
+}
+
+/**
+ * Binary-search a sorted array with a comparator against one captured target.
+ *
+ * The comparator receives an item and returns how it relates to the target:
+ * negative when the item is before it, positive when after it, zero when equal.
+ * The first equal item is returned, so duplicates behave like a lower bound.
+ */
+export function binarySearchBy<T>(
+  items: $ReadOnlyArray<T>,
+  compareItemToTarget: (item: T) => number,
+): SearchResult {
+  const index = search(items.length, (at) => compareItemToTarget(items[at]) >= 0);
+  const found = index < items.length && compareItemToTarget(items[index]) === 0;
+  return { index, found };
+}
+
+/**
+ * Binary-search a sorted array for `target`.
+ *
+ * `compare` is the same comparator the array was sorted with. If `target` is
+ * absent, the returned index is where it can be inserted without disturbing the
+ * order.
+ */
+export function binarySearch<T>(
+  items: $ReadOnlyArray<T>,
+  target: T,
+  compare: Compare<T>,
+): SearchResult {
+  return binarySearchBy(items, (item) => compare(item, target));
+}
+
+function assertSearchLength(length: number): void {
+  if (!Number.isSafeInteger(length) || length < 0) {
+    throw new RangeError(
+      `@uniflowed/std/slices: search length must be a non-negative safe integer, got ${String(
+        length,
+      )}`,
+    );
+  }
+}

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Six modules, and what is asserted here is the property that makes each one
+// Seven modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -52,6 +52,7 @@ import {
 import { as, chain, is, join as joinErrors, unwrap, wrap } from "@uniflowed/std/errors";
 import { Heap, heapify } from "@uniflowed/std/heap";
 import { InvalidHexError, decode, dump, encode, isValid } from "@uniflowed/std/hex";
+import { binarySearch, binarySearchBy, search } from "@uniflowed/std/slices";
 import { Group, Mutex, Semaphore, WaitGroup, once } from "@uniflowed/std/sync";
 
 import { everyMisuseIsReported } from "../../tests/library/type-tests.js";
@@ -880,6 +881,46 @@ describe("hex", () => {
   });
 });
 
+describe("slices", () => {
+  it("finds the first true index of a monotone predicate", () => {
+    expect(search(8, (index) => index >= 5)).toBe(5);
+    expect(search(8, () => false)).toBe(8);
+    expect(search(8, () => true)).toBe(0);
+  });
+
+  it("refuses a length that is not a searchable array bound", () => {
+    expect(() => search(-1, () => true)).toThrow(RangeError);
+    expect(() => search(1.5, () => true)).toThrow(RangeError);
+    expect(() => search(Number.MAX_SAFE_INTEGER + 1, () => true)).toThrow(RangeError);
+  });
+
+  it("finds the first equal item and otherwise returns the insertion point", () => {
+    const numbers = [1, 3, 3, 3, 7, 9];
+    expect(binarySearch(numbers, 3, (left, right) => left - right)).toEqual({
+      index: 1,
+      found: true,
+    });
+    expect(binarySearch(numbers, 6, (left, right) => left - right)).toEqual({
+      index: 4,
+      found: false,
+    });
+    expect(binarySearch(numbers, 12, (left, right) => left - right)).toEqual({
+      index: 6,
+      found: false,
+    });
+  });
+
+  it("searches objects through a captured target", () => {
+    const rows = [{ id: "a" }, { id: "c" }, { id: "f" }];
+    const wanted = "c";
+
+    expect(binarySearchBy(rows, (row) => row.id.localeCompare(wanted))).toEqual({
+      index: 1,
+      found: true,
+    });
+  });
+});
+
 describe("the types", () => {
   it("reports every misuse in tests/type-tests/std-inference.js", () => {
     // Running proves what the code does; only the checker can prove what a
@@ -917,7 +958,7 @@ describe("what ships is one list in three places", () => {
     return found.sort();
   };
 
-  it("is the same six in the registry and the package manifest", () => {
+  it("is the same shipped modules in the registry and the package manifest", () => {
     const manifest = JSON.parse(
       fs.readFileSync(path.join(REPO, "packages/std/package.json"), "utf8"),
     );
@@ -932,7 +973,7 @@ describe("what ships is one list in three places", () => {
     expect(ships()).toEqual(subpaths);
   });
 
-  it("is the same six the reference page's table names", () => {
+  it("is the same shipped modules the reference page's table names", () => {
     const page = fs.readFileSync(path.join(REPO, "docs/app/reference/std/$page.mdx"), "utf8");
     const start = page.indexOf("## What ships today");
     expect(start).toBeGreaterThan(-1);

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -33,6 +33,7 @@ import { background, key, withCancel, withTimeout, withValue } from "../../packa
 import { as, is, join, wrap } from "../../packages/std/errors.js";
 import { Heap, heapify } from "../../packages/std/heap.js";
 import { decode, encode } from "../../packages/std/hex.js";
+import { binarySearch, binarySearchBy, search } from "../../packages/std/slices.js";
 import { Group, Mutex, Semaphore, once } from "../../packages/std/sync.js";
 
 class HttpError extends Error {
@@ -162,6 +163,26 @@ export const encodeGivesText: Uint8Array = encode(left);
 // expect: string
 export const builderWritesBytes: mixed = new Builder().write("text");
 
+// --- slices -----------------------------------------------------------------
+
+// expect: number is incompatible with string
+export const searchAnswersAnIndex: string = search(4, (index) => index >= 2);
+
+// The sorted array decides the element type, not `any`.
+const sortedNumbers: $ReadOnlyArray<number> = [1, 3, 5];
+const compareNumbers = (left: number, right: number): number => left - right;
+const searchSortedNumbers = (target: number) => binarySearch(sortedNumbers, target, compareNumbers);
+const searchNumbers = binarySearch(sortedNumbers, 3, (left, right) => left - right);
+// expect: boolean is incompatible with number
+export const binarySearchFoundIsBoolean: number = searchNumbers.found;
+
+// expect: "3" is incompatible with number
+export const binarySearchTargetHasElementType: mixed = searchSortedNumbers("3");
+
+const searchRows = binarySearchBy([{ id: "a" }, { id: "b" }], (row) => row.id.localeCompare("b"));
+// expect: number is incompatible with string
+export const binarySearchByIndexIsNumber: string = searchRows.index;
+
 // --- what is *not* an error -------------------------------------------------
 //
 // Without these the fixture would pass just as happily on a package whose every
@@ -186,3 +207,11 @@ export const bytesCompare: -1 | 0 | 1 = compare(left, left);
 export const bytesSplit: $ReadOnlyArray<Uint8Array> = split(left, left);
 export const hexEncodes: string = encode(left);
 export const hexDecodes: Uint8Array = decode("dead");
+export const searchIndex: number = search(4, (index) => index >= 2);
+export const binarySearchResult: { readonly index: number, readonly found: boolean } = binarySearch(
+  sortedNumbers,
+  3,
+  (left, right) => left - right,
+);
+export const binarySearchByResult: { readonly index: number, readonly found: boolean } =
+  binarySearchBy([{ id: "a" }, { id: "b" }], (row) => row.id.localeCompare("b"));


### PR DESCRIPTION
## Summary
- add @uniflowed/std/slices with search, binarySearchBy, and binarySearch
- wire the module through package exports, std registry, docs, and type fixtures
- cover lower-bound duplicate/insertion behavior plus Flow misuse diagnostics

Part of #710.

## Verification
- nix develop --command target/ci/uf test packages/std/std.test.js
- nix develop --command target/ci/uf fmt --check packages/std/slices.js packages/std/std.test.js tests/type-tests/std-inference.js 'docs/app/reference/std/.mdx' packages/std/index.js packages/std/package.json
- nix develop --command cargo test -p uf_std --profile ci
- nix develop --command cargo test -p uf_lib --profile ci the_std_registry_names_exactly_what_the_std_package_exports -- --nocapture
- nix develop --command cargo test -p uf_lib --test package_surface --profile ci -- --nocapture
- nix develop --command cargo clippy -p uf_std -p uf_lib --profile ci -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791714295&installation_model_id=422833&pr_number=779&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F779&signature=d00e7b1cf324be6ed3a0d2041fa14494c9c47ab245b9fdeedb086731153e8fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `@uniflowed/std/slices` module.
  - Added `search`, `binarySearch`, and `binarySearchBy` helpers for locating items or insertion points in sorted arrays.
  - Search results include the matching index and whether a match was found.

- **Documentation**
  - Updated the standard library reference to include the new slices module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->