### PR TITLE
feat(std): ship zip container

### DIFF
--- a/crates/uf_std/src/registry.rs
+++ b/crates/uf_std/src/registry.rs
@@ -443,6 +443,11 @@ pub fn std_modules() -> StdModuleList {
                 "values",
             ],
         ),
+        StdModule::ships(
+            "@uniflowed/std/zip",
+            StdCategory::Data,
+            &["ZipReader", "ZipWriter", "deflate", "inflate"],
+        ),
         // ---------------------------------------------------------------
         // Planned: nobody has written it.
         // ---------------------------------------------------------------
@@ -569,14 +574,7 @@ pub fn std_modules() -> StdModuleList {
             StdCategory::Data,
             &["uuidV4", "uuidV7", "parseUuid"],
         ),
-        // #710's next tranche: `archive/zip` and `archive/tar`, reading at
-        // least. The compression half is `DecompressionStream` on all four
-        // runtimes; the container format is not.
-        StdModule::planned(
-            "@uniflowed/std/zip",
-            StdCategory::Data,
-            &["ZipReader", "ZipWriter", "deflate", "inflate"],
-        ),
+        // #710's next tranche: `archive/tar`, reading at least.
         StdModule::planned(
             "@uniflowed/std/import-meta",
             StdCategory::Environment,

--- a/docs/app/reference/std/$page.mdx
+++ b/docs/app/reference/std/$page.mdx
@@ -34,7 +34,7 @@ try {
 
 ## What ships today
 
-Eighteen modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
+Nineteen modules. Each is a separate subpath, so importing `@uniflowed/std/hex`
 brings in a hex codec and nothing else.
 
 | Import | Go's name | What it is |
@@ -57,9 +57,10 @@ brings in a hex codec and nothing else.
 | `@uniflowed/std/io` | `io` | Byte `Reader`/`Writer`, `copy`, `readAll`, `limitReader` and Web Stream adapters |
 | `@uniflowed/std/bufio` | `bufio` | Buffered byte reads plus `Scanner` line, word, byte and custom splits |
 | `@uniflowed/std/textproto` | `net/textproto` | MIME header blocks with canonical keys, repeated values and folded lines |
+| `@uniflowed/std/zip` | `archive/zip` | ZIP central-directory reading and writing over store and web DEFLATE streams |
 
 The root `@uniflowed/std` is unchanged: it is a declaration surface whose
-functions raise `NativeRuntimeRequiredError`, and it is not what these eighteen are.
+functions raise `NativeRuntimeRequiredError`, and it is not what these nineteen are.
 Everything above runs.
 
 ## The types are the point
@@ -226,12 +227,12 @@ on them rather than replacing them.
 ### Missing, and worth having
 
 The first six at the top of this page are tranche 1. `slices`, `base32`, `list`,
-`csv`, `binary`, `path`, `glob`, `hash`, `time`, `io`, `bufio` and `textproto` are the first next-tranche
+`csv`, `binary`, `path`, `glob`, `hash`, `time`, `io`, `bufio`, `textproto` and `zip` are the first next-tranche
 pieces. What remains, roughly in order of value:
 
 | Go | What it would be |
 | --- | --- |
-| `archive/zip`, `archive/tar` | Reading, at least. The compression half is `DecompressionStream`; the container format is not |
+| `archive/tar` | Reading, at least. The container format is not built into the platform |
 
 `sync.RWMutex` is deliberately absent rather than pending: readers and writers
 cannot run at the same time in one runtime, so it would buy a fairness policy

--- a/packages/std/index.js
+++ b/packages/std/index.js
@@ -24,7 +24,7 @@ export type StdCategory =
  * `"ships"` is the subpaths that have real code behind their own export paths:
  * the six of ubugeeei-prod/uf#711 — `errors`, `sync`, `context`, `bytes`,
  * `heap`, `hex` — plus `slices`, `base32`, `list`, `csv`, `binary`, `path`,
- * `glob`, `hash`, `time`, `io`, `bufio` and `textproto` from #710's next tranche.
+ * `glob`, `hash`, `time`, `io`, `bufio`, `textproto` and `zip` from #710's next tranche.
  * `"declared"` is this module: functions that raise
  * `NativeRuntimeRequiredError`. `"planned"` means nobody has written it, and
  * nothing more; `"declined"` is a decision that the platform or another

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -31,6 +31,7 @@
     "./sync": "./sync.js",
     "./textproto": "./textproto.js",
     "./time": "./time.js",
+    "./zip": "./zip.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -53,6 +54,7 @@
     "sync.js",
     "textproto.js",
     "time.js",
+    "zip.js",
     "!*.test.js"
   ],
   "dependencies": {

--- a/packages/std/std.test.js
+++ b/packages/std/std.test.js
@@ -2,7 +2,7 @@
 //
 // `@uniflowed/std`: the Go standard library modules that JavaScript is missing.
 //
-// Eighteen modules, and what is asserted here is the property that makes each one
+// Nineteen modules, and what is asserted here is the property that makes each one
 // worth importing rather than the fact that it returns something. A `heap` that
 // pops in the wrong order is a heap; an `errors.is` that hangs on a cycle
 // answers every question correctly until the one that matters; a `Group` that
@@ -130,6 +130,12 @@ import {
   minutes,
   seconds,
 } from "@uniflowed/std/time";
+import {
+  ZipReader,
+  ZipWriter,
+  deflate as zipDeflate,
+  inflate as zipInflate,
+} from "@uniflowed/std/zip";
 
 import { everyMisuseIsReported } from "../../tests/library/type-tests.js";
 
@@ -1518,6 +1524,52 @@ describe("textproto", () => {
     expect(() => parseHeaders("bad key: value\r\n\r\n")).toThrow(InvalidHeaderError);
     expect(() => parseHeaders("ok: value\r\n \u0001folded\r\n\r\n")).toThrow(InvalidHeaderError);
     expect(() => stringifyHeaderBlock({ Ok: ["bad\nvalue"] })).toThrow(InvalidHeaderError);
+  });
+});
+
+describe("zip", () => {
+  it("deflates and inflates raw byte ranges with web streams", async () => {
+    const input = fromUtf8("the quick brown fox ".repeat(20));
+
+    const compressed = await zipDeflate(input);
+    const output = await zipInflate(compressed);
+
+    expect(compressed.length).toBeLessThan(input.length);
+    expect(toUtf8(output)).toBe(toUtf8(input));
+  });
+
+  it("writes a central directory and reads store and deflate entries", async () => {
+    const writer = new ZipWriter();
+    await writer.add("hello.txt", fromUtf8("hello"), { compression: "store" });
+    await writer.add("nested/readme.txt", fromUtf8("read me ".repeat(12)));
+
+    const reader = new ZipReader(writer.bytes());
+
+    expect(reader.entries().map((entry) => [entry.path, entry.compression, entry.size])).toEqual([
+      ["hello.txt", "store", 5],
+      ["nested/readme.txt", "deflate", 96],
+    ]);
+    expect(toUtf8(await reader.read("hello.txt"))).toBe("hello");
+    expect(toUtf8(await reader.read("nested/readme.txt"))).toBe("read me ".repeat(12));
+  });
+
+  it("rejects corrupted entry data instead of returning unchecked bytes", async () => {
+    const writer = new ZipWriter();
+    const payload = fromUtf8("payload");
+    await writer.add("file.txt", payload, { compression: "store" });
+    const archive = writer.bytes();
+    const at = indexOf(archive, payload);
+    expect(at).toBeGreaterThan(-1);
+
+    const corrupted = archive.slice();
+    corrupted[at] ^= 0xff;
+
+    await expect(new ZipReader(corrupted).read("file.txt")).rejects.toThrow("CRC32");
+  });
+
+  it("rejects unsafe paths and unsupported archives", async () => {
+    await expect(new ZipWriter().add("../escape.txt", b(1))).rejects.toThrow("unsafe");
+    expect(() => new ZipReader(b(1, 2, 3))).toThrow("end of central directory");
   });
 });
 

--- a/packages/std/zip.js
+++ b/packages/std/zip.js
@@ -1,0 +1,475 @@
+// @flow
+//
+// `@uniflowed/std/zip`: ZIP container reading and writing.
+//
+// The web platform already owns the DEFLATE codec through
+// `CompressionStream` and `DecompressionStream`. What it does not own is the
+// ZIP container around the compressed byte ranges: the central directory, local
+// headers, CRC checks and file names. This module keeps that split explicit.
+
+import { crc32 } from "./hash.js";
+
+export type ZipCompression = "store" | "deflate";
+
+export type ZipEntry = {
+  readonly path: string,
+  readonly compression: ZipCompression,
+  readonly size: number,
+  readonly compressedSize: number,
+  readonly crc32: number,
+};
+
+type ZipRecord = {
+  readonly entry: ZipEntry,
+  readonly localHeaderOffset: number,
+};
+
+type WriteRecord = {
+  readonly entry: ZipEntry,
+  readonly data: Uint8Array,
+};
+
+type StreamReadStep = {
+  readonly done?: boolean,
+  readonly value?: mixed,
+  ...
+};
+
+type StreamReader = {
+  readonly read: () => Promise<StreamReadStep>,
+  readonly cancel?: (reason?: mixed) => Promise<void> | void,
+  ...
+};
+
+type ReadableStreamLike = {
+  readonly getReader: () => StreamReader,
+  ...
+};
+
+type StreamWriter = {
+  readonly write: (chunk: Uint8Array) => Promise<void> | void,
+  readonly close: () => Promise<void> | void,
+  readonly abort?: (reason?: mixed) => Promise<void> | void,
+  ...
+};
+
+type WritableStreamLike = {
+  readonly getWriter: () => StreamWriter,
+  ...
+};
+
+type ByteTransform = {
+  readonly readable: ReadableStreamLike,
+  readonly writable: WritableStreamLike,
+  ...
+};
+
+export type ByteTransformFactory = (format: "deflate-raw") => ByteTransform;
+
+export type ZipCodecOptions = {
+  readonly makeCompressionStream?: ByteTransformFactory,
+  readonly makeDecompressionStream?: ByteTransformFactory,
+};
+
+export type ZipReaderOptions = {
+  readonly makeDecompressionStream?: ByteTransformFactory,
+};
+
+export type ZipWriterOptions = {
+  readonly compression?: ZipCompression,
+  readonly makeCompressionStream?: ByteTransformFactory,
+};
+
+/** Deflate raw bytes with the host's web compression stream. */
+export async function deflate(bytes: Uint8Array, options?: ZipCodecOptions): Promise<Uint8Array> {
+  return transformBytes(bytes, options?.makeCompressionStream ?? defaultCompressionStream);
+}
+
+/** Inflate raw DEFLATE bytes with the host's web decompression stream. */
+export async function inflate(bytes: Uint8Array, options?: ZipCodecOptions): Promise<Uint8Array> {
+  return transformBytes(bytes, options?.makeDecompressionStream ?? defaultDecompressionStream);
+}
+
+/** Read entries from an in-memory ZIP archive. */
+export class ZipReader {
+  _bytes: Uint8Array;
+  _view: DataView;
+  _records: Array<ZipRecord>;
+  _byPath: Map<string, ZipRecord>;
+  _makeDecompressionStream: ByteTransformFactory;
+
+  constructor(bytes: Uint8Array, options?: ZipReaderOptions) {
+    this._bytes = bytes;
+    this._view = view(bytes);
+    this._makeDecompressionStream = options?.makeDecompressionStream ?? defaultDecompressionStream;
+    this._records = readCentralDirectory(bytes, this._view);
+    this._byPath = new Map();
+    for (const record of this._records) {
+      if (this._byPath.has(record.entry.path)) {
+        throw new Error(`@uniflowed/std/zip: duplicate entry ${JSON.stringify(record.entry.path)}`);
+      }
+      this._byPath.set(record.entry.path, record);
+    }
+  }
+
+  entries(): $ReadOnlyArray<ZipEntry> {
+    return this._records.map((record) => record.entry);
+  }
+
+  async read(pathOrEntry: string | ZipEntry): Promise<Uint8Array> {
+    const path = typeof pathOrEntry === "string" ? pathOrEntry : pathOrEntry.path;
+    const record = this._byPath.get(path);
+    if (record == null) {
+      throw new Error(`@uniflowed/std/zip: entry not found: ${JSON.stringify(path)}`);
+    }
+    const compressed = readCompressedData(this._bytes, this._view, record);
+    const entry = record.entry;
+    const data =
+      entry.compression === "store"
+        ? compressed.slice()
+        : await inflate(compressed, { makeDecompressionStream: this._makeDecompressionStream });
+    if (data.length !== entry.size) {
+      throw new Error(`@uniflowed/std/zip: ${entry.path} inflated to the wrong size`);
+    }
+    if (crc32(data) !== entry.crc32) {
+      throw new Error(`@uniflowed/std/zip: ${entry.path} failed CRC32 verification`);
+    }
+    return data;
+  }
+}
+
+/** Write a small in-memory ZIP archive. */
+export class ZipWriter {
+  _records: Array<WriteRecord>;
+  _makeCompressionStream: ByteTransformFactory;
+
+  constructor(options?: ZipWriterOptions) {
+    this._records = [];
+    this._makeCompressionStream = options?.makeCompressionStream ?? defaultCompressionStream;
+  }
+
+  async add(path: string, bytes: Uint8Array, options?: ZipWriterOptions): Promise<ZipEntry> {
+    const checked = checkedPath(path);
+    if (this._records.some((record) => record.entry.path === checked)) {
+      throw new Error(`@uniflowed/std/zip: duplicate entry ${JSON.stringify(checked)}`);
+    }
+    const compression = checkedCompression(options?.compression ?? "deflate");
+    const owned = bytes.slice();
+    const data =
+      compression === "store"
+        ? owned
+        : await deflate(owned, {
+            makeCompressionStream: options?.makeCompressionStream ?? this._makeCompressionStream,
+          });
+    const entry = {
+      path: checked,
+      compression,
+      size: owned.length,
+      compressedSize: data.length,
+      crc32: crc32(owned),
+    };
+    this._records.push({ entry, data });
+    return entry;
+  }
+
+  bytes(): Uint8Array {
+    const local = [];
+    const central = [];
+    let offset = 0;
+    for (const record of this._records) {
+      const name = ENCODER.encode(record.entry.path);
+      const header = localHeader(record.entry, name);
+      local.push(header, name, record.data);
+      central.push(centralHeader(record.entry, name, offset));
+      offset += header.length + name.length + record.data.length;
+    }
+    const centralOffset = offset;
+    const centralBytes = concat(central);
+    const end = endOfCentralDirectory(this._records.length, centralBytes.length, centralOffset);
+    return concat(local.concat([centralBytes, end]));
+  }
+}
+
+async function transformBytes(
+  bytes: Uint8Array,
+  makeTransform: ByteTransformFactory,
+): Promise<Uint8Array> {
+  const transform = makeTransform("deflate-raw");
+  const read = readStream(transform.readable);
+  const writer = transform.writable.getWriter();
+  await writer.write(bytes);
+  await writer.close();
+  return await read;
+}
+
+async function readStream(stream: ReadableStreamLike): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks = [];
+  for (;;) {
+    const next = await reader.read();
+    if (next.done === true) {
+      return concat(chunks);
+    }
+    if (!(next.value instanceof Uint8Array)) {
+      await reader.cancel?.("@uniflowed/std/zip: stream produced a non-byte chunk");
+      throw new TypeError("@uniflowed/std/zip: stream produced a non-byte chunk");
+    }
+    chunks.push(next.value);
+  }
+}
+
+function readCentralDirectory(bytes: Uint8Array, data: DataView): Array<ZipRecord> {
+  const end = findEnd(bytes, data);
+  const records = [];
+  let offset = end.centralOffset;
+  for (let index = 0; index < end.entries; index += 1) {
+    need(bytes, offset, 46, "central directory header");
+    if (u32(data, offset) !== CENTRAL_FILE_HEADER) {
+      throw new Error("@uniflowed/std/zip: invalid central directory signature");
+    }
+    const flags = u16(data, offset + 8);
+    if ((flags & ENCRYPTED) !== 0) {
+      throw new Error("@uniflowed/std/zip: encrypted entries are not supported");
+    }
+    const compression = compressionFromMethod(u16(data, offset + 10));
+    const crc = u32(data, offset + 16);
+    const compressedSize = u32(data, offset + 20);
+    const size = u32(data, offset + 24);
+    const nameLength = u16(data, offset + 28);
+    const extraLength = u16(data, offset + 30);
+    const commentLength = u16(data, offset + 32);
+    const disk = u16(data, offset + 34);
+    const localHeaderOffset = u32(data, offset + 42);
+    if (disk !== 0 || isZip64(size) || isZip64(compressedSize) || isZip64(localHeaderOffset)) {
+      throw new Error("@uniflowed/std/zip: Zip64 and multi-disk archives are not supported");
+    }
+    const nameOffset = offset + 46;
+    need(bytes, nameOffset, nameLength + extraLength + commentLength, "central directory name");
+    const path = checkedPath(
+      decodeName(bytes.subarray(nameOffset, nameOffset + nameLength), flags),
+    );
+    records.push({
+      entry: { path, compression, size, compressedSize, crc32: crc },
+      localHeaderOffset,
+    });
+    offset = nameOffset + nameLength + extraLength + commentLength;
+  }
+  if (offset !== end.centralOffset + end.centralSize) {
+    throw new Error("@uniflowed/std/zip: central directory size does not match its entries");
+  }
+  return records;
+}
+
+function readCompressedData(bytes: Uint8Array, data: DataView, record: ZipRecord): Uint8Array {
+  const offset = record.localHeaderOffset;
+  need(bytes, offset, 30, "local file header");
+  if (u32(data, offset) !== LOCAL_FILE_HEADER) {
+    throw new Error("@uniflowed/std/zip: invalid local file header signature");
+  }
+  const nameLength = u16(data, offset + 26);
+  const extraLength = u16(data, offset + 28);
+  const start = offset + 30 + nameLength + extraLength;
+  need(bytes, start, record.entry.compressedSize, "compressed entry data");
+  return bytes.subarray(start, start + record.entry.compressedSize);
+}
+
+function findEnd(
+  bytes: Uint8Array,
+  data: DataView,
+): {
+  readonly entries: number,
+  readonly centralSize: number,
+  readonly centralOffset: number,
+} {
+  for (
+    let offset = bytes.length - 22;
+    offset >= Math.max(0, bytes.length - 0xffff - 22);
+    offset -= 1
+  ) {
+    if (u32(data, offset) !== END_OF_CENTRAL_DIRECTORY) continue;
+    const entries = u16(data, offset + 10);
+    const centralSize = u32(data, offset + 12);
+    const centralOffset = u32(data, offset + 16);
+    const commentLength = u16(data, offset + 20);
+    if (offset + 22 + commentLength !== bytes.length) continue;
+    if (
+      u16(data, offset + 4) !== 0 ||
+      u16(data, offset + 6) !== 0 ||
+      entries !== u16(data, offset + 8) ||
+      entries === 0xffff ||
+      isZip64(centralSize) ||
+      isZip64(centralOffset)
+    ) {
+      throw new Error("@uniflowed/std/zip: Zip64 and multi-disk archives are not supported");
+    }
+    need(bytes, centralOffset, centralSize, "central directory");
+    return { entries, centralSize, centralOffset };
+  }
+  throw new Error("@uniflowed/std/zip: end of central directory not found");
+}
+
+function localHeader(entry: ZipEntry, name: Uint8Array): Uint8Array {
+  const out = new Uint8Array(30);
+  const data = view(out);
+  put32(data, 0, LOCAL_FILE_HEADER);
+  put16(data, 4, VERSION_NEEDED);
+  put16(data, 6, UTF8_NAMES);
+  put16(data, 8, methodForCompression(entry.compression));
+  put32(data, 14, entry.crc32);
+  put32(data, 18, entry.compressedSize);
+  put32(data, 22, entry.size);
+  put16(data, 26, name.length);
+  return out;
+}
+
+function centralHeader(entry: ZipEntry, name: Uint8Array, localHeaderOffset: number): Uint8Array {
+  const out = new Uint8Array(46 + name.length);
+  const data = view(out);
+  put32(data, 0, CENTRAL_FILE_HEADER);
+  put16(data, 4, VERSION_NEEDED);
+  put16(data, 6, VERSION_NEEDED);
+  put16(data, 8, UTF8_NAMES);
+  put16(data, 10, methodForCompression(entry.compression));
+  put32(data, 16, entry.crc32);
+  put32(data, 20, entry.compressedSize);
+  put32(data, 24, entry.size);
+  put16(data, 28, name.length);
+  put32(data, 42, localHeaderOffset);
+  out.set(name, 46);
+  return out;
+}
+
+function endOfCentralDirectory(entries: number, size: number, offset: number): Uint8Array {
+  const out = new Uint8Array(22);
+  const data = view(out);
+  put32(data, 0, END_OF_CENTRAL_DIRECTORY);
+  put16(data, 8, entries);
+  put16(data, 10, entries);
+  put32(data, 12, size);
+  put32(data, 16, offset);
+  return out;
+}
+
+function concat(chunks: $ReadOnlyArray<Uint8Array>): Uint8Array {
+  const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+function decodeName(bytes: Uint8Array, flags: number): string {
+  if ((flags & UTF8_NAMES) === 0) {
+    for (const byte of bytes) {
+      if (byte > 0x7f) {
+        throw new Error("@uniflowed/std/zip: non-UTF-8 entry names are not supported");
+      }
+    }
+  }
+  return DECODER.decode(bytes);
+}
+
+function checkedPath(path: string): string {
+  if (
+    path === "" ||
+    path.includes("\0") ||
+    path.includes("\\") ||
+    path.startsWith("/") ||
+    /^[A-Za-z]:/.test(path)
+  ) {
+    throw new Error(`@uniflowed/std/zip: unsafe entry path ${JSON.stringify(path)}`);
+  }
+  const parts = path.split("/");
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    const trailingDirectorySlash = index === parts.length - 1 && part === "";
+    if (trailingDirectorySlash) continue;
+    if (part === "" || part === "." || part === "..") {
+      throw new Error(`@uniflowed/std/zip: unsafe entry path ${JSON.stringify(path)}`);
+    }
+  }
+  return path;
+}
+
+function checkedCompression(compression: ZipCompression): ZipCompression {
+  if (compression !== "store" && compression !== "deflate") {
+    throw new Error(`@uniflowed/std/zip: unknown compression ${String(compression)}`);
+  }
+  return compression;
+}
+
+function compressionFromMethod(method: number): ZipCompression {
+  if (method === 0) return "store";
+  if (method === 8) return "deflate";
+  throw new Error(`@uniflowed/std/zip: compression method ${String(method)} is not supported`);
+}
+
+function methodForCompression(compression: ZipCompression): number {
+  return compression === "store" ? 0 : 8;
+}
+
+function defaultCompressionStream(format: "deflate-raw"): ByteTransform {
+  return defaultTransform("CompressionStream", format);
+}
+
+function defaultDecompressionStream(format: "deflate-raw"): ByteTransform {
+  return defaultTransform("DecompressionStream", format);
+}
+
+function defaultTransform(name: string, format: "deflate-raw"): ByteTransform {
+  const globals: { readonly [string]: mixed } = globalThis;
+  const constructor = globals[name];
+  if (typeof constructor !== "function") {
+    throw new Error(`@uniflowed/std/zip: ${name} is not available`);
+  }
+  const Transform = constructor as $FlowFixMe;
+  return new Transform(format);
+}
+
+function view(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function need(bytes: Uint8Array, offset: number, length: number, label: string): void {
+  if (offset < 0 || length < 0 || offset + length > bytes.length) {
+    throw new Error(`@uniflowed/std/zip: truncated ${label}`);
+  }
+}
+
+function u16(data: DataView, offset: number): number {
+  return data.getUint16(offset, true);
+}
+
+function u32(data: DataView, offset: number): number {
+  return data.getUint32(offset, true);
+}
+
+function put16(data: DataView, offset: number, value: number): void {
+  if (value < 0 || value > 0xffff) {
+    throw new RangeError("@uniflowed/std/zip: value does not fit in uint16");
+  }
+  data.setUint16(offset, value, true);
+}
+
+function put32(data: DataView, offset: number, value: number): void {
+  if (value < 0 || value > 0xffffffff) {
+    throw new RangeError("@uniflowed/std/zip: value does not fit in uint32");
+  }
+  data.setUint32(offset, value, true);
+}
+
+function isZip64(value: number): boolean {
+  return value === 0xffffffff;
+}
+
+const LOCAL_FILE_HEADER = 0x04034b50;
+const CENTRAL_FILE_HEADER = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY = 0x06054b50;
+const ENCRYPTED = 1 << 0;
+const UTF8_NAMES = 1 << 11;
+const VERSION_NEEDED = 20;
+const ENCODER: TextEncoder = new TextEncoder();
+const DECODER: TextDecoder = new TextDecoder();

--- a/tests/type-tests/std-inference.js
+++ b/tests/type-tests/std-inference.js
@@ -74,6 +74,13 @@ import {
 } from "../../packages/std/textproto.js";
 import type { HeaderMap } from "../../packages/std/textproto.js";
 import { Duration, Ticker, Timer, after, milliseconds, seconds } from "../../packages/std/time.js";
+import {
+  ZipReader,
+  ZipWriter,
+  deflate as zipDeflate,
+  inflate as zipInflate,
+} from "../../packages/std/zip.js";
+import type { ZipEntry } from "../../packages/std/zip.js";
 
 class HttpError extends Error {
   status: number;
@@ -300,6 +307,25 @@ export const textprotoSetValueNeedsText: mixed = setHeader(headers, "x-trace", 1
 // expect: number is incompatible with string
 export const textprotoErrorLineIsNumeric: string = headerError.line;
 
+// --- zip --------------------------------------------------------------------
+
+const zipReader = new ZipReader(left);
+const zipWriter = new ZipWriter();
+
+// expect: Promise
+export const zipReadIsAsync: Uint8Array = zipReader.read("file.txt");
+
+// expect: 1 is incompatible with string
+export const zipAddPathNeedsText: mixed = zipWriter.add(1, left);
+
+export const zipAddCompressionIsChecked: mixed = zipWriter.add("file.txt", left, {
+  // expect: "brotli" is incompatible with ZipCompression
+  compression: "brotli",
+});
+
+// expect: Promise
+export const zipDeflateIsAsync: Uint8Array = zipDeflate(left);
+
 // --- slices -----------------------------------------------------------------
 
 // expect: number is incompatible with string
@@ -427,6 +453,11 @@ export const textprotoChanged: HeaderMap = appendHeader(
   "three",
 );
 export const textprotoBlock: string = stringifyHeaderBlock(headers);
+export const zipEntries: $ReadOnlyArray<ZipEntry> = zipReader.entries();
+export const zipInflatedBytes: Promise<Uint8Array> = zipInflate(left);
+export const zipAddedEntry: Promise<ZipEntry> = zipWriter.add("file.txt", left, {
+  compression: "store",
+});
 export const searchIndex: number = search(4, (index) => index >= 2);
 export const binarySearchResult: { readonly index: number, readonly found: boolean } = binarySearch(
   sortedNumbers,


### PR DESCRIPTION
## Summary
- add `@uniflowed/std/zip` with ZIP central-directory reading and writing
- bridge raw deflate/inflate through web `CompressionStream` and `DecompressionStream`
- update package exports, std registry metadata, docs, runtime tests, and type-inference coverage

Advances #710.

## Verification
- `uf fmt --check packages/std/zip.js packages/std/std.test.js tests/type-tests/std-inference.js packages/std/package.json packages/std/index.js crates/uf_std/src/registry.rs 'docs/app/reference/std/$page.mdx'`\n- `uf test packages/std/std.test.js`\n- `cargo fmt -p uf_std --check`\n- `cargo test -p uf_lib the_std_registry_names_exactly_what_the_std_package_exports --profile ci`\n- `cargo test -p uf_std std_registry_covers_requested_modules --profile ci`\n- `cargo test -p uf_lib --test package_surface a_shipping_std_module_is_the_one_that_runs --profile ci`\n- `cargo test -p uf_lib --test package_surface a_std_module_that_claims_wintertc_alignment_names_no_host --profile ci`\n- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791772079&installation_model_id=422833&pr_number=794&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F794&signature=866d1c97628f1857d9b70989ae918f0f43e183a0f115cd2a7ea237b0548993f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->