### PR TITLE
feat(build): expose native target contract

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -404,6 +404,7 @@ pub(crate) fn build(
         "transform": "uf transform",
         "host": host.name(),
         "target": app_target.as_str(),
+        "targetContract": target_contract(app_target),
         "entries": resolved.config.build.entries,
         "routes": routes.iter().map(|route| json!({
             "path": route.path,
@@ -1060,6 +1061,36 @@ fn runtime_target_name(target: &RuntimeTarget) -> &'static str {
         RuntimeTarget::ReactNative => "react-native",
         RuntimeTarget::Server => "server",
         RuntimeTarget::Hermes => "hermes",
+    }
+}
+
+fn target_contract(target: RouteTarget) -> serde_json::Value {
+    match target {
+        RouteTarget::Web => json!({
+            "runtime": "web",
+            "renderer": { "status": "implemented", "kind": "react-dom" },
+            "router": { "status": "implemented", "kind": "document" },
+            "transform": { "status": "implemented", "kind": "vite" },
+        }),
+        RouteTarget::Native | RouteTarget::Ios | RouteTarget::Android => json!({
+            "runtime": "react-native",
+            "renderer": {
+                "status": "pending",
+                "kind": "react-native-host-config",
+                "package": "@uniflowed/react-native",
+                "reason": "React Native rendering still needs a native test renderer and host config"
+            },
+            "router": {
+                "status": "pending",
+                "kind": "navigator",
+                "reason": "React Native routes need a navigator runtime rather than document URLs"
+            },
+            "transform": {
+                "status": "pending",
+                "kind": "metro",
+                "reason": "React Native builds still need a Metro/native transformer contract"
+            },
+        }),
     }
 }
 

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -359,6 +359,65 @@ fn minimal_app() -> Vec<(&'static str, &'static str)> {
     ]
 }
 
+/// A React Native target is a target contract, not only a route suffix.
+///
+/// `--target native` already narrows the route table to `$page.native.js`.
+/// Until the renderer, navigator runtime and Metro contract exist, the build
+/// manifest also has to say that those pieces are pending, so a downstream
+/// tool cannot mistake a document build for a complete React Native artefact.
+#[test]
+fn a_native_target_manifest_names_the_pending_native_contract() {
+    if !fixture_ready() {
+        return;
+    }
+    let mut files = minimal_app();
+    files.push((
+        "app/$page.native.js",
+        "// @flow\nimport * as React from \"@uniflowed/react\";\n\nexport component Page() {\n  return <main>native home</main>;\n}\n",
+    ));
+    let project = Project::new(&files);
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(project.path())
+        .args(["build", "--target", "native"])
+        .output()
+        .unwrap();
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "{said}");
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(project.path().join(".uf/build/meta/uf-build-manifest.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(manifest["target"], serde_json::json!("native"));
+    assert_eq!(
+        manifest["targetContract"]["runtime"],
+        serde_json::json!("react-native")
+    );
+    assert_eq!(
+        manifest["targetContract"]["renderer"]["status"],
+        serde_json::json!("pending")
+    );
+    assert_eq!(
+        manifest["targetContract"]["router"]["kind"],
+        serde_json::json!("navigator")
+    );
+    assert_eq!(
+        manifest["targetContract"]["transform"]["kind"],
+        serde_json::json!("metro")
+    );
+    assert_eq!(
+        manifest["routes"][0]["page"],
+        serde_json::json!("app/$page.native.js"),
+        "the build did not consume the native route target:\n{manifest:#}"
+    );
+}
+
 /// A middleware must run before the path it guards answers.
 ///
 /// `$middleware.js` was a reserved name in the Rust router, a reserved name


### PR DESCRIPTION
## Summary
- add a machine-readable targetContract section to the build manifest
- mark React Native app targets as pending for renderer, navigator router, and Metro transform contracts
- cover --target native selecting a native page while preserving the pending native contract in the manifest

## Validation
- npm ci
- cargo fmt --all -- --check
- git diff --check
- cargo check -p uf_cli --all-targets
- cargo test -p uf_cli --test vite a_native_target_manifest_names_the_pending_native_contract -- --nocapture

Closes part of #501.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791814151&installation_model_id=422833&pr_number=831&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F831&signature=aa937e7e90205e3bb8b91fbbd9824254594a3cfad97ffe4ae3d7fefc1efa48b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->