### PR TITLE
feat(ui): add field render escape hatch

### DIFF
--- a/packages/ui/field.js
+++ b/packages/ui/field.js
@@ -189,6 +189,7 @@ export component FieldRoot(
   required?: boolean = false,
   field?: FieldSource,
   group?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const base = useId();
@@ -237,20 +238,20 @@ export component FieldRoot(
     hasError,
   ]);
 
+  const props = withProps(rest, {
+    // A group names itself, describes itself and reports its own validity,
+    // because there is no one control inside it to carry any of the three.
+    // See the module header.
+    "aria-describedby": group ? state.describedBy : undefined,
+    "aria-invalid": group && state.invalid ? "true" : undefined,
+    "aria-labelledby": group ? state.labelId : undefined,
+    children,
+    role: group ? "group" : undefined,
+  });
+
   return (
     <FieldContext.Provider value={state}>
-      <div
-        {...rest}
-        // A group names itself, describes itself and reports its own validity,
-        // because there is no one control inside it to carry any of the three.
-        // See the module header.
-        aria-describedby={group ? state.describedBy : undefined}
-        aria-invalid={group && state.invalid ? "true" : undefined}
-        aria-labelledby={group ? state.labelId : undefined}
-        role={group ? "group" : undefined}
-      >
-        {children}
-      </div>
+      {render != null ? render(props) : <div {...props} />}
     </FieldContext.Provider>
   );
 }
@@ -262,22 +263,16 @@ export component FieldRoot(
  * `<label for>` naming something that is not a form control is ignored by every
  * browser, and ignored silently. The module header says more.
  */
-export component FieldLabel(children: React.Node, ...rest: Rest) {
+export component FieldLabel(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const field = useField("Field.Label");
   // `rest` first: a caller `id` here would break the relationship the control
   // points at, and it would break it silently.
   if (field.group) {
-    return (
-      <span {...rest} id={field.labelId}>
-        {children}
-      </span>
-    );
+    const props = withProps(rest, { children, id: field.labelId });
+    return render != null ? render(props) : <span {...props} />;
   }
-  return (
-    <label {...rest} htmlFor={field.controlId} id={field.labelId}>
-      {children}
-    </label>
-  );
+  const props = withProps(rest, { children, htmlFor: field.controlId, id: field.labelId });
+  return render != null ? render(props) : <label {...props} />;
 }
 
 /**
@@ -307,7 +302,7 @@ export component FieldControl(render: RenderProp) {
 }
 
 /** Help text, which the control points at while it is rendered. */
-export component FieldDescription(children: React.Node, ...rest: Rest) {
+export component FieldDescription(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const field = useField("Field.Description");
   const register = field.registerDescription;
   useEffect(() => {
@@ -315,11 +310,8 @@ export component FieldDescription(children: React.Node, ...rest: Rest) {
     return () => register(false);
   }, [register]);
 
-  return (
-    <p {...rest} id={field.descriptionId}>
-      {children}
-    </p>
-  );
+  const props = withProps(rest, { children, id: field.descriptionId });
+  return render != null ? render(props) : <p {...props} />;
 }
 
 /**
@@ -334,7 +326,7 @@ export component FieldDescription(children: React.Node, ...rest: Rest) {
  * store does not need the caller to reach back into `formState.errors` for a
  * string the source is already carrying.
  */
-export component FieldError(children?: React.Node, ...rest: Rest) {
+export component FieldError(children?: React.Node, render?: RenderProp, ...rest: Rest) {
   const field = useField("Field.Error");
   const register = field.registerError;
   useEffect(() => {
@@ -345,9 +337,10 @@ export component FieldError(children?: React.Node, ...rest: Rest) {
   if (!field.invalid) {
     return null;
   }
-  return (
-    <p {...rest} id={field.errorId} role="alert">
-      {children ?? field.message}
-    </p>
-  );
+  const props = withProps(rest, {
+    children: children ?? field.message,
+    id: field.errorId,
+    role: "alert",
+  });
+  return render != null ? render(props) : <p {...props} />;
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -263,7 +263,7 @@ describe("Field", () => {
 
   it("describes the control with the help text", () => {
     render(<EmailField invalid={false} />);
-    const control = screen.getByLabelText("Email address");
+    const control = screen.getByRole("textbox", { name: "Email address" });
     const described = control.getAttribute("aria-describedby") ?? "";
     const help = screen.getByText("We will not share it.");
     expect(described.split(" ")).toContain(help.getAttribute("id"));
@@ -313,6 +313,35 @@ describe("Field", () => {
       message = String(error);
     }
     expect(message).toContain("Field.Label must be rendered inside a Field.Root");
+  });
+
+  it("hands the field wiring to caller-rendered parts", () => {
+    render(
+      <Field.Root render={(props) => <section {...props} />} invalid>
+        <Field.Label render={(props) => <strong {...props} />}>Email address</Field.Label>
+        <Field.Control render={(props) => <input type="email" {...props} />} />
+        <Field.Description render={(props) => <small {...props} />}>
+          We will not share it.
+        </Field.Description>
+        <Field.Error render={(props) => <output {...props} />}>
+          That is not an email address.
+        </Field.Error>
+      </Field.Root>,
+    );
+
+    const control = screen.getByRole("textbox", { name: "Email address" });
+    const label = screen.getByText("Email address");
+    const help = screen.getByText("We will not share it.");
+    const error = screen.getByRole("alert");
+    expect(label.tagName).toBe("STRONG");
+    expect(help.tagName).toBe("SMALL");
+    expect(error.tagName).toBe("OUTPUT");
+    expect(control.getAttribute("aria-labelledby")).toBe(label.getAttribute("id"));
+    const described = control.getAttribute("aria-describedby") ?? "";
+    expect(described.split(" ")).toContain(help.getAttribute("id"));
+    expect(described.split(" ")).toContain(error.getAttribute("id"));
+    expect(control).toHaveAttribute("aria-invalid", "true");
+    expect(danglingReferences()).toEqual([]);
   });
 });
 
@@ -473,6 +502,32 @@ describe("Field: a group that a label cannot point at", () => {
     // roving tab stop, which is `radio-group.js`'s job and not this one's.
     expect(screen.getByRole("radiogroup")).toBeInTheDocument();
     expect(screen.getAllByRole("radio").length).toBe(2);
+  });
+
+  it("keeps a caller-rendered group named and described by caller-rendered text", () => {
+    render(
+      <Field.Root group invalid render={(props) => <fieldset {...props} />}>
+        <Field.Label render={(props) => <legend {...props} />}>Plan</Field.Label>
+        <Field.Description render={(props) => <small {...props} />}>
+          You can change this later.
+        </Field.Description>
+        <Field.Error render={(props) => <output {...props} />}>Choose a plan.</Field.Error>
+      </Field.Root>,
+    );
+
+    const group = screen.getByRole("group");
+    const label = screen.getByText("Plan");
+    const help = screen.getByText("You can change this later.");
+    const error = screen.getByRole("alert");
+    expect(group.tagName).toBe("FIELDSET");
+    expect(label.tagName).toBe("LEGEND");
+    expect(accessibleName(group)).toBe("Plan");
+    expect(group.getAttribute("aria-labelledby")).toBe(label.getAttribute("id"));
+    const described = group.getAttribute("aria-describedby") ?? "";
+    expect(described.split(" ")).toContain(help.getAttribute("id"));
+    expect(described.split(" ")).toContain(error.getAttribute("id"));
+    expect(group).toHaveAttribute("aria-invalid", "true");
+    expect(danglingReferences()).toEqual([]);
   });
 });
 
@@ -8522,6 +8577,10 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Drawer.Title",
     "Drawer.Trigger",
     "Field.Control",
+    "Field.Description",
+    "Field.Error",
+    "Field.Label",
+    "Field.Root",
     "HoverCard.Trigger",
     "Menu.Body",
     "Menu.CheckboxItem",
@@ -8619,10 +8678,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Combobox.Status",
     "DatePicker.Input",
     "DatePicker.Root",
-    "Field.Description",
-    "Field.Error",
-    "Field.Label",
-    "Field.Root",
     "HoverCard.Body",
     "InputOtp.Group",
     "InputOtp.Root",


### PR DESCRIPTION
## Summary
- add `render?: RenderProp` to `Field.Root`, `Field.Label`, `Field.Description`, and `Field.Error`
- keep field ids, group ARIA, error alerts, and described-by wiring on caller-rendered elements
- move the Field parts from FIXED to RENDER in the #303 guard table

Refs #303.

## Validation
- `npm ci --prefer-offline --no-audit --no-fund`
- `tools/upstream/sync.sh`
- `git diff --check`
- `target/debug/uf fmt packages/ui/field.js packages/ui/ui.test.js --check`
- `target/debug/uf test packages/ui/ui.test.js --filter Field`
- `target/debug/uf test packages/ui/ui.test.js --filter "the escape hatch: which part hands its element to the caller"`

Note: full `target/debug/uf test packages/ui/ui.test.js` currently reports the existing Calendar/DatePicker Temporal failures locally; the Field and guard slices pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791808670&installation_model_id=422833&pr_number=820&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F820&signature=2b9b83c40995f829eb1a2008e02e10f4f6aa0d65f203876f9f3e1a4b9e4d741c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom rendering of field roots, labels, descriptions, and error messages through a render callback.
  * Custom-rendered field elements retain accessibility attributes and field relationships, including labels, descriptions, and validation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->