### PR TITLE
feat(ui): add accordion render escape hatch

### DIFF
--- a/docs/app/guide/ui/$page.mdx
+++ b/docs/app/guide/ui/$page.mdx
@@ -56,12 +56,14 @@ renders what you wrote between the tags. The part is still the part — a
 `Menu.Item` rendered as an `<a>` is what `Menu.Body`'s `renders*` constraint
 accepts, and that constraint is the thing a copied source cannot keep.
 
-`Dialog`, `AlertDialog`, `Sheet`, `Drawer`, `Menu`, `ContextMenu`, `Menubar`,
-`Tabs`, `Switch` and `Checkbox` take it on every part that renders an element,
-along with `Field.Control`, `Tooltip.Trigger`, `HoverCard.Trigger` and
-`Sidebar.Item`. The rest of the package does not have it yet; the table in
-`tests/library/ui.test.js` names every part and which of the three states it is
-in, and the suite fails if that table stops matching the files.
+`Accordion`, `Alert`, `AlertDialog`, `Avatar`, `Breadcrumb`, `Collapsible`,
+`Dialog`, `Drawer`, `Menu`, `ContextMenu`, `Menubar`, `Sheet`, `Skeleton` and
+`Tabs` take it on every fixed-element part, as do the single-part `Checkbox`,
+`Progress`, `Separator`, `Switch` and `Toggle`, along with `Field.Control`,
+`Tooltip.Trigger`, `HoverCard.Trigger` and `Sidebar.Item`. The rest of the
+package does not have it yet; the table in `packages/ui/ui.test.js` names every
+part and which of the three states it is in, and the suite fails if that table
+stops matching the files.
 [#303](https://github.com/ubugeeei-prod/uf/issues/303) is the argument, and
 `packages/ui/index.js`'s header is where the decision is recorded.
 
@@ -81,10 +83,10 @@ be a weaker promise than not.
 Every example on this page was rendered and asserted before it was published;
 the keyboard tables below cite the test in
 [`packages/ui/ui.test.js`](https://github.com/ubugeeei-prod/uf/blob/main/packages/ui/ui.test.js)
-that holds each row. `uf test packages/ui/ui.test.js` runs 119 of them, in 1.1
-seconds. There is exactly one row no test holds, and rather than leaving it to
-be discovered it is named where it appears, under Checkbox — a row with no test
-is how it came to say the wrong thing.
+that holds each row. `uf test packages/ui/ui.test.js` runs the suite. There is
+exactly one row no test holds, and rather than leaving it to be discovered it is
+named where it appears, under Checkbox — a row with no test is how it came to
+say the wrong thing.
 
 ## Field
 

--- a/packages/ui/accordion.js
+++ b/packages/ui/accordion.js
@@ -90,8 +90,13 @@ import {
   useState,
 } from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { PartEvent, RenderProp, Rest } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 import { moveOnKey } from "./internal/roving-focus.js";
 import type { RovingSet } from "./internal/roving-focus.js";
 import { useMeasuredHeight, usePresence, useUntilFound } from "./internal/disclosure.js";
@@ -176,6 +181,7 @@ export component AccordionRoot(
   value?: $ReadOnlyArray<string>,
   onValueChange?: (value: $ReadOnlyArray<string>) => void,
   measure?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const [open, setOpen] = useControlled<$ReadOnlyArray<string>>(value, defaultValue, onValueChange);
@@ -203,22 +209,20 @@ export component AccordionRoot(
     () => ({ open, toggle, closable: type === "multiple" || collapsible, type, measure }),
     [open, toggle, type, collapsible, measure],
   );
-  const passed = withoutComposed(rest, ["onKeyDown"]);
+  const props = withProps(withoutComposed(rest, ["onKeyDown"]), {
+    children,
+    // The name the arrow keys use to tell this accordion's headers from those
+    // of an accordion nested inside one of its panels.
+    "data-accordion": "",
+    onKeyDown: composeHandlers(rest.onKeyDown, (event: PartEvent) => {
+      const stack: $FlowFixMe = event.currentTarget;
+      moveOnKey(event, stack, HEADERS);
+    }),
+  });
 
   return (
     <AccordionContext.Provider value={state}>
-      <div
-        {...passed}
-        // The name the arrow keys use to tell this accordion's headers from
-        // those of an accordion nested inside one of its panels.
-        data-accordion=""
-        onKeyDown={composeHandlers(rest.onKeyDown, (event) => {
-          const stack: $FlowFixMe = event.currentTarget;
-          moveOnKey(event, stack, HEADERS);
-        })}
-      >
-        {children}
-      </div>
+      {render == null ? <div {...props} /> : render(props)}
     </AccordionContext.Provider>
   );
 }
@@ -235,6 +239,7 @@ export component AccordionItem(
   value: string,
   children: renders* (AccordionHeader | AccordionContent),
   disabled?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const accordion = useAccordion("Accordion.Item");
@@ -257,9 +262,11 @@ export component AccordionItem(
     [base, open, toggle, value, accordion.closable, disabled, present],
   );
 
+  const props = withProps(rest, { children });
+
   return (
     <AccordionItemContext.Provider value={state}>
-      <div {...rest}>{children}</div>
+      {render == null ? <div {...props} /> : render(props)}
     </AccordionItemContext.Provider>
   );
 }
@@ -290,35 +297,34 @@ export component AccordionHeader(
  * It carries no `tabIndex` of its own on purpose: every header stays in the
  * page's tab order, which is what makes this an accordion and not a tab list.
  */
-export component AccordionTrigger(children: React.Node, ...rest: Rest) {
+export component AccordionTrigger(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const item = useAccordionItem("Accordion.Trigger");
-  const passed = withoutComposed(rest, ["onClick"]);
   // Locked and disabled are two different sentences a reader hears the same
   // way, and both are `aria-disabled` rather than `disabled` so the header
   // stays where they can find it: "this section will not close" and "this
   // section is unavailable".
   const inert = item.locked || item.disabled;
 
-  return (
-    <button
-      {...passed}
-      aria-controls={item.present ? item.contentId : undefined}
-      aria-disabled={inert ? "true" : undefined}
-      aria-expanded={item.open ? "true" : "false"}
-      // What the arrow keys look for. Not a role, because the accordion pattern
-      // has none to look for; see the module header.
-      data-accordion-trigger=""
-      id={item.triggerId}
-      onClick={composeHandlers(rest.onClick, () => {
-        if (!inert) {
-          item.toggle();
-        }
-      })}
-      type="button"
-    >
-      {children}
-    </button>
-  );
+  const props = withProps(withoutComposed(rest, ["onClick"]), {
+    "aria-controls": item.present ? item.contentId : undefined,
+    "aria-disabled": inert ? "true" : undefined,
+    "aria-expanded": item.open ? "true" : "false",
+    children,
+    // What the arrow keys look for. Not a role, because the accordion pattern
+    // has none to look for; see the module header.
+    "data-accordion-trigger": "",
+    id: item.triggerId,
+    onClick: composeHandlers(rest.onClick, () => {
+      if (!inert) {
+        item.toggle();
+      }
+    }),
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <button {...props} type="button" />;
 }
 
 /**
@@ -327,7 +333,7 @@ export component AccordionTrigger(children: React.Node, ...rest: Rest) {
  * `internal/disclosure.js` explains what "stays in the document" is worth and
  * what `hidden` is upgraded to for it.
  */
-export component AccordionContent(children: React.Node, ...rest: Rest) {
+export component AccordionContent(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const accordion = useAccordion("Accordion.Content");
   const item = useAccordionItem("Accordion.Content");
   const contentRef = useRef<HTMLElement | null>(null);
@@ -335,19 +341,20 @@ export component AccordionContent(children: React.Node, ...rest: Rest) {
   useUntilFound(contentRef, item.open);
   useMeasuredHeight(contentRef, accordion.measure);
 
-  return (
-    <div
-      {...withoutComposed(rest, ["ref"])}
-      // The name a reader hears for this landmark is the header they pressed.
-      aria-labelledby={item.triggerId}
-      hidden={!item.open}
-      id={item.contentId}
-      ref={composeRefs(rest.ref, (element) => {
-        contentRef.current = element;
-      })}
-      role="region"
-    >
-      {children}
-    </div>
-  );
+  const props = withProps(withoutComposed(rest, ["ref"]), {
+    // The name a reader hears for this landmark is the header they pressed.
+    "aria-labelledby": item.triggerId,
+    children,
+    hidden: !item.open,
+    id: item.contentId,
+    ref: composeRefs(rest.ref, (element: HTMLElement | null) => {
+      contentRef.current = element;
+    }),
+    role: "region",
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -7306,6 +7306,72 @@ describe("Accordion", () => {
     expect(screen.queryAllByRole("heading", { level: 3 })).toEqual([]);
   });
 
+  it("hands stack, item, trigger and panel behaviour to caller-rendered elements", async () => {
+    const keyed = fn();
+    const clicked = fn();
+    render(
+      <Accordion.Root
+        defaultValue={["shipping"]}
+        onKeyDown={keyed}
+        render={(props) => <section {...props} data-testid="faq" />}
+      >
+        <Accordion.Item
+          render={(props) => <article {...props} data-testid="shipping-item" />}
+          value="shipping"
+        >
+          <Accordion.Header level={3}>
+            <Accordion.Trigger
+              onClick={clicked}
+              render={(props) => <a href="#shipping" {...props} />}
+            >
+              Shipping
+            </Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content
+            render={(props) => <section {...props} data-testid="shipping-panel" />}
+          >
+            ships in two days
+          </Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="returns">
+          <Accordion.Header level={3}>
+            <Accordion.Trigger>Returns</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>thirty days</Accordion.Content>
+        </Accordion.Item>
+      </Accordion.Root>,
+    );
+
+    const root = screen.getByTestId("faq");
+    const item = screen.getByTestId("shipping-item");
+    const trigger = screen.getByRole("link", { name: "Shipping" });
+    const panel = screen.getByTestId("shipping-panel");
+
+    expect(root.tagName).toBe("SECTION");
+    expect(root).toHaveAttribute("data-accordion", "");
+    expect(item.tagName).toBe("ARTICLE");
+    expect(trigger.tagName).toBe("A");
+    expect(trigger).toHaveAttribute("href", "#shipping");
+    expect(trigger).not.toHaveAttribute("type");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(trigger.getAttribute("aria-controls")).toBe(panel.getAttribute("id"));
+    expect(panel.tagName).toBe("SECTION");
+    expect(panel).toHaveAttribute("role", "region");
+    expect(panel.getAttribute("aria-labelledby")).toBe(trigger.getAttribute("id"));
+    expect(panel.textContent).toBe("ships in two days");
+    expect(danglingReferences()).toEqual([]);
+
+    act(() => trigger.focus());
+    await userEvent.keyboard("{ArrowDown}");
+    expect(keyed).toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Returns" })).toHaveFocus();
+
+    await userEvent.click(trigger);
+    expect(clicked).toHaveBeenCalled();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(panel).toHaveAttribute("hidden", "until-found");
+  });
+
   it("keeps a single accordion to one open item", async () => {
     render(<Faq />);
     expect(showing()).toEqual(["ships in two days"]);
@@ -8370,6 +8436,10 @@ describe("the escape hatch: which part hands its element to the caller", () => {
 
   /** Parts that take `render` and hand their props to the caller. */
   const RENDER: $ReadOnlyArray<string> = [
+    "Accordion.Content",
+    "Accordion.Item",
+    "Accordion.Root",
+    "Accordion.Trigger",
     "Alert.Description",
     "Alert.Root",
     "Alert.Title",
@@ -8500,10 +8570,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
 
   /** Parts whose element a caller still cannot change. #303's remainder; it only shrinks. */
   const FIXED: $ReadOnlyArray<string> = [
-    "Accordion.Content",
-    "Accordion.Item",
-    "Accordion.Root",
-    "Accordion.Trigger",
     "Calendar.Day",
     "Calendar.Month",
     "Calendar.Root",


### PR DESCRIPTION
## Summary

- add `render?: RenderProp` to Accordion root, item, trigger, and content while preserving ARIA, data attributes, composed handlers, refs, and default button `type`
- add a focused Accordion behavior test for caller-rendered root, item, trigger, and panel elements
- move Accordion fixed-element parts from the #303 `FIXED` table to `RENDER` and refresh the UI guide status

## Validation

- `npm ci --prefer-offline --no-audit --no-fund`
- `tools/upstream/sync.sh`
- `cargo build --bin uf`
- `./target/debug/uf test packages/ui/ui.test.js -t Accordion`
- `./target/debug/uf test packages/ui/ui.test.js -t "escape hatch"`
- `./target/debug/uf fmt --check packages/ui/accordion.js packages/ui/ui.test.js 'docs/app/guide/ui/$page.mdx'`\n- `git diff --check`\n\nPart of #303.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791804130&installation_model_id=422833&pr_number=814&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F814&signature=89b0fa2f64dca95a399fdf351c16184c22139ab330fa8961ab7521fc338d6818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->