### PR TITLE
feat(ui): add render escape hatch to small parts

### DIFF
--- a/packages/ui/progress.js
+++ b/packages/ui/progress.js
@@ -38,7 +38,8 @@
 
 import * as React from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { withProps } from "./internal/merge-props.js";
 import { clamp } from "./internal/range.js";
 
 /**
@@ -57,6 +58,9 @@ import { clamp } from "./internal/range.js";
  * `Slider`, whose value may be its own, a progress bar's value arrived as a
  * prop, so the caller already has everything they need to size a bar with and
  * a helpful custom property would only be their own arithmetic handed back.
+ *
+ * `render` changes the element and not the accessibility contract: the
+ * progressbar role and value attributes are the props handed to the caller.
  */
 export component Progress(
   value?: number | null = null,
@@ -64,23 +68,24 @@ export component Progress(
   max?: number = 100,
   valueText?: string,
   children?: React.Node,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const known = value == null ? null : clamp(value, min, max);
+  const props = withProps(rest, {
+    "aria-valuemax": max,
+    "aria-valuemin": min,
+    // Omitted, not zeroed. `aria-valuenow="0"` tells a reader that nothing
+    // has happened; leaving it out tells them the amount is unknown, which
+    // is the true one and the one a spinner means.
+    "aria-valuenow": known ?? undefined,
+    "aria-valuetext": valueText,
+    children,
+    role: "progressbar",
+  });
 
-  return (
-    <div
-      {...rest}
-      aria-valuemax={max}
-      aria-valuemin={min}
-      // Omitted, not zeroed. `aria-valuenow="0"` tells a reader that nothing
-      // has happened; leaving it out tells them the amount is unknown, which
-      // is the true one and the one a spinner means.
-      aria-valuenow={known ?? undefined}
-      aria-valuetext={valueText}
-      role="progressbar"
-    >
-      {children}
-    </div>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }

--- a/packages/ui/separator.js
+++ b/packages/ui/separator.js
@@ -51,7 +51,8 @@
 // One element, two attributes, nothing to remember. It renders on a server.
 
 import type { Orientation } from "./internal/roving-focus.js";
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { withProps } from "./internal/merge-props.js";
 
 export type { Orientation } from "./internal/roving-focus.js";
 
@@ -75,14 +76,22 @@ export type { Orientation } from "./internal/roving-focus.js";
  * `aria-orientation` is written out even for the horizontal case, where ARIA
  * would default to it. It is the attribute a reader of this markup is looking
  * for, and a default that is left implicit is a default somebody has to know.
+ *
+ * `render` changes the element carrying that decision, not the decision
+ * itself: decorative rules stay hidden, semantic rules keep the separator
+ * role and orientation.
  */
 export component Separator(
   decorative?: boolean = false,
   orientation?: Orientation = "horizontal",
+  render?: RenderProp,
   ...rest: Rest
 ) {
-  if (decorative) {
-    return <div {...rest} aria-hidden="true" />;
+  const props = decorative
+    ? withProps(rest, { "aria-hidden": "true" })
+    : withProps(rest, { "aria-orientation": orientation, role: "separator" });
+  if (render != null) {
+    return render(props);
   }
-  return <div {...rest} aria-orientation={orientation} role="separator" />;
+  return <div {...props} />;
 }

--- a/packages/ui/toggle.js
+++ b/packages/ui/toggle.js
@@ -44,49 +44,62 @@
 
 import * as React from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import { composeHandlers, withProps, withoutComposed } from "./internal/merge-props.js";
 import { useControlled } from "./internal/controlled-state.js";
 
-/** A button whose state stays applied: pressed or not. */
+/**
+ * A button whose state stays applied: pressed or not.
+ *
+ * `render` is the escape hatch. A caller-rendered element gets `role="button"`
+ * because it may be a link or a `div`; the native button branch keeps the role
+ * implicit and only adds `type="button"`, which is true of the element rather
+ * than of the toggle behaviour.
+ */
 export component Toggle(
   pressed?: boolean,
   defaultPressed?: boolean = false,
   onPressedChange?: (pressed: boolean) => void,
   disabled?: boolean = false,
   children?: React.Node,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const [on, setOn] = useControlled(pressed, defaultPressed, onPressedChange);
   const passed = withoutComposed(rest, ["onClick", "onKeyDown"]);
+  const semantics = {
+    "aria-pressed": on ? "true" : "false",
+    children,
+    disabled,
+    onClick: composeHandlers(rest.onClick, (_event: PartEvent) => {
+      if (!disabled) {
+        setOn(!on);
+      }
+    }),
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      if (disabled || (event.key !== " " && event.key !== "Enter")) {
+        return;
+      }
+      // Preventing the default stops `Space` scrolling the page, and stops
+      // the browser's own click arriving after this handler and pressing the
+      // button a second time — back to where it started, which reads as the
+      // key having done nothing at all.
+      event.preventDefault();
+      setOn(!on);
+    }),
+  };
+
+  if (render != null) {
+    return render(withProps(passed, { ...semantics, role: "button" }));
+  }
 
   return (
     <button
-      {...passed}
+      {...withProps(passed, semantics)}
       // No `role`: this *is* a button, and `aria-pressed` is what makes it a
       // toggle one. Adding `role="button"` to a `<button>` would be noise, and
       // adding any other role would be a lie about what pressing it does.
-      aria-pressed={on ? "true" : "false"}
-      disabled={disabled}
-      onClick={composeHandlers(rest.onClick, () => {
-        if (!disabled) {
-          setOn(!on);
-        }
-      })}
-      onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-        if (disabled || (event.key !== " " && event.key !== "Enter")) {
-          return;
-        }
-        // Preventing the default stops `Space` scrolling the page, and stops
-        // the browser's own click arriving after this handler and pressing the
-        // button a second time — back to where it started, which reads as the
-        // key having done nothing at all.
-        event.preventDefault();
-        setOn(!on);
-      })}
       type="button"
-    >
-      {children}
-    </button>
+    />
   );
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -5272,6 +5272,21 @@ describe("Progress", () => {
     // reader reads out loud.
     expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "10");
   });
+
+  it("hands the progressbar contract to a caller-rendered element", () => {
+    render(
+      <Progress
+        aria-label="Uploading"
+        max={10}
+        render={(props) => <section {...props} />}
+        value={4}
+      />,
+    );
+    const bar = screen.getByRole("progressbar", { name: "Uploading" });
+    expect(bar.tagName).toBe("SECTION");
+    expect(bar).toHaveAttribute("aria-valuenow", "4");
+    expect(bar).toHaveAttribute("aria-valuemax", "10");
+  });
 });
 
 describe("Slider", () => {
@@ -6271,6 +6286,22 @@ describe("Separator", () => {
     // nobody finds out — so the default is the mistake that can be corrected.
     expect(screen.getByRole("separator")).toBeInTheDocument();
   });
+
+  it("hands the chosen separator semantics to a caller-rendered element", () => {
+    const { rerender } = render(
+      <Separator
+        orientation="vertical"
+        render={(props) => <span {...props} data-testid="rule" />}
+      />,
+    );
+    const rule = screen.getByRole("separator");
+    expect(rule.tagName).toBe("SPAN");
+    expect(rule).toHaveAttribute("aria-orientation", "vertical");
+
+    rerender(<Separator decorative render={(props) => <span {...props} data-testid="rule" />} />);
+    expect(screen.queryByRole("separator")).toBe(null);
+    expect(screen.getByTestId("rule")).toHaveAttribute("aria-hidden", "true");
+  });
 });
 
 describe("Skeleton", () => {
@@ -6640,6 +6671,19 @@ describe("Toggle", () => {
     // A toggle button is a button, and a button activates on both keys.
     await userEvent.keyboard("{Enter}");
     expect(control).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("hands toggle-button behaviour to a caller-rendered element", async () => {
+    render(<Toggle aria-label="Bold" render={(props) => <div {...props} tabIndex={0} />} />);
+    const control = screen.getByRole("button", { name: "Bold" });
+    expect(control.tagName).toBe("DIV");
+    expect(control).toHaveAttribute("aria-pressed", "false");
+
+    await userEvent.click(control);
+    expect(control).toHaveAttribute("aria-pressed", "true");
+    control.focus();
+    await userEvent.keyboard(" ");
+    expect(control).toHaveAttribute("aria-pressed", "false");
   });
 
   it("does not press while disabled", async () => {
@@ -8241,6 +8285,8 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Menubar.Separator",
     "Menubar.SubTrigger",
     "Menubar.Trigger",
+    "Progress",
+    "Separator",
     "Sheet.Body",
     "Sheet.Close",
     "Sheet.Description",
@@ -8255,6 +8301,7 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Tabs.Panel",
     "Tabs.Root",
     "Tabs.Tab",
+    "Toggle",
     "Tooltip.Trigger",
   ];
 
@@ -8347,7 +8394,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Pagination.Root",
     "Popover.Body",
     "Popover.Trigger",
-    "Progress",
     "RadioGroup.Indicator",
     "RadioGroup.Item",
     "RadioGroup.Root",
@@ -8366,7 +8412,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Select.Separator",
     "Select.Trigger",
     "Select.Value",
-    "Separator",
     "Sidebar.Body",
     "Sidebar.Footer",
     "Sidebar.Header",
@@ -8391,7 +8436,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Toast.Region",
     "Toast.Root",
     "Toast.Title",
-    "Toggle",
     "ToggleGroup.Item",
     "ToggleGroup.Root",
     "Tooltip.Body",


### PR DESCRIPTION
Part of #303.

## Summary
- add the shared `render` escape hatch to `Progress`, `Separator`, and `Toggle`
- keep each part's accessibility contract authoritative when caller-rendered elements are used
- move those parts into the escape-hatch audit and add behavior coverage

## Verification
- `uf fmt --check packages/ui/progress.js packages/ui/separator.js packages/ui/toggle.js packages/ui/ui.test.js`
- `uf test packages/ui/ui.test.js --filter "Progress >"`
- `uf test packages/ui/ui.test.js --filter "Separator >"`
- `uf test packages/ui/ui.test.js --filter "Toggle >"`
- `uf test packages/ui/ui.test.js --filter "the escape hatch: which part hands its element to the caller"`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791789706&installation_model_id=422833&pr_number=802&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F802&signature=ba17bcf4ee43968412a607f9d8928c2cd93d6d910287463bb6149c585e41c8ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->