### PR TITLE
perf(check): reuse dependency digest buffers

### DIFF
--- a/crates/uf_check/src/upstream/graph.rs
+++ b/crates/uf_check/src/upstream/graph.rs
@@ -95,6 +95,33 @@ pub(super) struct Graph<'a> {
     local: Vec<Digest>,
 }
 
+/// Reused storage for one dependency walk.
+///
+/// A batch asks for one dependency digest per source. Allocating the reached,
+/// seen and frontier buffers inside each query made a warm cache hit pay the
+/// same tiny setup cost once per file, even though the graph itself is fixed.
+pub(super) struct DependencyScratch {
+    reached: Vec<usize>,
+    seen: Vec<bool>,
+    frontier: Vec<usize>,
+}
+
+impl DependencyScratch {
+    pub(super) fn new(modules: usize) -> Self {
+        Self {
+            reached: Vec::new(),
+            seen: vec![false; modules],
+            frontier: Vec::new(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.reached.clear();
+        self.seen.fill(false);
+        self.frontier.clear();
+    }
+}
+
 impl<'a> Graph<'a> {
     /// Resolve every import in the batch.
     pub(super) fn new(
@@ -134,19 +161,27 @@ impl<'a> Graph<'a> {
     /// that two runs that reach the same modules by different routes — which
     /// they do, because discovery order follows whichever file was checked
     /// first — agree on the digest.
-    pub(super) fn dependency_digest(&self, index: usize) -> String {
-        let mut reached = vec![index];
-        let mut seen = vec![false; self.facts.len()];
-        seen[index] = true;
-        let mut frontier = vec![index];
-        while let Some(module) = frontier.pop() {
+    pub(super) fn scratch(&self) -> DependencyScratch {
+        DependencyScratch::new(self.facts.len())
+    }
+
+    pub(super) fn dependency_digest(
+        &self,
+        index: usize,
+        scratch: &mut DependencyScratch,
+    ) -> String {
+        scratch.reset();
+        scratch.reached.push(index);
+        scratch.seen[index] = true;
+        scratch.frontier.push(index);
+        while let Some(module) = scratch.frontier.pop() {
             for resolution in &self.resolutions[module] {
                 if let Resolution::Module(next) = *resolution
-                    && !seen[next]
+                    && !scratch.seen[next]
                 {
-                    seen[next] = true;
-                    reached.push(next);
-                    frontier.push(next);
+                    scratch.seen[next] = true;
+                    scratch.reached.push(next);
+                    scratch.frontier.push(next);
                 }
             }
         }
@@ -154,10 +189,12 @@ impl<'a> Graph<'a> {
         // path and gives the first one every import, so the second can still
         // be reached as itself — and two files that sort equal must not be
         // ordered by whichever the sort happened to move.
-        reached.sort_unstable_by_key(|module| (self.paths[*module], *module));
+        scratch
+            .reached
+            .sort_unstable_by_key(|module| (self.paths[*module], *module));
 
         let mut digest = Fields::new("uf-check-dependencies-v1");
-        for module in reached {
+        for &module in &scratch.reached {
             digest.push(self.paths[module]);
             digest.push_digest(&self.local[module]);
         }

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -316,6 +316,7 @@ fn check_batch(
     let mut skipped = 0usize;
     let mut from_cache = 0usize;
     let mut result = Ok(());
+    let mut dependencies = graph.scratch();
     for (index, source) in sources.iter().enumerate() {
         if facts[index].skipped {
             skipped += 1;
@@ -323,7 +324,7 @@ fn check_batch(
         untyped.extend(graph.untyped(index));
         host_conditional.extend(graph.host_conditional(index));
 
-        let dependencies = graph.dependency_digest(index);
+        let dependency_digest = graph.dependency_digest(index, &mut dependencies);
         // The record is about this file; the digest says whether it is still
         // about this *batch*. Both have to hold, and they fail for different
         // reasons: the key stops matching when the file was edited, the digest
@@ -331,7 +332,7 @@ fn check_batch(
         // batch, so a project checked both whole and by path finds both here.
         let believed = records[index]
             .as_ref()
-            .and_then(|record| record.answer(&dependencies))
+            .and_then(|record| record.answer(&dependency_digest))
             .map(<[TypeDiagnostic]>::to_vec);
         if let Some(found) = believed {
             diagnostics.extend(found);
@@ -346,7 +347,7 @@ fn check_batch(
             // moved, so a settled warm run still touches no file on disk.
             if let Some(cache) = cache
                 && let Some(record) = records[index].as_mut()
-                && record.touch(&dependencies)
+                && record.touch(&dependency_digest)
             {
                 cache.write(&keys[index], record);
             }
@@ -364,7 +365,7 @@ fn check_batch(
                     let record =
                         records[index].get_or_insert_with(|| record_of(source.path, &facts[index]));
                     record.remember(CachedAnswer {
-                        dependencies,
+                        dependencies: dependency_digest,
                         diagnostics: found.clone(),
                     });
                     cache.write(&keys[index], record);

--- a/crates/uf_check/tests/cache_hit_allocations.rs
+++ b/crates/uf_check/tests/cache_hit_allocations.rs
@@ -21,6 +21,10 @@ static GLOBAL: CountingAllocator = CountingAllocator::new();
 /// environment by one.
 const CEILING: u64 = 20_000;
 
+/// Above the current cost with room for JSON and platform allocator drift, and
+/// below the old cost that allocated fresh dependency-walk buffers per file.
+const BATCH_CEILING: u64 = 4_400;
+
 #[test]
 fn a_full_cache_hit_does_not_rebuild_the_check_environment() {
     let project = TempDir::new().unwrap();
@@ -50,6 +54,42 @@ fn a_full_cache_hit_does_not_rebuild_the_check_environment() {
         "a full cache hit took {} allocations, over the {CEILING} ceiling. \
          That usually means check::environment was rebuilt even though every \
          file was answered from the cache.",
+        delta.allocations,
+    );
+}
+
+#[test]
+fn a_full_cache_hit_reuses_dependency_walk_storage_across_the_batch() {
+    let project = TempDir::new().unwrap();
+    let cache = CheckCache::open(project.path()).expect("this process can name its own binary");
+    let limits = CheckLimits::default().without_timeout();
+    let paths: Vec<String> = (0..64).map(|index| format!("module{index}.js")).collect();
+    let sources: Vec<Source<'_>> = paths
+        .iter()
+        .map(|path| Source::new(path, "// @flow\nexport const answer: number = 42;\n"))
+        .collect();
+
+    let cold = check_sources_cached(&sources, &[], &limits, Some(&cache)).expect("checks");
+    assert_eq!(cold.files_from_cache, 0);
+
+    let _window = Window::open();
+    CountingAllocator::enable();
+    let before = AllocSnapshot::capture();
+    let warm = check_sources_cached(&sources, &[], &limits, Some(&cache)).expect("checks");
+    let after = AllocSnapshot::capture();
+    CountingAllocator::disable();
+
+    assert_eq!(
+        warm.files_from_cache, 64,
+        "the cache should answer the whole batch"
+    );
+    assert!(warm.diagnostics.is_empty(), "{:#?}", warm.diagnostics);
+
+    let delta = after.delta_from(&before);
+    assert!(
+        delta.allocations <= BATCH_CEILING,
+        "a 64-file full cache hit took {} allocations, over the {BATCH_CEILING} ceiling. \
+         That usually means per-file dependency-digest storage is being allocated again.",
         delta.allocations,
     );
 }


### PR DESCRIPTION
## Summary

- reuses dependency-digest walk buffers across a `uf check` batch instead of allocating fresh `reached`, `seen`, and `frontier` storage once per source
- keeps dependency digest ordering and cache semantics unchanged
- adds a 64-file full-cache-hit allocation guard for the batch path

Refs #678

## Evidence

Measured after `tools/upstream/sync.sh` with the same batch-cache shape used in #816:

```sh
cargo run --example alloc_report -p uf_check -- packages/pm/index.js --cache --batch 64
```

Warm cache hit: 4,314 allocations / 1.17 MiB. #816 recorded the same shape at 4,503 allocations after its environment-build fix; this slice removes the remaining per-file dependency-walk buffer churn.

## Verification

- [x] `tools/upstream/sync.sh`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p uf_check`
- [x] `cargo clippy -p uf_check --all-targets --all-features -- -D warnings`
- [x] `cargo test -p uf_check --test cache_hit_allocations`
- [x] `cargo test -p uf_check graph`
- [x] `cargo test -p uf_check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791810231&installation_model_id=422833&pr_number=824&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F824&signature=e8dc3f6f50ec97b320fd0e8254defa236c625f76f290ad2c02562b5fd6daca20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->