### PR TITLE
perf(check): reuse dependency digest hex buffer

### DIFF
--- a/crates/uf_check/src/cache.rs
+++ b/crates/uf_check/src/cache.rs
@@ -160,13 +160,20 @@ pub(crate) type Digest = [u8; 32];
 /// spelled one nibble wrong would be two records filed under one name, and
 /// there is no value here to fall back to that would be safe.
 pub(crate) fn hex(digest: &Digest) -> String {
-    const DIGITS: [u8; 16] = *b"0123456789abcdef";
     let mut out = String::with_capacity(digest.len() * 2);
+    hex_into(digest, &mut out);
+    out
+}
+
+/// Write a digest as lowercase hex into caller-owned storage.
+pub(crate) fn hex_into(digest: &Digest, out: &mut String) {
+    const DIGITS: [u8; 16] = *b"0123456789abcdef";
+    out.clear();
+    out.reserve(digest.len() * 2);
     for byte in digest {
         out.push(char::from(DIGITS[usize::from(byte >> 4)]));
         out.push(char::from(DIGITS[usize::from(byte & 0xf)]));
     }
-    out
 }
 
 /// A digest over anything upstream already knows how to hash.

--- a/crates/uf_check/src/upstream/graph.rs
+++ b/crates/uf_check/src/upstream/graph.rs
@@ -38,7 +38,7 @@ use uf_profiler::profile_span;
 
 use super::project::ProjectModules;
 use super::resolve;
-use crate::cache::{CachedRequire, Digest, Fields, hex};
+use crate::cache::{CachedRequire, Digest, Fields, hex_into};
 
 /// What a check needs to know about one file before it checks anything.
 ///
@@ -104,6 +104,7 @@ pub(super) struct DependencyScratch {
     reached: Vec<usize>,
     seen: Vec<bool>,
     frontier: Vec<usize>,
+    digest: String,
 }
 
 impl DependencyScratch {
@@ -112,6 +113,7 @@ impl DependencyScratch {
             reached: Vec::new(),
             seen: vec![false; modules],
             frontier: Vec::new(),
+            digest: String::with_capacity(std::mem::size_of::<Digest>() * 2),
         }
     }
 
@@ -165,11 +167,11 @@ impl<'a> Graph<'a> {
         DependencyScratch::new(self.facts.len())
     }
 
-    pub(super) fn dependency_digest(
+    pub(super) fn dependency_digest<'scratch>(
         &self,
         index: usize,
-        scratch: &mut DependencyScratch,
-    ) -> String {
+        scratch: &'scratch mut DependencyScratch,
+    ) -> &'scratch str {
         scratch.reset();
         scratch.reached.push(index);
         scratch.seen[index] = true;
@@ -198,7 +200,8 @@ impl<'a> Graph<'a> {
             digest.push(self.paths[module]);
             digest.push_digest(&self.local[module]);
         }
-        hex(&digest.finish())
+        hex_into(&digest.finish(), &mut scratch.digest);
+        &scratch.digest
     }
 
     /// The specifiers the `index`th file imports that resolved to nothing

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -332,7 +332,7 @@ fn check_batch(
         // batch, so a project checked both whole and by path finds both here.
         let believed = records[index]
             .as_ref()
-            .and_then(|record| record.answer(&dependency_digest))
+            .and_then(|record| record.answer(dependency_digest))
             .map(<[TypeDiagnostic]>::to_vec);
         if let Some(found) = believed {
             diagnostics.extend(found);
@@ -347,7 +347,7 @@ fn check_batch(
             // moved, so a settled warm run still touches no file on disk.
             if let Some(cache) = cache
                 && let Some(record) = records[index].as_mut()
-                && record.touch(&dependency_digest)
+                && record.touch(dependency_digest)
             {
                 cache.write(&keys[index], record);
             }
@@ -365,7 +365,7 @@ fn check_batch(
                     let record =
                         records[index].get_or_insert_with(|| record_of(source.path, &facts[index]));
                     record.remember(CachedAnswer {
-                        dependencies: dependency_digest,
+                        dependencies: dependency_digest.to_owned(),
                         diagnostics: found.clone(),
                     });
                     cache.write(&keys[index], record);

--- a/crates/uf_check/tests/cache_hit_allocations.rs
+++ b/crates/uf_check/tests/cache_hit_allocations.rs
@@ -22,8 +22,8 @@ static GLOBAL: CountingAllocator = CountingAllocator::new();
 const CEILING: u64 = 20_000;
 
 /// Above the current cost with room for JSON and platform allocator drift, and
-/// below the old cost that allocated fresh dependency-walk buffers per file.
-const BATCH_CEILING: u64 = 4_400;
+/// below the old cost that allocated fresh dependency-digest hex per file.
+const BATCH_CEILING: u64 = 4_300;
 
 #[test]
 fn a_full_cache_hit_does_not_rebuild_the_check_environment() {


### PR DESCRIPTION
## Summary

- reuses the dependency-digest hex string inside the existing graph scratch storage
- keeps cache record format and dependency digest contents unchanged
- tightens the 64-file full-cache-hit allocation guard after #824

Refs #678

## Evidence

Measured with the same batch-cache shape used after #824:

```sh
cargo run --example alloc_report -p uf_check -- packages/pm/index.js --cache --batch 64
```

Warm cache hit: 4,251 allocations / 1.17 MiB. #824 recorded this shape at 4,314 allocations, so this removes the remaining per-file dependency-digest hex allocation from the warm full-cache-hit loop.

## Verification

- [x] `tools/upstream/sync.sh`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p uf_check`
- [x] `cargo clippy -p uf_check --all-targets --all-features -- -D warnings`
- [x] `cargo test -p uf_check --test cache_hit_allocations -- --nocapture`
- [x] `cargo test -p uf_check graph`
- [x] `cargo run --example alloc_report -p uf_check -- packages/pm/index.js --cache --batch 64`
- [x] `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791813065&installation_model_id=422833&pr_number=829&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F829&signature=11c2aa9276b42f49ce2878598dc7b2b3d28201bccf045a545390c4433f0b598d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->