### PR TITLE
chore(release): remove stray alpha.24 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,12 @@
 # Changelog
 
-## uf@0.0.0-alpha.24
-
-_2026-09-12_
-
-### Added
-
-- **ui**: add render escape hatch to avatar parts (#806)
-- **ui**: add render escape hatch to alert parts (#805)
-
 ## uf@0.0.0-alpha.23
 
 _2026-09-12_
 
 ### Added
 
+- **ui**: add render escape hatch to skeleton parts (#809)
 - **ui**: add render escape hatch to avatar parts (#806)
 - **ui**: add render escape hatch to alert parts (#805)
 


### PR DESCRIPTION
## Summary
- remove the stray alpha.24 changelog section above the alpha.23 entry
- add Skeleton (#809), which merged before the alpha.23 tag, to the alpha.23 changelog
- keep alpha.23 as the current release state before tagging

## Verification
- `git diff --check`
- `tools/ci/changelog-covers-the-release.sh`