### PR TITLE
feat(std): ship list container

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -241,7 +241,7 @@ pub fn std_modules() -> StdModuleList {
         // that one to the file.
         StdModule::declared("@uniflowed/std", StdCategory::Types),
         // ---------------------------------------------------------------
-        // What ships. ubugeeei-prod/uf#711, the first tranche, plus the first
+        // What ships. ubugeeei-prod/uf#711, the first tranche, plus
         // next-tranche pieces from ubugeeei-prod/uf#710.
         // ---------------------------------------------------------------
         //
@@ -331,6 +331,11 @@ pub fn std_modules() -> StdModuleList {
             "@uniflowed/std/slices",
             StdCategory::Data,
             &["binarySearch", "binarySearchBy", "search"],
+        ),
+        StdModule::ships(
+            "@uniflowed/std/list",
+            StdCategory::Data,
+            &["Element", "List"],
         ),
         // ---------------------------------------------------------------
         // Planned: nobody has written it.

--- a/crates/uf_std/src/tests.rs
+++ b/crates/uf_std/src/tests.rs
@@ -51,8 +51,8 @@ fn std_registry_covers_requested_modules() {
     assert!(specifiers.contains(&"@uniflowed/std/zip"));
     assert!(specifiers.contains(&"@uniflowed/std/import-meta"));
     assert!(specifiers.contains(&"@uniflowed/std/defer"));
-    // The six of ubugeeei-prod/uf#711 plus the first helpers from #710's next
-    // tranche, named here as well as held to
+    // The six of ubugeeei-prod/uf#711 plus helpers from #710's next tranche,
+    // named here as well as held to
     // `packages/std` by `crates/uf_lib`: this list is what a reader checks
     // first, and a shipped module missing from it is the drift #710 is about.
     for shipped in [
@@ -64,6 +64,7 @@ fn std_registry_covers_requested_modules() {
         "@uniflowed/std/hex",
         "@uniflowed/std/base32",
         "@uniflowed/std/slices",
+        "@uniflowed/std/list",
     ] {
         let module = modules
             .iter()

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Eight modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Nine modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -47,9 +47,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/hex` | `encoding/hex` | `encode`, `decode`, `isValid`, `dump` |
 | `@uniflowed/std/base32` | `encoding/base32` | RFC 4648 base32 for byte strings and human-entered secrets |
 | `@uniflowed/std/slices` | `sort.Search`, `slices.BinarySearch` | Lower-bound search and insertion points for sorted arrays |
+| `@uniflowed/std/list` | `container/list` | A doubly linked list with stable element handles |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these eight are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these nine are.
 Everything above runs.
 
 ## The types are the point
@@ -215,8 +216,9 @@ on them rather than replacing them.
 
 ### Missing, and worth having
 
-The first six at the top of this page are tranche 1. `slices` and `base32` are
-the first next-tranche pieces. What remains, roughly in order of value:
+The first six at the top of this page are tranche 1. `slices`, `base32` and
+`list` are the first next-tranche pieces. What remains, roughly in order of
+value:
 
 | Go | What it would be |
 | --- | --- |
@@ -225,7 +227,6 @@ the first next-tranche pieces. What remains, roughly in order of value:
 | `encoding/csv` | RFC 4180, reading and writing. Every hand-rolled `split(",")` is wrong on quoted fields |
 | `encoding/binary` | `getUint16`/`putUint32`/… over a cursor, and **varint**, which `DataView` does not have |
 | `hash/crc32`, `hash/fnv`, `hash/adler32` | WebCrypto has none of them. The strongest native candidate on this list, because CRC32 has a hardware instruction — so measure it before writing the JavaScript |
-| `container/list` | A doubly linked list, for LRU caches and anything that splices from the middle |
 | `time` durations and tickers | A `Duration` with the arithmetic, `Ticker`, `Timer`, `AfterFunc`, and the leak-free cancellation `context` already had to solve once |
 | `path/filepath` | `join`, `clean`, `rel`, `ext`, `base`, `dir`, and a real glob matcher |
 | `archive/zip`, `archive/tar` | Reading, at least. The compression half is `DecompressionStream`; the container format is not |

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -23,7 +23,7 @@ export type StdCategory =
  *
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
- * `heap`, `hex` — plus `slices` and `base32` from #710's next tranche.
+ * `heap`, `hex` — plus `slices`, `base32` and `list` from #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/list.js
+++ b/packages/std/list.js
@@ -1,0 +1,267 @@
+// @flow
+//
+// `@uniflowed/std/list`: Go's `container/list`, with stable element handles.
+//
+// JavaScript arrays are a good default container, but they make one specific
+// workload expensive: "I already know the item, now move it to the front" is
+// `O(n)` because the array has to find it and then shift everything between the
+// old and new positions. That is the hot path of an LRU cache, a scheduler that
+// reprioritises existing work, and any queue that splices from the middle.
+//
+// This module is the small linked-list primitive for that case. A `List` gives
+// back an `Element` when a value is inserted, and that element stays a handle to
+// its node until it is removed. Moving or removing by handle is `O(1)`.
+//
+// # Handles belong to one list
+//
+// The cost of a stable handle is that it has identity. A value can appear in a
+// list many times; the element is the thing that says "this occurrence". To
+// keep bugs loud, every method that receives an element checks that it still
+// belongs to this list. Reusing a removed element or an element from another
+// list throws a `RangeError` instead of corrupting two lists at once.
+//
+// # Cost
+//
+// `pushFront`, `pushBack`, `insertBefore`, `insertAfter`, `remove` and every
+// `move*` method are `O(1)`. Iteration is linear, and yields the list's values
+// rather than its elements because the common case is reading contents; callers
+// that need handles keep the values returned by the insertion methods.
+
+/** A stable handle to one occurrence of a value inside a `List`. */
+export class Element<T> {
+  _list: List<T> | null;
+  _previous: Element<T> | null;
+  _next: Element<T> | null;
+  _value: T;
+
+  /**
+   * A detached element.
+   *
+   * `List` methods create the useful elements. The constructor is public
+   * because JavaScript classes cannot export a type without a constructor; an
+   * element created directly has a value but belongs to no list.
+   */
+  constructor(value: T) {
+    this._list = null;
+    this._previous = null;
+    this._next = null;
+    this._value = value;
+  }
+
+  /** The value this element carries. */
+  value(): T {
+    return this._value;
+  }
+
+  /** The next element, or `undefined` at the back or after removal. */
+  next(): Element<T> | void {
+    return this._list == null ? undefined : (this._next ?? undefined);
+  }
+
+  /** The previous element, or `undefined` at the front or after removal. */
+  previous(): Element<T> | void {
+    return this._list == null ? undefined : (this._previous ?? undefined);
+  }
+}
+
+/**
+ * A doubly linked list with stable element handles.
+ *
+ * ```js
+ * const recency = new List<string>();
+ * const inbox = recency.pushFront("inbox");
+ * recency.pushFront("home");
+ * recency.moveToFront(inbox);
+ * [...recency.values()]; // ["inbox", "home"]
+ * ```
+ */
+export class List<T> {
+  #front: Element<T> | null = null;
+  #back: Element<T> | null = null;
+  #size: number = 0;
+
+  /** A list holding `initial`, in order, if any values are given. */
+  constructor(initial?: $ReadOnlyArray<T>) {
+    if (initial != null) {
+      for (const value of initial) {
+        this.pushBack(value);
+      }
+    }
+  }
+
+  /** How many elements are in the list. */
+  size(): number {
+    return this.#size;
+  }
+
+  /** Whether the list holds nothing. */
+  isEmpty(): boolean {
+    return this.#size === 0;
+  }
+
+  /** The front element, or `undefined` when the list is empty. */
+  front(): Element<T> | void {
+    return this.#front ?? undefined;
+  }
+
+  /** The back element, or `undefined` when the list is empty. */
+  back(): Element<T> | void {
+    return this.#back ?? undefined;
+  }
+
+  /** Add `value` at the front and return its element handle. */
+  pushFront(value: T): Element<T> {
+    const element = new Element(value);
+    this.#insertBetween(element, null, this.#front);
+    return element;
+  }
+
+  /** Add `value` at the back and return its element handle. */
+  pushBack(value: T): Element<T> {
+    const element = new Element(value);
+    this.#insertBetween(element, this.#back, null);
+    return element;
+  }
+
+  /** Add `value` immediately before `mark`. */
+  insertBefore(value: T, mark: Element<T>): Element<T> {
+    this.#assertMember(mark);
+    const element = new Element(value);
+    this.#insertBetween(element, mark._previous, mark);
+    return element;
+  }
+
+  /** Add `value` immediately after `mark`. */
+  insertAfter(value: T, mark: Element<T>): Element<T> {
+    this.#assertMember(mark);
+    const element = new Element(value);
+    this.#insertBetween(element, mark, mark._next);
+    return element;
+  }
+
+  /** Remove `element` and return its value. */
+  remove(element: Element<T>): T {
+    this.#assertMember(element);
+    this.#unlink(element);
+    return element.value();
+  }
+
+  /** Move `element` to the front. */
+  moveToFront(element: Element<T>): void {
+    this.#assertMember(element);
+    if (element === this.#front) {
+      return;
+    }
+    this.#unlink(element);
+    this.#insertBetween(element, null, this.#front);
+  }
+
+  /** Move `element` to the back. */
+  moveToBack(element: Element<T>): void {
+    this.#assertMember(element);
+    if (element === this.#back) {
+      return;
+    }
+    this.#unlink(element);
+    this.#insertBetween(element, this.#back, null);
+  }
+
+  /** Move `element` immediately before `mark`. Both must belong to this list. */
+  moveBefore(element: Element<T>, mark: Element<T>): void {
+    this.#assertMember(element);
+    this.#assertMember(mark);
+    if (element === mark || element._next === mark) {
+      return;
+    }
+    this.#unlink(element);
+    this.#insertBetween(element, mark._previous, mark);
+  }
+
+  /** Move `element` immediately after `mark`. Both must belong to this list. */
+  moveAfter(element: Element<T>, mark: Element<T>): void {
+    this.#assertMember(element);
+    this.#assertMember(mark);
+    if (element === mark || element._previous === mark) {
+      return;
+    }
+    this.#unlink(element);
+    this.#insertBetween(element, mark, mark._next);
+  }
+
+  /** Remove everything and detach every element. */
+  clear(): void {
+    let element = this.#front;
+    while (element != null) {
+      const next = element._next;
+      element._list = null;
+      element._previous = null;
+      element._next = null;
+      element = next;
+    }
+    this.#front = null;
+    this.#back = null;
+    this.#size = 0;
+  }
+
+  /** The list's values from front to back. */
+  *values(): Generator<T, void, void> {
+    let element = this.#front;
+    while (element != null) {
+      const next = element._next;
+      yield element.value();
+      element = next;
+    }
+  }
+
+  /** Iterate values from front to back. */
+  [Symbol.iterator](): Iterator<T> {
+    return this.values();
+  }
+
+  /** Return the values as an array, preserving order. */
+  toArray(): $ReadOnlyArray<T> {
+    return [...this.values()];
+  }
+
+  #assertMember(element: Element<T>): void {
+    if (element._list !== this) {
+      throw new RangeError("@uniflowed/std/list: element does not belong to this list");
+    }
+  }
+
+  #insertBetween(element: Element<T>, previous: Element<T> | null, next: Element<T> | null): void {
+    element._list = this;
+    element._previous = previous;
+    element._next = next;
+    if (previous == null) {
+      this.#front = element;
+    } else {
+      previous._next = element;
+    }
+    if (next == null) {
+      this.#back = element;
+    } else {
+      next._previous = element;
+    }
+    this.#size += 1;
+  }
+
+  #unlink(element: Element<T>): void {
+    const previous = element._previous;
+    const next = element._next;
+    if (previous == null) {
+      this.#front = next;
+    } else {
+      previous._next = next;
+    }
+    if (next == null) {
+      this.#back = previous;
+    } else {
+      next._previous = previous;
+    }
+    element._list = null;
+    element._previous = null;
+    element._next = null;
+    this.#size -= 1;
+  }
+}

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -19,6 +19,7 @@
     "./errors": "./errors.js",
     "./heap": "./heap.js",
     "./hex": "./hex.js",
+    "./list": "./list.js",
     "./slices": "./slices.js",
     "./sync": "./sync.js",
     "./package.json": "./package.json"
@@ -31,6 +32,7 @@
     "heap.js",
     "hex.js",
     "index.js",
+    "list.js",
     "slices.js",
     "sync.js",
     "!*.test.js"

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Eight modules, and what is asserted here is the property that makes each one
+// Nine modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -60,6 +60,7 @@ import {
 import { as, chain, is, join as joinErrors, unwrap, wrap } from "@uniflowed/std/errors";
 import { Heap, heapify } from "@uniflowed/std/heap";
 import { InvalidHexError, decode, dump, encode, isValid } from "@uniflowed/std/hex";
+import { Element, List } from "@uniflowed/std/list";
 import { binarySearch, binarySearchBy, search } from "@uniflowed/std/slices";
 import { Group, Mutex, Semaphore, WaitGroup, once } from "@uniflowed/std/sync";
 
@@ -795,6 +796,89 @@ describe("heap", () => {
     expect([...queue.toArray()].sort((x, y) => x - y)).toEqual([1, 2, 3]);
     queue.clear();
     expect(queue.size()).toBe(0);
+  });
+});
+
+describe("list", () => {
+  it("keeps stable element handles while values move", () => {
+    const recent = new List<string>();
+    const inbox = recent.pushBack("inbox");
+    const home = recent.pushBack("home");
+    const searchItem = recent.pushFront("search");
+
+    expect(recent.size()).toBe(3);
+    expect(recent.front()).toBe(searchItem);
+    expect(recent.back()).toBe(home);
+    expect(recent.toArray()).toEqual(["search", "inbox", "home"]);
+
+    recent.moveToFront(home);
+    expect(recent.front()).toBe(home);
+    expect(searchItem.previous()).toBe(home);
+    expect(searchItem.next()).toBe(inbox);
+    expect([...recent.values()]).toEqual(["home", "search", "inbox"]);
+  });
+
+  it("inserts before and after existing elements in constant time", () => {
+    const queue = new List<number>([2, 4]);
+    const four = queue.back();
+    if (four == null) throw new Error("expected a back element");
+
+    const one = queue.insertBefore(1, queue.front() ?? four);
+    const three = queue.insertBefore(3, four);
+    const five = queue.insertAfter(5, four);
+
+    expect(queue.toArray()).toEqual([1, 2, 3, 4, 5]);
+    expect(one.next()?.value()).toBe(2);
+    expect(three.previous()?.value()).toBe(2);
+    expect(five.previous()).toBe(four);
+  });
+
+  it("moves elements relative to other elements without changing handles", () => {
+    const list = new List<string>(["a", "b", "c", "d"]);
+    const a = list.front();
+    const d = list.back();
+    if (a == null || d == null) throw new Error("expected both ends");
+    const b = a.next();
+    const c = d.previous();
+    if (b == null || c == null) throw new Error("expected middle elements");
+
+    list.moveAfter(a, c);
+    expect(list.toArray()).toEqual(["b", "c", "a", "d"]);
+    expect(a.previous()).toBe(c);
+
+    list.moveBefore(d, b);
+    expect(list.toArray()).toEqual(["d", "b", "c", "a"]);
+    expect(list.front()).toBe(d);
+    expect(list.back()).toBe(a);
+  });
+
+  it("removes and clears by detaching elements", () => {
+    const list = new List<number>([1, 2, 3]);
+    const two = list.front()?.next();
+    if (two == null) throw new Error("expected a middle element");
+
+    expect(list.remove(two)).toBe(2);
+    expect(list.toArray()).toEqual([1, 3]);
+    expect(two.next()).toBe(undefined);
+    expect(two.previous()).toBe(undefined);
+    expect(() => list.remove(two)).toThrow(RangeError);
+
+    const front = list.front();
+    list.clear();
+    expect(list.isEmpty()).toBe(true);
+    expect(list.front()).toBe(undefined);
+    expect(front?.next()).toBe(undefined);
+  });
+
+  it("refuses elements from another list or no list", () => {
+    const left = new List<string>(["a"]);
+    const right = new List<string>(["b"]);
+    const alien = right.front();
+    if (alien == null) throw new Error("expected an element");
+
+    expect(() => left.insertAfter("x", alien)).toThrow(RangeError);
+    expect(() => left.moveToBack(alien)).toThrow(RangeError);
+    expect(() => left.remove(new Element("detached"))).toThrow(RangeError);
   });
 });
 

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -34,6 +34,7 @@ import { background, key, withCancel, withTimeout, withValue } from "../../packa
 import { as, is, join, wrap } from "../../packages/std/errors.js";
 import { Heap, heapify } from "../../packages/std/heap.js";
 import { decode, encode } from "../../packages/std/hex.js";
+import { List } from "../../packages/std/list.js";
 import { binarySearch, binarySearchBy, search } from "../../packages/std/slices.js";
 import { Group, Mutex, Semaphore, once } from "../../packages/std/sync.js";
 
@@ -89,6 +90,17 @@ export const comparatorSeesTheElement: mixed = new Heap<number>((a, b) => a.toUp
 const words = heapify(["b", "a"], (a, b) => (a < b ? -1 : 1));
 // expect: string is incompatible with number
 export const heapifyKeepsTheElement: number | void = words.peek();
+
+// --- list -------------------------------------------------------------------
+
+const pages = new List<string>(["home"]);
+const page = pages.pushFront("inbox");
+
+// expect: string is incompatible with number
+export const listElementHasItsValueType: number = page.value();
+
+// expect: 1 is incompatible with string
+export const listTakesItsElementType: mixed = pages.pushBack(1);
 
 // --- context ----------------------------------------------------------------
 //
@@ -201,6 +213,8 @@ export const joinIsNullable: Error | null = join(new Error("a"));
 export const heapPops: number | void = numbers.pop();
 export const heapifyInfers: string | void = words.peek();
 export const drainYieldsElements: Array<number> = [...numbers.drain()];
+export const listFront: string | void = pages.front()?.value();
+export const listValues: Array<string> = [...pages.values()];
 export const keyReads: string | void = withValue(root, TRACE, "abc").value(TRACE);
 export const attemptReads: number | void = withValue(root, ATTEMPT, 1).value(ATTEMPT);
 export const cancelTakesNothing: void = cancel();


### PR DESCRIPTION
## Summary
- add @uniflowed/std/list with Element and List stable handles for container/list-style linked lists
- publish the subpath through package exports/files, registry metadata, and the std reference page
- cover runtime behavior, package-surface drift, and Flow inference for list values

Part of #710.

## Tests
- UF_PROJECT_ROOT=. UF_BINARY=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target/ci-opt/uf /Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target/ci-opt/uf test packages/std/std.test.js
- nix develop --command cargo fmt --all -- --check
- nix develop --command env CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target cargo test -p uf_std -p uf_lib --profile ci
- nix develop --command env CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target cargo clippy -p uf_std -p uf_lib --all-targets --all-features --profile ci -- -D warnings
- git diff --check
- npm pack --workspace @uniflowed/std --json --dry-run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791718972&installation_model_id=422833&pr_number=781&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F781&signature=2695144f0f70bf6f993c7eaf4ad3393909564b4ff5591a9a17f4f3ea3e2be49f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `@uniflowed/std/list` module.
  - Added a doubly linked list with stable element handles, insertion, removal, repositioning, clearing, iteration, and array conversion.
  - Added type-safe `List` and `Element` APIs.
  - Exposed the module as a package subpath.

- **Documentation**
  - Updated standard-library documentation to include the shipped list module and revised module counts.

- **Tests**
  - Added coverage for list behavior, invalid handles, and type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->