### PR TITLE
feat(ui): add render escape hatch to avatar parts

### DIFF
--- a/packages/ui/avatar.js
+++ b/packages/ui/avatar.js
@@ -74,7 +74,12 @@ import {
 import { useTimeout } from "@uniflowed/hooks/timing";
 
 import type { RenderProp, Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withProps, withoutComposed } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 
 /**
  * Where an avatar's image is between having been asked for and being there.
@@ -218,7 +223,7 @@ export component AvatarImage(
     alt,
     onError: composeHandlers(rest.onError, () => report(source, "error")),
     onLoad: composeHandlers(rest.onLoad, () => report(source, "loaded")),
-    ref: composeRefs(rest.ref, (node) => {
+    ref: composeRefs(rest.ref, (node: HTMLImageElement | null) => {
       element.current = node;
     }),
     src: source ?? undefined,

--- a/packages/ui/avatar.js
+++ b/packages/ui/avatar.js
@@ -73,8 +73,8 @@ import {
 } from "@uniflowed/react";
 import { useTimeout } from "@uniflowed/hooks/timing";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { composeHandlers, composeRefs, withProps, withoutComposed } from "./internal/merge-props.js";
 
 /**
  * Where an avatar's image is between having been asked for and being there.
@@ -122,7 +122,7 @@ hook useAvatar(part: string): AvatarState {
  * in a table cell, in a paragraph, inside a button's label — and a block
  * element is invalid in half of those.
  */
-export component AvatarRoot(children: React.Node, ...rest: Rest) {
+export component AvatarRoot(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const [seen, setSeen] = useState<Seen>(START);
   const [hasImage, setHasImage] = useState(false);
 
@@ -151,10 +151,11 @@ export component AvatarRoot(children: React.Node, ...rest: Rest) {
     }),
     [seen, hasImage, report],
   );
+  const props = withProps(rest, { children });
 
   return (
     <AvatarContext.Provider value={state}>
-      <span {...rest}>{children}</span>
+      {render != null ? render(props) : <span {...props} />}
     </AvatarContext.Provider>
   );
 }
@@ -175,7 +176,12 @@ export component AvatarRoot(children: React.Node, ...rest: Rest) {
  * stylesheet: `hidden` loses to any `display` the caller sets, and a caller who
  * has not written that rule yet would see both.
  */
-export component AvatarImage(alt?: string = "", src?: string | null, ...rest: Rest) {
+export component AvatarImage(
+  alt?: string = "",
+  src?: string | null,
+  render?: RenderProp,
+  ...rest: Rest
+) {
   const avatar = useAvatar("Avatar.Image");
   const element = useRef<HTMLImageElement | null>(null);
   const report = avatar.report;
@@ -208,18 +214,19 @@ export component AvatarImage(alt?: string = "", src?: string | null, ...rest: Re
   if (avatar.status === "error") {
     return null;
   }
-  return (
-    <img
-      {...passed}
-      alt={alt}
-      onError={composeHandlers(rest.onError, () => report(source, "error"))}
-      onLoad={composeHandlers(rest.onLoad, () => report(source, "loaded"))}
-      ref={composeRefs(rest.ref, (node) => {
-        element.current = node;
-      })}
-      src={source ?? undefined}
-    />
-  );
+  const props = withProps(passed, {
+    alt,
+    onError: composeHandlers(rest.onError, () => report(source, "error")),
+    onLoad: composeHandlers(rest.onLoad, () => report(source, "loaded")),
+    ref: composeRefs(rest.ref, (node) => {
+      element.current = node;
+    }),
+    src: source ?? undefined,
+  });
+  if (render != null) {
+    return render(props);
+  }
+  return <img {...props} />;
 }
 
 /**
@@ -235,7 +242,12 @@ export component AvatarImage(alt?: string = "", src?: string | null, ...rest: Re
  * avatar with no `Avatar.Image` at all are both answers rather than waits, and
  * the fallback for either is immediate.
  */
-export component AvatarFallback(children: React.Node, delay?: number = 300, ...rest: Rest) {
+export component AvatarFallback(
+  children: React.Node,
+  delay?: number = 300,
+  render?: RenderProp,
+  ...rest: Rest
+) {
   const avatar = useAvatar("Avatar.Fallback");
   const [elapsed, setElapsed] = useState(false);
   const waiting = avatar.hasImage && avatar.status === "loading";
@@ -251,5 +263,9 @@ export component AvatarFallback(children: React.Node, delay?: number = 300, ...r
   if (avatar.status === "loaded" || (waiting && delay > 0 && !elapsed)) {
     return null;
   }
-  return <span {...rest}>{children}</span>;
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(props);
+  }
+  return <span {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -6263,6 +6263,32 @@ describe("Avatar", () => {
     expect(pictureIn(container)).toHaveAttribute("alt", "Ada Lovelace");
   });
 
+  it("hands the avatar state contract to caller-rendered elements", () => {
+    render(
+      <Avatar.Root render={(props) => <span {...props} data-testid="avatar-root" />}>
+        <Avatar.Image
+          alt="Ada Lovelace"
+          render={(props) => <img {...props} data-testid="avatar-image" />}
+          src="/ada.png"
+        />
+        <Avatar.Fallback
+          delay={0}
+          render={(props) => <strong {...props} data-testid="avatar-fallback" />}
+        >
+          AL
+        </Avatar.Fallback>
+      </Avatar.Root>,
+    );
+
+    const image = screen.getByTestId("avatar-image");
+    expect(screen.getByTestId("avatar-root").contains(image)).toBe(true);
+    expect(image).toHaveAttribute("alt", "Ada Lovelace");
+    fireEvent.error(image);
+    expect(screen.queryByTestId("avatar-image")).toBe(null);
+    expect(screen.getByTestId("avatar-fallback").tagName).toBe("STRONG");
+    expect(screen.getByTestId("avatar-fallback").textContent).toBe("AL");
+  });
+
   it("takes the fallback away again once the image arrives", () => {
     const { container } = render(<Example />);
     fireEvent.load(pictureIn(container));
@@ -8282,6 +8308,9 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "AlertDialog.Overlay",
     "AlertDialog.Title",
     "AlertDialog.Trigger",
+    "Avatar.Fallback",
+    "Avatar.Image",
+    "Avatar.Root",
     "Breadcrumb.Item",
     "Breadcrumb.Link",
     "Breadcrumb.List",
@@ -8397,9 +8426,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Accordion.Item",
     "Accordion.Root",
     "Accordion.Trigger",
-    "Avatar.Fallback",
-    "Avatar.Image",
-    "Avatar.Root",
     "Calendar.Day",
     "Calendar.Month",
     "Calendar.Root",


### PR DESCRIPTION
Summary:
- Add `render` to Avatar root, image, and fallback without changing the loading/error state machine.
- Move Avatar parts into the render escape hatch table with caller-rendered coverage.

Validation:
- `git diff --check origin/main...HEAD`

Part of #303.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791794071&installation_model_id=422833&pr_number=806&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F806&signature=2f6d7b4ff144c275257144188f193b5621dcbf7513903a7d814030b2d3a07e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->