### PR TITLE
feat(ui): add render escape hatch to alert parts

### DIFF
--- a/packages/ui/alert.js
+++ b/packages/ui/alert.js
@@ -65,7 +65,8 @@
 
 import * as React from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { withProps } from "./internal/merge-props.js";
 
 /**
  * A callout: a panel that is part of the page, or one that just appeared.
@@ -87,12 +88,17 @@ import type { Rest } from "./internal/merge-props.js";
  * header is about: the role is a promise about a change, and a box that was
  * always there has no change to report.
  */
-export component AlertRoot(children: React.Node, live?: boolean = false, ...rest: Rest) {
-  return (
-    <div {...rest} role={live ? "alert" : undefined}>
-      {children}
-    </div>
-  );
+export component AlertRoot(
+  children: React.Node,
+  live?: boolean = false,
+  render?: RenderProp,
+  ...rest: Rest
+) {
+  const props = withProps(rest, { children, role: live ? "alert" : undefined });
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }
 
 /**
@@ -110,14 +116,27 @@ export component AlertRoot(children: React.Node, live?: boolean = false, ...rest
  * the six HTML has is clamped, because `<h7>` is not an element and is
  * announced as nothing at all.
  */
-export component AlertTitle(children: React.Node, level?: number = 3, ...rest: Rest) {
+export component AlertTitle(
+  children: React.Node,
+  level?: number = 3,
+  render?: RenderProp,
+  ...rest: Rest
+) {
   const clamped = Math.min(6, Math.max(1, Math.trunc(level)));
   const Heading = `h${String(clamped)}`;
+  const props = withProps(rest, { children });
 
-  return <Heading {...rest}>{children}</Heading>;
+  if (render != null) {
+    return render(withProps(props, { "aria-level": clamped, role: "heading" }));
+  }
+  return <Heading {...props} />;
 }
 
 /** What the callout says, under its heading. */
-export component AlertDescription(children: React.Node, ...rest: Rest) {
-  return <p {...rest}>{children}</p>;
+export component AlertDescription(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(props);
+  }
+  return <p {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -6186,6 +6186,23 @@ describe("Alert", () => {
     // nothing at all — which loses the heading rather than deepening it.
     expect(screen.getByRole("heading", { level: 6 })).toBeInTheDocument();
   });
+
+  it("hands the callout contract to caller-rendered elements", () => {
+    render(
+      <Alert.Root live render={(props) => <section {...props} data-testid="callout" />}>
+        <Alert.Title level={2} render={(props) => <span {...props} />}>
+          Could not save
+        </Alert.Title>
+        <Alert.Description render={(props) => <div {...props} />}>
+          The server said no.
+        </Alert.Description>
+      </Alert.Root>,
+    );
+
+    expect(screen.getByTestId("callout")).toHaveAttribute("role", "alert");
+    expect(screen.getByRole("heading", { level: 2, name: "Could not save" })).toBeInTheDocument();
+    expect(screen.getByText("The server said no.")).toBeInTheDocument();
+  });
 });
 
 describe("Avatar", () => {
@@ -8253,6 +8270,9 @@ describe("the escape hatch: which part hands its element to the caller", () => {
 
   /** Parts that take `render` and hand their props to the caller. */
   const RENDER: $ReadOnlyArray<string> = [
+    "Alert.Description",
+    "Alert.Root",
+    "Alert.Title",
     "AlertDialog.Action",
     "AlertDialog.Body",
     "AlertDialog.Cancel",
@@ -8342,7 +8362,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
   /** Parts with no element of their own: a context, or another part of this package. */
   const NO_ELEMENT: $ReadOnlyArray<string> = [
     "Accordion.Header",
-    "Alert.Title",
     "AlertDialog.Root",
     "Calendar.Next",
     "Calendar.Previous",
@@ -8378,8 +8397,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Accordion.Item",
     "Accordion.Root",
     "Accordion.Trigger",
-    "Alert.Description",
-    "Alert.Root",
     "Avatar.Fallback",
     "Avatar.Image",
     "Avatar.Root",


### PR DESCRIPTION
Summary:
- Add `render` to Alert root, title, and description while preserving live-region and heading semantics.
- Move Alert parts into the render escape hatch table with caller-rendered coverage.

Validation:
- `git diff --check origin/main...HEAD`

Part of #303.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791792204&installation_model_id=422833&pr_number=805&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F805&signature=47140f5301eea8b21d7dda0627bbacca98796e597d133e25a34e9fbf6a3c0a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->