### PR TITLE
fix(rsc): keep package client boundaries

### DIFF
--- a/crates/uf_cli/src/commands/dev/rsc.rs
+++ b/crates/uf_cli/src/commands/dev/rsc.rs
@@ -412,20 +412,43 @@ fn reason_line(graph: &RscGraph, module: &Utf8Path) -> String {
                 .filter_map(|id| graph.module_by_id(*id))
                 .map(|module| module.path.as_str())
                 .collect::<Vec<_>>();
-            match paths.split_last() {
-                // The chain reads as the imports somebody would follow, and
-                // the last hop is named for what it is rather than left to be
-                // inferred from the arrow before it.
-                Some((boundary, above)) => format!(
-                    "{} imports {boundary}, which declares `\"use client\"`",
-                    above.join(" imports ")
-                ),
-                None => "it reaches a client boundary".to_owned(),
-            }
+            path_boundary_reason(&paths)
+        }
+        ClientBundleReason::ImportsPackage { chain, specifier } => {
+            let paths = chain
+                .iter()
+                .filter_map(|id| graph.module_by_id(*id))
+                .map(|module| module.path.as_str())
+                .collect::<Vec<_>>();
+            package_boundary_reason(&paths, &specifier)
         }
         ClientBundleReason::Isolated => {
             "the split and the explanation disagree about it, which is a bug in uf".to_owned()
         }
+    }
+}
+
+fn path_boundary_reason(paths: &[&str]) -> String {
+    match paths.split_last() {
+        // The chain reads as the imports somebody would follow, and the last
+        // hop is named for what it is rather than left to be inferred from the
+        // arrow before it.
+        Some((boundary, above)) => format!(
+            "{} imports {boundary}, which declares `\"use client\"`",
+            above.join(" imports ")
+        ),
+        None => "it reaches a client boundary".to_owned(),
+    }
+}
+
+fn package_boundary_reason(paths: &[&str], specifier: &str) -> String {
+    match paths {
+        [] => "it reaches a client boundary".to_owned(),
+        [only] => format!("{only} imports {specifier}, which uf knows is a client module"),
+        _ => format!(
+            "{} imports {specifier}, which uf knows is a client module",
+            paths.join(" imports ")
+        ),
     }
 }
 

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -5460,7 +5460,7 @@ fn the_client_bundle_loses_a_route_that_needs_no_javascript() {
         &fs::read_to_string(root.join(".uf/build/meta/uf-rsc-manifest.json")).unwrap(),
     )
     .unwrap();
-    assert_eq!(manifest["version"], serde_json::json!(2));
+    assert_eq!(manifest["version"], serde_json::json!(3));
     let proximity = |path: &str| {
         manifest["modules"]
             .as_array()

--- a/crates/uf_lib/src/registry.rs
+++ b/crates/uf_lib/src/registry.rs
@@ -1100,10 +1100,9 @@ pub const CLIENT_MODULE_PACKAGE: &str = "@uniflowed/ui";
 /// are Server Components, and shipping them to the browser because they came
 /// out of the same package would be exactly the mistake RSC exists to stop.
 ///
-/// uf's own package only. A third party needs a way to *declare* a client root
-/// — a manifest field, or the `react-server` export condition — which is the
-/// other half of #718 and waits on whether a manifest may name a specifier
-/// rather than a path.
+/// uf's own package only. A third party still needs a way to *declare* a
+/// client root — a manifest field, or the `react-server` export condition —
+/// before the same package-specifier boundary can be populated from its data.
 pub const CLIENT_MODULE_SUBPATHS: &[&str] = &[
     "accordion",
     "alert-dialog",

--- a/crates/uf_rsc/src/graph.rs
+++ b/crates/uf_rsc/src/graph.rs
@@ -232,13 +232,22 @@ impl ClientBoundaryProximity {
     }
 }
 
-/// A server module importing a `"use client"` module.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// The far side of a server-to-client import.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ClientBoundaryTarget {
+    /// A project module the graph scanned.
+    Module(ModuleId),
+    /// A package module the graph knows without walking `node_modules`.
+    Package(CompactString),
+}
+
+/// A server module importing a client module.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClientBoundary {
     /// The server module that owns the import.
     pub importer: ModuleId,
-    /// The `"use client"` module, which becomes a client bundle root.
-    pub client_module: ModuleId,
+    /// The client module, which becomes a client bundle root.
+    pub target: ClientBoundaryTarget,
 }
 
 /// One module as it is fed into [`RscGraphBuilder`].
@@ -380,7 +389,7 @@ pub struct RscGraph {
     modules: Vec<RscModule>,
     index: FxHashMap<Utf8PathBuf, ModuleId>,
     boundaries: Vec<ClientBoundary>,
-    bundle_roots: Vec<ModuleId>,
+    bundle_roots: Vec<ClientBoundaryTarget>,
     diagnostics: Vec<RscDiagnostic>,
 }
 
@@ -420,7 +429,7 @@ impl RscGraph {
     }
 
     /// Client bundle roots, ordered.
-    pub fn client_bundle_roots(&self) -> &[ModuleId] {
+    pub fn client_bundle_roots(&self) -> &[ClientBoundaryTarget] {
         &self.bundle_roots
     }
 
@@ -501,6 +510,16 @@ impl RscGraph {
         work.push_back(id);
 
         while let Some(current) = work.pop_front() {
+            if let Some(specifier) = self.modules[current.index()]
+                .external_imports
+                .iter()
+                .find(|specifier| uf_lib::is_client_module(specifier))
+            {
+                return ClientBundleReason::ImportsPackage {
+                    chain: self.chain_to(id, current, &predecessor),
+                    specifier: specifier.clone(),
+                };
+            }
             for target in self.modules[current.index()].imports.iter().copied() {
                 if seen[target.index()] {
                     continue;
@@ -537,9 +556,11 @@ impl RscGraph {
 
 /// Why the browser has to be able to evaluate a module.
 ///
-/// The answer [`RscGraph::client_bundle_reason`] gives, and the three shapes it
-/// can take. There is no fourth: a module is a boundary, is above one, or is
-/// not the browser's business.
+/// The answer [`RscGraph::client_bundle_reason`] gives.
+///
+/// A package client module can be the far side of the boundary too, but it is
+/// still the same question: this module is a boundary, is above one, or is not
+/// the browser's business.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClientBundleReason {
     /// Nothing the browser evaluates reaches this module.
@@ -559,6 +580,16 @@ pub enum ClientBundleReason {
     /// after it. Never empty, and never one element long — a chain of one
     /// would be [`Self::Declared`] said badly.
     Imports(Vec<ModuleId>),
+    /// The module imports a known package client module, through this chain.
+    ///
+    /// The chain names project modules only: the package specifier is not a
+    /// module id because it deliberately was not read from `node_modules`.
+    ImportsPackage {
+        /// Project modules followed to the importer of `specifier`.
+        chain: Vec<ModuleId>,
+        /// Bare specifier imported at the boundary.
+        specifier: CompactString,
+    },
 }
 
 #[cfg(test)]

--- a/crates/uf_rsc/src/graph/build.rs
+++ b/crates/uf_rsc/src/graph/build.rs
@@ -21,8 +21,8 @@ use super::resolve::{
     resolve_specifier,
 };
 use super::{
-    ClientBoundary, ClientBoundaryProximity, EntryKind, ModuleId, ModuleReachability, RscGraph,
-    RscModule, RscModuleInput,
+    ClientBoundary, ClientBoundaryProximity, ClientBoundaryTarget, EntryKind, ModuleId,
+    ModuleReachability, RscGraph, RscModule, RscModuleInput,
 };
 
 /// Collects modules and entries, then resolves them into an [`RscGraph`].
@@ -303,7 +303,15 @@ fn collect_boundaries(
             if environments[target.index()] == ModuleEnvironment::Client {
                 boundaries.push(ClientBoundary {
                     importer: ModuleId(position as u32),
-                    client_module: target,
+                    target: ClientBoundaryTarget::Module(target),
+                });
+            }
+        }
+        for import in &edges.external {
+            if uf_lib::is_client_module(&import.specifier) {
+                boundaries.push(ClientBoundary {
+                    importer: ModuleId(position as u32),
+                    target: ClientBoundaryTarget::Package(import.specifier.clone()),
                 });
             }
         }
@@ -353,10 +361,10 @@ fn collect_bundle_roots(
     entries: &[(Utf8PathBuf, EntryKind)],
     index: &FxHashMap<Utf8PathBuf, ModuleId>,
     environments: &[ModuleEnvironment],
-) -> Vec<ModuleId> {
-    let mut roots: Vec<ModuleId> = boundaries
+) -> Vec<ClientBoundaryTarget> {
+    let mut roots: Vec<ClientBoundaryTarget> = boundaries
         .iter()
-        .map(|boundary| boundary.client_module)
+        .map(|boundary| boundary.target.clone())
         .collect();
     for (path, kind) in entries {
         if *kind != EntryKind::Client {
@@ -365,7 +373,7 @@ fn collect_bundle_roots(
         if let Some(id) = index.get(path)
             && environments[id.index()] == ModuleEnvironment::Client
         {
-            roots.push(*id);
+            roots.push(ClientBoundaryTarget::Module(*id));
         }
     }
     roots.sort_unstable();

--- a/crates/uf_rsc/src/graph/tests/reachability.rs
+++ b/crates/uf_rsc/src/graph/tests/reachability.rs
@@ -35,19 +35,65 @@ fn a_client_module_imported_by_a_server_module_is_a_boundary() {
     let graph = builder.build();
 
     assert_eq!(graph.client_boundaries().len(), 1);
-    let boundary = graph.client_boundaries()[0];
+    let boundary = &graph.client_boundaries()[0];
     assert_eq!(
         graph.module_by_id(boundary.importer).unwrap().path,
         "app/page.js"
     );
+    let ClientBoundaryTarget::Module(client_module) = &boundary.target else {
+        panic!(
+            "expected a project module boundary, got {:?}",
+            boundary.target
+        );
+    };
     assert_eq!(
-        graph.module_by_id(boundary.client_module).unwrap().path,
+        graph.module_by_id(*client_module).unwrap().path,
         "app/Counter.js"
     );
     assert_eq!(graph.client_bundle_roots().len(), 1);
     assert_eq!(
         graph.module("app/Counter.js").unwrap().reachability,
         ModuleReachability::ClientOnly
+    );
+}
+
+#[test]
+fn a_known_client_package_module_imported_by_a_server_module_is_a_boundary() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(server("app/page.js").with_import("@uniflowed/ui/switch"));
+    builder.add_entry("app/page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    assert_eq!(graph.client_boundaries().len(), 1);
+    assert_eq!(
+        graph.client_boundaries()[0].target,
+        ClientBoundaryTarget::Package(CompactString::const_new("@uniflowed/ui/switch"))
+    );
+    assert_eq!(
+        graph.client_bundle_roots(),
+        &[ClientBoundaryTarget::Package(CompactString::const_new(
+            "@uniflowed/ui/switch"
+        ))]
+    );
+    assert_eq!(
+        graph.module("app/page.js").unwrap().proximity,
+        ClientBoundaryProximity::ReachesBoundary
+    );
+    assert!(
+        graph
+            .module("app/page.js")
+            .unwrap()
+            .requires_client_bundle()
+    );
+    assert_eq!(
+        graph
+            .module("app/page.js")
+            .unwrap()
+            .external_imports
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec![CompactString::const_new("@uniflowed/ui/switch")]
     );
 }
 
@@ -285,13 +331,13 @@ fn a_use_server_module_a_client_module_imports_stays_on_the_server() {
     // It is not a client bundle root and nothing about it is: the reference is
     // what the browser gets, and a reference is not a module of this graph.
     assert_eq!(graph.client_bundle_roots().len(), 1);
-    assert_eq!(
-        graph
-            .module_by_id(graph.client_bundle_roots()[0])
-            .unwrap()
-            .path,
-        "app/Counter.js"
-    );
+    let ClientBoundaryTarget::Module(root) = &graph.client_bundle_roots()[0] else {
+        panic!(
+            "expected a project module root, got {:?}",
+            graph.client_bundle_roots()[0]
+        );
+    };
+    assert_eq!(graph.module_by_id(*root).unwrap().path, "app/Counter.js");
 }
 
 #[test]
@@ -388,6 +434,26 @@ fn a_module_above_a_boundary_names_the_imports_that_reach_it() {
     assert_eq!(
         chain(&graph, "app/section.js"),
         ["app/section.js", "app/Counter.js"]
+    );
+}
+
+#[test]
+fn a_module_above_a_package_boundary_names_the_import_that_reaches_it() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_module(server("app/page.js").with_import("./section.js"));
+    builder.add_module(server("app/section.js").with_import("@uniflowed/ui/switch"));
+    builder.add_entry("app/page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    assert_eq!(
+        reason(&graph, "app/page.js"),
+        ClientBundleReason::ImportsPackage {
+            chain: vec![
+                graph.module_id("app/page.js").unwrap(),
+                graph.module_id("app/section.js").unwrap(),
+            ],
+            specifier: CompactString::const_new("@uniflowed/ui/switch"),
+        }
     );
 }
 

--- a/crates/uf_rsc/src/lib.rs
+++ b/crates/uf_rsc/src/lib.rs
@@ -53,15 +53,15 @@ pub use directive::{
     ModuleEnvironment, module_environment, scan_directives,
 };
 pub use graph::{
-    ClientBoundary, ClientBoundaryProximity, ClientBundleReason, EntryKind, ModuleId,
-    ModuleReachability, RscDiagnostic, RscGraph, RscGraphBuilder, RscModule, RscModuleInput,
-    RscSeverity, SERVER_ONLY_PACKAGES, SERVER_ONLY_SUFFIX, SpecifierResolution, is_inside_project,
-    is_server_only_specifier, normalize_module_path, resolve_specifier,
+    ClientBoundary, ClientBoundaryProximity, ClientBoundaryTarget, ClientBundleReason, EntryKind,
+    ModuleId, ModuleReachability, RscDiagnostic, RscGraph, RscGraphBuilder, RscModule,
+    RscModuleInput, RscSeverity, SERVER_ONLY_PACKAGES, SERVER_ONLY_SUFFIX, SpecifierResolution,
+    is_inside_project, is_server_only_specifier, normalize_module_path, resolve_specifier,
 };
 pub use manifest::{
     RSC_MANIFEST_BUILD_DIR, RSC_MANIFEST_ENV, RSC_MANIFEST_FILE_NAME, RSC_MANIFEST_VERSION,
-    RscManifest, RscManifestAction, RscManifestBoundary, RscManifestDiagnostic, RscManifestModule,
-    write_manifest,
+    RscManifest, RscManifestAction, RscManifestBoundary, RscManifestClientReference,
+    RscManifestDiagnostic, RscManifestModule, write_manifest,
 };
 pub use project::{
     IGNORED_DIRECTORIES, NON_APP_SUFFIXES, ProjectScanOptions, ROUTER_ENTRY_FILES, RscAnalysis,

--- a/crates/uf_rsc/src/manifest.rs
+++ b/crates/uf_rsc/src/manifest.rs
@@ -21,7 +21,9 @@ use serde::{Deserialize, Serialize};
 use crate::RscError;
 use crate::action::{ActionId, ServerActionKind, ServerActionRegistry};
 use crate::directive::ModuleEnvironment;
-use crate::graph::{ClientBoundaryProximity, ModuleReachability, RscGraph, RscSeverity};
+use crate::graph::{
+    ClientBoundaryProximity, ClientBoundaryTarget, ModuleReachability, RscGraph, RscSeverity,
+};
 
 /// File name of the manifest inside the build output directory.
 pub const RSC_MANIFEST_FILE_NAME: &str = "uf-rsc-manifest.json";
@@ -48,10 +50,10 @@ pub const RSC_MANIFEST_ENV: &str = "UF_RSC_MANIFEST";
 
 /// Schema version of the manifest.
 ///
-/// 2 added `proximity` to every module: version 1 published the client
-/// boundaries and nothing that said which modules were *above* one, so a reader
-/// could not tell a route that needs the browser from one that does not.
-pub const RSC_MANIFEST_VERSION: u32 = 2;
+/// 3 lets client boundaries and bundle roots name package specifiers as well
+/// as project paths. Version 2 could only name scanned files, so a reader could
+/// not represent a package client module without pretending it was a path.
+pub const RSC_MANIFEST_VERSION: u32 = 3;
 
 /// The serialized React Server Components manifest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -68,7 +70,7 @@ pub struct RscManifest {
     /// Server-to-client import edges, ordered.
     pub client_boundaries: Vec<RscManifestBoundary>,
     /// Client bundle roots, ordered.
-    pub client_bundle_roots: Vec<Utf8PathBuf>,
+    pub client_bundle_roots: Vec<RscManifestClientReference>,
     /// Callable server actions, ordered by id.
     pub server_actions: Vec<RscManifestAction>,
     /// Contract violations, ordered.
@@ -105,8 +107,24 @@ pub struct RscManifestModule {
 pub struct RscManifestBoundary {
     /// The server module that owns the import.
     pub importer: Utf8PathBuf,
-    /// The `"use client"` module it imports.
-    pub module: Utf8PathBuf,
+    /// The client module it imports.
+    pub target: RscManifestClientReference,
+}
+
+/// A client module named by the manifest.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum RscManifestClientReference {
+    /// A project module, path-relative to the project root.
+    Module {
+        /// Path relative to the project root.
+        path: Utf8PathBuf,
+    },
+    /// A package module, named by the exact imported specifier.
+    Package {
+        /// Imported bare specifier.
+        specifier: CompactString,
+    },
 }
 
 /// One callable server action.
@@ -186,22 +204,21 @@ impl RscManifest {
             .filter_map(|boundary| {
                 Some(RscManifestBoundary {
                     importer: graph.module_by_id(boundary.importer)?.path.clone(),
-                    module: graph.module_by_id(boundary.client_module)?.path.clone(),
+                    target: manifest_client_reference(graph, &boundary.target)?,
                 })
             })
             .collect();
         client_boundaries.sort_by(|left, right| {
             left.importer
                 .cmp(&right.importer)
-                .then(left.module.cmp(&right.module))
+                .then(left.target.cmp(&right.target))
         });
         client_boundaries.dedup();
 
-        let mut client_bundle_roots: Vec<Utf8PathBuf> = graph
+        let mut client_bundle_roots: Vec<RscManifestClientReference> = graph
             .client_bundle_roots()
             .iter()
-            .filter_map(|id| graph.module_by_id(*id))
-            .map(|module| module.path.clone())
+            .filter_map(|target| manifest_client_reference(graph, target))
             .collect();
         client_bundle_roots.sort();
         client_bundle_roots.dedup();
@@ -255,6 +272,24 @@ impl RscManifest {
             serde_json::to_string_pretty(self).map_err(|source| RscError::Serialize { source })?;
         json.push('\n');
         Ok(json)
+    }
+}
+
+fn manifest_client_reference(
+    graph: &RscGraph,
+    target: &ClientBoundaryTarget,
+) -> Option<RscManifestClientReference> {
+    match target {
+        ClientBoundaryTarget::Module(id) => {
+            graph
+                .module_by_id(*id)
+                .map(|module| RscManifestClientReference::Module {
+                    path: module.path.clone(),
+                })
+        }
+        ClientBoundaryTarget::Package(specifier) => Some(RscManifestClientReference::Package {
+            specifier: specifier.clone(),
+        }),
     }
 }
 

--- a/crates/uf_rsc/src/manifest/tests.rs
+++ b/crates/uf_rsc/src/manifest/tests.rs
@@ -104,6 +104,39 @@ fn collections_are_sorted() {
 }
 
 #[test]
+fn known_package_client_modules_are_written_as_manifest_targets() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_source(
+        "app/$page.js",
+        "import { Switch } from \"@uniflowed/ui/switch\";\nexport default function Page() {}\n",
+    );
+    builder.add_entry("app/$page.js", EntryKind::Server);
+    let graph = builder.build();
+    let registry =
+        ServerActionRegistry::from_graph(&graph, &BuildId::new("fixture-build-id").unwrap());
+    let manifest = RscManifest::new(&graph, &registry);
+
+    assert_eq!(manifest.client_boundaries.len(), 1);
+    assert_eq!(manifest.client_boundaries[0].importer, "app/$page.js");
+    assert_eq!(
+        manifest.client_boundaries[0].target,
+        RscManifestClientReference::Package {
+            specifier: CompactString::const_new("@uniflowed/ui/switch")
+        }
+    );
+    assert_eq!(
+        manifest.client_bundle_roots,
+        [RscManifestClientReference::Package {
+            specifier: CompactString::const_new("@uniflowed/ui/switch")
+        }]
+    );
+    assert_eq!(
+        manifest.modules[0].proximity,
+        ClientBoundaryProximity::ReachesBoundary
+    );
+}
+
+#[test]
 fn writing_the_manifest_creates_the_output_directory() {
     let (graph, registry) = fixture();
     let manifest = RscManifest::new(&graph, &registry);

--- a/crates/uf_rsc/src/tests.rs
+++ b/crates/uf_rsc/src/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 fn the_crate_reexports_the_public_surface() {
     assert_eq!(module_environment(""), ModuleEnvironment::Server);
     assert_eq!(RSC_MANIFEST_FILE_NAME, "uf-rsc-manifest.json");
-    assert_eq!(RSC_MANIFEST_VERSION, 2);
+    assert_eq!(RSC_MANIFEST_VERSION, 3);
     assert_eq!(ACTION_ID_HEX_LEN, 64);
 }
 

--- a/crates/uf_rsc/tests/fixtures/uf-rsc-manifest.json
+++ b/crates/uf_rsc/tests/fixtures/uf-rsc-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "engine": "uf-native",
   "buildFingerprint": "71527ae95b8871ca4467cfe1c007937a061888fad13c7da20eb669bacb59fb0b",
   "modules": [
@@ -45,11 +45,17 @@
   "clientBoundaries": [
     {
       "importer": "app/$page.js",
-      "module": "app/client/Counter.js"
+      "target": {
+        "kind": "module",
+        "path": "app/client/Counter.js"
+      }
     }
   ],
   "clientBundleRoots": [
-    "app/client/Counter.js"
+    {
+      "kind": "module",
+      "path": "app/client/Counter.js"
+    }
   ],
   "serverActions": [
     {

--- a/packages/vite/internal/rsc.js
+++ b/packages/vite/internal/rsc.js
@@ -47,13 +47,12 @@ export const RSC_MANIFEST_ENV = "UF_RSC_MANIFEST";
 /**
  * The manifest schema this understands.
  *
- * Version 1 published the client boundaries and nothing that said which
- * modules sat *above* one, so it cannot answer the question this module asks.
- * An older manifest is therefore refused rather than read optimistically: a
- * missing `proximity` would read as `undefined`, compare unequal to
- * `"reaches-boundary"`, and quietly drop every route from the client bundle.
+ * Version 3 lets client boundaries name package specifiers as well as project
+ * paths. An older manifest is therefore refused rather than read
+ * optimistically: it cannot know a route imports a package client module, and
+ * quietly dropping that route would be the worst possible answer.
  */
-const SUPPORTED_VERSION = 2;
+const SUPPORTED_VERSION = 3;
 
 /**
  * Read the RSC manifest, or `null` when there is nothing usable to read.

--- a/packages/vite/rsc-split.test.js
+++ b/packages/vite/rsc-split.test.js
@@ -124,7 +124,7 @@ function splitProject(): string {
 }
 
 /** The manifest that project's analysis would produce. */
-function splitManifest(version: number = 2) {
+function splitManifest(version: number = 3) {
   return {
     version,
     engine: "uf-native",
@@ -203,14 +203,13 @@ describe("the client route table", () => {
     expect(source).toContain(`import(${JSON.stringify(path.join(root, "app/$page.js"))})`);
   });
 
-  it("ships every page when the manifest is older than the field it needs", () => {
-    // Version 1 published the boundaries and nothing that said which modules
-    // sat above one. Read optimistically it would answer `undefined` for every
-    // module, compare unequal to `"reaches-boundary"`, and drop the whole
-    // application from the browser.
+  it("ships every page when the manifest is older than the package boundary schema", () => {
+    // Version 2 could only name scanned files as client roots. Reading it
+    // optimistically would miss a package client boundary and drop the route
+    // that imported it, so older manifests remove nothing.
     const root = splitProject();
     const table = scanRoutes(path.join(root, "app"));
-    const shipsPage = clientRouteFilter(manifestIn(root, splitManifest(1)), root, table);
+    const shipsPage = clientRouteFilter(manifestIn(root, splitManifest(2)), root, table);
 
     const source = routesModuleSource(table, { shipsPage });
 

--- a/tests/library/server-actions.test.js
+++ b/tests/library/server-actions.test.js
@@ -702,7 +702,7 @@ describe("the endpoint a server action is dialled at", () => {
 describe("the two tables the manifest becomes", () => {
   const root = "/project";
   const manifest = {
-    version: 2,
+    version: 3,
     serverActions: [
       {
         id: RECORD,
@@ -913,7 +913,7 @@ describe("the module the browser is given in place of a `use server` file", () =
   const root = path.join(repository, "crates", "uf_cli", "tests", "fixtures", "rsc-split-app");
   const action = path.join(root, "app", "counter", "_actions", "tally.js");
   const manifest = {
-    version: 2,
+    version: 3,
     modules: [],
     serverActions: [
       {


### PR DESCRIPTION
## Summary
- teach the RSC graph to treat known @uniflowed/ui client subpaths as client boundaries without walking node_modules
- bump the RSC manifest to version 3 so boundaries and bundle roots can name either project modules or package specifiers
- keep the Vite manifest reader on the new schema and fail safe for older manifests

Closes #718

## Verification
- cargo fmt -p uf_rsc -p uf_cli -p uf_lib
- git diff --check
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--std-tar/target cargo check -p uf_rsc --lib --profile ci
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--std-tar/target cargo check -p uf_cli --lib --profile ci
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--std-tar/target cargo test -p uf_rsc --lib --profile ci package
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--std-tar/target cargo test -p uf_rsc --lib --profile ci the_manifest_matches_its_snapshot

`cargo run -p uf_cli --bin uf --profile ci -- test packages/vite/rsc-split.test.js` reached the linker and failed locally with `errno=28` because the workstation had only a few hundred MiB free. The PR Actions should cover the full JS/Flow test surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791775800&installation_model_id=422833&pr_number=797&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F797&signature=56887048673015e75627a934f62c9d4fdf1d379d7c9c6cb6244afb65f9651735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->