### PR TITLE
feat(std): ship binary cursor and varints

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -328,6 +328,22 @@ pub fn std_modules() -> StdModuleList {
             ],
         ),
         StdModule::ships(
+            "@uniflowed/std/binary",
+            StdCategory::Data,
+            &[
+                "BIG_ENDIAN",
+                "Cursor",
+                "InvalidBinaryError",
+                "LITTLE_ENDIAN",
+                "putUvarint",
+                "putVarint",
+                "uvarint",
+                "uvarintLength",
+                "varint",
+                "varintLength",
+            ],
+        ),
+        StdModule::ships(
             "@uniflowed/std/slices",
             StdCategory::Data,
             &["binarySearch", "binarySearchBy", "search"],

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Ten modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Eleven modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -49,9 +49,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/slices` | `sort.Search`, `slices.BinarySearch` | Lower-bound search and insertion points for sorted arrays |
 | `@uniflowed/std/list` | `container/list` | A doubly linked list with stable element handles |
 | `@uniflowed/std/csv` | `encoding/csv` | RFC 4180 parsing and writing without `split(",")` bugs |
+| `@uniflowed/std/binary` | `encoding/binary` | Checked `DataView` cursor reads and writes, plus Go-compatible varints |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these ten are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these eleven are.
 Everything above runs.
 
 ## The types are the point
@@ -217,15 +218,14 @@ on them rather than replacing them.
 
 ### Missing, and worth having
 
-The first six at the top of this page are tranche 1. `slices`, `base32`, `list`
-and `csv` are the first next-tranche pieces. What remains, roughly in order of
-value:
+The first six at the top of this page are tranche 1. `slices`, `base32`, `list`,
+`csv` and `binary` are the first next-tranche pieces. What remains, roughly in
+order of value:
 
 | Go | What it would be |
 | --- | --- |
 | `io` | `Reader`/`Writer` over `Uint8Array`, `copy`, `readAll`, `limitReader`, and adapters to and from Web Streams. Held back for a concrete reason: `ReadableStream` is not polymorphic in the Flow libdefs uf's checker uses, so `ReadableStream<Uint8Array>` is refused, and fixing that libdef is the first half of the item |
 | `bufio` | A buffered reader, and `Scanner` with line, word and custom split functions |
-| `encoding/binary` | `getUint16`/`putUint32`/… over a cursor, and **varint**, which `DataView` does not have |
 | `hash/crc32`, `hash/fnv`, `hash/adler32` | WebCrypto has none of them. The strongest native candidate on this list, because CRC32 has a hardware instruction — so measure it before writing the JavaScript |
 | `time` durations and tickers | A `Duration` with the arithmetic, `Ticker`, `Timer`, `AfterFunc`, and the leak-free cancellation `context` already had to solve once |
 | `path/filepath` | `join`, `clean`, `rel`, `ext`, `base`, `dir`, and a real glob matcher |

--- a/packages/std/binary.js
+++ b/packages/std/binary.js
@@ -1,0 +1,317 @@
+// @flow
+//
+// `@uniflowed/std/binary`: Go's `encoding/binary`, over `DataView`.
+//
+// JavaScript has the byte-order primitives already: `DataView#getUint16`,
+// `setUint32`, `getFloat64`, and the rest. What it does not have is the piece
+// every binary protocol parser writes around them: a cursor that advances only
+// after a checked read or write, plus Go-compatible varints.
+//
+// This module is deliberately a thin layer. A `Cursor` owns no memory and does
+// no copies unless the caller asks to write bytes from another buffer. Reads
+// return numbers where `DataView` does, varints return `bigint`, and every
+// bounds failure points at the offset that could not be read or written.
+
+/** Byte order for multi-byte numbers. */
+export type ByteOrder = "big" | "little";
+
+/** Big-endian byte order, matching `DataView`'s default and Go's `BigEndian`. */
+export const BIG_ENDIAN: ByteOrder = "big";
+
+/** Little-endian byte order, matching Go's `LittleEndian`. */
+export const LITTLE_ENDIAN: ByteOrder = "little";
+
+/** Options for a cursor over a byte buffer. */
+export type CursorOptions = {
+  readonly byteOrder?: ByteOrder,
+};
+
+/** A varint decoded from the start of a byte slice. */
+export type VarintResult = {
+  readonly value: bigint,
+  readonly read: number,
+};
+
+/** A malformed binary value. */
+export class InvalidBinaryError extends Error {
+  offset: number;
+
+  constructor(message: string, offset: number) {
+    super(message);
+    this.name = "InvalidBinaryError";
+    this.offset = offset;
+  }
+}
+
+/** A checked cursor over a `Uint8Array`. */
+export class Cursor {
+  _bytes: Uint8Array;
+  _view: DataView;
+  _offset: number;
+  _byteOrder: ByteOrder;
+
+  constructor(bytes: Uint8Array, options?: CursorOptions) {
+    this._bytes = bytes;
+    this._view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    this._offset = 0;
+    this._byteOrder = checkedByteOrder(options?.byteOrder ?? BIG_ENDIAN);
+  }
+
+  /** The underlying bytes. Writes through the cursor are visible here. */
+  bytes(): Uint8Array {
+    return this._bytes;
+  }
+
+  /** Current offset in bytes. */
+  offset(): number {
+    return this._offset;
+  }
+
+  /** Bytes left between the current offset and the end of the buffer. */
+  remaining(): number {
+    return this._bytes.length - this._offset;
+  }
+
+  /** Move to an absolute byte offset. */
+  seek(offset: number): void {
+    assertInteger(offset, "offset", 0, this._bytes.length);
+    this._offset = offset;
+  }
+
+  /** Move forward by `length` bytes. */
+  skip(length: number): void {
+    this._offset = this._claim(length);
+  }
+
+  /** Return a view of the next `length` bytes and advance past it. */
+  getBytes(length: number): Uint8Array {
+    const offset = this._claim(length);
+    return this._bytes.subarray(offset, offset + length);
+  }
+
+  /** Copy `bytes` into the cursor and advance past them. */
+  putBytes(bytes: Uint8Array): void {
+    const offset = this._claim(bytes.length);
+    this._bytes.set(bytes, offset);
+  }
+
+  getUint8(): number {
+    const offset = this._claim(1);
+    return this._view.getUint8(offset);
+  }
+
+  putUint8(value: number): void {
+    assertInteger(value, "uint8", 0, 0xff);
+    const offset = this._claim(1);
+    this._view.setUint8(offset, value);
+  }
+
+  getInt8(): number {
+    const offset = this._claim(1);
+    return this._view.getInt8(offset);
+  }
+
+  putInt8(value: number): void {
+    assertInteger(value, "int8", -0x80, 0x7f);
+    const offset = this._claim(1);
+    this._view.setInt8(offset, value);
+  }
+
+  getUint16(byteOrder?: ByteOrder): number {
+    const offset = this._claim(2);
+    return this._view.getUint16(offset, this._little(byteOrder));
+  }
+
+  putUint16(value: number, byteOrder?: ByteOrder): void {
+    assertInteger(value, "uint16", 0, 0xffff);
+    const offset = this._claim(2);
+    this._view.setUint16(offset, value, this._little(byteOrder));
+  }
+
+  getInt16(byteOrder?: ByteOrder): number {
+    const offset = this._claim(2);
+    return this._view.getInt16(offset, this._little(byteOrder));
+  }
+
+  putInt16(value: number, byteOrder?: ByteOrder): void {
+    assertInteger(value, "int16", -0x8000, 0x7fff);
+    const offset = this._claim(2);
+    this._view.setInt16(offset, value, this._little(byteOrder));
+  }
+
+  getUint32(byteOrder?: ByteOrder): number {
+    const offset = this._claim(4);
+    return this._view.getUint32(offset, this._little(byteOrder));
+  }
+
+  putUint32(value: number, byteOrder?: ByteOrder): void {
+    assertInteger(value, "uint32", 0, 0xffffffff);
+    const offset = this._claim(4);
+    this._view.setUint32(offset, value, this._little(byteOrder));
+  }
+
+  getInt32(byteOrder?: ByteOrder): number {
+    const offset = this._claim(4);
+    return this._view.getInt32(offset, this._little(byteOrder));
+  }
+
+  putInt32(value: number, byteOrder?: ByteOrder): void {
+    assertInteger(value, "int32", -0x80000000, 0x7fffffff);
+    const offset = this._claim(4);
+    this._view.setInt32(offset, value, this._little(byteOrder));
+  }
+
+  getFloat32(byteOrder?: ByteOrder): number {
+    const offset = this._claim(4);
+    return this._view.getFloat32(offset, this._little(byteOrder));
+  }
+
+  putFloat32(value: number, byteOrder?: ByteOrder): void {
+    const offset = this._claim(4);
+    this._view.setFloat32(offset, value, this._little(byteOrder));
+  }
+
+  getFloat64(byteOrder?: ByteOrder): number {
+    const offset = this._claim(8);
+    return this._view.getFloat64(offset, this._little(byteOrder));
+  }
+
+  putFloat64(value: number, byteOrder?: ByteOrder): void {
+    const offset = this._claim(8);
+    this._view.setFloat64(offset, value, this._little(byteOrder));
+  }
+
+  /** Decode an unsigned varint at the current offset. */
+  getUvarint(): bigint {
+    const result = uvarint(this._bytes.subarray(this._offset));
+    this._offset += result.read;
+    return result.value;
+  }
+
+  /** Encode an unsigned varint at the current offset. */
+  putUvarint(value: bigint): void {
+    this.putBytes(putUvarint(value));
+  }
+
+  /** Decode a signed varint at the current offset. */
+  getVarint(): bigint {
+    const result = varint(this._bytes.subarray(this._offset));
+    this._offset += result.read;
+    return result.value;
+  }
+
+  /** Encode a signed varint at the current offset. */
+  putVarint(value: bigint): void {
+    this.putBytes(putVarint(value));
+  }
+
+  _claim(length: number): number {
+    assertInteger(length, "length", 0, Number.MAX_SAFE_INTEGER);
+    const offset = this._offset;
+    const next = offset + length;
+    if (next > this._bytes.length) {
+      throw new RangeError(
+        `@uniflowed/std/binary: need ${String(length)} byte(s) at offset ${String(
+          offset,
+        )}, but only ${String(this._bytes.length - offset)} remain`,
+      );
+    }
+    this._offset = next;
+    return offset;
+  }
+
+  _little(byteOrder?: ByteOrder): boolean {
+    return checkedByteOrder(byteOrder ?? this._byteOrder) === LITTLE_ENDIAN;
+  }
+}
+
+/** Decode an unsigned LEB128 varint from the start of `bytes`. */
+export function uvarint(bytes: Uint8Array): VarintResult {
+  let value = 0n;
+  let shift = 0n;
+  for (let index = 0; index < bytes.length; index += 1) {
+    const byte = bytes[index];
+    if (byte < 0x80) {
+      return { value: value | (BigInt(byte) << shift), read: index + 1 };
+    }
+    value |= BigInt(byte & 0x7f) << shift;
+    shift += 7n;
+  }
+  throw new InvalidBinaryError("@uniflowed/std/binary: truncated uvarint", bytes.length);
+}
+
+/** Encode an unsigned LEB128 varint. */
+export function putUvarint(value: bigint): Uint8Array {
+  assertUnsignedBigInt(value, "uvarint");
+  const out = new Uint8Array(uvarintLength(value));
+  let current = value;
+  let index = 0;
+  while (current >= 0x80n) {
+    out[index] = Number(current & 0x7fn) | 0x80;
+    current >>= 7n;
+    index += 1;
+  }
+  out[index] = Number(current);
+  return out;
+}
+
+/** Number of bytes needed to encode `value` as an unsigned varint. */
+export function uvarintLength(value: bigint): number {
+  assertUnsignedBigInt(value, "uvarint");
+  let current = value;
+  let length = 1;
+  while (current >= 0x80n) {
+    current >>= 7n;
+    length += 1;
+  }
+  return length;
+}
+
+/** Decode a signed Go-style zig-zag varint from the start of `bytes`. */
+export function varint(bytes: Uint8Array): VarintResult {
+  const result = uvarint(bytes);
+  const half = result.value >> 1n;
+  return {
+    value: (result.value & 1n) === 0n ? half : -(half + 1n),
+    read: result.read,
+  };
+}
+
+/** Encode a signed Go-style zig-zag varint. */
+export function putVarint(value: bigint): Uint8Array {
+  return putUvarint(zigZag(value));
+}
+
+/** Number of bytes needed to encode `value` as a signed varint. */
+export function varintLength(value: bigint): number {
+  return uvarintLength(zigZag(value));
+}
+
+function zigZag(value: bigint): bigint {
+  return value < 0n ? (-value << 1n) - 1n : value << 1n;
+}
+
+function checkedByteOrder(byteOrder: ByteOrder): ByteOrder {
+  if (byteOrder !== BIG_ENDIAN && byteOrder !== LITTLE_ENDIAN) {
+    throw new RangeError(
+      `@uniflowed/std/binary: byte order must be "big" or "little", got ${String(byteOrder)}`,
+    );
+  }
+  return byteOrder;
+}
+
+function assertUnsignedBigInt(value: bigint, name: string): void {
+  if (value < 0n) {
+    throw new RangeError(`@uniflowed/std/binary: ${name} must be non-negative`);
+  }
+}
+
+function assertInteger(value: number, name: string, min: number, max: number): void {
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new RangeError(
+      `@uniflowed/std/binary: ${name} must be an integer in [${String(min)}, ${String(
+        max,
+      )}], got ${String(value)}`,
+    );
+  }
+}

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -23,8 +23,8 @@ export type StdCategory =
  *
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
- * `heap`, `hex` — plus `slices`, `base32`, `list` and `csv` from #710's next
- * tranche.
+ * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv` and `binary` from
+ * #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": "./index.js",
     "./base32": "./base32.js",
+    "./binary": "./binary.js",
     "./bytes": "./bytes.js",
     "./context": "./context.js",
     "./csv": "./csv.js",
@@ -27,6 +28,7 @@
   },
   "files": [
     "base32.js",
+    "binary.js",
     "bytes.js",
     "context.js",
     "csv.js",

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Ten modules, and what is asserted here is the property that makes each one
+// Eleven modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -46,6 +46,18 @@ import {
   encodedLength as encodedBase32Length,
   isValid as isValidBase32,
 } from "@uniflowed/std/base32";
+import {
+  BIG_ENDIAN,
+  Cursor,
+  InvalidBinaryError,
+  LITTLE_ENDIAN,
+  putUvarint,
+  putVarint,
+  uvarint,
+  uvarintLength,
+  varint,
+  varintLength,
+} from "@uniflowed/std/binary";
 import {
   CANCELLED,
   DEADLINE_EXCEEDED,
@@ -1064,6 +1076,100 @@ describe("csv", () => {
     }
 
     expect(() => parseCsv('a"b')).toThrow(InvalidCsvError);
+  });
+});
+
+describe("binary", () => {
+  it("advances a cursor over checked DataView reads and writes", () => {
+    const bytes = new Uint8Array(16);
+    const writer = new Cursor(bytes);
+
+    writer.putUint16(0x1234, BIG_ENDIAN);
+    writer.putUint32(0x89abcdef, LITTLE_ENDIAN);
+    writer.putInt16(-2);
+    writer.putFloat32(1.5, LITTLE_ENDIAN);
+
+    expect(writer.offset()).toBe(12);
+    expect(Array.from(bytes.slice(0, 8))).toEqual([0x12, 0x34, 0xef, 0xcd, 0xab, 0x89, 0xff, 0xfe]);
+
+    const reader = new Cursor(bytes);
+    expect(reader.getUint16()).toBe(0x1234);
+    expect(reader.getUint32(LITTLE_ENDIAN)).toBe(0x89abcdef);
+    expect(reader.getInt16()).toBe(-2);
+    expect(reader.getFloat32(LITTLE_ENDIAN)).toBe(1.5);
+    expect(reader.remaining()).toBe(4);
+  });
+
+  it("fails before a cursor can read, write or seek outside the buffer", () => {
+    const reader = new Cursor(b(0, 1));
+    expect(reader.getUint16()).toBe(1);
+    expect(() => reader.getUint8()).toThrow(RangeError);
+    expect(() => reader.seek(3)).toThrow(RangeError);
+
+    expect(() => new Cursor(b(0)).putUint16(0x100)).toThrow(RangeError);
+    expect(() => new Cursor(b(0)).putUint8(0x100)).toThrow(RangeError);
+  });
+
+  it("encodes and decodes unsigned varints with the Go wire shape", () => {
+    const vectors: Array<[bigint, Array<number>]> = [
+      [0n, [0x00]],
+      [127n, [0x7f]],
+      [128n, [0x80, 0x01]],
+      [300n, [0xac, 0x02]],
+      [624485n, [0xe5, 0x8e, 0x26]],
+    ];
+
+    for (const [value, encoded] of vectors) {
+      const bytes = putUvarint(value);
+      expect(Array.from(bytes)).toEqual(encoded);
+      expect(uvarint(bytes)).toEqual({ value, read: encoded.length });
+      expect(uvarintLength(value)).toBe(encoded.length);
+    }
+  });
+
+  it("encodes and decodes signed zig-zag varints", () => {
+    const vectors: Array<[bigint, Array<number>]> = [
+      [0n, [0x00]],
+      [-1n, [0x01]],
+      [1n, [0x02]],
+      [-2n, [0x03]],
+      [-300n, [0xd7, 0x04]],
+      [300n, [0xd8, 0x04]],
+    ];
+
+    for (const [value, encoded] of vectors) {
+      const bytes = putVarint(value);
+      expect(Array.from(bytes)).toEqual(encoded);
+      expect(varint(bytes)).toEqual({ value, read: encoded.length });
+      expect(varintLength(value)).toBe(encoded.length);
+    }
+  });
+
+  it("lets a cursor read and write varints in sequence", () => {
+    const bytes = new Uint8Array(8);
+    const cursor = new Cursor(bytes);
+    cursor.putVarint(-300n);
+    cursor.putUvarint(624485n);
+    expect(cursor.offset()).toBe(5);
+
+    cursor.seek(0);
+    expect(cursor.getVarint()).toBe(-300n);
+    expect(cursor.getUvarint()).toBe(624485n);
+    expect(cursor.offset()).toBe(5);
+  });
+
+  it("names truncated varints by offset", () => {
+    try {
+      uvarint(b(0x80));
+      throw new Error("uvarint should have refused a truncated sequence");
+    } catch (failure) {
+      expect(failure).toBeInstanceOf(InvalidBinaryError);
+      if (failure instanceof InvalidBinaryError) {
+        expect(failure.offset).toBe(1);
+      }
+    }
+
+    expect(() => putUvarint(-1n)).toThrow(RangeError);
   });
 });
 

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -29,6 +29,7 @@
 // rather than inside the packages they are about.
 
 import { decode as decodeBase32, encode as encodeBase32 } from "../../packages/std/base32.js";
+import { Cursor, putVarint, uvarint } from "../../packages/std/binary.js";
 import { Builder, compare, equal, split } from "../../packages/std/bytes.js";
 import { background, key, withCancel, withTimeout, withValue } from "../../packages/std/context.js";
 import { parse as parseCsv, stringify as stringifyCsv } from "../../packages/std/csv.js";
@@ -189,6 +190,20 @@ export const csvCellsAreText: number = parseCsv("a")[0][0];
 // expect: 1 is incompatible with string
 export const csvStringifyTakesText: mixed = stringifyCsv([[1]]);
 
+const binaryCursor = new Cursor(left);
+
+// expect: number is incompatible with string
+export const binaryCursorReadsNumbers: string = binaryCursor.getUint16();
+
+// expect: not a number" is incompatible with number
+export const binaryCursorWritesNumbers: mixed = binaryCursor.putUint32("not a number");
+
+// expect: bigint is incompatible with number
+export const uvarintReadsBigInts: number = uvarint(left).value;
+
+// expect: 1 is incompatible with bigint
+export const putVarintTakesBigInts: mixed = putVarint(1);
+
 // --- slices -----------------------------------------------------------------
 
 // expect: number is incompatible with string
@@ -239,6 +254,10 @@ export const base32Encodes: string = encodeBase32(left);
 export const base32Decodes: Uint8Array = decodeBase32("MY======");
 export const csvRows: $ReadOnlyArray<$ReadOnlyArray<string>> = parseCsv("a,b");
 export const csvText: string = stringifyCsv([["a", "b"]]);
+export const binaryCursorOffset: number = binaryCursor.offset();
+export const binaryCursorRead: number = binaryCursor.getUint16();
+export const binaryUvarint: bigint = uvarint(left).value;
+export const binaryPutVarint: Uint8Array = putVarint(-1n);
 export const searchIndex: number = search(4, (index) => index >= 2);
 export const binarySearchResult: { readonly index: number, readonly found: boolean } = binarySearch(
   sortedNumbers,


### PR DESCRIPTION
## Summary
- add @uniflowed/std/binary with Cursor, byte-order helpers, and checked DataView reads/writes
- add unsigned and signed varint encode/decode helpers
- wire the module through the std package manifest, registry, docs, runtime tests, and type fixture

Part of #710.

## Checks
- tools/upstream/sync.sh
- cargo fmt -p uf_std --check
- cargo test -p uf_lib the_std_registry_names_exactly_what_the_std_package_exports --profile ci
- cargo test -p uf_lib --test package_surface a_shipping_std_module_is_the_one_that_runs --profile ci
- cargo test -p uf_lib --test package_surface a_std_module_that_claims_wintertc_alignment_names_no_host --profile ci
- cargo build --profile ci-opt --bin uf
- uf fmt --check packages/std/binary.js packages/std/std.test.js tests/type-tests/std-inference.js packages/std/index.js docs/app/reference/std/\$page.mdx packages/std/package.json
- uf test packages/std/std.test.js

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791727552&installation_model_id=422833&pr_number=785&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F785&signature=c968c9dde0285fd92db4005c582d69831e92e29b56f84e581a03fe0deb355299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->