### PR TITLE
feat(ui): add collapsible render escape hatch

### DIFF
--- a/packages/ui/collapsible.js
+++ b/packages/ui/collapsible.js
@@ -53,7 +53,12 @@ import * as React from "@uniflowed/react";
 import { createContext, useContext, useId, useMemo, useRef, useState } from "@uniflowed/react";
 
 import type { RenderProp, Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withProps, withoutComposed } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 import { useMeasuredHeight, usePresence, useUntilFound } from "./internal/disclosure.js";
 import { useControlled } from "./internal/controlled-state.js";
 

--- a/packages/ui/collapsible.js
+++ b/packages/ui/collapsible.js
@@ -52,8 +52,8 @@
 import * as React from "@uniflowed/react";
 import { createContext, useContext, useId, useMemo, useRef, useState } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { composeHandlers, composeRefs, withProps, withoutComposed } from "./internal/merge-props.js";
 import { useMeasuredHeight, usePresence, useUntilFound } from "./internal/disclosure.js";
 import { useControlled } from "./internal/controlled-state.js";
 
@@ -105,34 +105,33 @@ export component CollapsibleRoot(
   return <CollapsibleContext.Provider value={state}>{children}</CollapsibleContext.Provider>;
 }
 
-/** The button that shows and hides the content. */
+/** The control that shows and hides the content. */
 export component CollapsibleTrigger(
   children: React.Node,
   disabled?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const collapsible = useCollapsible("Collapsible.Trigger");
-  const passed = withoutComposed(rest, ["onClick"]);
+  const props = withProps(withoutComposed(rest, ["onClick"]), {
+    // Named only while the content is in the document. A caller who renders
+    // the content conditionally — or not at all until data arrives — would
+    // otherwise have this trigger pointing at nothing.
+    "aria-controls": collapsible.present ? collapsible.contentId : undefined,
+    "aria-expanded": collapsible.open ? "true" : "false",
+    children,
+    disabled,
+    onClick: composeHandlers(rest.onClick, () => {
+      if (!disabled) {
+        collapsible.setOpen(!collapsible.open);
+      }
+    }),
+  });
 
-  return (
-    <button
-      {...passed}
-      // Named only while the content is in the document. A caller who renders
-      // the content conditionally — or not at all until data arrives — would
-      // otherwise have this button pointing at nothing.
-      aria-controls={collapsible.present ? collapsible.contentId : undefined}
-      aria-expanded={collapsible.open ? "true" : "false"}
-      disabled={disabled}
-      onClick={composeHandlers(rest.onClick, () => {
-        if (!disabled) {
-          collapsible.setOpen(!collapsible.open);
-        }
-      })}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -142,23 +141,24 @@ export component CollapsibleTrigger(
  * the module header, and `internal/disclosure.js` for what `hidden` is upgraded
  * to and why that takes an effect.
  */
-export component CollapsibleContent(children: React.Node, ...rest: Rest) {
+export component CollapsibleContent(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const collapsible = useCollapsible("Collapsible.Content");
   const contentRef = useRef<HTMLElement | null>(null);
   usePresence(collapsible.registerContent);
   useUntilFound(contentRef, collapsible.open);
   useMeasuredHeight(contentRef, collapsible.measure);
 
-  return (
-    <div
-      {...withoutComposed(rest, ["ref"])}
-      hidden={!collapsible.open}
-      id={collapsible.contentId}
-      ref={composeRefs(rest.ref, (element) => {
-        contentRef.current = element;
-      })}
-    >
-      {children}
-    </div>
-  );
+  const props = withProps(withoutComposed(rest, ["ref"]), {
+    children,
+    hidden: !collapsible.open,
+    id: collapsible.contentId,
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      contentRef.current = element;
+    }),
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -7143,10 +7143,7 @@ describe("Collapsible", () => {
     const clicked = fn();
     render(
       <Collapsible.Root>
-        <Collapsible.Trigger
-          onClick={clicked}
-          render={(props) => <a href="#details" {...props} />}
-        >
+        <Collapsible.Trigger onClick={clicked} render={(props) => <a href="#details" {...props} />}>
           Details
         </Collapsible.Trigger>
         <Collapsible.Content render={(props) => <section {...props} data-testid="panel" />}>

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -7139,6 +7139,63 @@ describe("Collapsible", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "true");
   });
 
+  it("hands trigger and content behaviour to caller-rendered elements", async () => {
+    const clicked = fn();
+    render(
+      <Collapsible.Root>
+        <Collapsible.Trigger
+          onClick={clicked}
+          render={(props) => <a href="#details" {...props} />}
+        >
+          Details
+        </Collapsible.Trigger>
+        <Collapsible.Content render={(props) => <section {...props} data-testid="panel" />}>
+          the small print
+        </Collapsible.Content>
+      </Collapsible.Root>,
+    );
+
+    const trigger = screen.getByRole("link", { name: "Details" });
+    const content = screen.getByTestId("panel");
+    expect(trigger.tagName).toBe("A");
+    expect(trigger).toHaveAttribute("href", "#details");
+    expect(trigger).not.toHaveAttribute("type");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger.getAttribute("aria-controls")).toBe(content.getAttribute("id"));
+    expect(content.tagName).toBe("SECTION");
+    expect(content.textContent).toBe("the small print");
+    expect(content).toHaveAttribute("hidden", "until-found");
+
+    await userEvent.click(trigger);
+    expect(clicked).toHaveBeenCalled();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(content).not.toHaveAttribute("hidden");
+    expect(danglingReferences()).toEqual([]);
+  });
+
+  it("does not open a caller-rendered trigger while disabled", async () => {
+    render(
+      <Collapsible.Root>
+        <Collapsible.Trigger
+          disabled
+          render={(props) => <div {...props} role="button" tabIndex={0} />}
+        >
+          Details
+        </Collapsible.Trigger>
+        <Collapsible.Content render={(props) => <section {...props} data-testid="panel" />}>
+          the small print
+        </Collapsible.Content>
+      </Collapsible.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Details" });
+    expect(trigger.tagName).toBe("DIV");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("panel")).toHaveAttribute("hidden", "until-found");
+  });
+
   it("claims no aria-controls when there is no content to name", () => {
     render(
       <Collapsible.Root>
@@ -8338,6 +8395,8 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Breadcrumb.Root",
     "Breadcrumb.Separator",
     "Checkbox",
+    "Collapsible.Content",
+    "Collapsible.Trigger",
     "ContextMenu.Body",
     "ContextMenu.CheckboxItem",
     "ContextMenu.Group",
@@ -8455,8 +8514,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Carousel.Item",
     "Carousel.Pause",
     "Carousel.Root",
-    "Collapsible.Content",
-    "Collapsible.Trigger",
     "Combobox.Empty",
     "Combobox.Group",
     "Combobox.GroupLabel",


### PR DESCRIPTION
## Summary
- Add `render?: RenderProp` to `Collapsible.Trigger` and `Collapsible.Content` while preserving ARIA, hidden state, composed click handlers, refs, children, and default button `type` behavior.
- Move the Collapsible trigger/content rows from `FIXED` to `RENDER` in the issue #303 UI coverage table.
- Add focused behavior tests for caller-rendered Collapsible trigger/content elements and disabled trigger behavior.

## Validation
- `npm ci`
- `cargo run -p uf_cli --bin uf -- test packages/ui/ui.test.js -t Collapsible`
- `cargo run -p uf_cli --bin uf -- test packages/ui/ui.test.js -t "the escape hatch"`
- `cargo run -p uf_cli --bin uf -- check packages/ui/collapsible.js`
- `git diff --check`

Refs #303

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791797744&installation_model_id=422833&pr_number=811&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F811&signature=0b60f1de7170abe3a031bdeb9a84fc5306a1130ab09f7ca790d6beb0a84aaf52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->