### PR TITLE
fix(check): resolve Flow export conditions

### DIFF
--- a/crates/uf_check/src/lib.rs
+++ b/crates/uf_check/src/lib.rs
@@ -38,6 +38,7 @@ mod error;
 mod flowconfig;
 mod limits;
 mod report;
+mod resolution;
 #[cfg(feature = "upstream-typecheck")]
 mod upstream;
 
@@ -50,6 +51,7 @@ pub use crate::error::CheckError;
 pub use crate::flowconfig::{LibPaths, lib_paths};
 pub use crate::limits::{CHECK_STACK_BYTES, CheckLimits};
 pub use crate::report::{BuiltinsTiming, CheckReport, ModuleClosure, Source, UnresolvedImport};
+pub use crate::resolution::{EXPORT_CONDITIONS, MAIN_FIELDS};
 
 /// Which type checker a build compiled in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/uf_check/src/resolution.rs
+++ b/crates/uf_check/src/resolution.rs
@@ -1,0 +1,66 @@
+//! Which file a package specifier means, and under what conditions.
+//!
+//! A dependency's `package.json` does not name one file per subpath. It names
+//! one per condition -- `import` against `require`, `browser` against `node`,
+//! `bun` and `deno` against neither -- and the resolver picks by asking which
+//! conditions are true of the thing doing the resolving.
+//!
+//! `uf check` answers two condition kinds:
+//!
+//! * `flow`, because uf is a Flow toolchain and `uf build --lib` publishes
+//!   Flow sources behind that condition.
+//! * `import`, because uf projects load packages as ES modules, not CommonJS.
+//!
+//! It deliberately answers no JavaScript host condition. One type check
+//! produces one graph, while uf claims Node, Bun, and experimental Deno hosts;
+//! choosing `node`, `bun`, `deno`, or `browser` here would make the checker a
+//! checker for that host rather than for the portable graph. The host-specific
+//! miss is reported separately so the cost is visible.
+
+/// The `exports` conditions a package subpath is resolved under.
+///
+/// Upstream honours `default` in addition to this list, and it matches in the
+/// order the manifest writes its keys. This is a set of keys uf answers to, not
+/// a priority order uf imposes.
+pub const EXPORT_CONDITIONS: &[&str] = &["flow", "import"];
+
+/// The `package.json` fields a package with no `exports` map is entered
+/// through.
+///
+/// Prefer `module` to `main` because uf checks the ESM graph. A legacy dual
+/// package with no `exports` map commonly leaves its CommonJS entry in `main`
+/// and its ESM entry in `module`; checking the CommonJS file is the same kind
+/// of wrong graph as choosing the `require` condition above.
+pub const MAIN_FIELDS: &[&str] = &["module", "main"];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_language_condition_is_answered() {
+        assert!(EXPORT_CONDITIONS.contains(&"flow"));
+        assert!(EXPORT_CONDITIONS.contains(&"import"));
+    }
+
+    #[test]
+    fn no_condition_names_a_host_or_graph() {
+        for named in ["node", "bun", "deno", "browser", "workerd", "react-server"] {
+            assert!(
+                !EXPORT_CONDITIONS.contains(&named),
+                "`{named}` names a host or graph; changing that is a decision \
+                 about what one `uf check` checks"
+            );
+        }
+    }
+
+    #[test]
+    fn the_commonjs_condition_is_not_answered() {
+        assert!(!EXPORT_CONDITIONS.contains(&"require"));
+    }
+
+    #[test]
+    fn a_package_with_no_exports_map_is_still_enterable_as_esm() {
+        assert_eq!(MAIN_FIELDS, ["module", "main"]);
+    }
+}

--- a/crates/uf_check/src/upstream/options.rs
+++ b/crates/uf_check/src/upstream/options.rs
@@ -5,6 +5,10 @@
 //! these are constants rather than configuration. They match what
 //! `flow_dot_js_wasm` runs with, which is the configuration Flow's own
 //! try-it-online uses, plus `uf`'s limits.
+//!
+//! The package entry fields and `exports` conditions are not Flow dialect
+//! options. They decide which file the checker types, and
+//! [`crate::resolution`] is where that decision is documented.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,32 +36,6 @@ const REACT_RULES: [ReactRule; 4] = [
 /// How many tokens of a file's header are scanned for a docblock.
 const MAX_HEADER_TOKENS: i32 = 10;
 
-/// The `package.json` fields a package with no `exports` map is entered through.
-///
-/// Prefer `module` to `main` because uf checks the ESM graph. A legacy dual
-/// package with no `exports` map commonly leaves its CommonJS entry in `main`
-/// and its ESM entry in `module`; checking the CommonJS file is the same kind
-/// of wrong graph as choosing the `require` condition below.
-///
-/// Stated rather than left to `Options::default()`, whose list is empty — with
-/// an empty list neither field is ever read, and a package that has no
-/// `exports` map would resolve to nothing at all.
-const NODE_MAIN_FIELDS: [&str; 2] = ["module", "main"];
-
-/// The `exports` conditions a package subpath is resolved under.
-///
-/// uf checks the module an ESM `import` loads, because that is the only module
-/// a uf project has: every package here is `"type": "module"`, and the
-/// transform, the dev server and the bundler all reach a package through
-/// `import`. Upstream honours `default` on top of whatever is listed, so a
-/// package with no conditions at all still resolves.
-///
-/// Listing more would be worse, not more permissive: conditions are matched in
-/// the order the *manifest* writes them, so adding `require` here would hand a
-/// dual package its CommonJS entry whenever it happened to list that first —
-/// the checker would then be typing a file the runtime never loads.
-const EXPORT_CONDITIONS: [&str; 1] = ["import"];
-
 /// Build the checker options for one run.
 ///
 /// Flow lints are left entirely off: `uf_lint` owns lint rules and reports them
@@ -73,8 +51,12 @@ pub(super) fn options(limits: &CheckLimits) -> Options {
         hook_compatibility: true,
         lint_severities: LintSettings::<Severity>::empty_severities(),
         max_header_tokens: MAX_HEADER_TOKENS,
-        node_main_fields: NODE_MAIN_FIELDS.iter().copied().map(String::from).collect(),
-        node_package_export_conditions: EXPORT_CONDITIONS
+        node_main_fields: crate::MAIN_FIELDS
+            .iter()
+            .copied()
+            .map(String::from)
+            .collect(),
+        node_package_export_conditions: crate::EXPORT_CONDITIONS
             .iter()
             .copied()
             .map(String::from)
@@ -169,13 +151,16 @@ mod tests {
     }
 
     #[test]
-    fn a_package_is_entered_the_way_an_es_module_import_enters_it() {
+    fn a_package_is_entered_under_the_conditions_uf_resolves_by() {
         let options = options(&CheckLimits::default());
 
-        assert_eq!(&*options.node_package_export_conditions, ["import"]);
+        assert_eq!(
+            &*options.node_package_export_conditions,
+            crate::EXPORT_CONDITIONS
+        );
         // Without this the entry fields of a package with no `exports` map are
         // never read, and such a package resolves to nothing.
-        assert_eq!(&*options.node_main_fields, ["module", "main"]);
+        assert_eq!(&*options.node_main_fields, crate::MAIN_FIELDS);
     }
 
     #[test]

--- a/crates/uf_check/src/upstream/packages.rs
+++ b/crates/uf_check/src/upstream/packages.rs
@@ -633,6 +633,43 @@ mod tests {
     }
 
     #[test]
+    fn a_uf_library_resolves_to_its_flow_source_and_not_its_build() {
+        let packages = packages(&[Source::new(
+            "node_modules/some-lib/package.json",
+            r#"{
+              "name": "some-lib",
+              "type": "module",
+              "exports": {
+                ".": { "flow": "./index.js", "default": "./dist/index.js" }
+              }
+            }"#,
+        )]);
+
+        assert_eq!(
+            exact(&packages, "some-lib"),
+            "node_modules/some-lib/index.js"
+        );
+    }
+
+    #[test]
+    fn a_manifest_that_writes_import_first_still_gets_its_import_target() {
+        let packages = packages(&[Source::new(
+            "node_modules/other-lib/package.json",
+            r#"{
+              "name": "other-lib",
+              "exports": {
+                ".": { "import": "./esm.js", "flow": "./src/index.js" }
+              }
+            }"#,
+        )]);
+
+        assert_eq!(
+            exact(&packages, "other-lib"),
+            "node_modules/other-lib/esm.js"
+        );
+    }
+
+    #[test]
     fn a_wildcard_subpath_expands() {
         let packages = packages(&[Source::new(
             "packages/glob/package.json",

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -197,6 +197,20 @@ major version and says so when it steps aside — asserting a version's behaviou
 on a version nobody ran the test against would be the unchecked claim this page
 exists to end.
 
+## What a dependency's host conditions get you
+
+A dependency can ship one target per condition: `node` against `browser`, `bun`
+or `deno` against neither, and `flow` against compiled JavaScript. `uf check`
+answers the conditions that are true of uf's portable module graph: `flow` and
+`import`. It answers no host condition.
+
+That means a package written as `{ "bun": "./b.js", "import": "./i.js" }` is
+typed as `./i.js`: right on Node, wrong on Bun, and intentionally visible as the
+cost of one shared graph. A package that publishes only host branches resolves
+to nothing and is reported separately from a missing package by
+`uf check --json` as a host-conditional module. Which host graph the checker
+should resolve, if any, is ubugeeei-prod/uf#735.
+
 ### Permissions, and why there is no `-A`
 
 Deno **is the only host that enforces the whole permission set**, and the model


### PR DESCRIPTION
## Summary
- resolve package exports under the `flow` condition alongside `import`
- keep package main-field fallback on `module` before `main`
- document that host-specific conditions stay unselected and add resolver regressions for uf-built libraries

Part of #736.
Refs #735.

## Tests
- `tools/upstream/sync.sh`
- `cargo test -p uf_check --lib resolution::tests --profile ci`
- `cargo test -p uf_check --lib upstream::packages::tests --profile ci`
- `cargo test -p uf_check --lib upstream::options::tests::a_package_is_entered_under_the_conditions_uf_resolves_by --profile ci`
- `cargo fmt -p uf_check --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725191&installation_model_id=422833&pr_number=783&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F783&signature=d03c4ec4ece4ae8bd51016a3f99c6254c4806a70486a5f253ff5b90c16ac89b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package checks now resolve `exports` entries using the `flow` and `import` conditions.
  * Packages without an `exports` map prioritize the `module` entry before `main`.
  * Host-specific and CommonJS conditions are not selected during resolution.
  * Host-only package branches are reported as host-conditional modules in JSON results.

* **Documentation**
  * Added guidance on how dependency host conditions affect package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->