### PR TITLE
perf(lint): skip non-code react tree hook gates

### DIFF
--- a/crates/uf_lint/src/runner/react_tree.rs
+++ b/crates/uf_lint/src/runner/react_tree.rs
@@ -41,7 +41,7 @@ use uf_infra::{FxHashMap, FxHashSet};
 use uf_profiler::profile_span;
 use uf_transform::{ReactCompilerMode, TransformOptions};
 
-use crate::scan::FileScan;
+use crate::scan::{FileScan, find_words};
 use crate::{Diagnostic, push_at, severity};
 
 /// `react/no-derived-state-effect`.
@@ -108,13 +108,14 @@ pub(super) fn wanted(scan: &FileScan<'_>, config: &UniflowedConfig) -> Option<Re
         return None;
     }
 
-    let source = &scan.file.source;
     // Both words, not just the effect: see `STATE`. Textual on purpose — the
-    // point is to decide without parsing, and a module that mentions
-    // `useState` in a comment costs one parse it would have paid anyway.
-    let wants_effects = derived.is_some() && source.contains(EFFECT) && source.contains(STATE);
-    let wants_memo =
-        memo.is_some() && (source.contains("useMemo") || source.contains("useCallback"));
+    // point is to decide without parsing. Read the scanner's code slices rather
+    // than the whole source so a comment or prose string that names a hook does
+    // not pay for the module-tree path.
+    let wants_effects =
+        derived.is_some() && mentions_code_word(scan, EFFECT) && mentions_code_word(scan, STATE);
+    let wants_memo = memo.is_some()
+        && (mentions_code_word(scan, "useMemo") || mentions_code_word(scan, "useCallback"));
     if !wants_effects && !wants_memo {
         return None;
     }
@@ -123,6 +124,19 @@ pub(super) fn wanted(scan: &FileScan<'_>, config: &UniflowedConfig) -> Option<Re
         memo,
         wants_effects,
         wants_memo,
+    })
+}
+
+/// Whether a hook-ish name is present where code can read it.
+///
+/// This is still a cheap textual gate, not binding analysis. It is deliberately
+/// narrower than `source.contains`: comments and string prose cannot be hook
+/// calls, and those false positives are exactly what make `uf lint` enter the
+/// allocation-heavy tree path for modules that cannot report anything here.
+fn mentions_code_word(scan: &FileScan<'_>, word: &str) -> bool {
+    scan.lines.iter().any(|line| {
+        let code = line.code();
+        find_words(code, word).any(|at| !line.in_string(at))
     })
 }
 
@@ -1357,4 +1371,66 @@ fn span_start(node: &Value) -> Option<u64> {
 /// The span's end, from the same pair.
 fn span_end(node: &Value) -> Option<u64> {
     node.get("range")?.as_array()?.get(1)?.as_u64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SourceFile;
+    use crate::scan::mask_inline_comments;
+    use uf_config::{RuleLevel, UniflowedConfig};
+    use uf_infra::CompactString;
+
+    fn only(rule: &str) -> UniflowedConfig {
+        let mut config = UniflowedConfig::default();
+        config.lint.rules.clear();
+        config
+            .lint
+            .rules
+            .insert(CompactString::from(rule), RuleLevel::Error);
+        config
+    }
+
+    fn wants(rule: &str, source: &str) -> bool {
+        let file = SourceFile {
+            path: "app/page.js".to_owned(),
+            source: source.to_owned(),
+        };
+        let masked = mask_inline_comments(&file.source);
+        let scan = FileScan::new(&file, &masked);
+        wanted(&scan, &only(rule)).is_some()
+    }
+
+    #[test]
+    fn comments_and_strings_do_not_request_the_react_tree_path() {
+        let source = r#"// @flow
+// useEffect useState useMemo useCallback
+const prose = "useEffect useState useMemo useCallback";
+component Page() {
+  return <main />;
+}
+"#;
+
+        assert!(!wants(DERIVED_STATE, source));
+        assert!(!wants(REDUNDANT_MEMO, source));
+    }
+
+    #[test]
+    fn code_hook_names_still_request_the_react_tree_path() {
+        let derived = r#"// @flow
+import { useEffect, useState } from "react";
+component Page() {
+  return <main />;
+}
+"#;
+        let memo = r#"// @flow
+import { useMemo } from "react";
+component Page() {
+  return <main />;
+}
+"#;
+
+        assert!(wants(DERIVED_STATE, derived));
+        assert!(wants(REDUNDANT_MEMO, memo));
+    }
 }


### PR DESCRIPTION
## Summary
- tighten the react tree lint gate to search existing FileScan code slices instead of whole-source contains checks
- avoid entering the allocation-heavy module tree path when hook names only appear in comments or string prose
- add runner-level tests for skipped non-code mentions and preserved code/import mentions

References #668.

## Validation
- cargo fmt --all --check
- cargo test -p uf_lint react_tree -- --nocapture
- git diff --check
- cargo run -p uf_lint --example alloc_report -- packages/router/internal/runtime.js

Note: local validation used the already-present upstream/flow checkout from the original worktree because this machine had only about 248 MiB free and a fresh submodule fetch failed with out-of-disk-space while writing the Flow pack.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791809747&installation_model_id=422833&pr_number=822&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F822&signature=c63459bf8142426beddd96e21607c336e2978ac5d57f868392abb38880212e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->