### PR TITLE
feat(std): ship text protocol headers

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -427,6 +427,22 @@ pub fn std_modules() -> StdModuleList {
                 "scanWords",
             ],
         ),
+        StdModule::ships(
+            "@uniflowed/std/textproto",
+            StdCategory::Network,
+            &[
+                "InvalidHeaderError",
+                "append",
+                "canonicalHeaderKey",
+                "get",
+                "parseHeaderBlock",
+                "parseHeaders",
+                "remove",
+                "set",
+                "stringifyHeaderBlock",
+                "values",
+            ],
+        ),
         // ---------------------------------------------------------------
         // Planned: nobody has written it.
         // ---------------------------------------------------------------

--- a/crates/uf_std/src/tests.rs
+++ b/crates/uf_std/src/tests.rs
@@ -73,6 +73,7 @@ fn std_registry_covers_requested_modules() {
         "@uniflowed/std/time",
         "@uniflowed/std/io",
         "@uniflowed/std/bufio",
+        "@uniflowed/std/textproto",
     ] {
         let module = modules
             .iter()

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Sixteen modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Eighteen modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -56,9 +56,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/time` | `time` | Duration arithmetic plus cancellable `Timer`, `Ticker` and `afterFunc` |
 | `@uniflowed/std/io` | `io` | Byte `Reader`/`Writer`, `copy`, `readAll`, `limitReader` and Web Stream adapters |
 | `@uniflowed/std/bufio` | `bufio` | Buffered byte reads plus `Scanner` line, word, byte and custom splits |
+| `@uniflowed/std/textproto` | `net/textproto` | MIME header blocks with canonical keys, repeated values and folded lines |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these seventeen are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these eighteen are.
 Everything above runs.
 
 ## The types are the point
@@ -225,13 +226,12 @@ on them rather than replacing them.
 ### Missing, and worth having
 
 The first six at the top of this page are tranche 1. `slices`, `base32`, `list`,
-`csv`, `binary`, `path`, `glob`, `hash`, `time`, `io` and `bufio` are the first next-tranche
+`csv`, `binary`, `path`, `glob`, `hash`, `time`, `io`, `bufio` and `textproto` are the first next-tranche
 pieces. What remains, roughly in order of value:
 
 | Go | What it would be |
 | --- | --- |
 | `archive/zip`, `archive/tar` | Reading, at least. The compression half is `DecompressionStream`; the container format is not |
-| `net/textproto` | MIME header parsing and `multipart/form-data` beyond what `FormData` gives |
 
 `sync.RWMutex` is deliberately absent rather than pending: readers and writers
 cannot run at the same time in one runtime, so it would buy a fairness policy

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -24,7 +24,7 @@ export type StdCategory =
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
  * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv`, `binary`, `path`,
- * `glob`, `hash`, `time`, `io` and `bufio` from #710's next tranche.
+ * `glob`, `hash`, `time`, `io`, `bufio` and `textproto` from #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -29,6 +29,7 @@
     "./path": "./path.js",
     "./slices": "./slices.js",
     "./sync": "./sync.js",
+    "./textproto": "./textproto.js",
     "./time": "./time.js",
     "./package.json": "./package.json"
   },
@@ -50,6 +51,7 @@
     "path.js",
     "slices.js",
     "sync.js",
+    "textproto.js",
     "time.js",
     "!*.test.js"
   ],

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Seventeen modules, and what is asserted here is the property that makes each one
+// Eighteen modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -108,6 +108,18 @@ import {
 } from "@uniflowed/std/path";
 import { binarySearch, binarySearchBy, search } from "@uniflowed/std/slices";
 import { Group, Mutex, Semaphore, WaitGroup, once } from "@uniflowed/std/sync";
+import {
+  InvalidHeaderError,
+  append as appendHeader,
+  canonicalHeaderKey,
+  get as getHeader,
+  parseHeaderBlock,
+  parseHeaders,
+  remove as removeHeader,
+  set as setHeader,
+  stringifyHeaderBlock,
+  values as headerValues,
+} from "@uniflowed/std/textproto";
 import {
   Ticker,
   Timer,
@@ -1451,6 +1463,61 @@ describe("bufio", () => {
 
     expect(await scanner.scan()).toBe(true);
     expect(scanner.text()).toBe("one");
+  });
+});
+
+describe("textproto", () => {
+  it("parses canonical MIME headers, repeated values and the rest of the body", () => {
+    const block = parseHeaderBlock(
+      "content-type: text/plain\r\nx-trace: one\r\nX-Trace: two\r\n folded\r\n\r\nbody",
+    );
+
+    expect(block.rest).toBe("body");
+    expect(getHeader(block.headers, "CONTENT-TYPE")).toBe("text/plain");
+    expect(headerValues(block.headers, "x-trace")).toEqual(["one", "two folded"]);
+    expect(Object.keys(block.headers)).toEqual(["Content-Type", "X-Trace"]);
+  });
+
+  it("updates header maps immutably", () => {
+    const original = parseHeaders("accept: text/html\n\n");
+    const changed = appendHeader(
+      setHeader(original, "accept", "application/json"),
+      "accept",
+      "*/*",
+    );
+
+    expect(headerValues(original, "Accept")).toEqual(["text/html"]);
+    expect(headerValues(changed, "ACCEPT")).toEqual(["application/json", "*/*"]);
+    expect(headerValues(removeHeader(changed, "accept"), "accept")).toEqual([]);
+  });
+
+  it("treats object prototype names as ordinary header keys", () => {
+    const parsed = parseHeaders("constructor: value\n__proto__: base\n folded\n\n");
+    const changed = appendHeader(setHeader({}, "__proto__", "plain"), "constructor", "made");
+
+    expect(Object.getPrototypeOf(parsed)).toBe(null);
+    expect(getHeader(parsed, "constructor")).toBe("value");
+    expect(headerValues(parsed, "__proto__")).toEqual(["base folded"]);
+    expect(Object.getPrototypeOf(changed)).toBe(null);
+    expect(getHeader(changed, "__proto__")).toBe("plain");
+    expect(getHeader({}, "constructor")).toBe(null);
+  });
+
+  it("stringifies terminated wire header blocks", () => {
+    const headers = appendHeader(setHeader({}, "content-type", "text/plain"), "x-trace", "one");
+
+    expect(stringifyHeaderBlock(headers)).toBe("Content-Type: text/plain\r\nX-Trace: one\r\n\r\n");
+    expect(stringifyHeaderBlock(headers, { lineTerminator: "\n" })).toBe(
+      "Content-Type: text/plain\nX-Trace: one\n\n",
+    );
+  });
+
+  it("rejects malformed header blocks", () => {
+    expect(canonicalHeaderKey("content-md5")).toBe("Content-Md5");
+    expect(() => parseHeaders(" folded\r\n\r\n")).toThrow(InvalidHeaderError);
+    expect(() => parseHeaders("bad key: value\r\n\r\n")).toThrow(InvalidHeaderError);
+    expect(() => parseHeaders("ok: value\r\n \u0001folded\r\n\r\n")).toThrow(InvalidHeaderError);
+    expect(() => stringifyHeaderBlock({ Ok: ["bad\nvalue"] })).toThrow(InvalidHeaderError);
   });
 });
 

--- a/packages/std/textproto.js
+++ b/packages/std/textproto.js
@@ -1,0 +1,293 @@
+// @flow
+//
+// `@uniflowed/std/textproto`: MIME-style text protocol headers.
+//
+// Fetch gives every runtime a `Headers` object, but a lot of protocol work
+// starts one layer lower: parse a header block out of bytes or text, keep all
+// repeated values, canonicalise keys the way Go's `net/textproto` does, and
+// leave the message body for the caller. This module is that small layer. It is
+// deliberately string-only and runtime-agnostic; multipart readers and specific
+// HTTP adapters can build on the parsed block rather than re-learning line
+// folding and repeated header values.
+
+export type HeaderMap = { +[string]: $ReadOnlyArray<string> };
+
+export type HeaderBlock = {
+  readonly headers: HeaderMap,
+  readonly rest: string,
+};
+
+export type StringifyOptions = {
+  /** Header line separator. Defaults to `\r\n`, the wire format shape. */
+  readonly lineTerminator?: "\n" | "\r\n",
+};
+
+type MutableHeaderMap = { [string]: Array<string> };
+type HeaderMapBuilder = { [string]: $ReadOnlyArray<string> };
+
+/** A malformed text-protocol header block, with a one-based line and column. */
+export class InvalidHeaderError extends Error {
+  line: number;
+  column: number;
+
+  constructor(message: string, line: number, column: number) {
+    super(`${message} at ${String(line)}:${String(column)}`);
+    this.name = "InvalidHeaderError";
+    this.line = line;
+    this.column = column;
+  }
+}
+
+/**
+ * Canonicalise a MIME header key.
+ *
+ * This follows Go's `CanonicalMIMEHeaderKey` shape: `content-type` becomes
+ * `Content-Type`, and each hyphen starts a new word. Invalid token characters
+ * are rejected rather than silently producing a key no wire protocol accepts.
+ */
+export function canonicalHeaderKey(key: string): string {
+  validateHeaderKey(key, 1, 1);
+  let canonical = "";
+  let upperNext = true;
+  for (let index = 0; index < key.length; index += 1) {
+    const character = key[index];
+    if (character === "-") {
+      canonical += "-";
+      upperNext = true;
+      continue;
+    }
+    canonical += upperNext ? character.toUpperCase() : character.toLowerCase();
+    upperNext = false;
+  }
+  return canonical;
+}
+
+/** Parse a complete header block and discard any body text after the blank line. */
+export function parseHeaders(source: string): HeaderMap {
+  return parseHeaderBlock(source).headers;
+}
+
+/**
+ * Parse a MIME-style header block.
+ *
+ * Lines may end in `\n`, `\r\n` or bare `\r`. The first blank line terminates
+ * the block and `rest` returns everything after it. A line beginning with a
+ * space or tab folds into the previous header value with one separating space.
+ */
+export function parseHeaderBlock(source: string): HeaderBlock {
+  const headers = emptyMutableHeaders();
+  let index = 0;
+  let line = 1;
+  let currentKey: string | null = null;
+
+  while (index < source.length) {
+    const start = index;
+    while (index < source.length && source[index] !== "\n" && source[index] !== "\r") {
+      index += 1;
+    }
+    const rawLine = source.slice(start, index);
+    const next = consumeLineTerminator(source, index);
+    index = next.index;
+
+    if (rawLine === "") {
+      return { headers: freezeHeaders(headers), rest: source.slice(index) };
+    }
+    if (rawLine[0] === " " || rawLine[0] === "\t") {
+      if (currentKey == null) {
+        throw new InvalidHeaderError(
+          "@uniflowed/std/textproto: continuation line without a header",
+          line,
+          1,
+        );
+      }
+      validateHeaderValue(rawLine, line, 1);
+      const values = headers[currentKey];
+      const lastIndex = values.length - 1;
+      values[lastIndex] = `${values[lastIndex]} ${trimHeaderValue(rawLine)}`;
+      line += 1;
+      continue;
+    }
+
+    const colon = rawLine.indexOf(":");
+    if (colon <= 0) {
+      throw new InvalidHeaderError(
+        "@uniflowed/std/textproto: expected header field name followed by ':'",
+        line,
+        colon < 0 ? rawLine.length + 1 : colon + 1,
+      );
+    }
+    const rawKey = rawLine.slice(0, colon);
+    validateHeaderKey(rawKey, line, 1);
+    const key = canonicalHeaderKey(rawKey);
+    const value = trimHeaderValue(rawLine.slice(colon + 1));
+    validateHeaderValue(value, line, colon + 2);
+    appendMutable(headers, key, value);
+    currentKey = key;
+    line += 1;
+
+    if (next.done) {
+      break;
+    }
+  }
+
+  return { headers: freezeHeaders(headers), rest: "" };
+}
+
+/** Serialize headers as a terminated header block. */
+export function stringifyHeaderBlock(headers: HeaderMap, options?: StringifyOptions): string {
+  const lineTerminator = options?.lineTerminator ?? "\r\n";
+  const lines = [];
+  for (const rawKey of Object.keys(headers)) {
+    const key = canonicalHeaderKey(rawKey);
+    for (const value of headers[rawKey]) {
+      validateHeaderValue(value, 1, key.length + 3);
+      lines.push(`${key}: ${value}`);
+    }
+  }
+  if (lines.length === 0) {
+    return lineTerminator;
+  }
+  return `${lines.join(lineTerminator)}${lineTerminator}${lineTerminator}`;
+}
+
+/** Return every value stored under `key`, preserving order. */
+export function values(headers: HeaderMap, key: string): $ReadOnlyArray<string> {
+  const canonical = canonicalHeaderKey(key);
+  return hasHeader(headers, canonical) ? headers[canonical] : [];
+}
+
+/** Return the first value stored under `key`, or `null` when it is absent. */
+export function get(headers: HeaderMap, key: string): string | null {
+  const found = values(headers, key);
+  return found.length === 0 ? null : found[0];
+}
+
+/** Return a new map where `key` has exactly one value. */
+export function set(headers: HeaderMap, key: string, value: string): HeaderMap {
+  const canonical = canonicalHeaderKey(key);
+  validateHeaderValue(value, 1, canonical.length + 3);
+  const next = without(headers, canonical);
+  next[canonical] = [value];
+  return next;
+}
+
+/** Return a new map with `value` appended under `key`. */
+export function append(headers: HeaderMap, key: string, value: string): HeaderMap {
+  const canonical = canonicalHeaderKey(key);
+  validateHeaderValue(value, 1, canonical.length + 3);
+  const next = without(headers, canonical);
+  next[canonical] = values(headers, canonical).concat([value]);
+  return next;
+}
+
+/** Return a new map without `key`. */
+export function remove(headers: HeaderMap, key: string): HeaderMap {
+  return without(headers, canonicalHeaderKey(key));
+}
+
+function consumeLineTerminator(
+  source: string,
+  index: number,
+): { readonly index: number, readonly done: boolean } {
+  if (index >= source.length) {
+    return { index, done: true };
+  }
+  if (source[index] === "\r" && source[index + 1] === "\n") {
+    return { index: index + 2, done: false };
+  }
+  return { index: index + 1, done: false };
+}
+
+function appendMutable(headers: MutableHeaderMap, key: string, value: string): void {
+  if (!hasHeader(headers, key)) {
+    headers[key] = [value];
+    return;
+  }
+  const existing = headers[key];
+  existing.push(value);
+}
+
+function freezeHeaders(headers: MutableHeaderMap): HeaderMap {
+  const frozen = emptyHeaderMap();
+  for (const key of Object.keys(headers)) {
+    frozen[key] = headers[key].slice();
+  }
+  return frozen;
+}
+
+function without(headers: HeaderMap, key: string): HeaderMap {
+  const next = emptyHeaderMap();
+  for (const existing of Object.keys(headers)) {
+    if (canonicalHeaderKey(existing) !== key) {
+      next[existing] = headers[existing].slice();
+    }
+  }
+  return next;
+}
+
+function emptyMutableHeaders(): MutableHeaderMap {
+  return (Object.create(null): MutableHeaderMap);
+}
+
+function emptyHeaderMap(): HeaderMapBuilder {
+  return (Object.create(null): HeaderMapBuilder);
+}
+
+function hasHeader(headers: HeaderMap | MutableHeaderMap, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(headers, key);
+}
+
+function trimHeaderValue(value: string): string {
+  return value.replace(/^[ \t]+|[ \t]+$/g, "").replace(/[ \t]+/g, " ");
+}
+
+function validateHeaderKey(key: string, line: number, column: number): void {
+  if (key === "") {
+    throw new InvalidHeaderError("@uniflowed/std/textproto: empty header field name", line, column);
+  }
+  for (let index = 0; index < key.length; index += 1) {
+    if (!isTokenCharacter(key.charCodeAt(index))) {
+      throw new InvalidHeaderError(
+        "@uniflowed/std/textproto: invalid header field name",
+        line,
+        column + index,
+      );
+    }
+  }
+}
+
+function validateHeaderValue(value: string, line: number, column: number): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if ((code < 0x20 && code !== 0x09) || code === 0x7f) {
+      throw new InvalidHeaderError(
+        "@uniflowed/std/textproto: invalid control character in header value",
+        line,
+        column + index,
+      );
+    }
+  }
+}
+
+function isTokenCharacter(code: number): boolean {
+  return (
+    (code >= 0x30 && code <= 0x39) ||
+    (code >= 0x41 && code <= 0x5a) ||
+    (code >= 0x61 && code <= 0x7a) ||
+    code === 0x21 ||
+    code === 0x23 ||
+    code === 0x24 ||
+    code === 0x25 ||
+    code === 0x26 ||
+    code === 0x27 ||
+    code === 0x2a ||
+    code === 0x2b ||
+    code === 0x2d ||
+    code === 0x2e ||
+    code === 0x5e ||
+    code === 0x5f ||
+    code === 0x60 ||
+    code === 0x7c ||
+    code === 0x7e
+  );
+}

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -61,6 +61,18 @@ import {
 } from "../../packages/std/path.js";
 import { binarySearch, binarySearchBy, search } from "../../packages/std/slices.js";
 import { Group, Mutex, Semaphore, once } from "../../packages/std/sync.js";
+import {
+  InvalidHeaderError,
+  append as appendHeader,
+  canonicalHeaderKey,
+  get as getHeader,
+  parseHeaderBlock,
+  parseHeaders,
+  set as setHeader,
+  stringifyHeaderBlock,
+  values as headerValues,
+} from "../../packages/std/textproto.js";
+import type { HeaderMap } from "../../packages/std/textproto.js";
 import { Duration, Ticker, Timer, after, milliseconds, seconds } from "../../packages/std/time.js";
 
 class HttpError extends Error {
@@ -271,6 +283,23 @@ const tokenTooLong = new TokenTooLongError(1024);
 // expect: number is incompatible with string
 export const bufioTokenLimitIsNumeric: string = tokenTooLong.limit;
 
+// --- textproto --------------------------------------------------------------
+
+const headers = parseHeaders("x-trace: one\n\n");
+const headerError = new InvalidHeaderError("bad", 2, 3);
+
+// expect: 1 is incompatible with string
+export const textprotoKeyNeedsText: mixed = canonicalHeaderKey(1);
+
+// expect: "" is incompatible with number
+export const textprotoGetAnswersText: number = getHeader(headers, "x-trace") ?? "";
+
+// expect: 1 is incompatible with string
+export const textprotoSetValueNeedsText: mixed = setHeader(headers, "x-trace", 1);
+
+// expect: number is incompatible with string
+export const textprotoErrorLineIsNumeric: string = headerError.line;
+
 // --- slices -----------------------------------------------------------------
 
 // expect: number is incompatible with string
@@ -387,6 +416,17 @@ export const bufioPeek: Promise<Uint8Array> = bufioReader.peek(1);
 export const bufioScannerBytes: Uint8Array = scanner.bytes();
 export const bufioScannerText: string = scanner.text();
 export const bufioScannerScan: Promise<boolean> = scanner.scan();
+export const textprotoHeaders: HeaderMap = headers;
+export const textprotoRest: string = parseHeaderBlock("x: y\n\nbody").rest;
+export const textprotoKey: string = canonicalHeaderKey("content-type");
+export const textprotoFirst: string | null = getHeader(headers, "x-trace");
+export const textprotoValues: $ReadOnlyArray<string> = headerValues(headers, "x-trace");
+export const textprotoChanged: HeaderMap = appendHeader(
+  setHeader(headers, "x-trace", "two"),
+  "x-trace",
+  "three",
+);
+export const textprotoBlock: string = stringifyHeaderBlock(headers);
 export const searchIndex: number = search(4, (index) => index >= 2);
 export const binarySearchResult: { readonly index: number, readonly found: boolean } = binarySearch(
   sortedNumbers,


### PR DESCRIPTION
## Summary
- add @uniflowed/std/textproto for MIME-style header block parsing and serialization
- preserve repeated header values, canonical field names, folded continuation lines and body rest
- publish the package export, std registry entry, docs row and runtime/type coverage

Refs #710

## Verification
- uf fmt --check packages/std/textproto.js packages/std/std.test.js tests/type-tests/std-inference.js packages/std/package.json packages/std/index.js crates/uf_std/src/registry.rs crates/uf_std/src/tests.rs docs/app/reference/std/$page.mdx
- uf test packages/std/std.test.js
- cargo fmt -p uf_std --check
- cargo test -p uf_lib the_std_registry_names_exactly_what_the_std_package_exports --profile ci
- cargo test -p uf_std std_registry_covers_requested_modules --profile ci
- cargo test -p uf_lib --test package_surface a_std_module_that_claims_wintertc_alignment_names_no_host --profile ci
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791770610&installation_model_id=422833&pr_number=793&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F793&signature=52159dc0c4ef1d08c981a972d5123f5ea932b27faefb6a57471338d8fb217afc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `textproto` standard module for parsing, manipulating, and serializing MIME-style headers.
  - Supports canonical header keys, repeated values, continuation lines, configurable line endings, body extraction, and detailed errors for malformed input.
  - Exposed the module through the standard package and included it among shipped modules.

- **Documentation**
  - Updated standard-library documentation to reflect the newly shipped module and revised module count.

- **Tests**
  - Added runtime and type coverage for parsing, serialization, updates, validation, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->