### PR TITLE
test(rsc): cover package client boundary routing

### DIFF
--- a/packages/vite/rsc-split.test.js
+++ b/packages/vite/rsc-split.test.js
@@ -216,6 +216,39 @@ describe("the client route table", () => {
     expect(source).toContain(`import(${JSON.stringify(path.join(root, "app/$page.js"))})`);
   });
 
+  it("keeps a route whose only client boundary is a package module", () => {
+    // Manifest version 3 can name a package specifier as the far side of a
+    // boundary. The route filter still decides from the importing project
+    // module's proximity: a page that imports `@uniflowed/ui/switch` is a page
+    // the browser must hydrate, even though there is no scanned file for the
+    // package module itself.
+    const root = splitProject();
+    const table = scanRoutes(path.join(root, "app"));
+    const manifest = manifestIn(root, {
+      ...splitManifest(),
+      modules: [
+        manifestModule("app/$layout.js", false),
+        manifestModule("app/$page.js", true),
+        manifestModule("app/counter/$page.js", false),
+      ],
+      clientBoundaries: [
+        {
+          importer: "app/$page.js",
+          target: { kind: "package", specifier: "@uniflowed/ui/switch" },
+        },
+      ],
+      clientBundleRoots: [{ kind: "package", specifier: "@uniflowed/ui/switch" }],
+    });
+    const shipsPage = clientRouteFilter(manifest, root, table);
+
+    const source = routesModuleSource(table, { shipsPage });
+
+    expect(source).toContain(`import(${JSON.stringify(path.join(root, "app/$page.js"))})`);
+    expect(source).not.toContain(
+      `import(${JSON.stringify(path.join(root, "app/counter/$page.js"))})`,
+    );
+  });
+
   it("ships a page the analysis never saw", () => {
     // `.mdx` is a page and is not `.js`, so it is in no manifest. The honest
     // reading of a module uf did not analyse is that it might reach a


### PR DESCRIPTION
## Summary
- add an RSC route-table regression test for manifest v3 package client boundaries
- assert the route importing the package boundary keeps its page import while an isolated sibling can still be dropped

Refs #252.

## Tests
- ./target/debug/uf fmt --check packages/vite/rsc-split.test.js
- ./target/debug/uf test packages/vite/rsc-split.test.js
- cargo test -p uf_cli --test vite the_client_bundle_loses_a_route_that_needs_no_javascript -- --exact

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791810195&installation_model_id=422833&pr_number=823&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F823&signature=d58b7fe5c3b2fa2154b7587588c9c7cad743085ab207d04a7b7838ca380979ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->