### PR TITLE
fix(router): pass params to slot defaults

### DIFF
--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -1227,7 +1227,12 @@ async function resolveRoute(
   // are: a slot is matched against the URL and depends on nothing the loader
   // produces, so the second match and its imports overlap the first page's
   // loader rather than following it.
-  const slots = resolveSlots(matched.route.slots ?? [], pathname, matched.route.layouts.length);
+  const slots = resolveSlots(
+    matched.route.slots ?? [],
+    pathname,
+    matched.route.layouts.length,
+    matched.params,
+  );
 
   // The loader, run here and awaited below — or not awaited at all.
   //
@@ -1311,17 +1316,21 @@ async function resolveSlots(
   records: $ReadOnlyArray<SlotRecord>,
   pathname: string,
   layoutCount: number,
+  fallbackParams: RouteParams,
 ): Promise<$ReadOnlyArray<ResolvedSlot>> {
   if (records.length === 0) {
     return [];
   }
-  return Promise.all(records.map((record) => resolveSlot(record, pathname, layoutCount)));
+  return Promise.all(
+    records.map((record) => resolveSlot(record, pathname, layoutCount, fallbackParams)),
+  );
 }
 
 async function resolveSlot(
   record: SlotRecord,
   pathname: string,
   layoutCount: number,
+  fallbackParams: RouteParams,
 ): Promise<ResolvedSlot> {
   // Clamped exactly as a template's `above` is, and for the same reason: a
   // hand-written table, or a `(group)` between the layout and the route, can
@@ -1331,7 +1340,7 @@ async function resolveSlot(
     name: record.name,
     above,
     page: null,
-    params: {},
+    params: fallbackParams,
     layouts: [],
     slots: [],
   };
@@ -1373,7 +1382,7 @@ async function resolveSlot(
     layouts: loaded,
     // The slot's own layouts are what a nested slot is measured against, so
     // the count handed down is this slot's rather than the route's.
-    slots: await resolveSlots(route.slots, pathname, loaded.length),
+    slots: await resolveSlots(route.slots, pathname, loaded.length, matched.params),
   };
 }
 

--- a/tests/library/parallel-routes.test.js
+++ b/tests/library/parallel-routes.test.js
@@ -341,6 +341,37 @@ describe("rendering a route that has one", () => {
     expect(result.html).toContain("the team default");
   });
 
+  it("passes the current route params to a slot default", async () => {
+    // A default is still rendered *at the current URL*. Under a dynamic
+    // segment, the page filling the slot needs the same params the layout that
+    // receives it sees, even though no route inside the slot matched.
+    component TeamDefault(params: { org?: string }) {
+      return <p>{`team default for ${params.org ?? "missing"}`}</p>;
+    }
+    const dynamicSlot = {
+      ...slot,
+      defaultPage: () => Promise.resolve({ default: TeamDefault }),
+      routes: [],
+    };
+    const { prerender } = createRenderer({
+      App: routerView("./app"),
+      routes: [
+        {
+          ...page("/dashboard/:org", "the org dashboard"),
+          params: [{ name: "org", catchAll: false }],
+          slots: [dynamicSlot],
+        },
+      ],
+      notFound: [],
+      errors: [],
+    });
+
+    const result = await prerender("/dashboard/acme", assets);
+
+    expect(result.html).toContain("the org dashboard");
+    expect(result.html).toContain("team default for acme");
+  });
+
   it("renders nothing for an unaddressed slot with no default", async () => {
     // The layout still receives the prop — as `null` — so a project can write
     // `{team ?? <Empty />}` and rely on it.


### PR DESCRIPTION
## Summary

- pass the current route params through to parallel-route slot defaults
- add a regression test for `$default.js` under a dynamic segment

Refs #267.

## Validation

- `target/debug/uf test tests/library/parallel-routes.test.js`
- `git diff --check`
- `target/debug/uf fmt --check packages/router/internal/runtime.js tests/library/parallel-routes.test.js`
- `cargo fmt --all -- --check`

Also attempted `target/debug/uf test packages/router tests/library/parallel-routes.test.js`; it reached 293 passing tests and failed two pre-existing environment-sensitive cases unrelated to this change: one render-anchor status expectation in `packages/router/metadata.test.js`, and one `Temporal.Instant.from` access in `packages/router/route-handler.test.js`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791813122&installation_model_id=422833&pr_number=830&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F830&signature=f79a124c865d470bae8dc1df60cd9ae7b5ab7f56288d7537b65692534ecf190d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->