### PR TITLE
feat(tui): report key release events

### DIFF
--- a/crates/uf_tui/src/lib.rs
+++ b/crates/uf_tui/src/lib.rs
@@ -42,7 +42,7 @@ pub struct TuiFrameworkContract {
     pub renderer: TuiRenderer,
     /// Layout engine used by boxes and components.
     pub layout: TuiLayoutEngine,
-    /// Input model used for keyboard, mouse, focus, and selection.
+    /// Input model used for keyboard, key release, mouse, focus, and selection.
     pub input: TuiInputModel,
     /// Runtime binding exposed to Flow and the uf runtime.
     pub runtime_binding: TuiRuntimeBinding,
@@ -163,9 +163,9 @@ pub enum TuiInputModel {
     /// a node at all, which is why it is a third name and not a detail of the
     /// second.
     ///
-    /// Key *release* is still not implemented — it needs the Kitty keyboard
-    /// protocol, and `KeyEvent.eventType` is always `"press"`. That is
-    /// ubugeeei-prod/uf#314.
+    /// Key press, repeat, and release events use the Kitty keyboard protocol
+    /// where a terminal supports it; legacy terminals keep reporting presses.
+    /// The other unfinished OpenTUI input behaviours remain ubugeeei-prod/uf#314.
     KeyboardMouseSelectionFocus,
 }
 

--- a/docs/app/guide/tui/$page.mdx
+++ b/docs/app/guide/tui/$page.mdx
@@ -114,7 +114,7 @@ produces these exactly, and it refuses to report a number that moved.
 
 | | first frame | one character | scroll one row | everything |
 | --- | --- | --- | --- | --- |
-| `@uniflowed/tui` | 2,102 | **8** | **345** | **534** |
+| `@uniflowed/tui` | 2,108 | **8** | **345** | **534** |
 | ink 7.1.1, default | **1,122** | 1,307 | 1,307 | 1,328 |
 | ink 7.1.1, `incrementalRendering` | **1,122** | 128 | 1,224 | 1,283 |
 

--- a/packages/tui/components.js
+++ b/packages/tui/components.js
@@ -513,6 +513,9 @@ export component Input(
 
   const onKeyDown = useCallback(
     (key: KeyEvent) => {
+      if (key.eventType === "release") {
+        return;
+      }
       if (key.name === "return") {
         if (onSubmit != null) {
           onSubmit(text);

--- a/packages/tui/index.js
+++ b/packages/tui/index.js
@@ -68,21 +68,21 @@
 //
 // Implemented, tested, and true: a component tree, flexbox layout in whole
 // cells, a cell buffer with correct wide-grapheme handling, a diff that emits
-// only changed cells, keyboard input with OpenTUI's key names and propagation
-// rules, bracketed paste, declarative focus, mouse input — press, release,
-// hover, drag with capture, drop and wheel, routed by a hit grid the painter
-// records — text selection by drag, one per renderer, read back with
+// only changed cells, keyboard input with OpenTUI's key names, propagation
+// rules and Kitty press/repeat/release event types, bracketed paste,
+// declarative focus, mouse input — press, release, hover, drag with capture,
+// drop and wheel, routed by a hit grid the painter records — text selection by
+// drag, one per renderer, read back with
 // `getSelectedText()`, a scrolling window onto content taller than it,
 // terminal capability and *size* detection that agrees with the CLI's, and an
 // in-memory renderer that runs the same code the terminal one does.
 //
-// Not here: key *release* (which needs the Kitty keyboard protocol), the
-// repeated-press gestures that widen a selection to a word or a line, images,
-// the rich content components, and everything under OpenTUI's "application
-// APIs" — including the clipboard, which is why `getSelectedText()` hands a
-// string back rather than putting it somewhere. They are
-// ubugeeei-prod/uf#314, and they are absent rather than present as functions
-// that throw — because a stub is what this package used to be.
+// Not here: the repeated-press gestures that widen a selection to a word or a
+// line, images, the rich content components, and everything under OpenTUI's
+// "application APIs" — including the clipboard, which is why
+// `getSelectedText()` hands a string back rather than putting it somewhere.
+// They are ubugeeei-prod/uf#314, and they are absent rather than present as
+// functions that throw — because a stub is what this package used to be.
 //
 // Also not here, and worth saying because ubugeeei-prod/uf#247 asked for it:
 // uf's own CLI does not draw through this. It cannot — `crates/uf_term` is
@@ -165,7 +165,7 @@ export type { WrapMode } from "./internal/paint.js";
 
 export type { Update } from "./diff.js";
 
-export type { InputDecoder, InputEvent, KeyEvent, KeySource } from "./keys.js";
+export type { InputDecoder, InputEvent, KeyEvent, KeyEventType, KeySource } from "./keys.js";
 export { createInputDecoder, decodeInput, decodeKeys } from "./keys.js";
 
 export type { MouseEvent, MouseEventType, Scroll, ScrollDirection } from "./mouse.js";

--- a/packages/tui/keys.js
+++ b/packages/tui/keys.js
@@ -52,8 +52,11 @@ import { LEGACY_REPORT_LENGTH, decodeMouse, legacyReportLength } from "./mouse.j
 /** Which of the two parsers produced an event. */
 export type KeySource = "raw" | "escape";
 
+/** What the terminal says happened to the key. */
+export type KeyEventType = "press" | "repeat" | "release";
+
 /**
- * One key press.
+ * One key event.
  *
  * `sequence` is the text the key stands for and `raw` is the bytes it arrived
  * as; they differ for every key that is not a printable character, and a
@@ -88,8 +91,8 @@ export type KeyEvent = {
   readonly ctrl: boolean,
   readonly shift: boolean,
   readonly meta: boolean,
-  /** Always `"press"`. Release reporting needs the Kitty protocol; see #314. */
-  readonly eventType: "press",
+  /** Whether this was a press, terminal repeat, or release event. */
+  readonly eventType: KeyEventType,
   /** Skip the focused node's handler, without silencing later global ones. */
   preventDefault(): void,
   /** Silence later global handlers, and the focused node's. */
@@ -159,6 +162,99 @@ const CSI_TILDE: { [string]: string } = {
   "24": "f12",
 };
 
+/** Non-Unicode Kitty `CSI u` key codes that do not already have legacy names. */
+const CSI_U_FUNCTION: { [string]: string } = {
+  "9": "tab",
+  "13": "return",
+  "27": "escape",
+  "127": "backspace",
+  "57358": "caps-lock",
+  "57359": "scroll-lock",
+  "57360": "num-lock",
+  "57361": "print-screen",
+  "57362": "pause",
+  "57363": "menu",
+  "57376": "f13",
+  "57377": "f14",
+  "57378": "f15",
+  "57379": "f16",
+  "57380": "f17",
+  "57381": "f18",
+  "57382": "f19",
+  "57383": "f20",
+  "57384": "f21",
+  "57385": "f22",
+  "57386": "f23",
+  "57387": "f24",
+  "57388": "f25",
+  "57389": "f26",
+  "57390": "f27",
+  "57391": "f28",
+  "57392": "f29",
+  "57393": "f30",
+  "57394": "f31",
+  "57395": "f32",
+  "57396": "f33",
+  "57397": "f34",
+  "57398": "f35",
+  "57399": "kp-0",
+  "57400": "kp-1",
+  "57401": "kp-2",
+  "57402": "kp-3",
+  "57403": "kp-4",
+  "57404": "kp-5",
+  "57405": "kp-6",
+  "57406": "kp-7",
+  "57407": "kp-8",
+  "57408": "kp-9",
+  "57409": "kp-decimal",
+  "57410": "kp-divide",
+  "57411": "kp-multiply",
+  "57412": "kp-subtract",
+  "57413": "kp-add",
+  "57414": "kp-enter",
+  "57415": "kp-equal",
+  "57416": "kp-separator",
+  "57417": "kp-left",
+  "57418": "kp-right",
+  "57419": "kp-up",
+  "57420": "kp-down",
+  "57421": "kp-pageup",
+  "57422": "kp-pagedown",
+  "57423": "kp-home",
+  "57424": "kp-end",
+  "57425": "kp-insert",
+  "57426": "kp-delete",
+  "57427": "kp-begin",
+  "57428": "media-play",
+  "57429": "media-pause",
+  "57430": "media-play-pause",
+  "57431": "media-reverse",
+  "57432": "media-stop",
+  "57433": "media-fast-forward",
+  "57434": "media-rewind",
+  "57435": "media-track-next",
+  "57436": "media-track-previous",
+  "57437": "media-record",
+  "57438": "volume-down",
+  "57439": "volume-up",
+  "57440": "volume-mute",
+  "57441": "left-shift",
+  "57442": "left-control",
+  "57443": "left-alt",
+  "57444": "left-super",
+  "57445": "left-hyper",
+  "57446": "left-meta",
+  "57447": "right-shift",
+  "57448": "right-control",
+  "57449": "right-alt",
+  "57450": "right-super",
+  "57451": "right-hyper",
+  "57452": "right-meta",
+  "57453": "iso-level3-shift",
+  "57454": "iso-level5-shift",
+};
+
 /** Build an event with its two propagation flags wired up. */
 function event(fields: {
   name: string,
@@ -168,6 +264,7 @@ function event(fields: {
   ctrl?: boolean,
   shift?: boolean,
   meta?: boolean,
+  eventType?: KeyEventType,
 }): KeyEvent {
   const key: KeyEvent = {
     kind: "key",
@@ -178,7 +275,7 @@ function event(fields: {
     ctrl: fields.ctrl === true,
     shift: fields.shift === true,
     meta: fields.meta === true,
-    eventType: "press",
+    eventType: fields.eventType ?? "press",
     defaultPrevented: false,
     propagationStopped: false,
     preventDefault() {
@@ -203,6 +300,49 @@ function modifiers(parameter: string | void): { ctrl: boolean, shift: boolean, m
   const value = Number.parseInt(parameter ?? "1", 10);
   const bits = Number.isFinite(value) && value > 0 ? value - 1 : 0;
   return { shift: (bits & 1) !== 0, meta: (bits & 2) !== 0, ctrl: (bits & 4) !== 0 };
+}
+
+/** The Kitty keyboard protocol encodes press/repeat/release as modifier sub-fields. */
+function keyEventType(parameter: string | void): KeyEventType | null {
+  if (parameter == null || parameter === "" || parameter === "1") {
+    return "press";
+  }
+  if (parameter === "2") {
+    return "repeat";
+  }
+  if (parameter === "3") {
+    return "release";
+  }
+  return null;
+}
+
+function codePoint(parameter: string | void): number | null {
+  if (parameter == null || parameter === "") {
+    return null;
+  }
+  const value = Number.parseInt(parameter, 10);
+  if (!Number.isFinite(value) || value < 0 || value > 0x10ffff) {
+    return null;
+  }
+  if (value >= 0xd800 && value <= 0xdfff) {
+    return null;
+  }
+  return value;
+}
+
+function codePointText(parameter: string | void): string {
+  if (parameter == null || parameter === "") {
+    return "";
+  }
+  const points: Array<number> = [];
+  for (const field of parameter.split(":")) {
+    const point = codePoint(field);
+    if (point == null || point < 0x20 || (point >= 0x7f && point <= 0x9f)) {
+      return "";
+    }
+    points.push(point);
+  }
+  return String.fromCodePoint(...points);
 }
 
 /**
@@ -260,18 +400,18 @@ export type InputDecoder = {
  * The longest run of bytes this decoder will hold waiting for the rest of it.
  *
  * Every sequence `incomplete` waits for is shorter: the paste introducer is
- * six bytes, an old-style mouse report is six, and an SGR report is
- * `ESC [ <` plus three decimal parameters, two semicolons and a final byte —
- * nineteen bytes for coordinates larger than any terminal has. Past this, the
- * bytes are not the sequence they looked like and are decoded as what they
- * are.
+ * six bytes, an old-style mouse report is six, and an SGR report is `ESC [ <`
+ * plus three decimal parameters, two semicolons and a final byte. Kitty's
+ * `CSI u` key reports can be longer because their associated text is encoded
+ * as code points. Past this, the bytes are not the sequence they looked like
+ * and are decoded as what they are.
  *
  * The bound is what makes the hold safe without a timer. `flush` is the
  * ordinary way out and a driver calls it when its stream ends; this is for the
  * case where nothing ever calls it and the terminal has sent `ESC [ <` and
  * then a thousand digits.
  */
-const HOLD_LIMIT = 32;
+const HOLD_LIMIT = 96;
 
 /**
  * Whether the bytes from `start` begin a sequence whose rest has not arrived.
@@ -287,7 +427,9 @@ const HOLD_LIMIT = 32;
  *     `?1003h` produces is a report per cell crossed, which is the traffic
  *     most likely to be split;
  *   * `ESC [ M` …, the old-style report, whose three payload bytes are
- *     arbitrary and become arbitrary keys.
+ *     arbitrary and become arbitrary keys;
+ *   * Kitty `CSI u` key reports, where splitting before the final `u` would
+ *     turn `CSI 97 ; 1 : 3 u` from "release A" into ordinary characters.
  *
  * Two bytes at least, so a lone `ESC` is still the Escape key: holding that
  * back would mean Escape never fires until the next keystroke, which is worse
@@ -319,6 +461,9 @@ function incomplete(input: string, start: number): boolean {
   if (rest.startsWith(MOUSE_LEGACY)) {
     return rest.length < LEGACY_REPORT_LENGTH;
   }
+  if (rest.startsWith(ESC + "[")) {
+    return /^[0-9:;]*$/.test(rest.slice(2));
+  }
   return false;
 }
 
@@ -333,13 +478,14 @@ export function createInputDecoder(): InputDecoder {
       const events: Array<InputEvent> = [];
       let input = waiting + chunk;
       waiting = "";
-      if (pending != null) {
+      const pasting = pending;
+      if (pasting != null) {
         const end = input.indexOf(PASTE_END);
         if (end < 0) {
-          pending += input;
+          pending = pasting + input;
           return events;
         }
-        const text = pending + input.slice(0, end);
+        const text = pasting + input.slice(0, end);
         pending = null;
         events.push(pasteEvent(text, PASTE_START + text + PASTE_END));
         input = input.slice(end + PASTE_END.length);
@@ -512,7 +658,7 @@ function decodeSequence(input: string, start: number): { key: KeyEvent, length: 
 
   let cursor = start + 2;
   let parameters = "";
-  while (cursor < input.length && /[0-9;]/.test(input[cursor])) {
+  while (cursor < input.length && /[0-9:;]/.test(input[cursor])) {
     parameters += input[cursor];
     cursor += 1;
   }
@@ -522,6 +668,14 @@ function decodeSequence(input: string, start: number): { key: KeyEvent, length: 
   }
   const raw = input.slice(start, cursor + 1);
   const [first, second] = parameters.split(";");
+
+  if (final === "u") {
+    const key = decodeKittyKey(parameters, raw);
+    if (key == null) {
+      return null;
+    }
+    return { key, length: raw.length };
+  }
 
   if (final === "~") {
     const name = CSI_TILDE[first];
@@ -542,6 +696,51 @@ function decodeSequence(input: string, start: number): { key: KeyEvent, length: 
   // `CSI Z` is Shift+Tab, and it carries no modifier parameter to say so.
   const mods = final === "Z" ? { ctrl: false, shift: true, meta: false } : modifiers(second);
   return { key: event({ name, sequence: "", raw, source: "escape", ...mods }), length: raw.length };
+}
+
+function decodeKittyKey(parameters: string, raw: string): KeyEvent | null {
+  const [keyParameter, modifierParameter, textParameter] = parameters.split(";");
+  const key = codePoint(keyParameter.split(":")[0]);
+  if (key == null) {
+    return null;
+  }
+  const modifierFields = modifierParameter?.split(":") ?? [];
+  const mods = modifiers(modifierFields[0]);
+  const eventType = keyEventType(modifierFields[1]);
+  if (eventType == null) {
+    return null;
+  }
+  const associatedText = codePointText(textParameter);
+  const functionName = CSI_U_FUNCTION[String(key)];
+  if (functionName != null) {
+    return event({
+      name: functionName,
+      sequence: "",
+      raw,
+      source: "escape",
+      ...mods,
+      eventType,
+    });
+  }
+  if (key === 0) {
+    return event({
+      name: "text",
+      sequence: eventType === "release" ? "" : associatedText,
+      raw,
+      source: "escape",
+      ...mods,
+      eventType,
+    });
+  }
+  const character = String.fromCodePoint(key);
+  const name = character === " " ? "space" : character.toLowerCase();
+  const sequence =
+    associatedText !== ""
+      ? associatedText
+      : eventType === "release" || mods.ctrl || mods.meta
+        ? ""
+        : character;
+  return event({ name, sequence, raw, source: "escape", ...mods, eventType });
 }
 
 /** One byte that is not part of an escape sequence. */

--- a/packages/tui/terminal.js
+++ b/packages/tui/terminal.js
@@ -75,6 +75,17 @@ const CLEAR = "\u001b[2J\u001b[H";
 const ENABLE_PASTE = "\u001b[?2004h";
 const DISABLE_PASTE = "\u001b[?2004l";
 /**
+ * Ask terminals that understand Kitty's keyboard protocol to report all keys
+ * as `CSI u`, including repeat/release event types and associated text.
+ *
+ * The flags are pushed onto the terminal's keyboard-mode stack and popped on
+ * exit, so a shell or parent program gets back whatever mode it had before.
+ * Terminals that do not implement the protocol ignore these bytes and keep
+ * sending the legacy sequences `keys.js` already decodes.
+ */
+const ENABLE_KEYBOARD_PROTOCOL = "\u001b[>27u";
+const DISABLE_KEYBOARD_PROTOCOL = "\u001b[<u";
+/**
  * Ask the terminal to report the mouse, in the four modes that answer.
  *
  * `?1000h` turns reporting on at all — presses and releases. `?1002h` adds
@@ -356,6 +367,7 @@ export function render(element: React.Node, options: RenderOptions = {}): Handle
       (alternateScreen ? ENTER_ALTERNATE : "") +
         HIDE_CURSOR +
         ENABLE_PASTE +
+        ENABLE_KEYBOARD_PROTOCOL +
         (mouse ? ENABLE_MOUSE : "") +
         CLEAR,
     );
@@ -431,6 +443,7 @@ export function render(element: React.Node, options: RenderOptions = {}): Handle
         }
         stdout.write(
           (mouse ? DISABLE_MOUSE : "") +
+            DISABLE_KEYBOARD_PROTOCOL +
             DISABLE_PASTE +
             SHOW_CURSOR +
             (alternateScreen ? LEAVE_ALTERNATE : "\n"),

--- a/packages/tui/tui.test.js
+++ b/packages/tui/tui.test.js
@@ -944,6 +944,39 @@ describe("input reaches what has focus", () => {
     expect([shiftTab.name, shiftTab.shift]).toEqual(["tab", true]);
   });
 
+  it("decodes Kitty key repeat and release events", () => {
+    const release = decodeKeys("\u001b[97;1:3u")[0];
+    expect([release.name, release.sequence, release.eventType]).toEqual(["a", "", "release"]);
+
+    const repeat = decodeKeys("\u001b[97;2:2;65u")[0];
+    expect([repeat.name, repeat.sequence, repeat.shift, repeat.eventType]).toEqual([
+      "a",
+      "A",
+      true,
+      "repeat",
+    ]);
+
+    const text = decodeKeys("\u001b[0;;229u")[0];
+    expect([text.name, text.sequence, text.eventType]).toEqual(["text", "å", "press"]);
+
+    const control = decodeKeys("\u001b[57442;1:3u")[0];
+    expect([control.name, control.eventType]).toEqual(["left-control", "release"]);
+  });
+
+  it("waits for the rest of a Kitty key report split across chunks", () => {
+    const decoder = createInputDecoder();
+
+    expect(decoder.push("\u001b[97;1:")).toEqual([]);
+    const events = decoder.push("3u");
+    expect(events.map((event) => event.kind)).toEqual(["key"]);
+    const [release] = events;
+    if (release == null || release.kind !== "key") {
+      throw new Error("the two halves did not make one key");
+    }
+    expect([release.name, release.eventType]).toEqual(["a", "release"]);
+    expect(decoder.flush()).toEqual([]);
+  });
+
   it("decodes a burst as several keys, because fast typing arrives as one chunk", () => {
     expect(decodeKeys("abc").map((key) => key.sequence)).toEqual(["a", "b", "c"]);
     expect(decodeKeys("a\u001b[Db").map((key) => key.name)).toEqual(["a", "left", "b"]);
@@ -1257,6 +1290,18 @@ describe("input reaches what has focus", () => {
     expect(frameRow(handle.frame(), 0).trimEnd()).toBe("");
     handle.stop();
   });
+
+  it("does not edit an input for a key release event", () => {
+    const handle = testRender(<Input defaultValue="" focused={true} width={6} height={1} />, {
+      width: 6,
+      height: 1,
+    });
+    handle.press("a");
+    handle.press("\u001b[97;1:3u");
+    handle.press("\u001b[98;1:2;98u");
+    expect(frameRow(handle.frame(), 0).trimEnd()).toBe("ab");
+    handle.stop();
+  });
 });
 
 describe("the mouse reaches what is under it", () => {
@@ -1367,7 +1412,7 @@ describe("the mouse reaches what is under it", () => {
     // without waiting — which is what keeps a terminal sending nonsense from
     // wedging a driver that never calls `flush`.
     const flooded = createInputDecoder();
-    expect(flooded.push(`\u001b[<${"0".repeat(40)}`).length > 0).toBe(true);
+    expect(flooded.push(`\u001b[<${"0".repeat(110)}`).length > 0).toBe(true);
     // And the decoder still works afterwards: nothing was left held.
     expect(flooded.push("\u001b[<0;2;2M").map((event) => event.kind)).toEqual(["mouse"]);
   });
@@ -2558,7 +2603,7 @@ describe("the guide's comparison against React Ink", () => {
     // The frame is 80×24 and addressed cell by cell, so the first one is the
     // expensive one — and then one character of a status line at the *top* of
     // the frame costs eight bytes, which is the whole claim.
-    expect(measured).toEqual([2102, 8, 345, 534]);
+    expect(measured).toEqual([2108, 8, 345, 534]);
     expect(published()).toEqual(measured);
   });
 });
@@ -2627,6 +2672,7 @@ describe("a real terminal, or something that is not one", () => {
     expect(opened).toContain("\u001b[?1049h"); // the alternate screen
     expect(opened).toContain("\u001b[?25l"); // and no cursor of the terminal's own
     expect(opened).toContain("\u001b[?2004h"); // and pasted text, bracketed
+    expect(opened).toContain("\u001b[>27u"); // and Kitty key repeat/release reports
     expect(opened).toContain("hi");
     // Raw mode, because a menu needs the keystroke rather than the line.
     expect(stdin.modes).toEqual([true]);
@@ -2637,6 +2683,7 @@ describe("a real terminal, or something that is not one", () => {
     expect(closed).toContain("\u001b[?1049l");
     // A terminal left in bracketed paste mode hands the *shell* the brackets.
     expect(closed).toContain("\u001b[?2004l");
+    expect(closed).toContain("\u001b[<u");
     expect(stdin.modes).toEqual([true, false]);
   });
 


### PR DESCRIPTION
## Summary
- enable Kitty keyboard protocol flags for interactive TUI sessions and restore the terminal mode on stop
- decode Kitty CSI u press/repeat/release events into KeyEvent.eventType
- keep Input from editing on release events and update the TUI contract/docs benchmark bytes

Part of #314.

## Verification
- uf test packages/tui/tui.test.js
- uf check packages/tui/keys.js packages/tui/mouse.js
- cargo test -p uf_tui

Note: `uf check packages/tui` still reports existing checker-limit errors in unrelated TUI files (for example React.Node and new Array inference). The targeted decoder check is clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791788239&installation_model_id=422833&pr_number=801&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F801&signature=a0b2f82b9d8cbf523c5ca9532092f1db5c5d0c63f31de755d174c1d0558e6b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Kitty keyboard protocol support for key press, repeat, and release events.
  - Added support for decoding associated text and split keyboard reports.
  - Terminals now enable the enhanced keyboard protocol during TUI sessions and restore the prior mode on exit.
  - Exported the keyboard event type for consumers.

- **Bug Fixes**
  - Prevented key-release events from triggering text editing or navigation actions.

- **Documentation**
  - Updated TUI input documentation and benchmark byte counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->