### PR TITLE
chore(release): uf@0.0.0-alpha.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## uf@0.0.0-alpha.26
+
+_2026-09-12_
+
+### Added
+
+- **ui**: add field render escape hatch (#820)
+
 ## uf@0.0.0-alpha.25
 
 _2026-09-12_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,7 +3514,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uf_assets"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "ab_glyph",
  "base64",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "uf_bundle"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "base64",
  "brotli",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "uf_check"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "uf_cli"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "uf_config"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "uf_doc"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "serde",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "uf_env"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "uf_flow"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "flow_parser",
  "thiserror",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "uf_fmt"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "uf_i18n"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "serde",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "uf_infra"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lib"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "uf_lint"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "criterion",
  "phf",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "uf_plugin"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "uf_pm"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "base64",
  "camino",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "uf_prepare"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "uf_profiler"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_project"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "uf_react_compiler"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rm"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "compact_str",
  "serde",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "uf_router"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "uf_rsc"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "uf_runtime"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "serde",
  "smallvec",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "uf_std"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "compact_str",
  "rustc-hash",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "uf_stylex"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "uf_task"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "base64",
  "camino",
@@ -3956,14 +3956,14 @@ dependencies = [
 
 [[package]]
 name = "uf_term"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "uf_test"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "camino",
  "compact_str",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "uf_transform"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "criterion",
  "flow_parser",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "uf_tui"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 dependencies = [
  "compact_str",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/uf"
 rust-version = "1.98"
-version = "0.0.0-alpha.25"
+version = "0.0.0-alpha.26"
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "description": "The uf documentation site, built with uf itself.",
   "dependencies": {
-    "@uniflowed/brand": "0.0.0-alpha.25",
-    "@uniflowed/config": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25",
-    "@uniflowed/router": "0.0.0-alpha.25",
-    "@uniflowed/vite": "0.0.0-alpha.25",
-    "@uniflowed/web": "0.0.0-alpha.25",
+    "@uniflowed/brand": "0.0.0-alpha.26",
+    "@uniflowed/config": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26",
+    "@uniflowed/router": "0.0.0-alpha.26",
+    "@uniflowed/vite": "0.0.0-alpha.26",
+    "@uniflowed/web": "0.0.0-alpha.26",
     "react": "^19.3.0",
     "react-dom": "^19.3.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,12 @@
     "docs": {
       "name": "uf-docs",
       "dependencies": {
-        "@uniflowed/brand": "0.0.0-alpha.25",
-        "@uniflowed/config": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25",
-        "@uniflowed/router": "0.0.0-alpha.25",
-        "@uniflowed/vite": "0.0.0-alpha.25",
-        "@uniflowed/web": "0.0.0-alpha.25",
+        "@uniflowed/brand": "0.0.0-alpha.26",
+        "@uniflowed/config": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26",
+        "@uniflowed/router": "0.0.0-alpha.26",
+        "@uniflowed/vite": "0.0.0-alpha.26",
+        "@uniflowed/web": "0.0.0-alpha.26",
         "react": "^19.3.0",
         "react-dom": "^19.3.0"
       }
@@ -4392,65 +4392,65 @@
     },
     "packages/brand": {
       "name": "@uniflowed/brand",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/browser": {
       "name": "@uniflowed/browser",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/cell": {
       "name": "@uniflowed/cell",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/cli": {
       "name": "@uniflowed/cli",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/config": {
       "name": "@uniflowed/config",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@uniflowed/core",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.25",
-        "@uniflowed/test": "0.0.0-alpha.25"
+        "@uniflowed/config": "0.0.0-alpha.26",
+        "@uniflowed/test": "0.0.0-alpha.26"
       }
     },
     "packages/effect": {
       "name": "@uniflowed/effect",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/fetch": {
       "name": "@uniflowed/fetch",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/form": {
       "name": "@uniflowed/form",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.25",
-        "@uniflowed/ui": "0.0.0-alpha.25",
-        "@uniflowed/validator": "0.0.0-alpha.25"
+        "@uniflowed/react": "0.0.0-alpha.26",
+        "@uniflowed/ui": "0.0.0-alpha.26",
+        "@uniflowed/validator": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4458,10 +4458,10 @@
     },
     "packages/graphql": {
       "name": "@uniflowed/graphql",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/fetch": "0.0.0-alpha.25"
+        "@uniflowed/fetch": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "relay-runtime": ">=20"
@@ -4469,19 +4469,19 @@
     },
     "packages/hmr": {
       "name": "@uniflowed/hmr",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/hooks": {
       "name": "@uniflowed/hooks",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4489,120 +4489,120 @@
     },
     "packages/host": {
       "name": "@uniflowed/host",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/i18n": {
       "name": "@uniflowed/i18n",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/immer": {
       "name": "@uniflowed/immer",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/jsx-runtime": {
       "name": "@uniflowed/jsx-runtime",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26"
       }
     },
     "packages/lib": {
       "name": "@uniflowed/lib",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/lint": {
       "name": "@uniflowed/lint",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/loader": {
       "name": "@uniflowed/loader",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.25",
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/fetch": "0.0.0-alpha.25"
+        "@uniflowed/cell": "0.0.0-alpha.26",
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/fetch": "0.0.0-alpha.26"
       }
     },
     "packages/markdown": {
       "name": "@uniflowed/markdown",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26"
       }
     },
     "packages/mock": {
       "name": "@uniflowed/mock",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/motion": {
       "name": "@uniflowed/motion",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26"
       }
     },
     "packages/orm": {
       "name": "@uniflowed/orm",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/pm": {
       "name": "@uniflowed/pm",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.25",
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/config": "0.0.0-alpha.26",
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/prepare": {
       "name": "@uniflowed/prepare",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/pwa": {
       "name": "@uniflowed/pwa",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/query": {
       "name": "@uniflowed/query",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25"
+        "@uniflowed/hooks": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4610,7 +4610,7 @@
     },
     "packages/react": {
       "name": "@uniflowed/react",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19"
@@ -4618,15 +4618,15 @@
     },
     "packages/react-compiler": {
       "name": "@uniflowed/react-compiler",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/react-native": {
       "name": "@uniflowed/react-native",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19.2.3",
@@ -4640,11 +4640,11 @@
     },
     "packages/react-testing": {
       "name": "@uniflowed/react-testing",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25",
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26",
         "happy-dom": "^20.13.2"
       },
       "peerDependencies": {
@@ -4654,7 +4654,7 @@
     },
     "packages/relay": {
       "name": "@uniflowed/relay",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",
@@ -4663,20 +4663,20 @@
     },
     "packages/rm": {
       "name": "@uniflowed/rm",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/config": "0.0.0-alpha.25",
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/config": "0.0.0-alpha.26",
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/router": {
       "name": "@uniflowed/router",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/hooks": "0.0.0-alpha.25",
-        "@uniflowed/server": "0.0.0-alpha.25"
+        "@uniflowed/hooks": "0.0.0-alpha.26",
+        "@uniflowed/server": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "react": ">=19",
@@ -4685,46 +4685,46 @@
     },
     "packages/runtime": {
       "name": "@uniflowed/runtime",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/server": {
       "name": "@uniflowed/server",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/state": {
       "name": "@uniflowed/state",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/cell": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25"
+        "@uniflowed/cell": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26"
       }
     },
     "packages/std": {
       "name": "@uniflowed/std",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/story": {
       "name": "@uniflowed/story",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/mock": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25",
-        "@uniflowed/react-testing": "0.0.0-alpha.25",
-        "@uniflowed/test": "0.0.0-alpha.25"
+        "@uniflowed/mock": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26",
+        "@uniflowed/react-testing": "0.0.0-alpha.26",
+        "@uniflowed/test": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4732,26 +4732,26 @@
     },
     "packages/stylex": {
       "name": "@uniflowed/stylex",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/temporal": {
       "name": "@uniflowed/temporal",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/test": {
       "name": "@uniflowed/test",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/host": "0.0.0-alpha.25"
+        "@uniflowed/host": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "axe-core": ">=4"
@@ -4764,31 +4764,31 @@
     },
     "packages/testing": {
       "name": "@uniflowed/testing",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react-testing": "0.0.0-alpha.25",
-        "@uniflowed/test": "0.0.0-alpha.25"
+        "@uniflowed/react-testing": "0.0.0-alpha.26",
+        "@uniflowed/test": "0.0.0-alpha.26"
       }
     },
     "packages/tui": {
       "name": "@uniflowed/tui",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/react": "0.0.0-alpha.25",
+        "@uniflowed/react": "0.0.0-alpha.26",
         "react-reconciler": "^0.34.0"
       }
     },
     "packages/ui": {
       "name": "@uniflowed/ui",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/hooks": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25",
-        "@uniflowed/state": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/hooks": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26",
+        "@uniflowed/state": "0.0.0-alpha.26"
       },
       "peerDependencies": {
         "react": ">=19"
@@ -4796,20 +4796,20 @@
     },
     "packages/validator": {
       "name": "@uniflowed/validator",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT"
     },
     "packages/vite": {
       "name": "@uniflowed/vite",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/rollup": "^3.1.1",
         "@shikijs/rehype": "^3.23.0",
-        "@uniflowed/host": "0.0.0-alpha.25",
-        "@uniflowed/router": "0.0.0-alpha.25",
-        "@uniflowed/server": "0.0.0-alpha.25",
-        "@uniflowed/validator": "0.0.0-alpha.25",
+        "@uniflowed/host": "0.0.0-alpha.26",
+        "@uniflowed/router": "0.0.0-alpha.26",
+        "@uniflowed/server": "0.0.0-alpha.26",
+        "@uniflowed/validator": "0.0.0-alpha.26",
         "rehype-slug": "^6.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
@@ -4830,21 +4830,21 @@
     },
     "packages/vrt": {
       "name": "@uniflowed/vrt",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/browser": "0.0.0-alpha.25",
-        "@uniflowed/core": "0.0.0-alpha.25"
+        "@uniflowed/browser": "0.0.0-alpha.26",
+        "@uniflowed/core": "0.0.0-alpha.26"
       }
     },
     "packages/web": {
       "name": "@uniflowed/web",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.0-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@uniflowed/core": "0.0.0-alpha.25",
-        "@uniflowed/hooks": "0.0.0-alpha.25",
-        "@uniflowed/react": "0.0.0-alpha.25"
+        "@uniflowed/core": "0.0.0-alpha.26",
+        "@uniflowed/hooks": "0.0.0-alpha.26",
+        "@uniflowed/react": "0.0.0-alpha.26"
       }
     }
   }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/brand",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Flow declarations for @uniflowed/brand, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/browser",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/browser, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cell",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Fine-grained reactivity: state, derived values, effects and resources, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/cli",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/cli, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/config",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Flow declarations for @uniflowed/config, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/core",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Shared native-runtime bridge for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.25",
-    "@uniflowed/test": "0.0.0-alpha.25"
+    "@uniflowed/config": "0.0.0-alpha.26",
+    "@uniflowed/test": "0.0.0-alpha.26"
   }
 }

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/effect",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Flow implementation for @uniflowed/effect, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,6 +22,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/fetch",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Typed HTTP over the platform fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/form",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Forms that do not re-render: uncontrolled fields, narrow subscriptions and schema validation, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -27,9 +27,9 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.25",
-    "@uniflowed/ui": "0.0.0-alpha.25",
-    "@uniflowed/validator": "0.0.0-alpha.25"
+    "@uniflowed/react": "0.0.0-alpha.26",
+    "@uniflowed/ui": "0.0.0-alpha.26",
+    "@uniflowed/validator": "0.0.0-alpha.26"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/graphql",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "The Relay environment, without the boilerplate, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/fetch": "0.0.0-alpha.25"
+    "@uniflowed/fetch": "0.0.0-alpha.26"
   },
   "peerDependencies": {
     "relay-runtime": ">=20"

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hmr",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/hmr, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -20,6 +20,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/hooks",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "The React hooks an application writes anyway, prerender-safe, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/host",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Running Flow on a Capability JS Host, with no bundler in the way.",
   "type": "module",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/i18n",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Type-safe internationalisation on MessageFormat 2: a message's arguments are checked at the call, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/immer",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Draft-based immutable updates for Flow React apps, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/jsx-runtime",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/jsx-runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,7 +19,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lib",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/lib, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/lint",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/lint, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/loader",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/loader, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,8 +19,8 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/cell": "0.0.0-alpha.25",
-    "@uniflowed/fetch": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/cell": "0.0.0-alpha.26",
+    "@uniflowed/fetch": "0.0.0-alpha.26"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/markdown",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/markdown, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,7 +19,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26"
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/mock",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "MSW-compatible request mocking over the platform's own fetch, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,6 +22,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/motion",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/motion, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,7 +19,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26"
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/orm",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/orm, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pm",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/pm, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,7 +19,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.25",
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/config": "0.0.0-alpha.26",
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/prepare",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/prepare, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/pwa",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/pwa, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/query",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "A query cache with de-duplication, structural sharing and stale-while-revalidate, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -29,8 +29,8 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25"
+    "@uniflowed/hooks": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-compiler",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/react-compiler, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-native",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "React Native, re-exported for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/react-testing/package.json
+++ b/packages/react-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react-testing",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "React Testing Library over a real DOM, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,8 +23,8 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25",
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26",
     "happy-dom": "^20.13.2"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/react",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "React, re-exported by name with its Flow types, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/relay",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Relay, re-exported by name, for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",

--- a/packages/rm/package.json
+++ b/packages/rm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/rm",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/rm, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,7 +19,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/config": "0.0.0-alpha.25",
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/config": "0.0.0-alpha.26",
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/router",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "The file-system router for Flow React applications: matching, layouts, loaders, navigation, server rendering and hydration.",
   "type": "module",
   "license": "MIT",
@@ -34,7 +34,7 @@
     "react-dom": ">=19"
   },
   "dependencies": {
-    "@uniflowed/hooks": "0.0.0-alpha.25",
-    "@uniflowed/server": "0.0.0-alpha.25"
+    "@uniflowed/hooks": "0.0.0-alpha.26",
+    "@uniflowed/server": "0.0.0-alpha.26"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/runtime",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/runtime, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,6 +19,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/server",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Request-scoped server functions for the Unified Toolchain for Flow (React).",
   "type": "module",
   "license": "MIT",
@@ -51,6 +51,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/state",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Atoms and the React binding for @uniflowed/state, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/cell": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25"
+    "@uniflowed/cell": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/std",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/std, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -60,6 +60,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/story/package.json
+++ b/packages/story/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/story",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Named, rendered states of a component that a person and a test can both reach, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -23,10 +23,10 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/mock": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25",
-    "@uniflowed/react-testing": "0.0.0-alpha.25",
-    "@uniflowed/test": "0.0.0-alpha.25"
+    "@uniflowed/mock": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26",
+    "@uniflowed/react-testing": "0.0.0-alpha.26",
+    "@uniflowed/test": "0.0.0-alpha.26"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/stylex",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Flow declarations for @uniflowed/stylex, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -22,6 +22,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/temporal",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Temporal, with uf's clock and a native-runtime calendar seam, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/test",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "The test API and worker for `uf test`: describe/it, a full matcher set, and the process uf fans test files out to.",
   "type": "module",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/host": "0.0.0-alpha.25"
+    "@uniflowed/host": "0.0.0-alpha.26"
   },
   "peerDependencies": {
     "axe-core": ">=4"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/testing",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "The test API under its other name: every binding re-exported from @uniflowed/test.",
   "type": "module",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/react-testing": "0.0.0-alpha.25",
-    "@uniflowed/test": "0.0.0-alpha.25"
+    "@uniflowed/react-testing": "0.0.0-alpha.26",
+    "@uniflowed/test": "0.0.0-alpha.26"
   }
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/tui",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "A React renderer whose host is a terminal, following OpenTUI, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/react": "0.0.0-alpha.25",
+    "@uniflowed/react": "0.0.0-alpha.26",
     "react-reconciler": "^0.34.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/ui",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Headless, accessible React components whose composition Flow checks, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -58,10 +58,10 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/hooks": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25",
-    "@uniflowed/state": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/hooks": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26",
+    "@uniflowed/state": "0.0.0-alpha.26"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/validator",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Schemas that parse rather than assert: typed inference, issue paths and JSON Schema export, part of the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vite",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "Vite, driven by uf.config.js: every Flow module through `uf transform`, MDX, the file-system router and static rendering as Vite plugins.",
   "type": "module",
   "license": "MIT",
@@ -34,10 +34,10 @@
   "dependencies": {
     "@mdx-js/rollup": "^3.1.1",
     "@shikijs/rehype": "^3.23.0",
-    "@uniflowed/host": "0.0.0-alpha.25",
-    "@uniflowed/router": "0.0.0-alpha.25",
-    "@uniflowed/server": "0.0.0-alpha.25",
-    "@uniflowed/validator": "0.0.0-alpha.25",
+    "@uniflowed/host": "0.0.0-alpha.26",
+    "@uniflowed/router": "0.0.0-alpha.26",
+    "@uniflowed/server": "0.0.0-alpha.26",
+    "@uniflowed/validator": "0.0.0-alpha.26",
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/vrt/package.json
+++ b/packages/vrt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/vrt",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "private": true,
   "description": "Flow declarations for @uniflowed/vrt, part of the Unified Toolchain for Flow.",
   "type": "module",
@@ -19,7 +19,7 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/browser": "0.0.0-alpha.25",
-    "@uniflowed/core": "0.0.0-alpha.25"
+    "@uniflowed/browser": "0.0.0-alpha.26",
+    "@uniflowed/core": "0.0.0-alpha.26"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniflowed/web",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "The primitives a web page is built from, for the Unified Toolchain for Flow.",
   "type": "module",
   "license": "MIT",
@@ -24,8 +24,8 @@
     "!*.test.js"
   ],
   "dependencies": {
-    "@uniflowed/core": "0.0.0-alpha.25",
-    "@uniflowed/hooks": "0.0.0-alpha.25",
-    "@uniflowed/react": "0.0.0-alpha.25"
+    "@uniflowed/core": "0.0.0-alpha.26",
+    "@uniflowed/hooks": "0.0.0-alpha.26",
+    "@uniflowed/react": "0.0.0-alpha.26"
   }
 }


### PR DESCRIPTION
## Summary
- release uf@0.0.0-alpha.26
- publish the UI field render escape hatch from #820
- bump workspace Cargo/npm package manifests and locks

## Validation
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791810264&installation_model_id=422833&pr_number=825&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F825&signature=053856ee1ba5845fcaf008d6f7fa371b26f2635f729eaf7dfb0c9c738c705a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->