### PR TITLE
fix(runtime): guard runtime manager host manifests

### DIFF
--- a/crates/uf_cli/src/commands/inspect.rs
+++ b/crates/uf_cli/src/commands/inspect.rs
@@ -296,7 +296,7 @@ fn inspect_payload(resolved: &ResolvedConfig) -> Result<serde_json::Value> {
     let test_runner = NativeTestRunnerPlan::runtime_agnostic();
     let package_manager = PackageManagerPlan::infer_from_config(&resolved.config);
     let package_manager_detection = detect_project_package_manager(resolved);
-    let runtime_manager = RuntimeManagerPlan::infer_from_config(&resolved.config);
+    let runtime_manager = RuntimeManagerPlan::infer_from_config(&resolved.config)?;
     // Every stage of the build is a plugin, so the resolved order here is the
     // order that actually runs — including whatever `plugins: [...]` adds.
     let pipeline = resolve_pipeline(&resolved.config, &resolved.root, PipelineMode::Build)?;

--- a/crates/uf_cli/src/commands/pm/install.rs
+++ b/crates/uf_cli/src/commands/pm/install.rs
@@ -315,7 +315,7 @@ fn write_plan(
     workspace: Option<&uf_pm::PackageManagerApplyReport>,
     workspace_packages: usize,
 ) -> Result<Utf8PathBuf> {
-    let runtime = uf_rm::RuntimeManagerPlan::infer_from_config(&resolved.config);
+    let runtime = uf_rm::RuntimeManagerPlan::infer_from_config(&resolved.config)?;
     let state_dir = resolved.root.join(".uf");
     std::fs::create_dir_all(&state_dir).with_context(|| format!("failed to create {state_dir}"))?;
     let path = state_dir.join("install.json");

--- a/crates/uf_rm/src/lib.rs
+++ b/crates/uf_rm/src/lib.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use uf_config::{RuntimeEngine, UniflowedConfig};
-use uf_runtime::{RuntimeContract, RuntimeHost};
+use uf_runtime::{HostSupport, RuntimeContract, RuntimeHost};
 
 /// Inline host list used by the runtime manager.
 pub type RuntimeHostList = SmallVec<[RuntimeHost; 8]>;
@@ -63,21 +63,27 @@ impl Default for RuntimeManagerPlan {
 
 impl RuntimeManagerPlan {
     /// Infer the runtime manager plan from the unified config.
-    pub fn infer_from_config(config: &UniflowedConfig) -> Self {
+    ///
+    /// This is deliberately a second guard behind `uf_config`'s validation.
+    /// `.uf/install.json` publishes `runtimeManager.hosts` as the hosts that
+    /// must be available, and an unchecked caller must not be able to put an
+    /// enum name with no Flow loader there by constructing `UniflowedConfig`
+    /// directly. See ubugeeei-prod/uf#246.
+    pub fn infer_from_config(config: &UniflowedConfig) -> Result<Self, RuntimeManagerError> {
         let mut plan = Self {
             engine: config.app.runtime.default,
             ..Self::default()
         };
         plan.hosts.clear();
         plan.hosts
-            .push(runtime_engine_to_host(config.app.runtime.default));
+            .push(runtime_engine_to_host(config.app.runtime.default)?);
         for engine in &config.app.runtime.compatibility {
-            let host = runtime_engine_to_host(*engine);
+            let host = runtime_engine_to_host(*engine)?;
             if !plan.hosts.contains(&host) {
                 plan.hosts.push(host);
             }
         }
-        plan
+        Ok(plan)
     }
 
     /// Return whether the default plan includes the uf runtime.
@@ -376,13 +382,60 @@ pub enum RuntimeUseStep {
     ActivateVersion,
 }
 
-/// The host a configured engine names.
+/// A runtime manager plan that would publish an unsupported host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeManagerError {
+    /// A configured runtime engine has a row in `uf_runtime::HOSTS`, but that
+    /// row has no Flow loader and therefore cannot run a uf project's source.
+    RuntimeEngineWithoutHost {
+        /// The configured engine name.
+        engine: &'static str,
+        /// How `uf_runtime::HOSTS` grades the row.
+        level: &'static str,
+        /// Where the rest of the host work is tracked.
+        tracking_issue: Option<u32>,
+    },
+}
+
+impl std::fmt::Display for RuntimeManagerError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RuntimeEngineWithoutHost {
+                engine,
+                level,
+                tracking_issue,
+            } => {
+                write!(
+                    formatter,
+                    "`{engine}` cannot be written to runtimeManager.hosts because \
+                     uf_runtime::HOSTS grades it {level} with no Flow loader"
+                )?;
+                if let Some(issue) = tracking_issue {
+                    write!(formatter, "; see ubugeeei-prod/uf#{issue}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for RuntimeManagerError {}
+
+/// The host a configured engine names, when it can run project source.
 ///
 /// One arm each, once, in `uf_config`: this mapping used to be written out
 /// here as well, and a second copy of "which row is this name" is how a name
 /// and its row drift apart.
-const fn runtime_engine_to_host(engine: RuntimeEngine) -> RuntimeHost {
-    engine.host()
+fn runtime_engine_to_host(engine: RuntimeEngine) -> Result<RuntimeHost, RuntimeManagerError> {
+    let support = HostSupport::for_host(engine.host());
+    if support.loads_flow() {
+        return Ok(support.host);
+    }
+    Err(RuntimeManagerError::RuntimeEngineWithoutHost {
+        engine: engine.as_str(),
+        level: support.level.as_str(),
+        tracking_issue: support.tracking_issue,
+    })
 }
 
 /// Runtime acquisition strategy.

--- a/crates/uf_rm/src/tests.rs
+++ b/crates/uf_rm/src/tests.rs
@@ -33,7 +33,7 @@ fn default_plan_is_capability_js_host_and_runtime_agnostic() {
 #[test]
 fn infers_hosts_from_config_without_duplicates() {
     let config = UniflowedConfig::default();
-    let plan = RuntimeManagerPlan::infer_from_config(&config);
+    let plan = RuntimeManagerPlan::infer_from_config(&config).unwrap();
 
     assert_eq!(plan.engine, RuntimeEngine::Node);
     assert_eq!(plan.hosts[0], RuntimeHost::Node);
@@ -44,6 +44,27 @@ fn infers_hosts_from_config_without_duplicates() {
             .count(),
         1
     );
+}
+
+#[test]
+fn refuses_a_host_without_a_loader_before_it_reaches_the_manifest() {
+    let mut config = UniflowedConfig::default();
+    config.app.runtime.compatibility.push(RuntimeEngine::Edge);
+
+    let error = RuntimeManagerPlan::infer_from_config(&config).unwrap_err();
+
+    assert_eq!(
+        error,
+        RuntimeManagerError::RuntimeEngineWithoutHost {
+            engine: "edge",
+            level: "planned",
+            tracking_issue: Some(246),
+        }
+    );
+    let message = error.to_string();
+    assert!(message.contains("runtimeManager.hosts"), "{message}");
+    assert!(message.contains("no Flow loader"), "{message}");
+    assert!(message.contains("246"), "{message}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make `uf_rm::RuntimeManagerPlan::infer_from_config` reject runtime engines whose `uf_runtime::HOSTS` row has no Flow loader before they can be written to `runtimeManager.hosts`
- propagate that refusal through `uf inspect --json` and `uf install` plan writing instead of publishing unsupported host names
- add a regression test that directly constructed config containing `edge` is refused with the #246 tracking issue

## Validation

- `tools/upstream/sync.sh`
- `cargo test -p uf_rm`
- `cargo test -p uf_config the_runtimes_a_project_may_name_are_the_ones_with_a_host`
- `cargo fmt --all --check`
- `git diff --check`

I also attempted targeted `uf_cli` inspect/install tests, but the local machine ran out of disk while compiling `uf_cli` (`No space left on device`). CI should cover the full workspace path.

Refs #246.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791815863&installation_model_id=422833&pr_number=834&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F834&signature=021a60e3c69b9e211c65ec62796f6b023a630a9c259c5ec403017d11c6a44568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->