### PR TITLE
perf(check): skip environment build on full cache hits

### DIFF
--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -54,7 +54,7 @@ use flow_parser::file_key::{FileKey, FileKeyInner};
 use flow_parser::loc::{LOC_NONE, Loc};
 use flow_parser::parse_error::ParseError;
 use flow_typing::{merge, type_inference};
-use flow_typing_context::Context;
+use flow_typing_context::{Context, Metadata};
 use flow_typing_errors::error_message::ErrorMessage;
 use flow_typing_errors::error_suppressions::ErrorSuppressions;
 use flow_typing_errors::flow_error::ErrorSet;
@@ -68,6 +68,44 @@ use crate::limits::CHECK_STACK_BYTES;
 use crate::upstream::graph::{Graph, ModuleFacts};
 use crate::upstream::project::{MkBuiltins, ProjectModules};
 use crate::{BuiltinsTiming, CheckError, CheckLimits, CheckReport, Source};
+
+/// The per-call builtin environment, built only if this batch really needs it.
+struct BatchEnvironment {
+    builtins: BuiltinsTiming,
+    base_metadata: Option<Metadata>,
+    mk_builtins: Option<MkBuiltins>,
+}
+
+impl BatchEnvironment {
+    fn new(builtins: BuiltinsTiming) -> Self {
+        Self {
+            builtins,
+            base_metadata: None,
+            mk_builtins: None,
+        }
+    }
+
+    fn mk_builtins(
+        &mut self,
+        libs: &[Source<'_>],
+        options: &Options,
+    ) -> Result<MkBuiltins, CheckError> {
+        if let Some(mk_builtins) = &self.mk_builtins {
+            return Ok(mk_builtins.dupe());
+        }
+
+        let mk_builtins = {
+            profile_span!("check::environment");
+            let master_cx = builtins::master_context(libs)?;
+            let base_metadata = flow_typing_context::mk_context_metadata(options, Arc::default());
+            let mk_builtins = merge::mk_builtins(&base_metadata, &master_cx);
+            self.base_metadata = Some(base_metadata);
+            mk_builtins
+        };
+        self.mk_builtins = Some(mk_builtins.dupe());
+        Ok(mk_builtins)
+    }
+}
 
 /// The absolute root every Flow path is resolved against.
 ///
@@ -122,7 +160,7 @@ pub(crate) fn module_closure<'a>(
         let mk_builtins = merge::mk_builtins(&base_metadata, &master_cx);
         // A batch of no files: this exists only to ask what the builtins
         // declare, which is a property of the compiler and not of any source.
-        let probe = ProjectModules::new(&[], options.clone(), mk_builtins, limits);
+        let probe = ProjectModules::new(&[], options.clone(), Some(mk_builtins), limits);
         let found = closure::closure(seeds, available, &options, &|specifier| {
             probe.declared_externally(specifier)
         });
@@ -210,8 +248,7 @@ fn check_batch(
         }
     }
 
-    let builtins = builtins::prepare(libs)?;
-    let master_cx = builtins::master_context(libs)?;
+    let mut environment = BatchEnvironment::new(builtins::prepare(libs)?);
     let options = {
         profile_span!("check::options");
         options::options(limits)
@@ -222,25 +259,11 @@ fn check_batch(
     // wasted work and wrong: a type crossing a module boundary is compared
     // against the importer's builtins, and two independent merges of `core.js`
     // do not agree on `Array`.
-    // Spanned together because they are one thing: the builtin environment this
-    // call will check against. `builtins::prepare` and `master_context` are
-    // memoized per process and read as zero after a warm-up, so this is where
-    // the per-*call* fixed cost ubugeeei-prod/uf#678 measured actually lands.
-    // `_base_metadata` is bound rather than dropped: `mk_builtins` is built
-    // from it, and the original code kept it alive for the rest of the
-    // function. Keeping that exactly, so the span is the only change here.
-    let (_base_metadata, mk_builtins) = {
-        profile_span!("check::environment");
-        let base_metadata = flow_typing_context::mk_context_metadata(&options, Arc::default());
-        let mk_builtins = merge::mk_builtins(&base_metadata, &master_cx);
-        (base_metadata, mk_builtins)
-    };
-    let modules = Rc::new(ProjectModules::new(
-        sources,
-        options.clone(),
-        mk_builtins.dupe(),
-        limits,
-    ));
+    // Built lazily: a fully warm cache already holds the file facts and
+    // diagnostics, so it does not need the per-call builtin environment #678
+    // measured. A cache miss installs it before parsing facts or inferring a
+    // file, and all files in that batch then share the same one.
+    let modules = Rc::new(ProjectModules::new(sources, options.clone(), None, limits));
 
     let started = Instant::now();
     // What each file's record is filed under. Computed even for a file the
@@ -275,6 +298,8 @@ fn check_batch(
                 // a shape this build does not understand: dropped, not
                 // repaired, so nothing downstream reads half of it.
                 *record = None;
+                let mk_builtins = environment.mk_builtins(libs, &options)?;
+                modules.set_mk_builtins(mk_builtins);
                 facts.push(modules.facts(index));
             }
         }
@@ -328,6 +353,8 @@ fn check_batch(
             continue;
         }
 
+        let mk_builtins = environment.mk_builtins(libs, &options)?;
+        modules.set_mk_builtins(mk_builtins.dupe());
         match check_one(index, &options, &mk_builtins, limits, source, &modules) {
             Ok(found) => {
                 if let Some(cache) = cache {
@@ -362,7 +389,7 @@ fn check_batch(
         files_from_cache: from_cache,
         untyped_modules: untyped.into_iter().collect(),
         host_conditional_modules: host_conditional.into_iter().collect(),
-        builtins,
+        builtins: environment.builtins,
         elapsed: started.elapsed(),
     })
 }

--- a/crates/uf_check/src/upstream/project.rs
+++ b/crates/uf_check/src/upstream/project.rs
@@ -159,13 +159,14 @@ pub(super) struct ProjectModules {
     /// manifest per package and hundreds of files importing them.
     packages: WorkspacePackages,
     options: Options,
-    /// One builtin environment for the whole batch.
+    /// One builtin environment for the whole batch, installed once something
+    /// needs it.
     ///
     /// Shared rather than made per file, and not only to save the merge: a type
     /// crossing from a dependency into the importing file is compared against
     /// the importer's builtins, so two files whose `Array` came from two
     /// separate merges would not agree on it.
-    mk_builtins: MkBuiltins,
+    mk_builtins: RefCell<Option<MkBuiltins>>,
     /// The wall-clock budget a dependency's merge is charged against when it is
     /// forced outside any importer's own context.
     file_timeout: Option<std::time::Duration>,
@@ -198,7 +199,7 @@ impl ProjectModules {
     pub(super) fn new(
         sources: &[Source<'_>],
         options: Options,
-        mk_builtins: MkBuiltins,
+        mk_builtins: Option<MkBuiltins>,
         limits: &CheckLimits,
     ) -> Self {
         profile_span!("check::project_modules");
@@ -210,12 +211,21 @@ impl ProjectModules {
                 .map(|source| (source.path.to_compact_string(), Box::from(source.source)))
                 .collect(),
             options,
-            mk_builtins,
+            mk_builtins: RefCell::new(mk_builtins),
             file_timeout: limits.file_timeout,
             signatures: RefCell::new(HashMap::new()),
             merged: RefCell::new(HashMap::new()),
             probe: RefCell::new(None),
             aloc_tables: RefCell::new(HashMap::new()),
+        }
+    }
+
+    /// Install the builtin environment this batch will use for any work that
+    /// reaches inference or a library-declaration query.
+    pub(super) fn set_mk_builtins(&self, mk_builtins: MkBuiltins) {
+        let mut slot = self.mk_builtins.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(mk_builtins);
         }
     }
 
@@ -384,9 +394,17 @@ impl ProjectModules {
             Arc::default(),
             aloc_table,
             resolve_require,
-            self.mk_builtins.dupe(),
+            self.mk_builtins(),
             CheckBudget::new(self.file_timeout),
         )
+    }
+
+    fn mk_builtins(&self) -> MkBuiltins {
+        self.mk_builtins
+            .borrow()
+            .as_ref()
+            .expect("builtin environment is installed before it is used")
+            .dupe()
     }
 
     /// Drop everything the merged dependencies hold.
@@ -404,6 +422,7 @@ impl ProjectModules {
             probe.post_inference_cleanup();
         }
         self.signatures.borrow_mut().clear();
+        self.mk_builtins.borrow_mut().take();
     }
 
     /// What `specifier`, imported from `importer`, resolves to.
@@ -669,7 +688,7 @@ impl ProjectModules {
                 Arc::default(),
                 signature.aloc_table.dupe(),
                 resolve_require,
-                self.mk_builtins.dupe(),
+                self.mk_builtins(),
                 CheckBudget::new(self.file_timeout),
             )
         };

--- a/crates/uf_check/tests/cache_hit_allocations.rs
+++ b/crates/uf_check/tests/cache_hit_allocations.rs
@@ -1,0 +1,55 @@
+//! What a full check-cache hit is allowed to cost.
+//!
+//! A warm run has to describe the batch, read the records and replay their
+//! diagnostics. It must not rebuild the per-call builtin environment that
+//! inference needs, because a run answered entirely from disk never reaches
+//! inference. ubugeeei-prod/uf#678 measured that environment at about 136,000
+//! allocations; this test sits far below that and far above the current warm
+//! cache cost, so it catches the fixed cost coming back without pinning every
+//! JSON or path allocation in the cache reader.
+
+#![cfg(feature = "upstream-typecheck")]
+
+use tempfile::TempDir;
+use uf_check::{CheckCache, CheckLimits, Source, check_sources_cached};
+use uf_profiler::{AllocSnapshot, CountingAllocator, Window};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator::new();
+
+/// Above the current cost by an order of magnitude, below rebuilding the
+/// environment by one.
+const CEILING: u64 = 20_000;
+
+#[test]
+fn a_full_cache_hit_does_not_rebuild_the_check_environment() {
+    let project = TempDir::new().unwrap();
+    let cache = CheckCache::open(project.path()).expect("this process can name its own binary");
+    let limits = CheckLimits::default().without_timeout();
+    let sources = [Source::new(
+        "app.js",
+        "// @flow\nexport const answer: number = 42;\n",
+    )];
+
+    let cold = check_sources_cached(&sources, &[], &limits, Some(&cache)).expect("checks");
+    assert_eq!(cold.files_from_cache, 0);
+
+    let _window = Window::open();
+    CountingAllocator::enable();
+    let before = AllocSnapshot::capture();
+    let warm = check_sources_cached(&sources, &[], &limits, Some(&cache)).expect("checks");
+    let after = AllocSnapshot::capture();
+    CountingAllocator::disable();
+
+    assert_eq!(warm.files_from_cache, 1, "the cache should answer the file");
+    assert!(warm.diagnostics.is_empty(), "{:#?}", warm.diagnostics);
+
+    let delta = after.delta_from(&before);
+    assert!(
+        delta.allocations <= CEILING,
+        "a full cache hit took {} allocations, over the {CEILING} ceiling. \
+         That usually means check::environment was rebuilt even though every \
+         file was answered from the cache.",
+        delta.allocations,
+    );
+}


### PR DESCRIPTION
## Summary

- avoids constructing the per-call Flow builtin environment when every source in a check batch is answered from the check cache
- keeps the same environment installation before any cached-facts miss or inference, so cold and edited checks keep the existing semantics
- adds a focused allocation guard for the full-cache-hit path

Refs #678

## Evidence

Measured with `cargo run --example alloc_report -p uf_check` after `tools/upstream/sync.sh`.

`packages/router/internal/runtime.js --cache`:

| run | before | after |
| --- | ---: | ---: |
| warm allocations | 138,187 | 1,804 |
| warm bytes | 7.04 MiB | 0.43 MiB |
| warm peak | 6.75 MiB | 0.26 MiB |
| cold allocations | 2,028,516 | 2,028,517 |
| edited allocations | 2,028,515 | 2,028,515 |

`packages/pm/index.js --cache --batch 64`:

| run | before | after |
| --- | ---: | ---: |
| warm allocations | 140,886 | 4,503 |
| warm bytes | 7.78 MiB | 1.17 MiB |
| warm peak | 6.86 MiB | 0.37 MiB |
| cold allocations | 682,502 | 682,502 |
| edited allocations | 682,501 | 682,501 |

Cold non-cache phase profile stayed at 2,028,307 allocations / 318.16 MiB for `runtime.js`; the change is only the fully cached path.

## Verification

From a clean checkout, materialize the upstream Flow submodule first:

```sh
tools/upstream/sync.sh
```

- [x] `tools/upstream/sync.sh`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p uf_check`
- [x] `cargo clippy -p uf_check --all-targets --all-features -- -D warnings`
- [x] `cargo test -p uf_check --test cache_hit_allocations`
- [ ] `cargo test -p uf_check` locally blocked by `ld: write() failed, errno=28` with the volume at about 380 MiB free; relying on Actions for the full package/workspace run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791804373&installation_model_id=422833&pr_number=816&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F816&signature=368d525496dd9bb1e53d8aabf6637e842dd12eaa9a302c89589b5e4b6a3a7b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->