### PR TITLE
feat(std): ship slash path helpers

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -358,6 +358,19 @@ pub fn std_modules() -> StdModuleList {
             StdCategory::Serialization,
             &["InvalidCsvError", "parse", "stringify"],
         ),
+        StdModule::ships(
+            "@uniflowed/std/path",
+            StdCategory::FileSystem,
+            &[
+                "basename",
+                "dirname",
+                "extname",
+                "isAbsolute",
+                "join",
+                "normalize",
+                "relative",
+            ],
+        ),
         // ---------------------------------------------------------------
         // Planned: nobody has written it.
         // ---------------------------------------------------------------
@@ -462,15 +475,6 @@ pub fn std_modules() -> StdModuleList {
             "@uniflowed/std/math",
             StdCategory::Data,
             &["clamp", "lerp", "mean", "percentile"],
-        ),
-        // #710's next tranche: `path/filepath` — `join`, `clean`, `rel`,
-        // `ext`, `base`, `dir` and a real glob matcher. Named in the root
-        // declaration surface as `joinPath` and `normalizePath`, and
-        // unimplemented there.
-        StdModule::planned(
-            "@uniflowed/std/path",
-            StdCategory::FileSystem,
-            &["join", "normalize", "dirname", "basename"],
         ),
         StdModule::planned(
             "@uniflowed/std/wasm",

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Eleven modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Twelve modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -50,9 +50,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/list` | `container/list` | A doubly linked list with stable element handles |
 | `@uniflowed/std/csv` | `encoding/csv` | RFC 4180 parsing and writing without `split(",")` bugs |
 | `@uniflowed/std/binary` | `encoding/binary` | Checked `DataView` cursor reads and writes, plus Go-compatible varints |
+| `@uniflowed/std/path` | `path/filepath` | Host-independent slash-path cleanup, joining and relative paths |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these eleven are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these twelve are.
 Everything above runs.
 
 ## The types are the point
@@ -219,8 +220,8 @@ on them rather than replacing them.
 ### Missing, and worth having
 
 The first six at the top of this page are tranche 1. `slices`, `base32`, `list`,
-`csv` and `binary` are the first next-tranche pieces. What remains, roughly in
-order of value:
+`csv`, `binary` and `path` are the first next-tranche pieces. What remains,
+roughly in order of value:
 
 | Go | What it would be |
 | --- | --- |
@@ -228,7 +229,7 @@ order of value:
 | `bufio` | A buffered reader, and `Scanner` with line, word and custom split functions |
 | `hash/crc32`, `hash/fnv`, `hash/adler32` | WebCrypto has none of them. The strongest native candidate on this list, because CRC32 has a hardware instruction — so measure it before writing the JavaScript |
 | `time` durations and tickers | A `Duration` with the arithmetic, `Ticker`, `Timer`, `AfterFunc`, and the leak-free cancellation `context` already had to solve once |
-| `path/filepath` | `join`, `clean`, `rel`, `ext`, `base`, `dir`, and a real glob matcher |
+| `path/filepath` glob matching | `glob`, `match`, and the `**`/character-class rules deliberately left out of slash-path cleanup |
 | `archive/zip`, `archive/tar` | Reading, at least. The compression half is `DecompressionStream`; the container format is not |
 | `net/textproto` | MIME header parsing and `multipart/form-data` beyond what `FormData` gives |
 

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -23,8 +23,8 @@ export type StdCategory =
  *
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
- * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv` and `binary` from
- * #710's next tranche.
+ * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv`, `binary` and
+ * `path` from #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -22,6 +22,7 @@
     "./heap": "./heap.js",
     "./hex": "./hex.js",
     "./list": "./list.js",
+    "./path": "./path.js",
     "./slices": "./slices.js",
     "./sync": "./sync.js",
     "./package.json": "./package.json"
@@ -37,6 +38,7 @@
     "hex.js",
     "index.js",
     "list.js",
+    "path.js",
     "slices.js",
     "sync.js",
     "!*.test.js"

--- a/packages/std/path.js
+++ b/packages/std/path.js
@@ -1,0 +1,144 @@
+// @flow
+//
+// `@uniflowed/std/path`: Go's `path/filepath`, for runtime-agnostic slash paths.
+//
+// JavaScript has URL paths, package subpaths and route paths everywhere, but no
+// host-independent path helpers for them. Node's `path` module is tied to Node
+// and has platform modes; this module deliberately is not. It treats `/` as the
+// separator on every runtime and performs lexical cleanup only: it never asks a
+// file system whether a segment exists or whether a symlink changes the answer.
+//
+// That makes it the right primitive for package exports, generated routes,
+// manifest entries and virtual file systems. Host file-system adapters can put
+// their own OS semantics at the boundary where the host is already known.
+
+/** Whether `path` starts at the slash-path root. */
+export function isAbsolute(path: string): boolean {
+  return path.startsWith("/");
+}
+
+/**
+ * Clean a slash path.
+ *
+ * Duplicate separators and `.` segments are removed. `..` removes the previous
+ * segment when there is one; leading `..` is preserved on relative paths and
+ * clamped at the root on absolute paths. Empty relative paths clean to `"."`.
+ */
+export function normalize(path: string): string {
+  const absolute = isAbsolute(path);
+  const parts = path.split("/");
+  const stack = [];
+
+  for (const part of parts) {
+    if (part === "" || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      if (stack.length > 0 && stack[stack.length - 1] !== "..") {
+        stack.pop();
+      } else if (!absolute) {
+        stack.push("..");
+      }
+      continue;
+    }
+    stack.push(part);
+  }
+
+  if (absolute) {
+    return stack.length === 0 ? "/" : `/${stack.join("/")}`;
+  }
+  return stack.length === 0 ? "." : stack.join("/");
+}
+
+/** Join path fragments with `/` and clean the result. */
+export function join(...parts: Array<string>): string {
+  if (parts.length === 0) {
+    return ".";
+  }
+  return normalize(parts.join("/"));
+}
+
+/** Return the directory containing `path`, after lexical cleanup. */
+export function dirname(path: string): string {
+  const cleaned = normalize(path);
+  if (cleaned === "." || cleaned === "/") {
+    return cleaned;
+  }
+  const slash = cleaned.lastIndexOf("/");
+  if (slash < 0) {
+    return ".";
+  }
+  if (slash === 0) {
+    return "/";
+  }
+  return cleaned.slice(0, slash);
+}
+
+/** Return the final path segment, after lexical cleanup. */
+export function basename(path: string): string {
+  const cleaned = normalize(path);
+  if (cleaned === "/" || cleaned === ".") {
+    return cleaned;
+  }
+  const slash = cleaned.lastIndexOf("/");
+  return slash < 0 ? cleaned : cleaned.slice(slash + 1);
+}
+
+/**
+ * Return the final extension of the final segment.
+ *
+ * This follows Go's `path.Ext`: the extension begins at the final dot in the
+ * final segment, so `.env` has extension `.env`.
+ */
+export function extname(path: string): string {
+  const base = basename(path);
+  if (base === "." || base === "/" || base === "..") {
+    return "";
+  }
+  const dot = base.lastIndexOf(".");
+  return dot < 0 ? "" : base.slice(dot);
+}
+
+/**
+ * Return a relative slash path from `from` to `to`.
+ *
+ * Both inputs must either be absolute or relative. The result is `"."` when
+ * the cleaned paths name the same location.
+ */
+export function relative(from: string, to: string): string {
+  const fromAbsolute = isAbsolute(from);
+  const toAbsolute = isAbsolute(to);
+  if (fromAbsolute !== toAbsolute) {
+    throw new RangeError("@uniflowed/std/path: cannot make a path relative across roots");
+  }
+
+  const fromParts = components(normalize(from));
+  const toParts = components(normalize(to));
+  let common = 0;
+  while (
+    common < fromParts.length &&
+    common < toParts.length &&
+    fromParts[common] === toParts[common]
+  ) {
+    common += 1;
+  }
+  if (fromParts[common] === "..") {
+    throw new RangeError(
+      "@uniflowed/std/path: cannot make a path relative from an unanchored parent",
+    );
+  }
+
+  const upward = Array.from({ length: fromParts.length - common }, () => "..");
+  const downward = toParts.slice(common);
+  const result = upward.concat(downward).join("/");
+  return result === "" ? "." : result;
+}
+
+/** Path components without root or current-directory sentinels. */
+function components(path: string): Array<string> {
+  if (path === "." || path === "/") {
+    return [];
+  }
+  const trimmed = path.startsWith("/") ? path.slice(1) : path;
+  return trimmed === "" ? [] : trimmed.split("/");
+}

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Eleven modules, and what is asserted here is the property that makes each one
+// Twelve modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -74,6 +74,15 @@ import { as, chain, is, join as joinErrors, unwrap, wrap } from "@uniflowed/std/
 import { Heap, heapify } from "@uniflowed/std/heap";
 import { InvalidHexError, decode, dump, encode, isValid } from "@uniflowed/std/hex";
 import { Element, List } from "@uniflowed/std/list";
+import {
+  basename,
+  dirname,
+  extname,
+  isAbsolute,
+  join as joinPath,
+  normalize,
+  relative,
+} from "@uniflowed/std/path";
 import { binarySearch, binarySearchBy, search } from "@uniflowed/std/slices";
 import { Group, Mutex, Semaphore, WaitGroup, once } from "@uniflowed/std/sync";
 
@@ -1210,6 +1219,42 @@ describe("slices", () => {
       index: 1,
       found: true,
     });
+  });
+});
+
+describe("path", () => {
+  it("cleans slash paths without asking a host file system", () => {
+    expect(normalize("")).toBe(".");
+    expect(normalize("./a//b/../c/")).toBe("a/c");
+    expect(normalize("/a/../../b")).toBe("/b");
+    expect(normalize("../../a")).toBe("../../a");
+  });
+
+  it("joins fragments and keeps absolute roots lexical", () => {
+    expect(joinPath("routes", "users", "..", "settings")).toBe("routes/settings");
+    expect(joinPath("/app/", "/routes", "index.js")).toBe("/app/routes/index.js");
+    expect(joinPath()).toBe(".");
+  });
+
+  it("names directory, base and extension like Go path helpers", () => {
+    expect(dirname("/app/routes/index.flow.js")).toBe("/app/routes");
+    expect(dirname("index.js")).toBe(".");
+    expect(dirname("/")).toBe("/");
+    expect(basename("/app/routes/")).toBe("routes");
+    expect(basename("")).toBe(".");
+    expect(extname("/app/.env")).toBe(".env");
+    expect(extname("archive.tar.gz")).toBe(".gz");
+    expect(extname("README")).toBe("");
+  });
+
+  it("computes relative paths only inside the same root shape", () => {
+    expect(relative("app/routes", "app/routes/admin/index.js")).toBe("admin/index.js");
+    expect(relative("app/routes/admin", "app/assets/logo.svg")).toBe("../../assets/logo.svg");
+    expect(relative("/app/routes", "/app/routes")).toBe(".");
+    expect(isAbsolute("/app/routes")).toBe(true);
+    expect(isAbsolute("app/routes")).toBe(false);
+    expect(() => relative("/app", "app")).toThrow(RangeError);
+    expect(() => relative("../a", "b")).toThrow(RangeError);
   });
 });
 

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -37,6 +37,11 @@ import { as, is, join, wrap } from "../../packages/std/errors.js";
 import { Heap, heapify } from "../../packages/std/heap.js";
 import { decode, encode } from "../../packages/std/hex.js";
 import { List } from "../../packages/std/list.js";
+import {
+  isAbsolute as pathIsAbsolute,
+  join as joinPath,
+  relative as relativePath,
+} from "../../packages/std/path.js";
 import { binarySearch, binarySearchBy, search } from "../../packages/std/slices.js";
 import { Group, Mutex, Semaphore, once } from "../../packages/std/sync.js";
 
@@ -224,6 +229,17 @@ const searchRows = binarySearchBy([{ id: "a" }, { id: "b" }], (row) => row.id.lo
 // expect: number is incompatible with string
 export const binarySearchByIndexIsNumber: string = searchRows.index;
 
+// --- path -------------------------------------------------------------------
+
+// expect: string is incompatible with number
+export const pathJoinAnswersText: number = joinPath("app", "routes");
+
+// expect: boolean is incompatible with string
+export const pathAbsoluteAnswersBoolean: string = pathIsAbsolute("/app");
+
+// expect: 1 is incompatible with string
+export const pathJoinTakesText: mixed = joinPath("app", 1);
+
 // --- what is *not* an error -------------------------------------------------
 //
 // Without these the fixture would pass just as happily on a package whose every
@@ -266,3 +282,6 @@ export const binarySearchResult: { readonly index: number, readonly found: boole
 );
 export const binarySearchByResult: { readonly index: number, readonly found: boolean } =
   binarySearchBy([{ id: "a" }, { id: "b" }], (row) => row.id.localeCompare("b"));
+export const pathJoinText: string = joinPath("app", "routes", "..", "assets");
+export const pathRelativeText: string = relativePath("app/routes", "app/assets");
+export const pathAbsoluteBoolean: boolean = pathIsAbsolute("/app");


### PR DESCRIPTION
## Summary
- add @uniflowed/std/path with runtime-agnostic slash-path helpers
- wire the module into package exports, std registry, reference docs, runtime tests, and Flow inference checks
- keep glob matching as the remaining path/filepath item for a separate std tranche

Refs #710.

## Verification
- npm ci --prefer-offline --no-audit --no-fund
- tools/upstream/sync.sh
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target cargo fmt -p uf_std --check
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target cargo test -p uf_lib the_std_registry_names_exactly_what_the_std_package_exports --profile ci
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target cargo test -p uf_lib --test package_surface a_shipping_std_module_is_the_one_that_runs --profile ci
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target cargo test -p uf_lib --test package_surface a_std_module_that_claims_wintertc_alignment_names_no_host --profile ci
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target cargo build --profile ci-opt --bin uf
- UF_BINARY=/Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target/ci-opt/uf /Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target/ci-opt/uf test packages/std/std.test.js
- UF_BINARY=/Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target/ci-opt/uf /Users/ubugeeei/Source/github.com/ubugeeei-prod/inflow/target/ci-opt/uf fmt --check packages/std/path.js packages/std/std.test.js tests/type-tests/std-inference.js packages/std/index.js docs/app/reference/std/$page.mdx
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791729059&installation_model_id=422833&pr_number=786&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F786&signature=782ad8dc3e51b26531fbc3897564baf287091e2f96d68a3444bb49cf7d1b0f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `@uniflowed/std/path` module for slash-based path utilities, including joining, normalization, relative paths, and path component inspection.
  - The module is now available as a supported standard library feature.

- **Documentation**
  - Updated the standard library reference to include the newly shipped path module and revised the list of planned functionality.

- **Tests**
  - Added coverage for path behavior and type checking across supported utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->