### PR TITLE
fix(vite): keep rsc boundary importers in client routes

### DIFF
--- a/packages/vite/internal/rsc.js
+++ b/packages/vite/internal/rsc.js
@@ -92,6 +92,14 @@ function clientModules(manifest) {
       module.environment === "client" || module.proximity === "reaches-boundary",
     );
   }
+  for (const boundary of manifest.clientBoundaries ?? []) {
+    if (boundary == null || typeof boundary.importer !== "string") continue;
+    modules.set(boundary.importer, true);
+  }
+  for (const root of manifest.clientBundleRoots ?? []) {
+    if (root == null || root.kind !== "module" || typeof root.path !== "string") continue;
+    modules.set(root.path, true);
+  }
   return modules;
 }
 

--- a/packages/vite/rsc-split.test.js
+++ b/packages/vite/rsc-split.test.js
@@ -249,6 +249,41 @@ describe("the client route table", () => {
     );
   });
 
+  it("keeps a route named by a manifest client-boundary edge", () => {
+    // The module summary is the fast path, but the manifest also carries the
+    // edge that made the summary true. Reading that edge here keeps the Vite
+    // side honest: if a future analysis regression writes an isolated summary
+    // beside a real boundary edge, the browser still gets the page instead of
+    // quietly dropping the only module that can hydrate it.
+    const root = splitProject();
+    const table = scanRoutes(path.join(root, "app"));
+    const manifest = manifestIn(root, {
+      ...splitManifest(),
+      modules: [
+        manifestModule("app/$layout.js", false),
+        manifestModule("app/$page.js", false),
+        manifestModule("app/counter/$page.js", false),
+        {
+          ...manifestModule("app/counter/Counter.js", false),
+          environment: "client",
+        },
+      ],
+      clientBoundaries: [
+        {
+          importer: "app/counter/$page.js",
+          target: { kind: "module", path: "app/counter/Counter.js" },
+        },
+      ],
+      clientBundleRoots: [{ kind: "module", path: "app/counter/Counter.js" }],
+    });
+    const shipsPage = clientRouteFilter(manifest, root, table);
+
+    const source = routesModuleSource(table, { shipsPage });
+
+    expect(source).toContain(`import(${JSON.stringify(path.join(root, "app/counter/$page.js"))})`);
+    expect(source).not.toContain(`import(${JSON.stringify(path.join(root, "app/$page.js"))})`);
+  });
+
   it("ships a page the analysis never saw", () => {
     // `.mdx` is a page and is not `.js`, so it is in no manifest. The honest
     // reading of a module uf did not analyse is that it might reach a


### PR DESCRIPTION
## Summary
- Treat RSC manifest client-boundary importers as client-needed modules when filtering the browser route table
- Keep module client bundle roots in the same client-needed map
- Add a regression test where the manifest boundary edge keeps an interactive route even if the module summary says isolated

Fixes part of #252.

## Validation
- `target/debug/uf test packages/vite/rsc-split.test.js`
- `target/debug/uf fmt --check packages/vite/internal/rsc.js packages/vite/rsc-split.test.js`
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791814358&installation_model_id=422833&pr_number=832&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F832&signature=abc4dbea67921943ce60041aaef390cc4ae4017cb5779b260cec746ec8acca0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->