### PR TITLE
test: cover Bun module mock aliases

### DIFF
--- a/crates/uf_cli/tests/bun_host.rs
+++ b/crates/uf_cli/tests/bun_host.rs
@@ -253,7 +253,7 @@ fn two_modules_imported_at_once_do_not_hold_the_host_open() {
 
 /// The program that asks Bun for a module mock and prints what it was told.
 ///
-/// It reaches for the four bindings a person actually writes rather than only
+/// It reaches for the seven bindings a person actually writes rather than only
 /// `mock`, because the promise `@uniflowed/test` makes is that *none* of them
 /// silently does nothing — a `unmock` that returned quietly on a host with no
 /// interception would leave a suite green and unmocked.
@@ -269,8 +269,11 @@ import { UnsupportedError, uft } from "@uniflowed/test";
 async function ask() {
   for (const [name, call] of [
     ["mock", () => uft.mock("./client.js", () => ({ send: () => "stand-in" }))],
+    ["doMock", () => uft.doMock("./client.js", () => ({ send: () => "stand-in" }))],
     ["unmock", () => uft.unmock("./client.js")],
+    ["doUnmock", () => uft.doUnmock("./client.js")],
     ["importActual", () => uft.importActual("./client.js")],
+    ["importMock", () => uft.importMock("./client.js")],
     ["resetModules", () => uft.resetModules()],
   ]) {
     try {
@@ -331,8 +334,11 @@ fn module_mocking_on_bun_refuses_by_name_rather_than_doing_nothing() {
     );
     for expected in [
         "mock=UnsupportedError",
+        "doMock=UnsupportedError",
         "unmock=UnsupportedError",
+        "doUnmock=UnsupportedError",
         "importActual=UnsupportedError",
+        "importMock=UnsupportedError",
         "resetModules=UnsupportedError",
         // Not "not implemented": the host, read off the runtime rather than
         // guessed, the hook it would need, and the two things that do work


### PR DESCRIPTION
## Summary
- extend the real Bun module-mocking refusal test to cover the full public surface: doMock, doUnmock, and importMock
- keep the current Bun behavior explicit: every module-mock binding raises UnsupportedError rather than returning quietly or replacing a module

## Validation
- cargo test -p uf_cli --test bun_host module_mocking_on_bun_refuses_by_name_rather_than_doing_nothing --profile ci --all-features
- cargo test -p uf_cli --test bun_host --profile ci --all-features
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791812952&installation_model_id=422833&pr_number=827&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F827&signature=0bb18509cd8f8e65c6dad0c2a91d33988cb1d38d68f24618b8684973e1a72786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->