### PR TITLE
feat(std): ship base32 codec

### DIFF
--- a/crates/uf_lib/tests/package_surface.rs
+++ b/crates/uf_lib/tests/package_surface.rs
@@ -1535,7 +1535,7 @@ fn every_advertised_module_resolves_to_a_package() {
         }
     }
 
-    // The std subpaths are six of these, and naming the number is how a
+    // The std subpaths are part of this set, and checking one of them is how a
     // regression that quietly stops walking them shows up as a failure rather
     // than as a shorter green run.
     assert!(
@@ -1609,12 +1609,12 @@ fn a_shipping_std_module_is_the_one_that_runs() {
 ///
 /// The flag used to be set by the constructor for all forty-five entries, which
 /// made it a claim about `@uniflowed/std/net` — `TcpListener`, `UdpSocket` — as
-/// loudly as about the six modules somebody wrote. It now means "this file was
-/// read and it imports no host", and this is the reading:
-/// `docs/app/reference/std` says of the six that "nothing here imports `node:`
-/// anything, touches `Buffer`, or reads `process`", and that claim is the
-/// difference between a module that runs on Deno and the edge and one that has
-/// only ever been run on Node.
+/// loudly as about modules somebody wrote. It now means "this file was read and
+/// it imports no host", and this is the reading: `docs/app/reference/std` says
+/// of the shipped modules that nothing here imports `node:` anything, touches
+/// `Buffer`, or reads `process`, and that claim is the difference between a
+/// module that runs on Deno and the edge and one that has only ever been run on
+/// Node.
 ///
 /// `code_only` first, so that `bytes.js`'s note about Go's `bytes.Buffer` and
 /// `hex.js`'s benchmark against Node's native `Buffer` stay what they are:

--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -54,20 +54,18 @@
 //!   subpath could be advertised with nothing behind it and every check in the
 //!   repository stayed green.
 //!
-//! And in `tests/library/std.test.js`, the one no cargo test can do: the six
+//! And in `tests/library/std.test.js`, the one no cargo test can do: the
 //! specifiers here, `package.json#exports`, and the table in
 //! `docs/app/reference/std` are one list in three places.
 //!
 //! # What `Planned` does not mean
 //!
 //! It means "nobody has written it", and nothing else. It is not a promise and
-//! the number of them is not a roadmap: #710's next tranche — `io`, `bufio`,
-//! `encoding/csv`, `encoding/binary`, `hash/crc32`, `slices.BinarySearch`,
-//! `encoding/base32`, `container/list`, `time` durations, `path/filepath`,
-//! `archive/zip` — is a checklist in that issue, and no row was added here for
-//! any of it. A specifier in this table is a name uf advertises, and
-//! advertising eleven more names nobody has written is the failure the status
-//! field exists to end, not a use for it.
+//! the number of them is not a roadmap: #710's next tranche is a checklist in
+//! that issue, and a row moves out of this idea-space only when the package has
+//! real code and an export path for it. A specifier in this table is a name uf
+//! advertises, and advertising names nobody has written is the failure the
+//! status field exists to end, not a use for it.
 
 use compact_str::{CompactString, ToCompactString};
 use serde::{Deserialize, Serialize};
@@ -236,7 +234,7 @@ pub fn std_modules() -> StdModuleList {
         //
         // `packages/std/index.js` is 274 lines of functions that raise
         // `NativeRuntimeRequiredError`, and it is deliberately still that: the
-        // six modules below are separate subpaths so that importing a hex
+        // shipped modules below are separate subpaths so that importing a hex
         // codec brings in a hex codec. Its export list is not repeated here —
         // `uf_lib::builtin_modules()` carries it, and
         // `the_registry_names_exactly_what_each_package_exports` already holds
@@ -244,7 +242,7 @@ pub fn std_modules() -> StdModuleList {
         StdModule::declared("@uniflowed/std", StdCategory::Types),
         // ---------------------------------------------------------------
         // What ships. ubugeeei-prod/uf#711, the first tranche, plus the first
-        // slice-search piece of #710's next tranche.
+        // next-tranche pieces from ubugeeei-prod/uf#710.
         // ---------------------------------------------------------------
         //
         // Every list below is exactly what the file exports, and a test reads
@@ -312,6 +310,18 @@ pub fn std_modules() -> StdModuleList {
                 "decode",
                 "decodedLength",
                 "dump",
+                "encode",
+                "encodedLength",
+                "isValid",
+            ],
+        ),
+        StdModule::ships(
+            "@uniflowed/std/base32",
+            StdCategory::Data,
+            &[
+                "InvalidBase32Error",
+                "decode",
+                "decodedLength",
                 "encode",
                 "encodedLength",
                 "isValid",

--- a/crates/uf_std/src/tests.rs
+++ b/crates/uf_std/src/tests.rs
@@ -51,8 +51,8 @@ fn std_registry_covers_requested_modules() {
     assert!(specifiers.contains(&"@uniflowed/std/zip"));
     assert!(specifiers.contains(&"@uniflowed/std/import-meta"));
     assert!(specifiers.contains(&"@uniflowed/std/defer"));
-    // The six of ubugeeei-prod/uf#711 plus the first search helper from #710's
-    // next tranche, named here as well as held to
+    // The six of ubugeeei-prod/uf#711 plus the first helpers from #710's next
+    // tranche, named here as well as held to
     // `packages/std` by `crates/uf_lib`: this list is what a reader checks
     // first, and a shipped module missing from it is the drift #710 is about.
     for shipped in [
@@ -62,6 +62,7 @@ fn std_registry_covers_requested_modules() {
         "@uniflowed/std/bytes",
         "@uniflowed/std/heap",
         "@uniflowed/std/hex",
+        "@uniflowed/std/base32",
         "@uniflowed/std/slices",
     ] {
         let module = modules

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Seven modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Eight modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -45,10 +45,11 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/bytes` | `bytes` | Searching, splitting and joining `Uint8Array`, plus `Builder` |
 | `@uniflowed/std/heap` | `container/heap` | A binary heap with a comparator |
 | `@uniflowed/std/hex` | `encoding/hex` | `encode`, `decode`, `isValid`, `dump` |
+| `@uniflowed/std/base32` | `encoding/base32` | RFC 4648 base32 for byte strings and human-entered secrets |
 | `@uniflowed/std/slices` | `sort.Search`, `slices.BinarySearch` | Lower-bound search and insertion points for sorted arrays |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these seven are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these eight are.
 Everything above runs.
 
 ## The types are the point
@@ -95,8 +96,8 @@ Everything here is pure Flow over the web platform: `Uint8Array`,
 
 | Host | Status | How that was established |
 | --- | --- | --- |
-| Node.js | **runs** | The suite: 61 assertions over all six modules, in `packages/std/std.test.js` |
-| Bun 1.3.13 | **runs** | Eighteen smoke assertions over all six, by hand, through `@uniflowed/host/bun-preload` |
+| Node.js | **runs** | `packages/std/std.test.js`, over every shipped module |
+| Bun 1.3.13 | **runs** | Eighteen smoke assertions over the first six, by hand, through `@uniflowed/host/bun-preload` |
 | Deno | expected | Not run. Inference from the API surface, below |
 | Edge / workers | expected | Not run. Same |
 
@@ -113,7 +114,7 @@ not a test.
 ## Why this is JavaScript and not Rust
 
 uf is a native toolchain, so "should this be native" is a fair question for
-every module. It was measured rather than guessed, and the answer for these six
+every module. It was measured rather than guessed, and the answer for these modules
 is no.
 
 The comparison is against Node's own C++ implementations of the same
@@ -214,8 +215,8 @@ on them rather than replacing them.
 
 ### Missing, and worth having
 
-The six at the top of this page are the first tranche. The next one, roughly in
-order of value:
+The first six at the top of this page are tranche 1. `slices` and `base32` are
+the first next-tranche pieces. What remains, roughly in order of value:
 
 | Go | What it would be |
 | --- | --- |
@@ -224,8 +225,6 @@ order of value:
 | `encoding/csv` | RFC 4180, reading and writing. Every hand-rolled `split(",")` is wrong on quoted fields |
 | `encoding/binary` | `getUint16`/`putUint32`/… over a cursor, and **varint**, which `DataView` does not have |
 | `hash/crc32`, `hash/fnv`, `hash/adler32` | WebCrypto has none of them. The strongest native candidate on this list, because CRC32 has a hardware instruction — so measure it before writing the JavaScript |
-| `slices.BinarySearch`, `sort.Search` | Binary search with a comparator: four lines that are wrong in half the places they are written |
-| `encoding/base32` | `atob` covers base64 and nothing covers base32, which is what TOTP secrets are in |
 | `container/list` | A doubly linked list, for LRU caches and anything that splices from the middle |
 | `time` durations and tickers | A `Duration` with the arithmetic, `Ticker`, `Timer`, `AfterFunc`, and the leak-free cancellation `context` already had to solve once |
 | `path/filepath` | `join`, `clean`, `rel`, `ext`, `base`, `dir`, and a real glob matcher |

--- a/packages/std/base32.js
+++ b/packages/std/base32.js
@@ -1,0 +1,261 @@
+// @flow
+//
+// `@uniflowed/std/base32`: Go's `encoding/base32`.
+//
+// Base32 is the alphabet people reach for when a byte string has to be copied
+// by a human: TOTP secrets, recovery tokens, DNS labels, storage keys. The web
+// platform has base64 in several shapes and no base32 at all, so every project
+// that needs it either ships a dependency for one loop or writes the loop
+// inline.
+//
+// This module implements RFC 4648's standard alphabet:
+// `A-Z` and `2-7`. Encoding produces uppercase. Decoding accepts uppercase and
+// lowercase, with or without `=` padding, because secrets are often printed
+// without padding and often pasted in lowercase. It does not accept separators
+// or whitespace; a caller that wants to group text for display should remove
+// the groups before decoding, at the boundary where that policy belongs.
+
+/** Whether encoded output should include RFC 4648 `=` padding. */
+export type Base32Padding = "include" | "omit";
+
+/** Options for [`encode`] and [`encodedLength`]. */
+export type Base32EncodeOptions = {
+  readonly padding?: Base32Padding,
+};
+
+/**
+ * A base32 string that could not be decoded.
+ *
+ * `offset` points at the byte in the input that made decoding impossible: the
+ * invalid character, the first padding character that appears in the wrong
+ * place, or the final character when the text length cannot name whole bytes.
+ */
+export class InvalidBase32Error extends Error {
+  offset: number;
+
+  constructor(message: string, offset: number) {
+    super(message);
+    this.name = "InvalidBase32Error";
+    this.offset = offset;
+  }
+}
+
+/** How many characters `n` bytes encode to. */
+export function encodedLength(n: number, options?: Base32EncodeOptions): number {
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new RangeError(
+      `@uniflowed/std/base32: byte length must be a non-negative safe integer, got ${String(n)}`,
+    );
+  }
+  if (n === 0) {
+    return 0;
+  }
+  const unpadded = Math.ceil((n * 8) / 5);
+  return options?.padding === "omit" ? unpadded : Math.ceil(unpadded / 8) * 8;
+}
+
+/** The maximum number of bytes `n` base32 characters can decode to. */
+export function decodedLength(n: number): number {
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new RangeError(
+      `@uniflowed/std/base32: text length must be a non-negative safe integer, got ${String(n)}`,
+    );
+  }
+  return Math.floor((n * 5) / 8);
+}
+
+/**
+ * Encode bytes as RFC 4648 base32.
+ *
+ * Padding is included by default, matching Go's `base32.StdEncoding`. Pass
+ * `{ padding: "omit" }` for TOTP-style secrets.
+ */
+export function encode(bytes: Uint8Array, options?: Base32EncodeOptions): string {
+  if (bytes.length === 0) {
+    return "";
+  }
+
+  const out = new Array<string>(encodedLength(bytes.length, options));
+  let written = 0;
+  let buffer = 0;
+  let bits = 0;
+
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out[written] = ALPHABET[(buffer >> bits) & 31];
+      written += 1;
+      buffer &= mask(bits);
+    }
+  }
+  if (bits > 0) {
+    out[written] = ALPHABET[(buffer << (5 - bits)) & 31];
+    written += 1;
+  }
+  if (options?.padding !== "omit") {
+    while (written < out.length) {
+      out[written] = "=";
+      written += 1;
+    }
+  }
+  return out.join("");
+}
+
+/**
+ * Decode RFC 4648 base32 text.
+ *
+ * Padded and unpadded text are accepted. The alphabet is case-insensitive; any
+ * other character, misplaced padding, impossible length, or non-zero trailing
+ * padding bit raises [`InvalidBase32Error`].
+ */
+export function decode(text: string): Uint8Array {
+  const bodyEnd = paddingStart(text);
+  const padding = text.length - bodyEnd;
+  if (padding > 0) {
+    validatePadding(text, bodyEnd, padding);
+  }
+  validateRemainder(bodyEnd, text.length === 0 ? 0 : Math.max(0, bodyEnd - 1));
+
+  const table = values();
+  const out = new Uint8Array(decodedLength(bodyEnd));
+  let written = 0;
+  let buffer = 0;
+  let bits = 0;
+
+  for (let index = 0; index < bodyEnd; index += 1) {
+    const value = digit(table, text.charCodeAt(index));
+    if (value < 0) {
+      throw invalid(text, index);
+    }
+    buffer = (buffer << 5) | value;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      out[written] = (buffer >> bits) & 0xff;
+      written += 1;
+      buffer &= mask(bits);
+    }
+  }
+  if (bits > 0 && buffer !== 0) {
+    throw new InvalidBase32Error("@uniflowed/std/base32: non-zero trailing bits", bodyEnd - 1);
+  }
+  return out;
+}
+
+/** Whether `text` would decode. */
+export function isValid(text: string): boolean {
+  try {
+    decode(text);
+    return true;
+  } catch (failure) {
+    if (failure instanceof InvalidBase32Error) {
+      return false;
+    }
+    throw failure;
+  }
+}
+
+/** Where padding starts, or `text.length` when there is none. */
+function paddingStart(text: string): number {
+  const first = text.indexOf("=");
+  return first < 0 ? text.length : first;
+}
+
+/** Check that every character after the first `=` is padding and in the right count. */
+function validatePadding(text: string, bodyEnd: number, padding: number): void {
+  for (let index = bodyEnd; index < text.length; index += 1) {
+    if (text[index] !== "=") {
+      throw invalid(text, index);
+    }
+  }
+  if (text.length % 8 !== 0) {
+    throw new InvalidBase32Error(
+      "@uniflowed/std/base32: padded input length must be a multiple of 8",
+      bodyEnd,
+    );
+  }
+  const expected = expectedPadding(bodyEnd % 8);
+  if (expected < 0) {
+    throw new InvalidBase32Error("@uniflowed/std/base32: invalid encoded length", bodyEnd - 1);
+  }
+  if (expected !== padding) {
+    throw new InvalidBase32Error(
+      `@uniflowed/std/base32: invalid padding, expected ${String(expected)} characters`,
+      bodyEnd,
+    );
+  }
+}
+
+/** How much padding a body remainder requires. */
+function expectedPadding(remainder: number): number {
+  switch (remainder) {
+    case 0:
+      return 0;
+    case 2:
+      return 6;
+    case 4:
+      return 4;
+    case 5:
+      return 3;
+    case 7:
+      return 1;
+    default:
+      return -1;
+  }
+}
+
+/** Check that a padding-free body length can name whole bytes. */
+function validateRemainder(length: number, offset: number): void {
+  if (expectedPadding(length % 8) < 0) {
+    throw new InvalidBase32Error("@uniflowed/std/base32: invalid encoded length", offset);
+  }
+}
+
+/** Look up one base32 digit. */
+function digit(table: Int16Array, code: number): number {
+  return code < table.length ? table[code] : -1;
+}
+
+/** Build the ASCII lookup table lazily. */
+function values(): Int16Array {
+  const built = VALUES;
+  if (built != null) {
+    return built;
+  }
+  const table = new Int16Array(128);
+  table.fill(-1);
+  for (let value = 0; value < ALPHABET.length; value += 1) {
+    const upper = ALPHABET.charCodeAt(value);
+    table[upper] = value;
+    const lower = lowerAscii(upper);
+    if (lower !== upper) {
+      table[lower] = value;
+    }
+  }
+  VALUES = table;
+  return table;
+}
+
+/** ASCII lowercase for the letters in the alphabet. */
+function lowerAscii(code: number): number {
+  return code >= 0x41 && code <= 0x5a ? code + 0x20 : code;
+}
+
+/** A mask with `bits` low bits set. */
+function mask(bits: number): number {
+  return bits === 0 ? 0 : (1 << bits) - 1;
+}
+
+/** A consistent invalid-character error. */
+function invalid(text: string, offset: number): InvalidBase32Error {
+  return new InvalidBase32Error(
+    `@uniflowed/std/base32: invalid character ${JSON.stringify(text[offset] ?? "")} at offset ${String(offset)}`,
+    offset,
+  );
+}
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+let VALUES: Int16Array | null = null;

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -23,7 +23,7 @@ export type StdCategory =
  *
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
- * `heap`, `hex` — and the `slices` search helper from #710's next tranche.
+ * `heap`, `hex` — plus `slices` and `base32` from #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -13,6 +13,7 @@
   },
   "exports": {
     ".": "./index.js",
+    "./base32": "./base32.js",
     "./bytes": "./bytes.js",
     "./context": "./context.js",
     "./errors": "./errors.js",
@@ -23,6 +24,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "base32.js",
     "bytes.js",
     "context.js",
     "errors.js",

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Seven modules, and what is asserted here is the property that makes each one
+// Eight modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -38,6 +38,14 @@ import {
   trimPrefix,
   trimSuffix,
 } from "@uniflowed/std/bytes";
+import {
+  InvalidBase32Error,
+  decode as decodeBase32,
+  decodedLength as decodedBase32Length,
+  encode as encodeBase32,
+  encodedLength as encodedBase32Length,
+  isValid as isValidBase32,
+} from "@uniflowed/std/base32";
 import {
   CANCELLED,
   DEADLINE_EXCEEDED,
@@ -881,6 +889,54 @@ describe("hex", () => {
   });
 });
 
+describe("base32", () => {
+  it("round-trips the RFC 4648 test vectors", () => {
+    const vectors = [
+      ["", ""],
+      ["f", "MY======"],
+      ["fo", "MZXQ===="],
+      ["foo", "MZXW6==="],
+      ["foob", "MZXW6YQ="],
+      ["fooba", "MZXW6YTB"],
+      ["foobar", "MZXW6YTBOI======"],
+    ];
+    for (const [plain, encoded] of vectors) {
+      const bytes = fromUtf8(plain);
+      expect(encodeBase32(bytes)).toBe(encoded);
+      expect(toUtf8(decodeBase32(encoded))).toBe(plain);
+    }
+  });
+
+  it("encodes without padding when a caller asks for the TOTP shape", () => {
+    expect(encodeBase32(fromUtf8("foobar"), { padding: "omit" })).toBe("MZXW6YTBOI");
+    expect(encodedBase32Length(6, { padding: "omit" })).toBe(10);
+    expect(encodedBase32Length(6)).toBe(16);
+    expect(decodedBase32Length(10)).toBe(6);
+  });
+
+  it("accepts unpadded lowercase input", () => {
+    expect(toUtf8(decodeBase32("mzxw6ytboi"))).toBe("foobar");
+    expect(isValidBase32("mzxw6ytboi")).toBe(true);
+  });
+
+  it("names invalid characters and padding by offset", () => {
+    expect(() => decodeBase32("M!======")).toThrow(InvalidBase32Error);
+    let offset = -1;
+    try {
+      decodeBase32("M!======");
+    } catch (failure) {
+      expect(failure).toBeInstanceOf(InvalidBase32Error);
+      if (failure instanceof InvalidBase32Error) {
+        offset = failure.offset;
+      }
+    }
+    expect(offset).toBe(1);
+
+    expect(() => decodeBase32("MZX=6===")).toThrow(InvalidBase32Error);
+    expect(isValidBase32("MZ======")).toBe(false);
+  });
+});
+
 describe("slices", () => {
   it("finds the first true index of a monotone predicate", () => {
     expect(search(8, (index) => index >= 5)).toBe(5);
@@ -938,7 +994,7 @@ describe("what ships is one list in three places", () => {
   // what a program can import, and `docs/app/reference/std` is what a reader is
   // told. Three copies of one fact, and until ubugeeei-prod/uf#710 nothing
   // compared any two of them: the registry named forty-four subpaths, none of
-  // which existed, and none of the six that do.
+  // which existed, and none of the shipped modules that do.
   //
   // The Rust side of the check is in `crates/uf_lib` — it parses each module
   // with uf's own Flow parser and holds the export lists name for name, which
@@ -984,7 +1040,7 @@ describe("what ships is one list in three places", () => {
     const table = page.slice(start, end === -1 ? page.length : end);
 
     const documented = [];
-    for (const match of table.matchAll(/`(@uniflowed\/std\/[a-z-]+)`/g)) {
+    for (const match of table.matchAll(/`(@uniflowed\/std\/[a-z0-9-]+)`/g)) {
       if (!documented.includes(match[1])) documented.push(match[1]);
     }
     expect(documented.sort()).toEqual(ships());

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -2,7 +2,7 @@
 //
 // What `@uniflowed/std` infers, and the test that says so.
 //
-// This file is *supposed* to fail `uf check`. The claim these six modules make
+// This file is *supposed* to fail `uf check`. The claim these modules make
 // is that a generic container, a typed error walk and a typed context key all
 // come back at the type the *call site* implies, with nothing annotated and no
 // `any` underneath — and a claim about inference cannot be proved by running
@@ -28,6 +28,7 @@
 // `tests/type-tests/anchoring.js` says the rest of why these fixtures live here
 // rather than inside the packages they are about.
 
+import { decode as decodeBase32, encode as encodeBase32 } from "../../packages/std/base32.js";
 import { Builder, compare, equal, split } from "../../packages/std/bytes.js";
 import { background, key, withCancel, withTimeout, withValue } from "../../packages/std/context.js";
 import { as, is, join, wrap } from "../../packages/std/errors.js";
@@ -139,7 +140,7 @@ const rows = new Group<number>();
 // expect: "not a number" is incompatible with number
 export const groupTakesItsElement: mixed = rows.go(() => "not a number");
 
-// --- bytes and hex ----------------------------------------------------------
+// --- bytes and encodings ----------------------------------------------------
 
 const left = new Uint8Array(2);
 
@@ -158,6 +159,12 @@ export const decodeGivesBytes: string = decode("dead");
 
 // expect: string, a primitive, cannot be used as a subtype of Uint8Array
 export const encodeGivesText: Uint8Array = encode(left);
+
+// expect: Uint8Array
+export const base32DecodeGivesBytes: string = decodeBase32("MY======");
+
+// expect: string, a primitive, cannot be used as a subtype of Uint8Array
+export const base32EncodeGivesText: Uint8Array = encodeBase32(left);
 
 // A builder writes bytes; a string is the other method.
 // expect: string
@@ -207,6 +214,8 @@ export const bytesCompare: -1 | 0 | 1 = compare(left, left);
 export const bytesSplit: $ReadOnlyArray<Uint8Array> = split(left, left);
 export const hexEncodes: string = encode(left);
 export const hexDecodes: Uint8Array = decode("dead");
+export const base32Encodes: string = encodeBase32(left);
+export const base32Decodes: Uint8Array = decodeBase32("MY======");
 export const searchIndex: number = search(4, (index) => index >= 2);
 export const binarySearchResult: { readonly index: number, readonly found: boolean } = binarySearch(
   sortedNumbers,


### PR DESCRIPTION
Part of #710.

## Summary
- add `@uniflowed/std/base32` with RFC 4648 encode/decode helpers, padding control, validity checks, and typed errors
- publish the subpath through `packages/std` exports/files and register it as a shipped std module
- extend std docs, type inference coverage, package-surface checks, and runtime tests

## Verification
- `/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target/ci-opt/uf fmt --check packages/std/base32.js packages/std/std.test.js tests/type-tests/std-inference.js docs/app/reference/std/$page.mdx packages/std/index.js packages/std/package.json`
- `UF_PROJECT_ROOT=. /Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target/ci-opt/uf test packages/std/std.test.js`
- `nix develop --command cargo fmt --all -- --check`
- `nix develop --command env CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target cargo test -p uf_std -p uf_lib --profile ci`
- `nix develop --command env CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target cargo clippy -p uf_std -p uf_lib --all-targets --all-features --profile ci -- -D warnings`
- `git diff --check`
- `npm pack --workspace @uniflowed/std --json --dry-run`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791716701&installation_model_id=422833&pr_number=780&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F780&signature=aecf7ba145199695b2c305f90d3b27ad18bc548bc807afb32879d2bfba6d8318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->