### PR TITLE
docs(tui): mark key release support implemented

### DIFF
--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -207,9 +207,11 @@
       `selectable` text highlights the cells between the two ends,
       `getSelectedText()` reads them back out of the frame, and
       `preventDefault()` on the press is how a box that means its own thing by
-      a drag keeps out of it. Key release, the clipboard that would carry the
-      selected text somewhere, the repeated-press gestures that widen one to a
-      word or a line, and rich content are ubugeeei-prod/uf#314.
+      a drag keeps out of it. Key press, repeat and release events are decoded
+      through Kitty keyboard reports when the terminal supports them, and
+      legacy terminals continue to send key presses. The clipboard that would
+      carry selected text somewhere, the repeated-press gestures that widen
+      one to a word or a line, and rich content are ubugeeei-prod/uf#314.
 - [ ] Cover the shadcn-style component catalog with typed imports, preset styles, and no copy step.
 - [ ] Keep compound UI APIs cohesive, for example `Dialog.Body`.
 - [x] Add UI `renders` type utility declarations under `packages/ui`.


### PR DESCRIPTION
## Summary
- update the issue roadmap so key press, repeat, and release support is no longer listed as outstanding
- keep #314 open for the remaining TUI gaps: clipboard, repeated-press selection gestures, and rich content

Refs #314

## Validation
- `cargo test -p uf_tui`
- `git diff --check`
- `cargo run -p uf_cli --bin uf -- test packages/tui/tui.test.js` could not complete locally because the checkout ran out of disk while building the CLI; this PR relies on Actions for the full suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791805690&installation_model_id=422833&pr_number=818&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F818&signature=89b322e109d0028b14422ca149f9a47ee055af6d403d80a4d54fa5dce34c25fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->