### PR TITLE
feat(ui): add render escape hatch to breadcrumb parts

### DIFF
--- a/packages/ui/breadcrumb.js
+++ b/packages/ui/breadcrumb.js
@@ -45,7 +45,8 @@
 
 import * as React from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { withProps } from "./internal/merge-props.js";
 
 /**
  * The trail, as a named landmark.
@@ -58,13 +59,14 @@ import type { Rest } from "./internal/merge-props.js";
 export component BreadcrumbRoot(
   children: React.Node,
   label?: string = "Breadcrumb",
+  render?: RenderProp,
   ...rest: Rest
 ) {
-  return (
-    <nav {...rest} aria-label={label}>
-      {children}
-    </nav>
-  );
+  const props = withProps(rest, { "aria-label": label, children });
+  if (render != null) {
+    return render(withProps(props, { role: "navigation" }));
+  }
+  return <nav {...props} />;
 }
 
 /**
@@ -76,19 +78,32 @@ export component BreadcrumbRoot(
  */
 export component BreadcrumbList(
   children: renders* (BreadcrumbItem | BreadcrumbSeparator),
+  render?: RenderProp,
   ...rest: Rest
 ) {
-  return <ol {...rest}>{children}</ol>;
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(withProps(props, { role: "list" }));
+  }
+  return <ol {...props} />;
 }
 
 /** One level of the trail. Holds a `Breadcrumb.Link` or a `Breadcrumb.Page`. */
-export component BreadcrumbItem(children: React.Node, ...rest: Rest) {
-  return <li {...rest}>{children}</li>;
+export component BreadcrumbItem(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(withProps(props, { role: "listitem" }));
+  }
+  return <li {...props} />;
 }
 
 /** A level you can go back to. */
-export component BreadcrumbLink(children: React.Node, ...rest: Rest) {
-  return <a {...rest}>{children}</a>;
+export component BreadcrumbLink(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(withProps(props, { role: "link" }));
+  }
+  return <a {...props} />;
 }
 
 /**
@@ -99,12 +114,12 @@ export component BreadcrumbLink(children: React.Node, ...rest: Rest) {
  * a link by accident. See the module header for why announcing it as a disabled
  * link is worse than announcing it as text.
  */
-export component BreadcrumbPage(children: React.Node, ...rest: Rest) {
-  return (
-    <span {...rest} aria-current="page">
-      {children}
-    </span>
-  );
+export component BreadcrumbPage(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { "aria-current": "page", children });
+  if (render != null) {
+    return render(props);
+  }
+  return <span {...props} />;
 }
 
 /**
@@ -114,10 +129,10 @@ export component BreadcrumbPage(children: React.Node, ...rest: Rest) {
  * design decision and this package makes none. What is not the caller's is that
  * it is announced to nobody.
  */
-export component BreadcrumbSeparator(children?: React.Node, ...rest: Rest) {
-  return (
-    <li {...rest} aria-hidden="true" role="presentation">
-      {children}
-    </li>
-  );
+export component BreadcrumbSeparator(children?: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { "aria-hidden": "true", children, role: "presentation" });
+  if (render != null) {
+    return render(props);
+  }
+  return <li {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -6089,6 +6089,34 @@ describe("Breadcrumb", () => {
     );
     expect(screen.getByRole("navigation", { name: "Fil d'Ariane" })).toBeInTheDocument();
   });
+
+  it("hands the trail contract to caller-rendered elements", () => {
+    render(
+      <Breadcrumb.Root label="Trail" render={(props) => <section {...props} />}>
+        <Breadcrumb.List render={(props) => <div {...props} data-testid="list" />}>
+          <Breadcrumb.Item render={(props) => <div {...props} data-testid="home" />}>
+            <Breadcrumb.Link href="/" render={(props) => <span {...props} />}>
+              Home
+            </Breadcrumb.Link>
+          </Breadcrumb.Item>
+          <Breadcrumb.Separator render={(props) => <span {...props} data-testid="slash" />}>
+            /
+          </Breadcrumb.Separator>
+          <Breadcrumb.Item render={(props) => <div {...props} data-testid="billing" />}>
+            <Breadcrumb.Page render={(props) => <strong {...props} />}>Billing</Breadcrumb.Page>
+          </Breadcrumb.Item>
+        </Breadcrumb.List>
+      </Breadcrumb.Root>,
+    );
+    const trail = screen.getByRole("navigation", { name: "Trail" });
+    expect(trail.tagName).toBe("SECTION");
+    expect(screen.getByTestId("list")).toHaveAttribute("role", "list");
+    expect(screen.getAllByRole("listitem").length).toBe(2);
+    expect(screen.getByRole("link", { name: "Home" }).tagName).toBe("SPAN");
+    expect(screen.getByText("Billing")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("slash")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByTestId("slash")).toHaveAttribute("role", "presentation");
+  });
 });
 
 describe("Alert", () => {
@@ -8234,6 +8262,12 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "AlertDialog.Overlay",
     "AlertDialog.Title",
     "AlertDialog.Trigger",
+    "Breadcrumb.Item",
+    "Breadcrumb.Link",
+    "Breadcrumb.List",
+    "Breadcrumb.Page",
+    "Breadcrumb.Root",
+    "Breadcrumb.Separator",
     "Checkbox",
     "ContextMenu.Body",
     "ContextMenu.CheckboxItem",
@@ -8349,12 +8383,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Avatar.Fallback",
     "Avatar.Image",
     "Avatar.Root",
-    "Breadcrumb.Item",
-    "Breadcrumb.Link",
-    "Breadcrumb.List",
-    "Breadcrumb.Page",
-    "Breadcrumb.Root",
-    "Breadcrumb.Separator",
     "Calendar.Day",
     "Calendar.Month",
     "Calendar.Root",


### PR DESCRIPTION
Summary:
- Add `render` to every Breadcrumb part while preserving navigation/list/current-page semantics.
- Move Breadcrumb parts from the fixed list to the render-hatch table and cover caller-rendered elements.

Validation:
- `git diff --check origin/main...HEAD`

Part of #303.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791790914&installation_model_id=422833&pr_number=803&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F803&signature=afc3942446096182e0ea6ab9c28ebbf89331ecf72655e8b8789bb257e2b1ff93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->