### PR TITLE
feat(std): ship buffered scanners

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -414,6 +414,19 @@ pub fn std_modules() -> StdModuleList {
                 "writerFromWritableStream",
             ],
         ),
+        StdModule::ships(
+            "@uniflowed/std/bufio",
+            StdCategory::Platform,
+            &[
+                "BufferedReader",
+                "Scanner",
+                "TokenTooLongError",
+                "newReader",
+                "scanBytes",
+                "scanLines",
+                "scanWords",
+            ],
+        ),
         // ---------------------------------------------------------------
         // Planned: nobody has written it.
         // ---------------------------------------------------------------

--- a/crates/uf_std/src/tests.rs
+++ b/crates/uf_std/src/tests.rs
@@ -72,6 +72,7 @@ fn std_registry_covers_requested_modules() {
         "@uniflowed/std/hash",
         "@uniflowed/std/time",
         "@uniflowed/std/io",
+        "@uniflowed/std/bufio",
     ] {
         let module = modules
             .iter()

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -55,9 +55,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/hash` | `hash/crc32`, `hash/fnv`, `hash/adler32` | Checksums and non-cryptographic hashes over bytes or UTF-8 text |
 | `@uniflowed/std/time` | `time` | Duration arithmetic plus cancellable `Timer`, `Ticker` and `afterFunc` |
 | `@uniflowed/std/io` | `io` | Byte `Reader`/`Writer`, `copy`, `readAll`, `limitReader` and Web Stream adapters |
+| `@uniflowed/std/bufio` | `bufio` | Buffered byte reads plus `Scanner` line, word, byte and custom splits |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these sixteen are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these seventeen are.
 Everything above runs.
 
 ## The types are the point
@@ -224,12 +225,11 @@ on them rather than replacing them.
 ### Missing, and worth having
 
 The first six at the top of this page are tranche 1. `slices`, `base32`, `list`,
-`csv`, `binary`, `path`, `glob`, `hash`, `time` and `io` are the first next-tranche
+`csv`, `binary`, `path`, `glob`, `hash`, `time`, `io` and `bufio` are the first next-tranche
 pieces. What remains, roughly in order of value:
 
 | Go | What it would be |
 | --- | --- |
-| `bufio` | A buffered reader, and `Scanner` with line, word and custom split functions |
 | `archive/zip`, `archive/tar` | Reading, at least. The compression half is `DecompressionStream`; the container format is not |
 | `net/textproto` | MIME header parsing and `multipart/form-data` beyond what `FormData` gives |
 

--- a/packages/std/bufio.js
+++ b/packages/std/bufio.js
@@ -1,0 +1,316 @@
+// @flow
+//
+// `@uniflowed/std/bufio`: buffered byte readers and token scanners.
+//
+// `@uniflowed/std/io` gives the small byte `Reader` contract. This module is
+// the layer that keeps a little unread data around: peeking without consuming,
+// reading one byte at a time without forcing every caller to manage leftovers,
+// and scanning lines or words with the same machinery a protocol parser would
+// give a custom split function.
+
+import type { Reader, ReadResult } from "./io.js";
+
+export type BufferedReaderOptions = {
+  readonly bufferSize?: number,
+};
+
+export type ScannerOptions = {
+  readonly bufferSize?: number,
+  readonly maxTokenSize?: number,
+  readonly split?: SplitFunc,
+};
+
+export type SplitResult = {
+  readonly advance: number,
+  readonly token: Uint8Array | null,
+};
+
+export type SplitFunc = (data: Uint8Array, atEof: boolean) => SplitResult;
+
+const DEFAULT_BUFFER_SIZE = 4096;
+const DEFAULT_MAX_TOKEN_SIZE = 64 * 1024;
+const EMPTY = new Uint8Array(0);
+
+const utf8 = new TextDecoder();
+
+/** A token grew beyond the scanner's configured maximum. */
+export class TokenTooLongError extends Error {
+  limit: number;
+
+  constructor(limit: number) {
+    super(`token exceeds maximum size of ${String(limit)} bytes`);
+    this.name = "TokenTooLongError";
+    this.limit = limit;
+  }
+}
+
+/** A byte reader with an internal buffer for peeking and small reads. */
+export class BufferedReader {
+  _reader: Reader;
+  _buffer: Uint8Array;
+  _bufferSize: number;
+  _atEof: boolean;
+
+  constructor(reader: Reader, options?: BufferedReaderOptions) {
+    this._reader = reader;
+    this._buffer = EMPTY;
+    this._bufferSize = checkedPositive(options?.bufferSize ?? DEFAULT_BUFFER_SIZE, "bufferSize");
+    this._atEof = false;
+  }
+
+  /** Bytes currently held in the buffer. */
+  buffered(): number {
+    return this._buffer.length;
+  }
+
+  /** Replace the underlying reader and drop buffered bytes. */
+  reset(reader: Reader): void {
+    this._reader = reader;
+    this._buffer = EMPTY;
+    this._atEof = false;
+  }
+
+  /** Return up to `maxBytes` bytes, or one buffered chunk when no bound is given. */
+  async read(maxBytes?: number): Promise<ReadResult> {
+    const requested = maxBytes == null ? this._bufferSize : checkedPositive(maxBytes, "maxBytes");
+    await this._fill(1);
+    if (this._buffer.length === 0) {
+      return { done: true };
+    }
+    const count = Math.min(requested, this._buffer.length);
+    return { done: false, value: this._take(count) };
+  }
+
+  /** Return `count` bytes without consuming them. Fewer bytes means EOF. */
+  async peek(count: number): Promise<Uint8Array> {
+    const requested = checkedNonNegative(count, "count");
+    await this._fill(requested);
+    return this._buffer.subarray(0, requested).slice();
+  }
+
+  /** Consume up to `count` bytes, returning how many were actually skipped. */
+  async discard(count: number): Promise<number> {
+    let remaining = checkedNonNegative(count, "count");
+    let discarded = 0;
+    while (remaining > 0) {
+      await this._fill(1);
+      if (this._buffer.length === 0) {
+        return discarded;
+      }
+      const step = Math.min(remaining, this._buffer.length);
+      this._drop(step);
+      discarded += step;
+      remaining -= step;
+    }
+    return discarded;
+  }
+
+  /** Read one byte, or `null` at EOF. */
+  async readByte(): Promise<number | null> {
+    await this._fill(1);
+    if (this._buffer.length === 0) {
+      return null;
+    }
+    const byte = this._buffer[0];
+    this._drop(1);
+    return byte;
+  }
+
+  async cancel(reason?: mixed): Promise<void> {
+    const cancel = this._reader.cancel;
+    if (cancel != null) {
+      await cancel.call(this._reader, reason);
+    }
+    this._atEof = true;
+    this._buffer = EMPTY;
+  }
+
+  async _fill(minBytes: number): Promise<void> {
+    while (!this._atEof && this._buffer.length < minBytes) {
+      const next = await this._reader.read(this._bufferSize);
+      if (next.done) {
+        this._atEof = true;
+        return;
+      }
+      if (next.value.length === 0) {
+        return;
+      }
+      this._append(next.value);
+    }
+  }
+
+  _append(chunk: Uint8Array): void {
+    if (this._buffer.length === 0) {
+      this._buffer = chunk.slice();
+      return;
+    }
+    const joined = new Uint8Array(this._buffer.length + chunk.length);
+    joined.set(this._buffer, 0);
+    joined.set(chunk, this._buffer.length);
+    this._buffer = joined;
+  }
+
+  _take(count: number): Uint8Array {
+    const out = this._buffer.subarray(0, count);
+    this._drop(count);
+    return out;
+  }
+
+  _drop(count: number): void {
+    this._buffer = count >= this._buffer.length ? EMPTY : this._buffer.subarray(count);
+  }
+}
+
+/** Create a buffered reader over an `io.Reader`. */
+export function newReader(reader: Reader, options?: BufferedReaderOptions): BufferedReader {
+  return new BufferedReader(reader, options);
+}
+
+/** A token scanner over a byte reader. */
+export class Scanner {
+  _reader: BufferedReader;
+  _split: SplitFunc;
+  _maxTokenSize: number;
+  _atEof: boolean;
+  _token: Uint8Array;
+  _error: Error | null;
+
+  constructor(reader: Reader, options?: ScannerOptions) {
+    const readerOptions =
+      options?.bufferSize == null ? undefined : { bufferSize: options.bufferSize };
+    this._reader =
+      reader instanceof BufferedReader ? reader : new BufferedReader(reader, readerOptions);
+    this._split = options?.split ?? scanLines;
+    this._maxTokenSize = checkedPositive(
+      options?.maxTokenSize ?? DEFAULT_MAX_TOKEN_SIZE,
+      "maxTokenSize",
+    );
+    this._atEof = false;
+    this._token = EMPTY;
+    this._error = null;
+  }
+
+  /** The most recent token as bytes. */
+  bytes(): Uint8Array {
+    return this._token.slice();
+  }
+
+  /** The most recent token decoded as UTF-8. */
+  text(): string {
+    return utf8.decode(this._token);
+  }
+
+  /** The terminal scanner error, or `null` after clean EOF. */
+  error(): Error | null {
+    return this._error;
+  }
+
+  /** Scan the next token. */
+  async scan(): Promise<boolean> {
+    this._token = EMPTY;
+    if (this._error != null) {
+      return false;
+    }
+
+    for (;;) {
+      await this._reader._fill(1);
+      const buffered = this._reader._buffer;
+      const result = this._split(buffered, this._atEof);
+      validateSplit(result, buffered.length);
+      if (result.token != null) {
+        if (result.token.length > this._maxTokenSize) {
+          this._error = new TokenTooLongError(this._maxTokenSize);
+          return false;
+        }
+        await this._reader.discard(result.advance);
+        this._token = result.token;
+        return true;
+      }
+      if (result.advance > 0) {
+        await this._reader.discard(result.advance);
+        continue;
+      }
+      if (buffered.length > this._maxTokenSize) {
+        this._error = new TokenTooLongError(this._maxTokenSize);
+        return false;
+      }
+      if (this._atEof) {
+        return false;
+      }
+
+      const previous = this._reader.buffered();
+      await this._reader._fill(previous + 1);
+      if (this._reader.buffered() === previous) {
+        this._atEof = true;
+      }
+    }
+  }
+}
+
+/** Split into one-byte tokens. */
+export function scanBytes(data: Uint8Array, _atEof: boolean): SplitResult {
+  if (data.length === 0) {
+    return { advance: 0, token: null };
+  }
+  return { advance: 1, token: data.subarray(0, 1) };
+}
+
+/** Split on `\n`, returning lines without `\r` or `\n`. */
+export function scanLines(data: Uint8Array, atEof: boolean): SplitResult {
+  for (let index = 0; index < data.length; index += 1) {
+    if (data[index] === 0x0a) {
+      const end = index > 0 && data[index - 1] === 0x0d ? index - 1 : index;
+      return { advance: index + 1, token: data.subarray(0, end) };
+    }
+  }
+  if (atEof && data.length > 0) {
+    const end = data[data.length - 1] === 0x0d ? data.length - 1 : data.length;
+    return { advance: data.length, token: data.subarray(0, end) };
+  }
+  return { advance: 0, token: null };
+}
+
+/** Split on ASCII whitespace. */
+export function scanWords(data: Uint8Array, atEof: boolean): SplitResult {
+  let start = 0;
+  while (start < data.length && isSpace(data[start])) {
+    start += 1;
+  }
+  for (let end = start; end < data.length; end += 1) {
+    if (isSpace(data[end])) {
+      return { advance: end + 1, token: data.subarray(start, end) };
+    }
+  }
+  if (atEof && start < data.length) {
+    return { advance: data.length, token: data.subarray(start) };
+  }
+  return { advance: start, token: null };
+}
+
+function isSpace(byte: number): boolean {
+  return byte === 0x20 || (byte >= 0x09 && byte <= 0x0d);
+}
+
+function validateSplit(result: SplitResult, available: number): void {
+  if (!Number.isSafeInteger(result.advance) || result.advance < 0) {
+    throw new RangeError("split advance must be a non-negative safe integer");
+  }
+  if (result.advance > available) {
+    throw new RangeError("split advance exceeds buffered bytes");
+  }
+}
+
+function checkedPositive(value: number, name: string): number {
+  const checked = checkedNonNegative(value, name);
+  if (checked === 0) {
+    throw new RangeError(`${name} must be greater than zero`);
+  }
+  return checked;
+}
+
+function checkedNonNegative(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`);
+  }
+  return value;
+}

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -23,8 +23,8 @@ export type StdCategory =
  *
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
- * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv`, `binary`, `path`
- * `glob`, `hash` and `time` from #710's next tranche.
+ * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv`, `binary`, `path`,
+ * `glob`, `hash`, `time`, `io` and `bufio` from #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -15,6 +15,7 @@
     ".": "./index.js",
     "./base32": "./base32.js",
     "./binary": "./binary.js",
+    "./bufio": "./bufio.js",
     "./bytes": "./bytes.js",
     "./context": "./context.js",
     "./csv": "./csv.js",
@@ -34,6 +35,7 @@
   "files": [
     "base32.js",
     "binary.js",
+    "bufio.js",
     "bytes.js",
     "context.js",
     "csv.js",

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Sixteen modules, and what is asserted here is the property that makes each one
+// Seventeen modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -46,6 +46,15 @@ import {
   encodedLength as encodedBase32Length,
   isValid as isValidBase32,
 } from "@uniflowed/std/base32";
+import {
+  BufferedReader,
+  Scanner,
+  TokenTooLongError,
+  newReader as newBufferedReader,
+  scanBytes,
+  scanLines,
+  scanWords,
+} from "@uniflowed/std/bufio";
 import {
   BIG_ENDIAN,
   Cursor,
@@ -1326,6 +1335,122 @@ describe("io", () => {
     await expect(writer.write("not bytes")).rejects.toThrow(TypeError);
 
     expect(out.length()).toBe(0);
+  });
+});
+
+describe("bufio", () => {
+  it("peeks without consuming and owns the peeked bytes", async () => {
+    const reader = new BufferedReader(readerFromBytes(b(1, 2, 3, 4), { chunkSize: 4 }), {
+      bufferSize: 4,
+    });
+
+    const peeked = await reader.peek(2);
+    peeked[0] = 9;
+
+    expect(await reader.read(3)).toEqual({ done: false, value: b(1, 2, 3) });
+    expect(reader.buffered()).toBe(1);
+    expect(await reader.readByte()).toBe(4);
+    expect(await reader.readByte()).toBe(null);
+  });
+
+  it("discards buffered bytes before reading more", async () => {
+    const reader = newBufferedReader(readerFromBytes(b(1, 2, 3, 4, 5), { chunkSize: 2 }), {
+      bufferSize: 2,
+    });
+
+    expect(await reader.discard(3)).toBe(3);
+    expect(Array.from(await readAll(reader))).toEqual([4, 5]);
+    expect(await reader.discard(3)).toBe(0);
+  });
+
+  it("scans lines across reader chunk boundaries", async () => {
+    const scanner = new Scanner(
+      readerFromBytes(fromUtf8("alpha\nbeta\r\ngamma"), { chunkSize: 2 }),
+    );
+    const lines = [];
+
+    while (await scanner.scan()) {
+      lines.push(scanner.text());
+    }
+
+    expect(lines).toEqual(["alpha", "beta", "gamma"]);
+    expect(scanner.error()).toBe(null);
+  });
+
+  it("scans words and bytes with built-in split functions", async () => {
+    const words = new Scanner(readerFromBytes(fromUtf8(" alpha\tbeta\n gamma")), {
+      split: scanWords,
+      bufferSize: 3,
+    });
+    const found = [];
+    while (await words.scan()) {
+      found.push(words.text());
+    }
+
+    expect(found).toEqual(["alpha", "beta", "gamma"]);
+
+    const bytes = new Scanner(readerFromBytes(b(7, 8)), { split: scanBytes });
+    expect(await bytes.scan()).toBe(true);
+    expect(bytes.bytes()).toEqual(b(7));
+    expect(await bytes.scan()).toBe(true);
+    expect(bytes.bytes()).toEqual(b(8));
+    expect(await bytes.scan()).toBe(false);
+  });
+
+  it("accepts custom split functions", async () => {
+    const splitSemicolon = (data, atEof) => {
+      const separator = data.indexOf(0x3b);
+      if (separator >= 0) {
+        return { advance: separator + 1, token: data.subarray(0, separator) };
+      }
+      if (atEof && data.length > 0) {
+        return { advance: data.length, token: data };
+      }
+      return { advance: 0, token: null };
+    };
+    const scanner = new Scanner(readerFromBytes(fromUtf8("red;green;blue")), {
+      split: splitSemicolon,
+    });
+    const values = [];
+
+    while (await scanner.scan()) {
+      values.push(scanner.text());
+    }
+
+    expect(values).toEqual(["red", "green", "blue"]);
+  });
+
+  it("stops when a token grows past the configured maximum", async () => {
+    const scanner = new Scanner(readerFromBytes(fromUtf8("abcdef"), { chunkSize: 2 }), {
+      maxTokenSize: 3,
+    });
+
+    expect(await scanner.scan()).toBe(false);
+    expect(scanner.error()).toBeInstanceOf(TokenTooLongError);
+  });
+
+  it("does not count separators or skipped prefixes against the maximum token size", async () => {
+    const lines = new Scanner(readerFromBytes(fromUtf8("abc\n")), {
+      maxTokenSize: 3,
+    });
+    expect(await lines.scan()).toBe(true);
+    expect(lines.text()).toBe("abc");
+    expect(lines.error()).toBe(null);
+
+    const words = new Scanner(readerFromBytes(fromUtf8("   abc"), { chunkSize: 6 }), {
+      maxTokenSize: 3,
+      split: scanWords,
+    });
+    expect(await words.scan()).toBe(true);
+    expect(words.text()).toBe("abc");
+    expect(words.error()).toBe(null);
+  });
+
+  it("exports line splitting as the default scanner split", async () => {
+    const scanner = new Scanner(readerFromBytes(fromUtf8("one\ntwo")), { split: scanLines });
+
+    expect(await scanner.scan()).toBe(true);
+    expect(scanner.text()).toBe("one");
   });
 });
 

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -29,6 +29,13 @@
 // rather than inside the packages they are about.
 
 import { decode as decodeBase32, encode as encodeBase32 } from "../../packages/std/base32.js";
+import {
+  BufferedReader,
+  Scanner,
+  TokenTooLongError,
+  newReader as newBufferedReader,
+  scanWords,
+} from "../../packages/std/bufio.js";
 import { Cursor, putVarint, uvarint } from "../../packages/std/binary.js";
 import { Builder, compare, equal, split } from "../../packages/std/bytes.js";
 import { background, key, withCancel, withTimeout, withValue } from "../../packages/std/context.js";
@@ -241,6 +248,29 @@ const shortWrite = new ShortWriteError(2, 1);
 // expect: number is incompatible with string
 export const ioShortWriteCountsAreNumbers: string = shortWrite.written;
 
+// --- bufio ------------------------------------------------------------------
+
+const bufferedReader = new BufferedReader(readerFromBytes(left));
+const scanner = new Scanner(readerFromBytes(left), { split: scanWords });
+
+// expect: Promise
+export const bufioPeekIsAsync: Uint8Array = bufferedReader.peek(1);
+
+export const bufioBufferSizeIsNumeric: mixed = new BufferedReader(readerFromBytes(left), {
+  // expect: "large" is incompatible with number
+  bufferSize: "large",
+});
+
+// expect: string is incompatible with number
+export const bufioScannerTextIsString: number = scanner.text();
+
+// expect: Promise
+export const bufioScannerScanIsAsync: boolean = scanner.scan();
+
+const tokenTooLong = new TokenTooLongError(1024);
+// expect: number is incompatible with string
+export const bufioTokenLimitIsNumeric: string = tokenTooLong.limit;
+
 // --- slices -----------------------------------------------------------------
 
 // expect: number is incompatible with string
@@ -352,6 +382,11 @@ export const binaryPutVarint: Uint8Array = putVarint(-1n);
 export const ioReadAllBytes: Promise<Uint8Array> = readAllBytes(readerFromBytes(left));
 export const ioCopyCount: Promise<number> = copyBytes(ioWriter, readerFromBytes(left));
 export const ioBufferBytes: Uint8Array = new BufferWriter().bytes();
+export const bufioReader: BufferedReader = newBufferedReader(readerFromBytes(left));
+export const bufioPeek: Promise<Uint8Array> = bufioReader.peek(1);
+export const bufioScannerBytes: Uint8Array = scanner.bytes();
+export const bufioScannerText: string = scanner.text();
+export const bufioScannerScan: Promise<boolean> = scanner.scan();
 export const searchIndex: number = search(4, (index) => index >= 2);
 export const binarySearchResult: { readonly index: number, readonly found: boolean } = binarySearch(
   sortedNumbers,


### PR DESCRIPTION
## Summary
- add @uniflowed/std/bufio with BufferedReader, Scanner, built-in byte/line/word splits and custom split support
- publish the package export and std registry entry
- document bufio as a shipped std module and cover runtime/type behavior

Refs #710

## Verification
- uf fmt --check packages/std/bufio.js packages/std/std.test.js tests/type-tests/std-inference.js
- uf test packages/std/std.test.js
- cargo fmt -p uf_std --check
- cargo test -p uf_lib --test package_surface a_shipping_std_module_is_the_one_that_runs --profile ci
- cargo test -p uf_lib --test package_surface a_std_module_that_claims_wintertc_alignment_names_no_host --profile ci
- cargo test -p uf_lib the_std_registry_names_exactly_what_the_std_package_exports --profile ci
- cargo test -p uf_std std_registry_covers_requested_modules --profile ci
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791769968&installation_model_id=422833&pr_number=791&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F791&signature=a2b31a48aa3f47a138883c30cbc4914c24817175b859aaab55ad3d6143c4cbeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->