### PR TITLE
feat(std): ship cancellable timers

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -381,6 +381,21 @@ pub fn std_modules() -> StdModuleList {
             StdCategory::Data,
             &["adler32", "crc32", "fnv1a32", "fnv1a64"],
         ),
+        StdModule::ships(
+            "@uniflowed/std/time",
+            StdCategory::Platform,
+            &[
+                "Duration",
+                "Ticker",
+                "Timer",
+                "after",
+                "afterFunc",
+                "hours",
+                "milliseconds",
+                "minutes",
+                "seconds",
+            ],
+        ),
         // ---------------------------------------------------------------
         // Planned: nobody has written it.
         // ---------------------------------------------------------------

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Fourteen modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Fifteen modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -53,9 +53,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/path` | `path/filepath` | Host-independent slash-path cleanup, joining and relative paths |
 | `@uniflowed/std/glob` | `path/filepath` | Slash-path glob matching with `*`, `?`, character classes and recursive `**` |
 | `@uniflowed/std/hash` | `hash/crc32`, `hash/fnv`, `hash/adler32` | Checksums and non-cryptographic hashes over bytes or UTF-8 text |
+| `@uniflowed/std/time` | `time` | Duration arithmetic plus cancellable `Timer`, `Ticker` and `afterFunc` |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these fourteen are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these fifteen are.
 Everything above runs.
 
 ## The types are the point
@@ -222,14 +223,13 @@ on them rather than replacing them.
 ### Missing, and worth having
 
 The first six at the top of this page are tranche 1. `slices`, `base32`, `list`,
-`csv`, `binary`, `path`, `glob` and `hash` are the first next-tranche pieces. What
-remains, roughly in order of value:
+`csv`, `binary`, `path`, `glob`, `hash` and `time` are the first next-tranche
+pieces. What remains, roughly in order of value:
 
 | Go | What it would be |
 | --- | --- |
 | `io` | `Reader`/`Writer` over `Uint8Array`, `copy`, `readAll`, `limitReader`, and adapters to and from Web Streams. Held back for a concrete reason: `ReadableStream` is not polymorphic in the Flow libdefs uf's checker uses, so `ReadableStream<Uint8Array>` is refused, and fixing that libdef is the first half of the item |
 | `bufio` | A buffered reader, and `Scanner` with line, word and custom split functions |
-| `time` durations and tickers | A `Duration` with the arithmetic, `Ticker`, `Timer`, `AfterFunc`, and the leak-free cancellation `context` already had to solve once |
 | `archive/zip`, `archive/tar` | Reading, at least. The compression half is `DecompressionStream`; the container format is not |
 | `net/textproto` | MIME header parsing and `multipart/form-data` beyond what `FormData` gives |
 

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -24,7 +24,7 @@ export type StdCategory =
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
  * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv`, `binary`, `path`
- * `glob` and `hash` from #710's next tranche.
+ * `glob`, `hash` and `time` from #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -27,6 +27,7 @@
     "./path": "./path.js",
     "./slices": "./slices.js",
     "./sync": "./sync.js",
+    "./time": "./time.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -45,6 +46,7 @@
     "path.js",
     "slices.js",
     "sync.js",
+    "time.js",
     "!*.test.js"
   ],
   "dependencies": {

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -87,6 +87,16 @@ import {
 } from "@uniflowed/std/path";
 import { binarySearch, binarySearchBy, search } from "@uniflowed/std/slices";
 import { Group, Mutex, Semaphore, WaitGroup, once } from "@uniflowed/std/sync";
+import {
+  Ticker,
+  Timer,
+  after,
+  afterFunc,
+  hours,
+  milliseconds,
+  minutes,
+  seconds,
+} from "@uniflowed/std/time";
 
 import { everyMisuseIsReported } from "../../tests/library/type-tests.js";
 
@@ -1339,6 +1349,84 @@ describe("hash", () => {
     expect(() => adler32("x", 0x1_0000_0000)).toThrow(RangeError);
     expect(() => fnv1a32("x", 0x1_0000_0000)).toThrow(RangeError);
     expect(() => fnv1a64("x", -1n)).toThrow(RangeError);
+  });
+});
+
+describe("time", () => {
+  it("does duration arithmetic without involving a clock", () => {
+    expect(seconds(2).milliseconds()).toBe(2_000);
+    expect(minutes(1).add(seconds(30)).seconds()).toBe(90);
+    expect(hours(1).sub(minutes(30)).milliseconds()).toBe(1_800_000);
+    expect(milliseconds(250).mul(4).compare(seconds(1))).toBe(0);
+    expect(seconds(-2).abs().milliseconds()).toBe(2_000);
+    expect(seconds(3).div(2).toString()).toBe("1500ms");
+    expect(() => seconds(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+
+  it("resolves after a duration", async () => {
+    let done = false;
+    const waited = after(milliseconds(5)).then(() => {
+      done = true;
+    });
+
+    expect(done).toBe(false);
+    await waited;
+    expect(done).toBe(true);
+  });
+
+  it("stops a timer and releases anyone waiting on it", async () => {
+    let ran = false;
+    const timer = afterFunc(seconds(1), () => {
+      ran = true;
+    });
+    const done = timer.done();
+
+    expect(timer.active()).toBe(true);
+    expect(timer.stop()).toBe(true);
+    expect(await done).toBe(false);
+    expect(ran).toBe(false);
+    expect(timer.stop()).toBe(false);
+  });
+
+  it("can reset a timer before it fires", async () => {
+    let count = 0;
+    const timer = new Timer(seconds(1), () => {
+      count += 1;
+    });
+
+    timer.reset(milliseconds(5));
+    expect(await timer.done()).toBe(true);
+    expect(count).toBe(1);
+    expect(timer.active()).toBe(false);
+  });
+
+  it("keeps an active timer alive when reset receives an invalid delay", async () => {
+    let count = 0;
+    const timer = new Timer(milliseconds(5), () => {
+      count += 1;
+    });
+
+    expect(() => timer.reset(milliseconds(2_147_483_648))).toThrow(RangeError);
+    expect(await timer.done()).toBe(true);
+    expect(count).toBe(1);
+  });
+
+  it("ticks until stopped and resolves pending waits on stop", async () => {
+    const ticker = new Ticker(milliseconds(5));
+    const first = await ticker.tick();
+
+    expect(typeof first).toBe("number");
+
+    const waiting = ticker.tick();
+    ticker.stop();
+    expect(await waiting).toBe(null);
+    expect(await ticker.tick()).toBe(null);
+    expect(ticker.stopped()).toBe(true);
+  });
+
+  it("rejects timer delays the host would clamp", () => {
+    expect(() => new Timer(milliseconds(2_147_483_648))).toThrow(RangeError);
+    expect(() => new Ticker(milliseconds(0))).toThrow(RangeError);
   });
 });
 

--- a/packages/std/time.js
+++ b/packages/std/time.js
@@ -1,0 +1,280 @@
+// @flow
+//
+// `@uniflowed/std/time`: durations and cancellable timers.
+//
+// This is not a clock, formatter or calendar package. JavaScript already has
+// `Date`, `Intl.DateTimeFormat`, and Temporal for that. This module is the
+// missing utility layer around the one primitive every runtime does share:
+// `setTimeout` and `setInterval`, with explicit cancellation so a stopped wait
+// releases its pending promises instead of leaving them parked forever.
+
+/** A duration or a millisecond count accepted by timer helpers. */
+export type DurationInput = Duration | number;
+
+/** A signed duration measured in milliseconds. */
+export class Duration {
+  _milliseconds: number;
+
+  constructor(milliseconds: number) {
+    this._milliseconds = finite(milliseconds, "duration");
+  }
+
+  milliseconds(): number {
+    return this._milliseconds;
+  }
+
+  seconds(): number {
+    return this._milliseconds / 1_000;
+  }
+
+  add(other: DurationInput): Duration {
+    return new Duration(this._milliseconds + asDuration(other, "duration").milliseconds());
+  }
+
+  sub(other: DurationInput): Duration {
+    return new Duration(this._milliseconds - asDuration(other, "duration").milliseconds());
+  }
+
+  mul(factor: number): Duration {
+    return new Duration(this._milliseconds * finite(factor, "factor"));
+  }
+
+  div(divisor: number): Duration {
+    const value = finite(divisor, "divisor");
+    if (value === 0) {
+      throw new RangeError("@uniflowed/std/time: divisor must not be zero");
+    }
+    return new Duration(this._milliseconds / value);
+  }
+
+  neg(): Duration {
+    return new Duration(-this._milliseconds);
+  }
+
+  abs(): Duration {
+    return new Duration(Math.abs(this._milliseconds));
+  }
+
+  compare(other: DurationInput): -1 | 0 | 1 {
+    const right = asDuration(other, "duration").milliseconds();
+    if (this._milliseconds < right) {
+      return -1;
+    }
+    if (this._milliseconds > right) {
+      return 1;
+    }
+    return 0;
+  }
+
+  toString(): string {
+    return `${String(this._milliseconds)}ms`;
+  }
+
+  valueOf(): number {
+    return this._milliseconds;
+  }
+}
+
+/** A one-shot timer. `done()` resolves `true` when it fires and `false` when stopped. */
+export class Timer {
+  _id: TimeoutID | null = null;
+  _state: "active" | "fired" | "stopped" = "stopped";
+  _callback: (() => mixed) | null = null;
+  _waiters: Array<(fired: boolean) => void> = [];
+
+  constructor(delay: DurationInput, callback?: () => mixed) {
+    this._callback = callback ?? null;
+    this.reset(delay);
+  }
+
+  done(): Promise<boolean> {
+    switch (this._state) {
+      case "fired":
+        return Promise.resolve(true);
+      case "stopped":
+        return Promise.resolve(false);
+      default:
+        return new Promise((resolve) => {
+          this._waiters.push(resolve);
+        });
+    }
+  }
+
+  stop(): boolean {
+    if (this._state !== "active") {
+      return false;
+    }
+    if (this._id != null) {
+      clearTimeout(this._id);
+      this._id = null;
+    }
+    this._state = "stopped";
+    this._settle(false);
+    return true;
+  }
+
+  reset(delay: DurationInput, callback?: () => mixed): void {
+    const nextDelay = timeoutDelay(delay, "timer delay");
+    if (callback !== undefined) {
+      this._callback = callback;
+    }
+    if (this._id != null) {
+      clearTimeout(this._id);
+      this._id = null;
+    }
+    this._state = "active";
+    this._id = setTimeout(() => {
+      this._fire();
+    }, nextDelay);
+  }
+
+  active(): boolean {
+    return this._state === "active";
+  }
+
+  _fire(): void {
+    if (this._state !== "active") {
+      return;
+    }
+    this._id = null;
+    this._state = "fired";
+    this._settle(true);
+    const callback = this._callback;
+    if (callback != null) {
+      callback();
+    }
+  }
+
+  _settle(fired: boolean): void {
+    const waiters = this._waiters;
+    this._waiters = [];
+    for (const resolve of waiters) {
+      resolve(fired);
+    }
+  }
+}
+
+/** A periodic timer. Slow consumers observe at most one queued tick. */
+export class Ticker {
+  _id: IntervalID;
+  _stopped: boolean = false;
+  _pending: number | null = null;
+  _waiters: Array<(tick: number | null) => void> = [];
+
+  constructor(interval: DurationInput) {
+    const delay = intervalDelay(interval);
+    this._id = setInterval(() => {
+      this._tick();
+    }, delay);
+  }
+
+  tick(): Promise<number | null> {
+    if (this._pending != null) {
+      const tick = this._pending;
+      this._pending = null;
+      return Promise.resolve(tick);
+    }
+    if (this._stopped) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => {
+      this._waiters.push(resolve);
+    });
+  }
+
+  stop(): void {
+    if (this._stopped) {
+      return;
+    }
+    clearInterval(this._id);
+    this._stopped = true;
+    this._pending = null;
+    const waiters = this._waiters;
+    this._waiters = [];
+    for (const resolve of waiters) {
+      resolve(null);
+    }
+  }
+
+  stopped(): boolean {
+    return this._stopped;
+  }
+
+  _tick(): void {
+    if (this._stopped) {
+      return;
+    }
+    const tick = Date.now();
+    const resolve = this._waiters.shift();
+    if (resolve != null) {
+      resolve(tick);
+      return;
+    }
+    this._pending = tick;
+  }
+}
+
+/** A duration measured in milliseconds. */
+export function milliseconds(value: number): Duration {
+  return new Duration(value);
+}
+
+/** A duration measured in seconds. */
+export function seconds(value: number): Duration {
+  return new Duration(finite(value, "seconds") * 1_000);
+}
+
+/** A duration measured in minutes. */
+export function minutes(value: number): Duration {
+  return new Duration(finite(value, "minutes") * 60_000);
+}
+
+/** A duration measured in hours. */
+export function hours(value: number): Duration {
+  return new Duration(finite(value, "hours") * 3_600_000);
+}
+
+/** Resolve after `delay`. */
+export function after(delay: DurationInput): Promise<void> {
+  return new Timer(delay).done().then(() => {});
+}
+
+/** Run `callback` after `delay`, returning the timer so it can be stopped. */
+export function afterFunc(delay: DurationInput, callback: () => mixed): Timer {
+  return new Timer(delay, callback);
+}
+
+function asDuration(input: DurationInput, name: string): Duration {
+  if (input instanceof Duration) {
+    return input;
+  }
+  if (typeof input === "number") {
+    return new Duration(input);
+  }
+  throw new TypeError(`@uniflowed/std/time: ${name} must be a Duration or milliseconds`);
+}
+
+function timeoutDelay(input: DurationInput, name: string): number {
+  const delay = Math.max(0, Math.ceil(asDuration(input, name).milliseconds()));
+  if (delay > MAX_TIMER_DELAY) {
+    throw new RangeError(`@uniflowed/std/time: ${name} exceeds the maximum timer delay`);
+  }
+  return delay;
+}
+
+function intervalDelay(input: DurationInput): number {
+  const delay = timeoutDelay(input, "ticker interval");
+  if (delay <= 0) {
+    throw new RangeError("@uniflowed/std/time: ticker interval must be greater than zero");
+  }
+  return delay;
+}
+
+function finite(value: number, name: string): number {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`@uniflowed/std/time: ${name} must be finite`);
+  }
+  return value;
+}
+
+const MAX_TIMER_DELAY = 2_147_483_647;

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -46,6 +46,7 @@ import {
 } from "../../packages/std/path.js";
 import { binarySearch, binarySearchBy, search } from "../../packages/std/slices.js";
 import { Group, Mutex, Semaphore, once } from "../../packages/std/sync.js";
+import { Duration, Ticker, Timer, after, milliseconds, seconds } from "../../packages/std/time.js";
 
 class HttpError extends Error {
   status: number;
@@ -264,6 +265,27 @@ export const fnv1a64AnswersABigInt: number = fnv1a64("hello");
 // expect: 1 is incompatible with
 export const hashInputIsBytesOrText: mixed = crc32(1);
 
+// --- time -------------------------------------------------------------------
+
+const oneSecond = seconds(1);
+const timer = new Timer(milliseconds(10));
+const ticker = new Ticker(milliseconds(10));
+
+// expect: number is incompatible with string
+export const durationMillisecondsAreNumbers: string = oneSecond.milliseconds();
+
+// expect: number
+export const timerDelayIsDurationOrMillis: mixed = new Timer("soon");
+
+// expect: Promise
+export const timerDoneIsAPromise: boolean = timer.done();
+
+// expect: number
+export const tickerTicksCanEnd: Promise<number> = ticker.tick();
+
+// expect: number
+export const afterDelayIsDurationOrMillis: mixed = after("soon");
+
 // --- what is *not* an error -------------------------------------------------
 //
 // Without these the fixture would pass just as happily on a package whose every
@@ -313,3 +335,8 @@ export const globPattern: GlobPattern = compiledGlob;
 export const globMatchBoolean: boolean = matchGlob(compiledGlob, "src/index.js");
 export const crc32Number: number = crc32(left);
 export const fnv64BigInt: bigint = fnv1a64("hello");
+export const durationValue: Duration = oneSecond;
+export const durationCompare: -1 | 0 | 1 = oneSecond.compare(500);
+export const timerDone: Promise<boolean> = timer.done();
+export const tickerTick: Promise<number | null> = ticker.tick();
+export const afterPromise: Promise<void> = after(milliseconds(1));


### PR DESCRIPTION
## Summary
- add @uniflowed/std/time with Duration arithmetic, Timer, Ticker, after, and afterFunc
- expose the time subpath in package exports and the std registry
- update std docs, runtime coverage, leak-free stop/reset behavior, and type inference checks

Part of #710.

## Verification
- uf fmt --check packages/std/time.js packages/std/std.test.js tests/type-tests/std-inference.js packages/std/package.json packages/std/index.js docs/app/reference/std/$page.mdx
- uf test packages/std/std.test.js
- cargo fmt -p uf_std --check
- cargo test -p uf_lib the_std_registry_names_exactly_what_the_std_package_exports --profile ci
- cargo test -p uf_lib --test package_surface a_shipping_std_module_is_the_one_that_runs --profile ci
- cargo test -p uf_lib --test package_surface a_std_module_that_claims_wintertc_alignment_names_no_host --profile ci
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791738956&installation_model_id=422833&pr_number=789&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F789&signature=98ec9a8d75c8a6dcfd8a84336f3ff53f6b9ace817b528093bcd8578bfe6b32e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `@uniflowed/std/time` module.
  * Added duration creation, arithmetic, comparison, and conversion utilities.
  * Added one-shot timers, periodic tickers, delayed promises, and callback-based delays.
  * Added timer cancellation, resetting, and validation for delay and interval values.

* **Documentation**
  * Added `time` to the shipped standard-library module list and reference documentation.

* **Tests**
  * Added coverage for duration operations, timers, tickers, delayed promises, and type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->