### PR TITLE
fix(rsc): classify project hook wrappers

### DIFF
--- a/crates/uf_rsc/src/graph.rs
+++ b/crates/uf_rsc/src/graph.rs
@@ -22,7 +22,7 @@ use std::sync::OnceLock;
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
-use uf_infra::{FxHashMap, FxHashSet, InlineVec, LineIndex};
+use uf_infra::{FxHashMap, InlineVec, LineIndex};
 
 use crate::directive::{
     DirectiveIssueList, FunctionDirective, FunctionDirectiveList, FunctionOwner, ModuleEnvironment,
@@ -74,59 +74,33 @@ pub const SERVER_ONLY_SUFFIX: &str = ".server.js";
 /// that needs no new data at all.
 pub const CLIENT_ONLY_HOOK_PACKAGE: &str = "@uniflowed/hooks";
 
-/// The hooks of [`CLIENT_ONLY_HOOK_PACKAGE`] a Server Component may not call.
+/// Server-component safety for hooks of [`CLIENT_ONLY_HOOK_PACKAGE`].
 ///
 /// Read from the registry rather than copied into a list here, so there is one
 /// place a hook's environment is written down and no second one to drift from
-/// it. Built once: `hook_descriptors()` allocates a `Vec` of owned names, and
-/// this is asked once per hook call in a server module.
-fn client_only_hooks() -> &'static FxHashSet<CompactString> {
-    static HOOKS: OnceLock<FxHashSet<CompactString>> = OnceLock::new();
+/// it. Built once: `hook_descriptors()` allocates a `Vec` of owned names.
+fn package_hook_safety() -> &'static FxHashMap<CompactString, bool> {
+    static HOOKS: OnceLock<FxHashMap<CompactString, bool>> = OnceLock::new();
     HOOKS.get_or_init(|| {
         uf_lib::hook_descriptors()
             .into_iter()
-            .filter(|hook| !hook.server_component_safe)
-            .map(|hook| hook.name)
+            .map(|hook| (hook.name, hook.server_component_safe))
             .collect()
     })
 }
 
+/// Whether a hook exported by [`CLIENT_ONLY_HOOK_PACKAGE`] is safe in a Server
+/// Component.
+pub(crate) fn package_hook_server_component_safe(hook: &str) -> Option<bool> {
+    package_hook_safety().get(hook).copied()
+}
+
 /// Whether `specifier` names [`CLIENT_ONLY_HOOK_PACKAGE`] or a subpath of it.
-fn is_client_only_hook_package(specifier: &str) -> bool {
+pub(crate) fn is_client_only_hook_package(specifier: &str) -> bool {
     specifier == CLIENT_ONLY_HOOK_PACKAGE
         || specifier
             .strip_prefix(CLIENT_ONLY_HOOK_PACKAGE)
             .is_some_and(|rest| rest.starts_with('/'))
-}
-
-/// The package a called hook came from, when this crate can say.
-///
-/// Attributed through the module's imports rather than through the binding the
-/// import introduced. That makes this answer wrong in exactly one shape: a
-/// module that imports `@uniflowed/hooks` *and* separately defines or imports
-/// its own `useMediaQuery`, and calls that one. It is the same imprecision the
-/// rest of this scanner already has — it matches identifiers against name
-/// lists — and it is narrower than the alternative of saying nothing, which is
-/// what this did before.
-///
-/// [`ImportSpecifier::bindings`] now carries what would narrow it: the
-/// `{ imported, local }` pairs say whether `useMediaQuery` is the name this
-/// module bound from that package or a different function that shares its
-/// spelling. Reading them here would change which calls are reported, so it
-/// belongs with the rest of the classification work rather than with the
-/// plumbing that made it possible — ubugeeei-prod/uf#388.
-///
-/// [`None`] is the honest answer and stays reported as one: a hook from a
-/// package with no table, a hook the project wrote, a hook reached through a
-/// value. See [`RscDiagnostic::UnclassifiedHookInServerModule`].
-fn client_only_hook_package(hook: &str, imports: &[ImportSpecifier]) -> Option<&'static str> {
-    if !client_only_hooks().contains(hook) {
-        return None;
-    }
-    imports
-        .iter()
-        .any(|import| is_client_only_hook_package(&import.specifier))
-        .then_some(CLIENT_ONLY_HOOK_PACKAGE)
 }
 
 /// Identifier of a module inside one [`RscGraph`].
@@ -322,6 +296,7 @@ impl RscModuleInput {
     pub fn with_export(mut self, name: impl Into<CompactString>, kind: ExportKind) -> Self {
         self.exports.push(ModuleExport {
             name: name.into(),
+            local: None,
             kind,
             line: 1,
         });

--- a/crates/uf_rsc/src/graph/build.rs
+++ b/crates/uf_rsc/src/graph/build.rs
@@ -9,12 +9,13 @@
 use std::collections::VecDeque;
 
 use camino::Utf8PathBuf;
-use uf_infra::{FxHashMap, InlineVec};
+use compact_str::CompactString;
+use uf_infra::{FxHashMap, FxHashSet, InlineVec};
 
 use crate::directive::ModuleEnvironment;
-use crate::scan::ImportSpecifier;
+use crate::scan::{ExportKind, HookCall, ImportKind, ImportSpecifier};
 
-use super::diagnostic::RscDiagnostic;
+use super::diagnostic::{ClientOnlyHookOrigin, RscDiagnostic};
 use super::report::{report_client_graph_leaks, report_module_diagnostics};
 use super::resolve::{
     SpecifierResolution, is_inside_project, normalize_module_path, resolve_candidates,
@@ -22,7 +23,8 @@ use super::resolve::{
 };
 use super::{
     ClientBoundary, ClientBoundaryProximity, ClientBoundaryTarget, EntryKind, ModuleId,
-    ModuleReachability, RscGraph, RscModule, RscModuleInput,
+    ModuleReachability, RscGraph, RscModule, RscModuleInput, is_client_only_hook_package,
+    package_hook_server_component_safe,
 };
 
 /// Collects modules and entries, then resolves them into an [`RscGraph`].
@@ -97,19 +99,22 @@ impl RscGraphBuilder {
         let boundaries = collect_boundaries(&resolved, &environments, &server_seen);
         let proximity = compute_proximity(&resolved, &boundaries);
         let bundle_roots = collect_bundle_roots(&boundaries, &entries, &index, &environments);
+        let hook_classifications = HookClassifications::new(&modules, &resolved);
 
         let mut graph_modules = Vec::with_capacity(modules.len());
-        for (position, module) in modules.into_iter().enumerate() {
+        for (position, module) in modules.iter().enumerate() {
             let reachability =
                 ModuleReachability::from_colours(server_seen[position], client_seen[position]);
             report_module_diagnostics(
-                &module,
+                module,
+                ModuleId(position as u32),
                 reachability,
-                &resolved[position].external,
+                &resolved[position],
+                &hook_classifications,
                 &mut diagnostics,
             );
             graph_modules.push(RscModule {
-                path: module.path,
+                path: module.path.clone(),
                 environment: module.environment,
                 reachability,
                 proximity: proximity[position],
@@ -119,8 +124,8 @@ impl RscGraphBuilder {
                     .iter()
                     .map(|import| import.specifier.clone())
                     .collect(),
-                exports: module.exports,
-                function_actions: module.function_actions,
+                exports: module.exports.clone(),
+                function_actions: module.function_actions.clone(),
             });
         }
 
@@ -149,7 +154,15 @@ impl RscGraphBuilder {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ResolvedImports {
     pub(crate) imports: InlineVec<ModuleId, 8>,
+    pub(crate) resolved: Vec<ResolvedModuleImport>,
     pub(crate) external: Vec<ImportSpecifier>,
+}
+
+/// One import clause resolved to a module in the graph.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedModuleImport {
+    pub(crate) import: ImportSpecifier,
+    pub(crate) target: ModuleId,
 }
 
 fn resolve_edges(
@@ -169,6 +182,10 @@ fn resolve_edges(
                             if !edges.imports.contains(&id) {
                                 edges.imports.push(id);
                             }
+                            edges.resolved.push(ResolvedModuleImport {
+                                import: import.clone(),
+                                target: id,
+                            });
                         }
                         None => edges.external.push(import.clone()),
                     }
@@ -191,6 +208,379 @@ fn resolve_edges(
     }
 
     resolved
+}
+
+/// One exported function or re-export the hook fixpoint can classify.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ExportKey {
+    module: ModuleId,
+    name: CompactString,
+}
+
+/// Verdict for one hook call in a server-reachable module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HookCallVerdict {
+    /// The hook resolves to an export that only runs in the browser.
+    ClientOnly(ClientOnlyHookOrigin),
+    /// The hook resolves to an export whose body was checked and found safe.
+    ServerSafe,
+    /// The graph cannot see enough to decide.
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExportStatus {
+    ClientOnly,
+    ServerSafe,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HookDependency {
+    PackageClientOnly,
+    PackageServerSafe,
+    Project(ExportKey),
+    Unknown,
+}
+
+/// Client-only and unknown project hook exports.
+///
+/// Function exports start as classified: the scanner saw their body and can
+/// decide whether that body directly reaches a client-only API. A body that
+/// calls an unknown hook stays unknown; a body that calls another project hook
+/// follows the edge until either a client-only export or an unknown edge is
+/// found. Re-exported hooks join the same graph through their `export { ... }
+/// from` binding.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct HookClassifications {
+    candidates: FxHashSet<ExportKey>,
+    client_only: FxHashSet<ExportKey>,
+    unknown: FxHashSet<ExportKey>,
+    module_paths: Vec<Utf8PathBuf>,
+}
+
+impl HookClassifications {
+    fn new(modules: &[RscModuleInput], resolved: &[ResolvedImports]) -> Self {
+        let mut candidates = FxHashSet::default();
+        for (position, module) in modules.iter().enumerate() {
+            let module_id = ModuleId(position as u32);
+            for export in &module.exports {
+                if matches!(export.kind, ExportKind::ReExport) || export.kind.is_function() {
+                    candidates.insert(ExportKey {
+                        module: module_id,
+                        name: export.name.clone(),
+                    });
+                }
+            }
+        }
+
+        let mut direct_client = FxHashSet::default();
+        let mut direct_unknown = FxHashSet::default();
+        let mut edges = Vec::new();
+
+        for (position, module) in modules.iter().enumerate() {
+            let module_id = ModuleId(position as u32);
+            let mut collector = HookDependencyCollector {
+                module,
+                module_id,
+                candidates: &candidates,
+                resolved: &resolved[position],
+                direct_client: &mut direct_client,
+                direct_unknown: &mut direct_unknown,
+                edges: &mut edges,
+            };
+            for export in &module.exports {
+                let source = ExportKey {
+                    module: module_id,
+                    name: export.name.clone(),
+                };
+                if !collector.is_candidate(&source) {
+                    continue;
+                }
+
+                if export.kind.is_function() {
+                    let owner = export.local.as_ref().unwrap_or(&export.name);
+                    collector.collect_function(&source, owner);
+                }
+
+                if matches!(export.kind, ExportKind::ReExport) {
+                    collector.collect_reexport(&source);
+                }
+            }
+        }
+
+        let mut client_only = direct_client;
+        loop {
+            let mut changed = false;
+            for (source, target) in &edges {
+                if client_only.contains(target) && client_only.insert(source.clone()) {
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        let mut unknown = direct_unknown;
+        loop {
+            let mut changed = false;
+            for (source, target) in &edges {
+                if !client_only.contains(target)
+                    && unknown.contains(target)
+                    && unknown.insert(source.clone())
+                {
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        Self {
+            candidates,
+            client_only,
+            unknown,
+            module_paths: modules.iter().map(|module| module.path.clone()).collect(),
+        }
+    }
+
+    pub(crate) fn call_verdict(
+        &self,
+        module: ModuleId,
+        call: &HookCall,
+        resolved: &ResolvedImports,
+    ) -> HookCallVerdict {
+        match package_hook_dependency(&call.name, &resolved.external) {
+            Some(HookDependency::PackageClientOnly) => {
+                return HookCallVerdict::ClientOnly(ClientOnlyHookOrigin::Package(
+                    CompactString::from(super::CLIENT_ONLY_HOOK_PACKAGE),
+                ));
+            }
+            Some(HookDependency::PackageServerSafe) => return HookCallVerdict::ServerSafe,
+            Some(HookDependency::Unknown) => return HookCallVerdict::Unknown,
+            Some(HookDependency::Project(_)) | None => {}
+        }
+
+        match project_hook_dependency(module, &call.name, resolved, &self.candidates) {
+            HookDependency::Project(target) => self.export_verdict(target),
+            HookDependency::Unknown => HookCallVerdict::Unknown,
+            HookDependency::PackageClientOnly | HookDependency::PackageServerSafe => {
+                unreachable!("project dependency only")
+            }
+        }
+    }
+
+    fn export_verdict(&self, key: ExportKey) -> HookCallVerdict {
+        match self.export_status(&key) {
+            Some(ExportStatus::ClientOnly) => {
+                let path = self.module_paths[key.module.index()].clone();
+                HookCallVerdict::ClientOnly(ClientOnlyHookOrigin::Module(path))
+            }
+            Some(ExportStatus::ServerSafe) => HookCallVerdict::ServerSafe,
+            Some(ExportStatus::Unknown) | None => HookCallVerdict::Unknown,
+        }
+    }
+
+    fn export_status(&self, key: &ExportKey) -> Option<ExportStatus> {
+        if !self.candidates.contains(key) {
+            return None;
+        }
+        if self.client_only.contains(key) {
+            return Some(ExportStatus::ClientOnly);
+        }
+        if self.unknown.contains(key) {
+            return Some(ExportStatus::Unknown);
+        }
+        Some(ExportStatus::ServerSafe)
+    }
+}
+
+struct HookDependencyCollector<'a> {
+    module: &'a RscModuleInput,
+    module_id: ModuleId,
+    candidates: &'a FxHashSet<ExportKey>,
+    resolved: &'a ResolvedImports,
+    direct_client: &'a mut FxHashSet<ExportKey>,
+    direct_unknown: &'a mut FxHashSet<ExportKey>,
+    edges: &'a mut Vec<(ExportKey, ExportKey)>,
+}
+
+impl HookDependencyCollector<'_> {
+    fn is_candidate(&self, source: &ExportKey) -> bool {
+        self.candidates.contains(source)
+    }
+
+    fn collect_function(&mut self, source: &ExportKey, owner: &str) {
+        if self
+            .module
+            .client_api_uses
+            .iter()
+            .any(|use_site| use_site.owner.as_deref() == Some(owner))
+        {
+            self.direct_client.insert(source.clone());
+        }
+
+        for call in self
+            .module
+            .hook_calls
+            .iter()
+            .filter(|call| call.owner.as_deref() == Some(owner))
+        {
+            if let Some(dependency) = package_hook_dependency(&call.name, &self.resolved.external) {
+                match dependency {
+                    HookDependency::PackageClientOnly => {
+                        self.direct_client.insert(source.clone());
+                    }
+                    HookDependency::PackageServerSafe => {}
+                    HookDependency::Unknown => {
+                        self.direct_unknown.insert(source.clone());
+                    }
+                    HookDependency::Project(_) => unreachable!("package dependency only"),
+                }
+                continue;
+            }
+
+            match project_hook_dependency(
+                self.module_id,
+                &call.name,
+                self.resolved,
+                self.candidates,
+            ) {
+                HookDependency::Project(target) => self.edges.push((source.clone(), target)),
+                HookDependency::Unknown => {
+                    self.direct_unknown.insert(source.clone());
+                }
+                HookDependency::PackageClientOnly | HookDependency::PackageServerSafe => {
+                    unreachable!("project dependency only")
+                }
+            }
+        }
+    }
+
+    fn collect_reexport(&mut self, source: &ExportKey) {
+        let mut found = false;
+        for import in self
+            .resolved
+            .resolved
+            .iter()
+            .filter(|import| import.import.kind == ImportKind::ReExport)
+        {
+            for binding in &import.import.bindings {
+                if binding.local != source.name {
+                    continue;
+                }
+                found = true;
+                let Some(name) = binding.imported.as_export_name() else {
+                    self.direct_unknown.insert(source.clone());
+                    continue;
+                };
+                let target = ExportKey {
+                    module: import.target,
+                    name: CompactString::from(name),
+                };
+                if self.candidates.contains(&target) {
+                    self.edges.push((source.clone(), target));
+                } else {
+                    self.direct_unknown.insert(source.clone());
+                }
+            }
+        }
+        for import in self.resolved.external.iter().filter(|import| {
+            import.kind == ImportKind::ReExport && is_client_only_hook_package(&import.specifier)
+        }) {
+            for binding in &import.bindings {
+                if binding.local != source.name {
+                    continue;
+                }
+                found = true;
+                let Some(imported) = binding.imported.as_export_name() else {
+                    self.direct_unknown.insert(source.clone());
+                    continue;
+                };
+                match package_hook_server_component_safe(imported) {
+                    Some(true) => {}
+                    Some(false) => {
+                        self.direct_client.insert(source.clone());
+                    }
+                    None => {
+                        self.direct_unknown.insert(source.clone());
+                    }
+                }
+            }
+        }
+        if !found {
+            self.direct_unknown.insert(source.clone());
+        }
+    }
+}
+
+fn package_hook_dependency(hook: &str, imports: &[ImportSpecifier]) -> Option<HookDependency> {
+    for import in imports
+        .iter()
+        .filter(|import| is_client_only_hook_package(&import.specifier))
+    {
+        for binding in &import.bindings {
+            if binding.local != hook {
+                continue;
+            }
+            let Some(imported) = binding.imported.as_export_name() else {
+                return Some(HookDependency::Unknown);
+            };
+            return Some(match package_hook_server_component_safe(imported) {
+                Some(true) => HookDependency::PackageServerSafe,
+                Some(false) => HookDependency::PackageClientOnly,
+                None => HookDependency::Unknown,
+            });
+        }
+    }
+    if imports
+        .iter()
+        .any(|import| import.bindings.iter().any(|binding| binding.local == hook))
+    {
+        return Some(HookDependency::Unknown);
+    }
+    None
+}
+
+fn project_hook_dependency(
+    module: ModuleId,
+    hook: &str,
+    resolved: &ResolvedImports,
+    candidates: &FxHashSet<ExportKey>,
+) -> HookDependency {
+    for import in resolved
+        .resolved
+        .iter()
+        .filter(|import| import.import.kind == ImportKind::Static)
+    {
+        for binding in &import.import.bindings {
+            if binding.local != hook {
+                continue;
+            }
+            let Some(name) = binding.imported.as_export_name() else {
+                return HookDependency::Unknown;
+            };
+            let target = ExportKey {
+                module: import.target,
+                name: CompactString::from(name),
+            };
+            if candidates.contains(&target) {
+                return HookDependency::Project(target);
+            }
+            return HookDependency::Unknown;
+        }
+    }
+
+    let local = ExportKey {
+        module,
+        name: CompactString::from(hook),
+    };
+    if candidates.contains(&local) {
+        return HookDependency::Project(local);
+    }
+    HookDependency::Unknown
 }
 
 /// Walk the graph with an explicit worklist, once per `(module, colour)` pair.

--- a/crates/uf_rsc/src/graph/diagnostic.rs
+++ b/crates/uf_rsc/src/graph/diagnostic.rs
@@ -5,6 +5,8 @@
 //! accumulates violations as data rather than as formatted strings, and
 //! [`RscSeverity`] keeps the manifest spelling of how serious one is.
 
+use std::fmt;
+
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
@@ -28,6 +30,24 @@ impl RscSeverity {
         match self {
             Self::Warn => "warn",
             Self::Error => "error",
+        }
+    }
+}
+
+/// Where a client-only hook verdict came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClientOnlyHookOrigin {
+    /// A published package with declared hook metadata.
+    Package(CompactString),
+    /// A project module whose exported hook body was classified by the graph.
+    Module(Utf8PathBuf),
+}
+
+impl fmt::Display for ClientOnlyHookOrigin {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Package(package) => write!(formatter, "`{package}`"),
+            Self::Module(module) => write!(formatter, "project module `{module}`"),
         }
     }
 }
@@ -93,7 +113,7 @@ pub enum RscDiagnostic {
         /// The offending path, as supplied.
         module: Utf8PathBuf,
     },
-    /// A hook a uf package exports that only runs in the browser.
+    /// A hook a package or project module exports that only runs in the browser.
     ///
     /// The half of [`Self::UnclassifiedHookInServerModule`] that can be
     /// decided. `useMediaQuery` is not on `CLIENT_ONLY_APIS` — it is not a
@@ -101,7 +121,8 @@ pub enum RscDiagnostic {
     /// so a Server Component calling it fails for exactly the reason
     /// `useState` does. The registry has said so for every hook
     /// `@uniflowed/hooks` exports since before `uf_rsc` existed; this is the
-    /// rule that reads it.
+    /// rule that reads it. Project hooks use the same verdict once the
+    /// export-level fixpoint can prove their bodies reach the same APIs.
     ///
     /// An error rather than a warning, because unlike its unclassified
     /// neighbour this *is* a verdict: the contract has no tolerances, and a
@@ -115,8 +136,8 @@ pub enum RscDiagnostic {
         module: Utf8PathBuf,
         /// Name of the hook as called.
         hook: CompactString,
-        /// The uf package that exports it.
-        package: CompactString,
+        /// The package or project module that exports it.
+        package: ClientOnlyHookOrigin,
         /// 1-based line.
         line: u32,
         /// 1-based column.

--- a/crates/uf_rsc/src/graph/report.rs
+++ b/crates/uf_rsc/src/graph/report.rs
@@ -8,17 +8,19 @@
 use compact_str::CompactString;
 
 use crate::directive::ModuleEnvironment;
-use crate::scan::{ExportKind, ImportSpecifier};
+use crate::scan::ExportKind;
 
-use super::build::ResolvedImports;
+use super::build::{HookCallVerdict, HookClassifications, ResolvedImports};
 use super::diagnostic::RscDiagnostic;
 use super::resolve::{is_server_only_path, is_server_only_specifier};
-use super::{ModuleReachability, RscModule, RscModuleInput, client_only_hook_package};
+use super::{ModuleId, ModuleReachability, RscModule, RscModuleInput};
 
 pub(crate) fn report_module_diagnostics(
     module: &RscModuleInput,
+    module_id: ModuleId,
     reachability: ModuleReachability,
-    external: &[ImportSpecifier],
+    resolved: &ResolvedImports,
+    hook_classifications: &HookClassifications,
     diagnostics: &mut Vec<RscDiagnostic>,
 ) {
     for issue in &module.directive_issues {
@@ -66,32 +68,37 @@ pub(crate) fn report_module_diagnostics(
         // the name lists do not know is only a question worth asking about
         // code the server runs.
         //
-        // Two answers now. A hook `@uniflowed/hooks` exports is decided, from
+        // Three answers now. A hook `@uniflowed/hooks` exports is decided from
         // the `server_component_safe` the registry has carried for it all
-        // along; anything else is still reported as the question it is,
-        // because "the graph said nothing" and "the graph checked and found
-        // nothing" are the same output otherwise and are not the same fact.
+        // along; a project hook whose export body the graph can follow is
+        // decided by the same fixpoint; anything else is still reported as the
+        // question it is.
         for call in &module.hook_calls {
-            match client_only_hook_package(&call.name, external) {
-                Some(package) => diagnostics.push(RscDiagnostic::ClientOnlyHookInServerModule {
-                    module: module.path.clone(),
-                    hook: call.name.clone(),
-                    package: CompactString::from(package),
-                    line: call.line,
-                    column: call.column,
-                }),
-                None => diagnostics.push(RscDiagnostic::UnclassifiedHookInServerModule {
-                    module: module.path.clone(),
-                    hook: call.name.clone(),
-                    line: call.line,
-                    column: call.column,
-                }),
+            match hook_classifications.call_verdict(module_id, call, resolved) {
+                HookCallVerdict::ClientOnly(package) => {
+                    diagnostics.push(RscDiagnostic::ClientOnlyHookInServerModule {
+                        module: module.path.clone(),
+                        hook: call.name.clone(),
+                        package,
+                        line: call.line,
+                        column: call.column,
+                    });
+                }
+                HookCallVerdict::ServerSafe => {}
+                HookCallVerdict::Unknown => {
+                    diagnostics.push(RscDiagnostic::UnclassifiedHookInServerModule {
+                        module: module.path.clone(),
+                        hook: call.name.clone(),
+                        line: call.line,
+                        column: call.column,
+                    });
+                }
             }
         }
     }
 
     if module.environment == ModuleEnvironment::Client || reachability.is_client_reachable() {
-        for import in external {
+        for import in &resolved.external {
             if is_server_only_specifier(&import.specifier) {
                 diagnostics.push(RscDiagnostic::ServerOnlyImportInClientModule {
                     module: module.path.clone(),

--- a/crates/uf_rsc/src/graph/tests/diagnostic.rs
+++ b/crates/uf_rsc/src/graph/tests/diagnostic.rs
@@ -337,7 +337,183 @@ fn the_one_server_safe_hook_is_not_reported_as_client_only() {
         "{:#?}",
         graph.diagnostics()
     );
+    assert!(
+        !graph
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.rule() == "rsc/unclassified-hook-in-server"),
+        "{:#?}",
+        graph.diagnostics()
+    );
     assert!(!graph.has_errors(), "{:#?}", graph.diagnostics());
+}
+
+/// The first half of ubugeeei-prod/uf#388: a hook the project wrote can be
+/// decided once the graph knows which export owns the body and which import
+/// binding a call names.
+#[test]
+fn a_project_hook_wrapping_a_client_api_is_decided() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_source(
+        "app/hooks.js",
+        "export hook useTheme() {\n  const [theme] = useState(\"system\");\n  return theme;\n}\n",
+    );
+    builder.add_source(
+        "app/page.js",
+        "import { useTheme as useAppTheme } from \"./hooks.js\";\n\
+         export default function Page() { return useAppTheme(); }",
+    );
+    builder.add_entry("app/page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    let diagnostic = graph
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.rule() == "rsc/client-only-hook-in-server"
+                && diagnostic.module().as_str() == "app/page.js"
+        })
+        .unwrap_or_else(|| panic!("the page call stayed undecided: {:#?}", graph.diagnostics()));
+    let message = diagnostic.to_string();
+    assert!(message.contains("useAppTheme"), "{message}");
+    assert!(
+        message.contains("project module `app/hooks.js`"),
+        "{message}"
+    );
+    assert!(
+        !graph.diagnostics().iter().any(|diagnostic| {
+            diagnostic.rule() == "rsc/unclassified-hook-in-server"
+                && diagnostic.module().as_str() == "app/page.js"
+        }),
+        "decided and asked about at once: {:#?}",
+        graph.diagnostics()
+    );
+}
+
+/// Default-exported declarations still have a local body name, and the graph
+/// must use that name for owner matching while keeping `default` for imports.
+#[test]
+fn a_default_exported_project_hook_wrapping_a_client_api_is_decided() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_source(
+        "app/hooks.js",
+        "export default function useTheme() {\n  const [theme] = useState(\"system\");\n  return theme;\n}\n",
+    );
+    builder.add_source(
+        "app/page.js",
+        "import useTheme from \"./hooks.js\";\n\
+         export default function Page() { return useTheme(); }",
+    );
+    builder.add_entry("app/page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    let diagnostic = graph
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.rule() == "rsc/client-only-hook-in-server"
+                && diagnostic.module().as_str() == "app/page.js"
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "the default hook call stayed undecided or server-safe: {:#?}",
+                graph.diagnostics()
+            )
+        });
+    let message = diagnostic.to_string();
+    assert!(message.contains("useTheme"), "{message}");
+    assert!(
+        message.contains("project module `app/hooks.js`"),
+        "{message}"
+    );
+}
+
+/// `export { local as exported }` has the same split without `default`.
+#[test]
+fn an_aliased_project_hook_wrapping_a_client_api_is_decided() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_source(
+        "app/hooks.js",
+        "function useTheme() {\n  useEffect(() => {});\n}\nexport { useTheme as useAppTheme };\n",
+    );
+    builder.add_source(
+        "app/page.js",
+        "import { useAppTheme } from \"./hooks.js\";\n\
+         export default function Page() { return useAppTheme(); }",
+    );
+    builder.add_entry("app/page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    assert!(
+        graph.diagnostics().iter().any(|diagnostic| {
+            diagnostic.rule() == "rsc/client-only-hook-in-server"
+                && diagnostic.module().as_str() == "app/page.js"
+        }),
+        "{:#?}",
+        graph.diagnostics()
+    );
+}
+
+/// The other verdict matters too: a project hook whose body the graph checked
+/// and found server-safe is no longer reported as "uf cannot say".
+#[test]
+fn a_project_hook_that_stays_server_safe_is_not_a_question() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_source(
+        "app/hooks.js",
+        "export hook useServerClock() { return Date.now(); }\n",
+    );
+    builder.add_source(
+        "app/page.js",
+        "import { useServerClock } from \"./hooks.js\";\n\
+         export default function Page() { return useServerClock(); }",
+    );
+    builder.add_entry("app/page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    assert!(graph.diagnostics().is_empty(), "{:#?}", graph.diagnostics());
+}
+
+/// Re-export barrels are part of the same export graph; otherwise the call site
+/// that imports from the barrel would fall back to the old warning.
+#[test]
+fn a_reexported_project_hook_carries_its_client_only_verdict() {
+    let mut builder = RscGraphBuilder::new();
+    builder.add_source(
+        "app/theme.js",
+        "export hook useTheme() {\n  useEffect(() => {});\n}\n",
+    );
+    builder.add_source(
+        "app/hooks.js",
+        "export { useTheme as useAppTheme } from \"./theme.js\";\n",
+    );
+    builder.add_source(
+        "app/page.js",
+        "import { useAppTheme } from \"./hooks.js\";\n\
+         export default function Page() { useAppTheme(); }",
+    );
+    builder.add_entry("app/page.js", EntryKind::Server);
+    let graph = builder.build();
+
+    let diagnostic = graph
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.rule() == "rsc/client-only-hook-in-server"
+                && diagnostic.module().as_str() == "app/page.js"
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "the barrel call stayed undecided: {:#?}",
+                graph.diagnostics()
+            )
+        });
+    assert!(
+        diagnostic
+            .to_string()
+            .contains("project module `app/hooks.js`"),
+        "{diagnostic}"
+    );
 }
 
 /// The import is what attributes the name, so a module that does not import

--- a/crates/uf_rsc/src/scan.rs
+++ b/crates/uf_rsc/src/scan.rs
@@ -204,6 +204,15 @@ impl ExportKind {
 pub struct ModuleExport {
     /// Exported name; `default` for a default export.
     pub name: CompactString,
+    /// Local declaration name when it differs from the exported name.
+    ///
+    /// `export default function Page()` exports `default`, but the body owner
+    /// recorded for hooks and client APIs is `Page`. `export { useTheme as
+    /// useAppTheme }` has the same split. Consumers that match a body back to an
+    /// export must use this when it is present, while import resolution must keep
+    /// using [`name`](Self::name).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local: Option<CompactString>,
     /// Shape of the exported binding.
     pub kind: ExportKind,
     /// 1-based line the export was declared on.

--- a/crates/uf_rsc/src/scan/exports.rs
+++ b/crates/uf_rsc/src/scan/exports.rs
@@ -49,26 +49,48 @@ fn collect_export(
     if next.is_punct(b'{') {
         let re_export = find_from_clause(source, tokens, position).is_some();
         let mut at = position + 2;
-        let mut pending: Option<&Token> = None;
+        let mut local: Option<&Token> = None;
+        let mut exported: Option<&Token> = None;
         while at < tokens.len() && !tokens[at].is_punct(b'}') {
             let token = &tokens[at];
+            if token.is_punct(b',') {
+                if let Some(exported) = exported.take() {
+                    push_named_export(
+                        source,
+                        local.unwrap_or(exported),
+                        exported,
+                        line,
+                        re_export,
+                        locals,
+                        exports,
+                    );
+                }
+                local = None;
+                at += 1;
+                continue;
+            }
             if token.kind == TokenKind::Ident {
                 if token.text(source) == "as" {
-                    pending = None;
                     at += 1;
                     continue;
                 }
-                pending = Some(token);
-            }
-            if token.is_punct(b',')
-                && let Some(name) = pending.take()
-            {
-                push_named_export(source, name, line, re_export, locals, exports);
+                if local.is_none() {
+                    local = Some(token);
+                }
+                exported = Some(token);
             }
             at += 1;
         }
-        if let Some(name) = pending.take() {
-            push_named_export(source, name, line, re_export, locals, exports);
+        if let Some(exported) = exported.take() {
+            push_named_export(
+                source,
+                local.unwrap_or(exported),
+                exported,
+                line,
+                re_export,
+                locals,
+                exports,
+            );
         }
         return;
     }
@@ -80,8 +102,11 @@ fn collect_export(
     match next.text(source) {
         "default" => {
             let kind = initializer_kind(source, tokens, position + 2);
+            let local = default_declaration_name(source, tokens, position + 2)
+                .filter(|local| local != "default");
             exports.push(ModuleExport {
                 name: CompactString::const_new("default"),
+                local,
                 kind,
                 line,
             });
@@ -91,6 +116,7 @@ fn collect_export(
             if let Some(name) = declaration_name(source, tokens, position + 3) {
                 exports.push(ModuleExport {
                     name,
+                    local: None,
                     kind: ExportKind::AsyncFunction,
                     line,
                 });
@@ -100,6 +126,7 @@ fn collect_export(
             if let Some(name) = declaration_name(source, tokens, position + 2) {
                 exports.push(ModuleExport {
                     name,
+                    local: None,
                     kind: ExportKind::SyncFunction,
                     line,
                 });
@@ -109,6 +136,7 @@ fn collect_export(
             if let Some(name) = declaration_name(source, tokens, position + 2) {
                 exports.push(ModuleExport {
                     name,
+                    local: None,
                     kind: ExportKind::Class,
                     line,
                 });
@@ -123,23 +151,26 @@ fn collect_export(
 
 fn push_named_export(
     source: &str,
-    name: &Token,
+    local: &Token,
+    exported: &Token,
     line: u32,
     re_export: bool,
     locals: &[(CompactString, ExportKind)],
     exports: &mut ExportList,
 ) {
-    let text = name.text(source);
+    let local_text = local.text(source);
+    let exported_text = exported.text(source);
     let kind = if re_export {
         ExportKind::ReExport
     } else {
         locals
             .iter()
-            .find(|(local, _)| local == text)
+            .find(|(local, _)| local == local_text)
             .map_or(ExportKind::Value, |(_, kind)| *kind)
     };
     exports.push(ModuleExport {
-        name: CompactString::from(text),
+        name: CompactString::from(exported_text),
+        local: (!re_export && local_text != exported_text).then(|| CompactString::from(local_text)),
         kind,
         line,
     });
@@ -148,6 +179,24 @@ fn push_named_export(
 fn declaration_name(source: &str, tokens: &[Token], position: usize) -> Option<CompactString> {
     let token = tokens.get(position)?;
     (token.kind == TokenKind::Ident).then(|| CompactString::from(token.text(source)))
+}
+
+fn default_declaration_name(
+    source: &str,
+    tokens: &[Token],
+    position: usize,
+) -> Option<CompactString> {
+    let token = tokens.get(position)?;
+    if token.kind != TokenKind::Ident {
+        return None;
+    }
+    match token.text(source) {
+        "async" => declaration_name(source, tokens, position + 2),
+        "function" | "hook" | "component" | "class" => {
+            declaration_name(source, tokens, position + 1)
+        }
+        _ => None,
+    }
 }
 
 /// Walk the declarators of a `const a = 1, b = 2;` statement.
@@ -195,7 +244,12 @@ fn collect_declarators(
             cursor += 1;
         }
 
-        exports.push(ModuleExport { name, kind, line });
+        exports.push(ModuleExport {
+            name,
+            local: None,
+            kind,
+            line,
+        });
 
         match tokens.get(cursor) {
             Some(token) if token.is_punct(b',') => at = cursor + 1,

--- a/crates/uf_rsc/src/scan/tests.rs
+++ b/crates/uf_rsc/src/scan/tests.rs
@@ -162,7 +162,7 @@ export const value = 1;
 export const handler = async () => {};
 export const wrapped = serverAction(async () => {});
 export class Widget {}
-export default async function () {}
+export default async function Page() {}
 "#;
     let exports = scan_exports(source);
     let shapes: Vec<_> = exports
@@ -181,20 +181,22 @@ export default async function () {}
             ("default", ExportKind::AsyncFunction),
         ]
     );
+    assert_eq!(exports[6].local.as_deref(), Some("Page"));
 }
 
 #[test]
 fn resolves_named_exports_through_local_declarations() {
-    let source = "async function refresh() {}\nfunction render() {}\nexport { refresh, render };";
+    let source =
+        "async function refresh() {}\nfunction render() {}\nexport { refresh, render as draw };";
     let exports = scan_exports(source);
     assert_eq!(
         exports
             .iter()
-            .map(|export| (export.name.as_str(), export.kind))
+            .map(|export| (export.name.as_str(), export.local.as_deref(), export.kind))
             .collect::<Vec<_>>(),
         vec![
-            ("refresh", ExportKind::AsyncFunction),
-            ("render", ExportKind::SyncFunction),
+            ("refresh", None, ExportKind::AsyncFunction),
+            ("draw", Some("render"), ExportKind::SyncFunction),
         ]
     );
 }

--- a/docs/app/$layout.js
+++ b/docs/app/$layout.js
@@ -13,7 +13,8 @@ import { Link, useRoute } from "@uniflowed/router";
 import type { Metadata } from "@uniflowed/router";
 
 import "./_design/seam.css";
-import { nextTheme, themeBootstrap, themeLabel, useTheme } from "./_design/theme.js";
+import { themeBootstrap } from "./_design/theme-static.js";
+import { ThemeToggle } from "./_design/theme.js";
 
 const VERSION = "0.0.0-alpha";
 
@@ -142,16 +143,6 @@ component Masthead() {
         <ThemeToggle />
       </nav>
     </header>
-  );
-}
-
-component ThemeToggle() {
-  const [theme, setTheme] = useTheme();
-
-  return (
-    <button className="theme-toggle" type="button" onClick={() => setTheme(nextTheme(theme))}>
-      {themeLabel(theme)}
-    </button>
   );
 }
 

--- a/docs/app/_design/theme-static.js
+++ b/docs/app/_design/theme-static.js
@@ -1,0 +1,36 @@
+// @flow
+//
+// Theme constants shared by the document and the client toggle.
+
+export type Theme = "system" | "light" | "dark";
+
+export const STORAGE_KEY: string = "uf-docs-theme";
+
+/**
+ * The script that runs before first paint.
+ *
+ * It has to be inline and synchronous: a stored dark preference applied after
+ * the first frame is a white flash, and there is no CSS that can express
+ * "read localStorage". Kept to one statement so it can be inlined safely.
+ */
+export const themeBootstrap: string =
+  `try{var t=localStorage.getItem(${JSON.stringify(STORAGE_KEY)});` +
+  `if(t==="dark"||t==="light")document.documentElement.dataset.theme=t}catch(e){}`;
+
+/** The theme after this one, cycling system -> light -> dark -> system. */
+export function nextTheme(theme: Theme): Theme {
+  return match (theme) {
+    "system" => "light",
+    "light" => "dark",
+    "dark" => "system",
+  };
+}
+
+/** What the toggle should say it will do. */
+export function themeLabel(theme: Theme): string {
+  return match (theme) {
+    "system" => "Theme: system",
+    "light" => "Theme: light",
+    "dark" => "Theme: dark",
+  };
+}

--- a/docs/app/_design/theme.js
+++ b/docs/app/_design/theme.js
@@ -18,20 +18,8 @@
 
 import { useEffect, useState } from "@uniflowed/react";
 
-export type Theme = "system" | "light" | "dark";
-
-const STORAGE_KEY = "uf-docs-theme";
-
-/**
- * The script that runs before first paint.
- *
- * It has to be inline and synchronous: a stored dark preference applied after
- * the first frame is a white flash, and there is no CSS that can express
- * "read localStorage". Kept to one statement so it can be inlined safely.
- */
-export const themeBootstrap: string =
-  `try{var t=localStorage.getItem(${JSON.stringify(STORAGE_KEY)});` +
-  `if(t==="dark"||t==="light")document.documentElement.dataset.theme=t}catch(e){}`;
+import { nextTheme, STORAGE_KEY, themeLabel } from "./theme-static.js";
+import type { Theme } from "./theme-static.js";
 
 /**
  * The current theme and a way to change it.
@@ -65,22 +53,14 @@ export hook useTheme(): [Theme, (next: Theme) => void] {
   return [theme, choose];
 }
 
-/** The theme after this one, cycling system → light → dark → system. */
-export function nextTheme(theme: Theme): Theme {
-  return match (theme) {
-    "system" => "light",
-    "light" => "dark",
-    "dark" => "system",
-  };
-}
+export component ThemeToggle() {
+  const [theme, setTheme] = useTheme();
 
-/** What the toggle should say it will do. */
-export function themeLabel(theme: Theme): string {
-  return match (theme) {
-    "system" => "Theme: system",
-    "light" => "Theme: light",
-    "dark" => "Theme: dark",
-  };
+  return (
+    <button className="theme-toggle" type="button" onClick={() => setTheme(nextTheme(theme))}>
+      {themeLabel(theme)}
+    </button>
+  );
 }
 
 function stored(): Theme {
@@ -97,6 +77,9 @@ function stored(): Theme {
 
 function apply(theme: Theme): void {
   const root = document.documentElement;
+  if (root == null) {
+    return;
+  }
   if (theme === "system") {
     delete root.dataset.theme;
   } else {


### PR DESCRIPTION
## Summary
- classify project hook exports with an export-graph fixpoint instead of warning on every unknown hook call
- resolve hook calls through import bindings, local exports, and re-export barrels
- keep truly unknown hooks as `rsc/unclassified-hook-in-server` while suppressing known server-safe hooks

Closes #388

## Verification
- `cargo fmt -p uf_rsc`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target cargo test -p uf_rsc --lib --profile ci graph::tests::diagnostic`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf/target cargo test -p uf_rsc --lib --profile ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791777378&installation_model_id=422833&pr_number=798&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F798&signature=1715d6250da84fa8c8b2531733bf95e25779afae38b5514a554be3a93c15d280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-module diagnostics by correctly tracing project-authored hooks and re-exports.
  - Server-safe hooks are no longer incorrectly reported as unsupported.
  - Client-only hooks used through project modules now produce more accurate diagnostics, including their source.

- **Documentation**
  - Improved theme handling in the documentation site, including safer initial theme application and more reliable theme switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->