### PR TITLE
fix(router): tighten payload row ids

### DIFF
--- a/packages/router/internal/payload-rows.js
+++ b/packages/router/internal/payload-rows.js
@@ -57,6 +57,7 @@ import {
   PAYLOAD_ROW_ATTRIBUTE,
   PayloadRowError,
   PayloadValueError,
+  payloadRowId,
   parseRowMessage,
 } from "./payload.js";
 
@@ -149,8 +150,8 @@ export function createPayloadReader(
     if (attribute == null) {
       return;
     }
-    const id = Number.parseInt(attribute, 10);
-    if (!Number.isSafeInteger(id)) {
+    const id = payloadRowId(attribute);
+    if (id == null) {
       return;
     }
     const slot = slots.get(id);

--- a/packages/router/internal/payload.js
+++ b/packages/router/internal/payload.js
@@ -581,6 +581,19 @@ function decodeReference(value: string, path: string, resolve: RowResolver): mix
 }
 
 /**
+ * The row id carried by a streamed row element, or `null` when the attribute
+ * is not one.
+ *
+ * This is the same grammar as the `$P<n>` reference without the `$P` tag:
+ * digits only, in range. The browser reads row elements from a live document,
+ * so accepting `Number.parseInt`'s looser spellings would let `1x` satisfy the
+ * row the model named as `$P1`.
+ */
+export function payloadRowId(value: string): number | null {
+  return parsePayloadRowId(value);
+}
+
+/**
  * The row a reference names, or `null` when the string is not one.
  *
  * Digits only, and read by hand rather than with `Number`, which accepts
@@ -591,7 +604,10 @@ function rowId(value: string): number | null {
   if (!value.startsWith(REFERENCE_PREFIX + ROW_TAG)) {
     return null;
   }
-  const digits = value.slice(2);
+  return parsePayloadRowId(value.slice(2));
+}
+
+function parsePayloadRowId(digits: string): number | null {
   if (digits.length === 0 || digits.length > 3) {
     return null;
   }

--- a/tests/library/payload.test.js
+++ b/tests/library/payload.test.js
@@ -51,6 +51,7 @@ import {
   encodePayload,
   encodeRowValue,
   parseRowMessage,
+  payloadRowId,
   payloadJson,
 } from "../../packages/router/internal/payload.js";
 import { createPayloadReader } from "../../packages/router/internal/payload-rows.js";
@@ -176,6 +177,8 @@ describe("the payload format", () => {
     expect(() => decodePayload({ a: "$P0" }, () => null, "data")).toThrow(PayloadValueError);
     expect(() => decodePayload({ a: "$P1e3" }, () => null, "data")).toThrow(PayloadValueError);
     expect(() => decodePayload({ a: "$P9999" }, () => null, "data")).toThrow(PayloadValueError);
+    expect(payloadRowId("1e3")).toBe(null);
+    expect(payloadRowId("1x")).toBe(null);
   });
 
   it("names where in the loader's answer the trouble was", () => {
@@ -261,7 +264,7 @@ describe("the payload format", () => {
 /** A document with a growing list of row scripts, and nothing else in it. */
 function rowDocument(): {|
   readonly document: $FlowFixMe,
-  readonly write: (id: number, text: string) => void,
+  readonly write: (id: number | string, text: string) => void,
   readonly observe: (callback: () => void) => () => void,
   readonly watchers: () => number,
 |} {
@@ -275,7 +278,7 @@ function rowDocument(): {|
       querySelectorAll: () => elements,
       documentElement: null,
     },
-    write(id: number, text: string) {
+    write(id: number | string, text: string) {
       elements.push({
         getAttribute: (name) => (name === PAYLOAD_ROW_ATTRIBUTE ? String(id) : null),
         textContent: text,
@@ -344,6 +347,17 @@ describe("reading rows out of a document", () => {
     doc.write(1, `{"value":"first"}`);
     doc.write(1, `{"value":"second"}`);
     expect(await row).toBe("first");
+  });
+
+  it("ignores row elements whose id is not the payload row grammar", async () => {
+    const doc = rowDocument();
+    const reader = createPayloadReader(doc.document, doc.observe);
+    const row = reader.resolve(1);
+    reader.watch();
+    doc.write("1x", `{"value":"wrong"}`);
+    doc.write("1e0", `{"value":"also wrong"}`);
+    doc.write(1, `{"value":"right"}`);
+    expect(await row).toBe("right");
   });
 
   it("never watches a document with nothing deferred in it", () => {


### PR DESCRIPTION
## Summary
- share the strict payload row-id grammar between `$P<n>` references and streamed `data-uf-row` elements
- ignore late row scripts with malformed ids instead of letting `Number.parseInt` satisfy a model row
- add payload tests for malformed streamed row ids

## Scope
- Refs #519. This is an incremental payload-contract hardening; it does not close the full element payload/client tree work.

## Validation
- `target/debug/uf test tests/library/payload.test.js`
- `target/debug/uf fmt --check packages/router/internal/payload.js packages/router/internal/payload-rows.js tests/library/payload.test.js`
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`

## Notes
- `target/debug/uf check packages/router/internal/payload.js packages/router/internal/payload-rows.js tests/library/payload.test.js` currently reports existing checker issues on untouched lines, so it is not used as a gate here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791816764&installation_model_id=422833&pr_number=836&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F836&signature=546dc109d9f8464d760dcaf4ebb9e8d06719469b95c5912428ecbe1b21f94688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of streamed payload row identifiers.
  * Invalid row identifiers are now ignored consistently, preventing malformed rows from being processed.
  * Valid row identifiers continue to be accepted and resolved as expected.
  * Added coverage for invalid identifier formats and mixed valid/invalid payload rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->