### PR TITLE
fix(router): reject ignored template file spellings

### DIFF
--- a/crates/uf_router/src/lib.rs
+++ b/crates/uf_router/src/lib.rs
@@ -31,6 +31,8 @@ pub const RESERVED_ROUTE_STEM: &str = "$route";
 /// The stem a slot's stand-in page is spelled with.
 pub const RESERVED_DEFAULT_STEM: &str = "$default";
 
+const UNSUPPORTED_TEMPLATE_FILES: [&str; 2] = ["template.js", "_uf.template.js"];
+
 /// What a page may be written in, in the order a directory holding two is
 /// resolved.
 ///
@@ -364,6 +366,20 @@ pub enum RouterError {
         /// What is wrong with it and what to do instead.
         reason: String,
     },
+    /// A file name that looks like a route template but is not one uf opens.
+    ///
+    /// `$template.js` is uf's template convention. Next.js's `template.js`, and
+    /// the old-looking `_uf.template.js`, used to sit in a public route
+    /// directory as ordinary project files. That is worse than unsupported:
+    /// the author asked for remount behaviour, got no error, and the route
+    /// looked like it worked.
+    #[error("{file}: {reason}")]
+    UnsupportedTemplateFile {
+        /// The file, as it is written on disk.
+        file: Utf8PathBuf,
+        /// What is wrong with it and what to do instead.
+        reason: String,
+    },
     /// A `@slot` whose segment declares no layout of its own.
     ///
     /// A slot renders *into* a layout — that is the whole of what a parallel
@@ -514,6 +530,10 @@ pub fn discover_routes_for_target(
     // interception used to become a literal URL segment and a live route, and
     // so did a slot before slots were served.
     refuse_unsupported_directories(&app_root)?;
+    // A wrong template spelling is the file version of the same failure: the
+    // project asked for remount behaviour and got a file the router never
+    // opens.
+    refuse_unsupported_template_files(&app_root)?;
     // And before any route is built for the opposite reason: a slot's pages are
     // routes uf renders, so what is wrong with a slot has to be said here
     // rather than discovered as a missing prop at render time.
@@ -755,6 +775,44 @@ fn refuse_unsupported_directories(app_root: &Utf8Path) -> Result<(), RouterError
         return Err(RouterError::UnsupportedRouteDirectory { directory, reason });
     }
     Ok(())
+}
+
+fn refuse_unsupported_template_files(app_root: &Utf8Path) -> Result<(), RouterError> {
+    let walk = WalkDir::new(app_root)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_entry(|entry| {
+            entry.depth() == 0
+                || !entry.file_type().is_dir()
+                || !entry.file_name().to_string_lossy().starts_with(['.', '_'])
+        });
+
+    for entry in walk {
+        let entry = entry.map_err(|source| RouterError::Walk {
+            path: app_root.to_path_buf(),
+            source,
+        })?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let file_name = entry.file_name().to_string_lossy();
+        if !UNSUPPORTED_TEMPLATE_FILES.contains(&file_name.as_ref()) {
+            continue;
+        }
+        let file = Utf8PathBuf::from_path_buf(entry.path().to_path_buf())
+            .map_err(|path| RouterError::NonUtf8(path.display().to_string()))?;
+        let reason = unsupported_template_file_reason(&file_name);
+        return Err(RouterError::UnsupportedTemplateFile { file, reason });
+    }
+    Ok(())
+}
+
+fn unsupported_template_file_reason(file_name: &str) -> String {
+    format!(
+        "`{file_name}` looks like a route template, but uf's route template file is \
+         `$template.js`. This file would be ignored rather than remounting the route, so it is \
+         refused; rename it to `$template.js`. https://github.com/ubugeeei-prod/uf/issues/267"
+    )
 }
 
 /// The first `@slot` segment of a path relative to the router root, if it has

--- a/crates/uf_router/src/tests.rs
+++ b/crates/uf_router/src/tests.rs
@@ -870,6 +870,24 @@ fn a_slot_with_a_default_and_a_layout_is_discovered() {
     assert_eq!(routes[0].path, "/");
 }
 
+#[test]
+fn unsupported_template_spellings_are_refused() {
+    for name in ["template.js", "_uf.template.js"] {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        fs::create_dir_all(root.join("app")).unwrap();
+        fs::write(root.join("app/$page.js"), "// @flow\n").unwrap();
+        fs::write(root.join("app").join(name), "// @flow\n").unwrap();
+
+        let error = discover_routes(&root, &UniflowedConfig::default()).unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains(name), "{name}: {message}");
+        assert!(message.contains("$template.js"), "{name}: {message}");
+        assert!(message.contains("refused"), "{name}: {message}");
+    }
+}
+
 /// A slot arrives as a prop named after its directory, so it may not be named
 /// after a prop the layout already has.
 ///

--- a/packages/router/template.test.js
+++ b/packages/router/template.test.js
@@ -100,6 +100,14 @@ describe("scanning for templates", () => {
     expect(source).toContain("$template.js");
     expect(source).toContain("templates: [{ above: 0, module: template0 }]");
   });
+
+  it("refuses template spellings the router would otherwise ignore", () => {
+    for (const file of ["template.js", "_uf.template.js"]) {
+      const root = appRoot(["$page.js", file]);
+
+      expect(() => scanRoutes(root)).toThrow("$template.js");
+    }
+  });
 });
 
 // --- Composition -------------------------------------------------------

--- a/packages/vite/internal/routes.js
+++ b/packages/vite/internal/routes.js
@@ -74,6 +74,9 @@ export const UNSUPPORTED_SEGMENTS = Object.freeze([
  */
 export const LAYOUT_PROP_NAMES = Object.freeze(["children", "params"]);
 
+/** Template spellings that look conventional elsewhere but uf will not open. */
+const UNSUPPORTED_TEMPLATE_FILES = Object.freeze(["template.js", "_uf.template.js"]);
+
 /** Extensions a page or layout may use; `.mdx` is a page written as content. */
 const PAGE_EXTENSIONS = [".js", ".jsx", ".mdx"];
 const MODULE_EXTENSIONS = [".js", ".jsx"];
@@ -327,6 +330,8 @@ export function scanRoutes(appRoot, options = {}) {
     const entries = readdirSync(directory, { withFileTypes: true }).sort((a, b) =>
       a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
     );
+
+    refuseUnsupportedTemplateFiles(directory, entries);
 
     // A `$default.js` answers one question — what a slot renders when the
     // URL says nothing about it — and this walk is everywhere a slot is not,
@@ -626,6 +631,8 @@ function scanSlot(parent, directoryName, name, segments, ownLayout, above, targe
       a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
     );
 
+    refuseUnsupportedTemplateFiles(current, entries);
+
     let nestedSlots = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
@@ -713,6 +720,24 @@ function findModule(directory, stem, extensions, target = "web") {
     }
   }
   return null;
+}
+
+function refuseUnsupportedTemplateFiles(directory, entries) {
+  for (const entry of entries) {
+    if (!entry.isFile() || !UNSUPPORTED_TEMPLATE_FILES.includes(entry.name)) {
+      continue;
+    }
+    const file = path.join(directory, entry.name);
+    throw new Error(`${file}: ${unsupportedTemplateFileReason(entry.name)}`);
+  }
+}
+
+function unsupportedTemplateFileReason(fileName) {
+  return (
+    `\`${fileName}\` looks like a route template, but uf's route template file is ` +
+    "`$template.js`. This file would be ignored rather than remounting the route, so it is " +
+    "refused; rename it to `$template.js`. https://github.com/ubugeeei-prod/uf/issues/267"
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- refuse `template.js` and `_uf.template.js` inside public router directories instead of silently ignoring them
- keep `$template.js` as the supported remounting template convention and point the error there
- cover the behavior in the Vite scanner and Rust route discovery tests

## Validation

- `cargo test -p uf_router unsupported_template_spellings_are_refused`
- `cargo test -p uf_router`
- `UF_BINARY=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--router-slot-default-regression/target/debug/uf /Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--router-slot-default-regression/target/debug/uf test packages/router/template.test.js`
- `UF_BINARY=/Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--router-slot-default-regression/target/debug/uf /Users/ubugeeei/Source/github.com/ubugeeei-prod/uf--router-slot-default-regression/target/debug/uf fmt --check packages/router/template.test.js packages/vite/internal/routes.js crates/uf_router/src/lib.rs crates/uf_router/src/tests.rs`
- `cargo fmt --all -- --check`
- `git diff --check`

## Issue

Covers the remaining `template.js` / `_uf.template.js` behavior from #267. The issue still has larger open work for interception and per-slot boundaries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791815925&installation_model_id=422833&pr_number=835&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F835&signature=c005ae7f6b1a8c524a467046e5d897ecac20fae5fc00a69fd813edac41b0b38f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->