### PR TITLE
feat(ui): add tooltip body render escape hatch

### DIFF
--- a/docs/app/guide/ui/$page.mdx
+++ b/docs/app/guide/ui/$page.mdx
@@ -60,7 +60,7 @@ accepts, and that constraint is the thing a copied source cannot keep.
 `Dialog`, `Drawer`, `Menu`, `ContextMenu`, `Menubar`, `Sheet`, `Skeleton` and
 `Tabs` take it on every fixed-element part, as do the single-part `Checkbox`,
 `Progress`, `Separator`, `Switch` and `Toggle`, along with `Field.Control`,
-`Tooltip.Trigger`, `HoverCard.Trigger` and `Sidebar.Item`. The rest of the
+`Tooltip.Trigger`, `Tooltip.Body`, `HoverCard.Trigger` and `Sidebar.Item`. The rest of the
 package does not have it yet; the table in `packages/ui/ui.test.js` names every
 part and which of the three states it is in, and the suite fails if that table
 stops matching the files.

--- a/packages/ui/tooltip.js
+++ b/packages/ui/tooltip.js
@@ -324,6 +324,7 @@ export component TooltipBody(
   alignOffset?: number = 0,
   avoidCollisions?: boolean = true,
   collisionPadding?: number = 0,
+  render?: RenderProp,
   side?: LogicalSide = "top",
   sideOffset?: number = 0,
   ...rest: Rest
@@ -378,21 +379,22 @@ export component TooltipBody(
     return null;
   }
 
-  return (
-    <div
-      {...withoutComposed(rest, ["ref"])}
-      data-align={anchored.align}
-      data-side={anchored.side}
-      data-state="open"
-      id={`${tooltip.base}-body`}
-      ref={composeRefs(rest.ref, (element) => {
-        bodyRef.current = element;
-      })}
-      role="tooltip"
-      // No `tabIndex`. A tooltip the keyboard can land in is a stop the reader
-      // did not ask for and cannot leave the way they expect.
-    >
-      {children}
-    </div>
-  );
+  const props = withProps(withoutComposed(rest, ["ref"]), {
+    children,
+    "data-align": anchored.align,
+    "data-side": anchored.side,
+    "data-state": "open",
+    id: `${tooltip.base}-body`,
+    ref: composeRefs(rest.ref, (element) => {
+      bodyRef.current = element;
+    }),
+    role: "tooltip",
+    // No `tabIndex`. A tooltip the keyboard can land in is a stop the reader
+    // did not ask for and cannot leave the way they expect.
+  });
+
+  if (render != null) {
+    return render(props);
+  }
+  return <div {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -4012,6 +4012,36 @@ describe("Tooltip", () => {
     expect(screen.queryByRole("tooltip")).toBe(null);
   });
 
+  it("keeps a caller-rendered body hoverable and described", () => {
+    uft.useFakeTimers();
+    const seen = { current: null };
+    render(
+      <Tooltip.Root>
+        <Tooltip.Trigger aria-label="Bold">B</Tooltip.Trigger>
+        <Tooltip.Body ref={seen} render={(props) => <section {...props} data-testid="tip" />}>
+          Bold
+        </Tooltip.Body>
+      </Tooltip.Root>,
+    );
+    const trigger = screen.getByRole("button", { name: "Bold" });
+    fireEvent.pointerEnter(trigger);
+    advance(700);
+
+    const tip = screen.getByRole("tooltip");
+    expect(tip.tagName).toBe("SECTION");
+    expect(tip.textContent).toBe("Bold");
+    expect(tip).toHaveAttribute("data-testid", "tip");
+    expect(tip).toHaveAttribute("data-state", "open");
+    expect(seen.current).toBe(tip);
+    expect(trigger.getAttribute("aria-describedby")).toBe(tip.id);
+
+    fireEvent.pointerLeave(trigger);
+    advance(100);
+    fireEvent.pointerEnter(tip);
+    advance(10_000);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+
   it("closes on Escape without moving the pointer", () => {
     uft.useFakeTimers();
     render(<Example />);
@@ -8533,6 +8563,7 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Tabs.Root",
     "Tabs.Tab",
     "Toggle",
+    "Tooltip.Body",
     "Tooltip.Trigger",
   ];
 
@@ -8649,7 +8680,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Toast.Title",
     "ToggleGroup.Item",
     "ToggleGroup.Root",
-    "Tooltip.Body",
   ];
 
   /** The parts `packages/ui/index.js` names, and the component behind each. */


### PR DESCRIPTION
## Summary
- Add `render?: RenderProp` support to `Tooltip.Body`.
- Preserve tooltip role, id, data attributes, composed ref, and hoverable body behavior when callers render their own element.
- Move `Tooltip.Body` from the fixed #303 guard list to the render list and refresh the UI guide text.

Refs #303

## Verification
- `/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--ui-render-accordion/target/debug/uf fmt --check packages/ui/tooltip.js packages/ui/ui.test.js docs/app/guide/ui/$page.mdx`
- `/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--ui-render-accordion/target/debug/uf test packages/ui/ui.test.js -t Tooltip`
- `/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--ui-render-accordion/target/debug/uf test packages/ui/ui.test.js -t "escape hatch"`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791805162&installation_model_id=422833&pr_number=817&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F817&signature=23a1c60889a06f26d22bd373fb10d8015833eeb1c244377be09ad02ebda7e2de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->