### PR TITLE
fix(config): evaluate task config modules

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -30,7 +30,7 @@ use uf_bundle::{
 };
 use uf_config::{
     DeployAdapter, FrameworkPreset, LibraryPlan, Navigation, Prerender, RenderingPlan,
-    RuntimeTarget, UniflowedConfig, load_config,
+    RuntimeTarget, UniflowedConfig,
 };
 use uf_router::{
     Route, RouteTarget, discover_routes_for_target, discover_server_modules_for_target,
@@ -49,7 +49,9 @@ use crate::commands::builder;
 use crate::commands::compile;
 use crate::commands::deploy;
 use crate::commands::lint::identifier_span;
-use crate::commands::vite::{Driver, Event, LinkContext, render_error, render_log, resolve_host};
+use crate::commands::vite::{
+    Driver, Event, LinkContext, load_project_config, render_error, render_log, resolve_host,
+};
 use crate::support::{
     PRODUCTION, plural, problem_summary, project_env, project_label, relative_to, write_json_file,
 };
@@ -140,7 +142,9 @@ pub(crate) fn build(
     let mut progress = ui.progress();
 
     progress.draw("loading configuration");
-    let resolved = timer.measure("config", || load_config(cwd))?;
+    let resolved = timer.measure("config", || {
+        load_project_config(cwd, requested_mode, PRODUCTION)
+    })?;
 
     // Which of the two builds this is, decided once. A project whose
     // `app.router.enabled` is false is a library, and everything below this

--- a/crates/uf_cli/src/commands/dev.rs
+++ b/crates/uf_cli/src/commands/dev.rs
@@ -37,7 +37,7 @@ use uf_term::{KeyValue, Status, Tone};
 use crate::commands::builder;
 use crate::commands::lint::identifier_span;
 use crate::commands::vite::{
-    Driver, Event, render_diagnostic, render_error, render_log, resolve_host,
+    Driver, Event, load_project_config, render_diagnostic, render_error, render_log, resolve_host,
 };
 use crate::support::{DEVELOPMENT, env_file_list, plural, project_env, project_label, relative_to};
 use crate::ui::Ui;
@@ -58,7 +58,7 @@ pub(crate) struct DevArgs {
 
 /// Start the dev server and render its events until it exits.
 pub(crate) fn dev(cwd: &Utf8Path, ui: &mut Ui, args: DevArgs) -> Result<()> {
-    let resolved = load_config(cwd)?;
+    let resolved = load_project_config(cwd, args.mode.as_deref(), DEVELOPMENT)?;
     let root = resolved.root.clone();
 
     // Exposing the server needs an allowlist; see docs/security.md. Vite

--- a/crates/uf_cli/src/commands/serve.rs
+++ b/crates/uf_cli/src/commands/serve.rs
@@ -49,11 +49,13 @@
 
 use anyhow::{Result, bail};
 use camino::Utf8Path;
-use uf_config::{Prerender, RenderingPlan, load_config};
+use uf_config::{Prerender, RenderingPlan};
 use uf_term::{KeyValue, Status, Tone};
 
 use crate::commands::builder;
-use crate::commands::vite::{Driver, Event, LogLevel, render_error, render_log, resolve_host};
+use crate::commands::vite::{
+    Driver, Event, LogLevel, load_project_config, render_error, render_log, resolve_host,
+};
 use crate::support::{PRODUCTION, env_file_list, plural, project_env, project_label};
 use crate::ui::Ui;
 
@@ -96,7 +98,7 @@ pub(crate) fn start(cwd: &Utf8Path, ui: &mut Ui, args: ServeArgs) -> Result<()> 
 }
 
 fn serve(cwd: &Utf8Path, ui: &mut Ui, args: ServeArgs, which: Server) -> Result<()> {
-    let resolved = load_config(cwd)?;
+    let resolved = load_project_config(cwd, args.mode.as_deref(), PRODUCTION)?;
     let root = resolved.root.clone();
 
     // The same rule `uf dev --host` enforces, and only for `preview`, because

--- a/crates/uf_cli/src/commands/task.rs
+++ b/crates/uf_cli/src/commands/task.rs
@@ -13,6 +13,7 @@ use uf_task::{Concurrency, Plan, PlanError, RunOptions, ScheduledTask, TaskCache
 use uf_term::{Cell, Column, Status, Table, Tone, display_width, truncate_to_width};
 
 use crate::cli::CreateCommand;
+use crate::commands::vite::load_project_config;
 use crate::commands::{create, pm, test};
 use crate::suggest::closest;
 use crate::support::{DEVELOPMENT, plural, project_env, project_label};
@@ -36,7 +37,7 @@ pub(crate) fn run_task(
     args: &[String],
     options: RunArgs,
 ) -> Result<()> {
-    let resolved = load_config(cwd)?;
+    let resolved = load_project_config(cwd, requested_mode, DEVELOPMENT)?;
     // A task is project code with a shell in front of it, so it reads the
     // project's `.env` files like everything else uf runs. `development` is the
     // default because a task is something a person runs at a terminal; a task
@@ -564,7 +565,7 @@ fn elide(text: &str, width: usize) -> String {
 /// have to read the config to use. This is the answer to "what can I run here",
 /// and it is the same list the unknown-task error points at.
 pub(crate) fn list_tasks(cwd: &Utf8Path, ui: &mut Ui) -> Result<()> {
-    let resolved = load_config(cwd)?;
+    let resolved = load_project_config(cwd, None, DEVELOPMENT)?;
     let tasks = &resolved.config.tasks;
 
     if tasks.is_empty() {

--- a/crates/uf_cli/src/commands/transform.rs
+++ b/crates/uf_cli/src/commands/transform.rs
@@ -36,7 +36,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
-use uf_config::load_config;
+use uf_config::{UniflowedConfig, load_config};
 use uf_transform::{
     CompilerDiagnostic, ReactCompilerMode, TransformError, TransformOptions, is_flow_module,
     transform,
@@ -157,8 +157,15 @@ const TRANSFORM_CACHE: [&str; 3] = [".uf", "cache", "transform"];
 
 /// Serve transform requests until stdin closes.
 pub(crate) fn transform_service(cwd: &Utf8Path) -> Result<()> {
-    let resolved = load_config(cwd)?;
-    let project = ProjectTransform::from_config(&resolved.config);
+    // The config loader itself reaches `uf transform` before the config can be
+    // evaluated. That bootstrap transform must not recursively ask the static
+    // config loader to read the file it is currently compiling.
+    let config = if std::env::var_os("UF_TRANSFORM_BOOTSTRAP_CONFIG").is_some() {
+        UniflowedConfig::default()
+    } else {
+        load_config(cwd)?.config
+    };
+    let project = ProjectTransform::from_config(&config);
 
     // A host starts this process only when it has something to compile, and
     // compiling is the only thing that adds to the cache — so a sweep here

--- a/crates/uf_cli/src/commands/vite.rs
+++ b/crates/uf_cli/src/commands/vite.rs
@@ -28,10 +28,14 @@ use anyhow::{Context, Result, anyhow, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde_json::Value;
 use uf_config::env_files::ProjectEnv;
-use uf_config::{CapabilityJsHost, UniflowedConfig};
+use uf_config::{
+    CapabilityJsHost, ConfigError, ResolvedConfig, UniflowedConfig, discover_config, discover_root,
+    load_config, parse_config_projection,
+};
 use uf_term::{CodeFrame, DiagnosticLevel, KeyValue, Status, Tone};
 
-use crate::commands::builder::Builder;
+use crate::commands::builder::{self, Builder};
+use crate::support::project_env;
 use crate::ui::Ui;
 
 /// A JavaScript host that can run the driver.
@@ -387,6 +391,86 @@ const STOP_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// How often to ask whether it has gone.
 const STOP_POLL: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// Load config for a command that is allowed to start the JavaScript builder.
+///
+/// The fast path stays static: a literal `uf.config.js` is still read by Rust
+/// alone, which keeps no-host commands cheap and preserves the long-standing
+/// test fixtures that use `defineConfig` as a shape rather than importing it.
+/// When the static reader hits actual JavaScript, bootstrap with the default
+/// host and builder, ask the builder driver to evaluate the module, and feed
+/// the JSON projection through the same `uf_config` validation.
+pub(crate) fn load_project_config(
+    cwd: &Utf8Path,
+    requested_mode: Option<&str>,
+    default_mode: &str,
+) -> Result<ResolvedConfig> {
+    match load_config(cwd) {
+        Ok(resolved) => Ok(resolved),
+        Err(error @ (ConfigError::UnsupportedExpression { .. } | ConfigError::Parse { .. })) => {
+            load_evaluated_config(cwd, requested_mode, default_mode).with_context(|| {
+                format!(
+                    "failed to evaluate uf.config.js after the static loader could not read it: \
+                     {error}"
+                )
+            })
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn load_evaluated_config(
+    cwd: &Utf8Path,
+    requested_mode: Option<&str>,
+    default_mode: &str,
+) -> Result<ResolvedConfig> {
+    let root = discover_root(cwd);
+    let config_path = discover_config(&root);
+    let mut resolved = ResolvedConfig {
+        root,
+        config_path,
+        config: UniflowedConfig::default(),
+    };
+    let Some(path) = resolved.config_path.clone() else {
+        return Ok(resolved);
+    };
+
+    let host = resolve_host(&resolved.config)?;
+    let builder = builder::resolve(&resolved.root, &resolved.config)?;
+    let env = project_env(&resolved, requested_mode, default_mode)?;
+    let mut driver = Driver::spawn(&host, &builder, &resolved.root, "config", &[], &env, &[])?;
+    let mut projection = None;
+    while let Some(event) = driver.next_event()? {
+        match event {
+            Event::Config { config } => projection = Some(config),
+            Event::Error(error) => {
+                driver.stop();
+                bail!("{}", error.message);
+            }
+            Event::Log {
+                level: LogLevel::Error,
+                message,
+            } => bail!("{message}"),
+            Event::ConfigLoaded { .. }
+            | Event::Phase { .. }
+            | Event::Log { .. }
+            | Event::Listening { .. }
+            | Event::Page { .. }
+            | Event::PageFailed { .. }
+            | Event::SourceChanged
+            | Event::Rendering { .. }
+            | Event::EnvChanged { .. }
+            | Event::Diagnostic(_)
+            | Event::RscSplit { .. }
+            | Event::Done { .. } => {}
+        }
+    }
+    driver.finish("uf config")?;
+
+    let projection = projection.ok_or_else(|| anyhow!("the builder did not report config"))?;
+    resolved.config = parse_config_projection(&path, projection)?;
+    Ok(resolved)
+}
 
 /// Everything a second Vite run of one build needs to find.
 ///

--- a/crates/uf_cli/tests/tasks.rs
+++ b/crates/uf_cli/tests/tasks.rs
@@ -44,6 +44,31 @@ fn run(root: &Path, args: &[&str]) -> Run {
     }
 }
 
+#[test]
+fn config_module_constants_can_define_tasks() {
+    if !support::host_ready() {
+        return;
+    }
+    let project = support::Project::new(&[]);
+    project.write(
+        "uf.config.js",
+        r#"// @flow
+import { defineConfig } from "@uniflowed/config";
+
+const output = "ran.txt";
+const tasks = {
+  hello: { command: `echo hi >> ${output}` },
+};
+
+export default defineConfig({ tasks });
+"#,
+    );
+
+    let run = run(project.path(), &["hello"]);
+    assert!(run.ok, "stdout:\n{}\nstderr:\n{}", run.stdout, run.stderr);
+    assert_eq!(lines(project.path(), "ran.txt"), vec!["hi"]);
+}
+
 fn lines(root: &Path, name: &str) -> Vec<String> {
     fs::read_to_string(root.join(name))
         .unwrap_or_default()

--- a/packages/host/bun-preload.js
+++ b/packages/host/bun-preload.js
@@ -51,6 +51,7 @@ Bun.plugin({
         development: true,
         sourceMap: false,
         inSourceTests: inSourceTests(),
+        configBootstrap: process.env.UF_TRANSFORM_BOOTSTRAP_CONFIG === "1",
       });
       if (out == null) return declined(args.path, source);
 

--- a/packages/host/internal/node-hooks.js
+++ b/packages/host/internal/node-hooks.js
@@ -85,6 +85,7 @@ export async function initialize(data) {
 export async function load(url, context, nextLoad) {
   if (!url.startsWith("file:")) return nextLoad(url, context);
   const filename = fileURLToPath(url);
+  if (isCompiledConfig(filename)) return nextLoad(url, context);
   if (!isFlowModule(filename)) return nextLoad(url, context);
 
   const source = readFileSync(filename, "utf8");
@@ -94,6 +95,10 @@ export async function load(url, context, nextLoad) {
   // package.json forgot `"type": "module"` still runs, rather than failing on
   // an `import` in what Node would have guessed was CommonJS.
   return { format: "module", source: code, shortCircuit: true };
+}
+
+function isCompiledConfig(filename) {
+  return filename.includes(`${path.sep}.uf${path.sep}config${path.sep}uf.config.`);
 }
 
 /**
@@ -164,18 +169,24 @@ async function cachedTransform(source, filename) {
     }
   }
 
+  const configBootstrap = process.env.UF_TRANSFORM_BOOTSTRAP_CONFIG === "1";
   const out = await transformFlow(source, filename, {
     root,
     development: true,
     sourceMap: true,
     inSourceTests: inSourceTests(),
+    configBootstrap,
   });
   if (out == null) return null;
   const output = out.map
     ? `${out.code}\n//# sourceMappingURL=data:application/json;base64,${Buffer.from(out.map).toString("base64")}\n`
     : out.code;
 
-  const written = cacheEntryFor(sharedService(root).identity, source, filename);
+  const written = cacheEntryFor(
+    sharedService(root, { configBootstrap }).identity,
+    source,
+    filename,
+  );
   if (written) {
     // Tolerant: a cache that cannot be written is a slower run, not a
     // failed one — a read-only checkout still works.

--- a/packages/host/transform.js
+++ b/packages/host/transform.js
@@ -277,6 +277,8 @@ export class TransformService {
    * @param {object} [options]
    * @param {string} [options.command] the `uf` binary; `ufBinary()` by default
    * @param {string} [options.root] project root, so `uf.config.js` is found
+   * @param {boolean} [options.configBootstrap] transform code that is needed
+   *   before `uf.config.js` can be evaluated
    */
   constructor(options = {}) {
     const command = options.command ?? ufBinary();
@@ -289,8 +291,15 @@ export class TransformService {
     // binary earlier and wrote under that would file build B's output under
     // build A's name, which is the original defect with a smaller window.
     this.#identity = ufBinaryIdentity(command);
+    const env = { ...process.env };
+    if (options.configBootstrap === true) {
+      env.UF_TRANSFORM_BOOTSTRAP_CONFIG = "1";
+    } else {
+      delete env.UF_TRANSFORM_BOOTSTRAP_CONFIG;
+    }
     this.#child = spawn(command, ["--cwd", root, "transform"], {
       stdio: ["pipe", "pipe", "inherit"],
+      env,
     });
 
     createInterface({ input: this.#child.stdout }).on("line", (line) => {
@@ -448,6 +457,7 @@ export class TransformService {
 }
 
 let shared = null;
+let sharedForConfigBootstrap = null;
 
 /**
  * The process-wide service, started on first use.
@@ -455,8 +465,18 @@ let shared = null;
  * The loader hooks and the config loader share one process per host rather
  * than one per module; it lives as long as the host does.
  */
-export function sharedService(root) {
-  shared ??= new TransformService({ root: root ?? process.env.UF_PROJECT_ROOT ?? process.cwd() });
+export function sharedService(root, options = {}) {
+  const entry = options.configBootstrap === true ? "bootstrap" : "project";
+  if (entry === "bootstrap") {
+    sharedForConfigBootstrap ??= new TransformService({
+      root: root ?? process.env.UF_PROJECT_ROOT ?? process.cwd(),
+      configBootstrap: true,
+    });
+    return sharedForConfigBootstrap;
+  }
+  shared ??= new TransformService({
+    root: root ?? process.env.UF_PROJECT_ROOT ?? process.cwd(),
+  });
   return shared;
 }
 
@@ -467,5 +487,7 @@ export function sharedService(root) {
  * transform comes back as `null`.
  */
 export function transformFlow(code, filename, options = {}) {
-  return sharedService(options.root).transform(filename, code, options);
+  return sharedService(options.root, {
+    configBootstrap: options.configBootstrap === true,
+  }).transform(filename, code, options);
 }

--- a/packages/vite/internal/config.js
+++ b/packages/vite/internal/config.js
@@ -72,7 +72,7 @@ export async function loadUfConfig(root) {
   }
 
   const compiled = await compileConfig(source, file, root);
-  const module = await import(pathToFileURL(compiled).href);
+  const module = await importConfigModule(compiled);
   const config = module.default;
   if (config == null || typeof config !== "object") {
     throw new Error(
@@ -80,6 +80,20 @@ export async function loadUfConfig(root) {
     );
   }
   return { config, file };
+}
+
+async function importConfigModule(compiled) {
+  const previous = process.env.UF_TRANSFORM_BOOTSTRAP_CONFIG;
+  process.env.UF_TRANSFORM_BOOTSTRAP_CONFIG = "1";
+  try {
+    return await import(pathToFileURL(compiled).href);
+  } finally {
+    if (previous == null) {
+      delete process.env.UF_TRANSFORM_BOOTSTRAP_CONFIG;
+    } else {
+      process.env.UF_TRANSFORM_BOOTSTRAP_CONFIG = previous;
+    }
+  }
 }
 
 /**
@@ -93,8 +107,14 @@ async function compileConfig(source, file, root) {
   const directory = path.join(root, COMPILED_DIR);
   const target = path.join(directory, `uf.config.${hash}.mjs`);
 
-  const out = await transformFlow(source, file, { root, sourceMap: false });
-  const code = rewriteRelativeImports(out?.code ?? source, path.dirname(file));
+  const out = await transformFlow(source, file, {
+    root,
+    sourceMap: false,
+    configBootstrap: true,
+  });
+  const code = rewriteConfigImports(
+    rewriteRelativeImports(out?.code ?? source, path.dirname(file)),
+  );
   // Atomically, because two `uf` commands in one project write this same path
   // at the same time — the hash is of the source, so they agree on the name —
   // and `writeFileSync` truncates before it writes. A reader that caught it
@@ -122,6 +142,13 @@ export function rewriteRelativeImports(code, baseDirectory) {
   return code.replace(
     /((?:\bfrom\s*|\bimport\s*\(?\s*)["'])(\.\.?\/[^"']*)(["'])/g,
     (_, head, specifier, tail) => `${head}${absolute(specifier)}${tail}`,
+  );
+}
+
+function rewriteConfigImports(code) {
+  return code.replace(
+    /^\s*import\s*\{\s*defineConfig\s*\}\s*from\s*["']@uniflowed\/config["'];?\n?/gm,
+    "function defineConfig(config) {\n  return config;\n}\n",
   );
 }
 


### PR DESCRIPTION
## Summary
- fall back to the builder driver's `config` projection when static config loading hits JavaScript expressions
- use that evaluated config for `uf run`, `uf build`, `uf dev`, `uf preview`, and `uf start`
- add an integration regression for tasks defined through constants and template literals

Part of #698.

## Tests
- `tools/upstream/sync.sh`
- `cargo fmt -p uf_cli --check`
- `git diff --check`
- `cargo check -p uf_cli --tests --profile ci`
- `cargo test -p uf_cli --test tasks config_module_constants_can_define_tasks --profile ci`
- `cargo test -p uf_cli --lib commands::vite::tests --profile ci`
- `cargo test -p uf_cli --test tasks --profile ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725897&installation_model_id=422833&pr_number=784&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F784&signature=8a053077dd1a87dbe973a06b3e97f1114d1a1f5b10c103977bbce51008f44761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->