### PR TITLE
feat(ui): add render escape hatch to skeleton parts

### DIFF
--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -524,11 +524,10 @@ export type { ToggleGroupType } from "./toggle-group.js";
 /**
  * The five that are one component rather than a namespace of parts.
  *
- * `Switch` and `Checkbox` take `render`, so the control a design system already
- * has — a `<div>` with a knob drawn in it, somebody's `<Pressable>` — keeps the
- * role, the state, the keys and the implicit form submission while being their
- * element. `Progress`, `Separator` and `Toggle` do not have it yet; see the
- * module header and the table in `tests/library/ui.test.js`.
+ * Each takes `render`, so the control or line a design system already has — a
+ * `<div>` with a knob drawn in it, somebody's `<Pressable>`, a presentational
+ * meter shell — keeps the role, state, keys and attributes while being their
+ * element. See the module headers and the table in `packages/ui/ui.test.js`.
  */
 export { Checkbox, Progress, Separator, Switch, Toggle };
 

--- a/packages/ui/skeleton.js
+++ b/packages/ui/skeleton.js
@@ -60,7 +60,8 @@
 import * as React from "@uniflowed/react";
 import { useEffect, useRef, useState } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { withProps } from "./internal/merge-props.js";
 
 /**
  * The region that is being filled in, and the sentence that says so.
@@ -86,12 +87,17 @@ import type { Rest } from "./internal/merge-props.js";
  *
  * `doneLabel` is announced only after a spell of `busy`, so a region that was
  * never loading never says it has loaded.
+ *
+ * `render` changes the element that owns the busy state. The live region stays
+ * beside it, mounted by this component, because that timing is the accessibility
+ * contract rather than markup the caller can safely recreate by sight.
  */
 export component SkeletonRoot(
   children: React.Node,
   busy?: boolean = true,
   label?: string = "Loading…",
   doneLabel?: string = "Loaded",
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const [message, setMessage] = useState("");
@@ -108,11 +114,14 @@ export component SkeletonRoot(
     setMessage(waited.current ? doneLabel : "");
   }, [busy, doneLabel, label]);
 
+  const props = withProps(rest, {
+    "aria-busy": busy ? "true" : undefined,
+    children,
+  });
+
   return (
     <>
-      <div {...rest} aria-busy={busy ? "true" : undefined}>
-        {children}
-      </div>
+      {render == null ? <div {...props} /> : render(props)}
       {/*
         Beside the region rather than inside it, so a reader walking into the
         content does not find a sentence about it sitting among the rows — and
@@ -137,11 +146,14 @@ export component SkeletonRoot(
  * `children` is allowed and is hidden with the rest of it, because sizing a
  * box by putting the text it stands in for inside it is a real technique and
  * there is no reason to make a caller reach for a second element to do it.
+ *
+ * `render` changes the placeholder element, not the fact that it is hidden
+ * from the accessibility tree.
  */
-export component SkeletonBox(children?: React.Node, ...rest: Rest) {
-  return (
-    <div {...rest} aria-hidden="true">
-      {children}
-    </div>
-  );
+export component SkeletonBox(children?: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { "aria-hidden": "true", children });
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -6443,6 +6443,26 @@ describe("Skeleton", () => {
     );
     expect(screen.getByRole("status").textContent).toBe("Chargement…");
   });
+
+  it("hands the busy region and hidden boxes to caller-rendered elements", () => {
+    render(
+      <Skeleton.Root busy={true} render={(props) => <section {...props} data-testid="loading" />}>
+        <Skeleton.Box render={(props) => <span {...props} data-testid="placeholder" />}>
+          Invoice
+        </Skeleton.Box>
+      </Skeleton.Root>,
+    );
+
+    const loading = screen.getByTestId("loading");
+    const placeholder = screen.getByTestId("placeholder");
+    expect(loading.tagName).toBe("SECTION");
+    expect(loading).toHaveAttribute("aria-busy", "true");
+    expect(loading.contains(placeholder)).toBe(true);
+    expect(placeholder.tagName).toBe("SPAN");
+    expect(placeholder).toHaveAttribute("aria-hidden", "true");
+    expect(placeholder.textContent).toBe("Invoice");
+    expect(screen.getByRole("status").textContent).toBe("Loading…");
+  });
 });
 
 describe("the five that are one element, audited rather than asserted", () => {
@@ -8379,6 +8399,8 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Sheet.Title",
     "Sheet.Trigger",
     "Sidebar.Item",
+    "Skeleton.Box",
+    "Skeleton.Root",
     "Switch",
     "Tabs.List",
     "Tabs.Panel",
@@ -8487,8 +8509,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Sidebar.Footer",
     "Sidebar.Header",
     "Sidebar.Trigger",
-    "Skeleton.Box",
-    "Skeleton.Root",
     "Slider.Range",
     "Slider.Root",
     "Slider.Thumb",


### PR DESCRIPTION
## Summary

- add `render?: RenderProp` to `Skeleton.Root` and `Skeleton.Box`
- keep `Skeleton.Root`'s status live region owned by the component while letting callers replace the busy region element
- move Skeleton parts from `FIXED` to `RENDER` in the #303 escape-hatch table and add a behavior test
- refresh the standalone component export comment now that the one-component primitives all expose `render`

Part of #303.

## Verification

- `/Users/ubugeeei/.local/bin/uf fmt --check packages/ui/skeleton.js packages/ui/ui.test.js packages/ui/index.js`
- `/Users/ubugeeei/.local/bin/uf check packages/ui/skeleton.js packages/ui/index.js`
- `git diff --check`
- PR #807 CI on the same commit `99276c27` passed all checks before that PR was closed by a stale head-ref event.

Note: local `uf test packages/ui/ui.test.js --filter "Skeleton"` could not run in this temporary worktree because `@uniflowed/host` is not installed there; CI has the workspace dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791796527&installation_model_id=422833&pr_number=809&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F809&signature=f275da65bf061f425c04b1e9f5bb33dceea93e0c257dd130468fbd44c2902ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->