### PR TITLE
perf(check): reuse cache key strings

### DIFF
--- a/crates/uf_check/src/cache.rs
+++ b/crates/uf_check/src/cache.rs
@@ -478,7 +478,10 @@ impl CheckCache {
     }
 
     fn entry_path(&self, key: &Digest) -> PathBuf {
-        self.directory.join(format!("{}.json", hex(key)))
+        let mut name = String::with_capacity(std::mem::size_of::<Digest>() * 2 + ".json".len());
+        hex_into(key, &mut name);
+        name.push_str(".json");
+        self.directory.join(name)
     }
 }
 

--- a/crates/uf_check/src/upstream/mod.rs
+++ b/crates/uf_check/src/upstream/mod.rs
@@ -269,12 +269,15 @@ fn check_batch(
     // What each file's record is filed under. Computed even for a file the
     // cache turns out to know nothing about, because it is also where the
     // recomputed answer is written back.
-    let libdefs = builtins::digest(libs);
     let keys: Vec<Digest> = match cache {
-        Some(cache) => sources
-            .iter()
-            .map(|source| file_key(cache, limits, &libdefs, source))
-            .collect(),
+        Some(cache) => {
+            let libdefs = builtins::digest(libs);
+            let limits_field = limits_field(limits);
+            sources
+                .iter()
+                .map(|source| file_key(cache, &limits_field, &libdefs, source))
+                .collect()
+        }
         None => Vec::new(),
     };
     let mut records: Vec<Option<Record>> = match cache {
@@ -405,13 +408,13 @@ fn check_batch(
 /// reports, including the files that reach nothing at all.
 fn file_key(
     cache: &CheckCache,
-    limits: &CheckLimits,
+    limits_field: &str,
     libdefs: &Digest,
     source: &Source<'_>,
 ) -> Digest {
     let mut fields = Fields::new("uf-check-file-v1");
     fields.push(cache.identity());
-    fields.push(&limits_field(limits));
+    fields.push(limits_field);
     fields.push_digest(libdefs);
     fields.push(source.path);
     fields.push(source.source);

--- a/crates/uf_check/tests/cache_hit_allocations.rs
+++ b/crates/uf_check/tests/cache_hit_allocations.rs
@@ -22,8 +22,8 @@ static GLOBAL: CountingAllocator = CountingAllocator::new();
 const CEILING: u64 = 20_000;
 
 /// Above the current cost with room for JSON and platform allocator drift, and
-/// below the old cost that allocated fresh dependency-digest hex per file.
-const BATCH_CEILING: u64 = 4_300;
+/// below the old cost that rebuilt cache-key strings per file.
+const BATCH_CEILING: u64 = 4_100;
 
 #[test]
 fn a_full_cache_hit_does_not_rebuild_the_check_environment() {


### PR DESCRIPTION
## Summary

- avoids a temporary cache entry filename string by writing digest hex directly into the final filename buffer
- formats the limits component of check file keys once per cached batch instead of once per source
- tightens the 64-file full-cache-hit allocation guard from 4,300 to 4,100 allocations

Refs #678

## Evidence

Measured with the same batch-cache shape used by #824 and #829:

```sh
cargo run --example alloc_report -p uf_check -- packages/pm/index.js --cache --batch 64
```

Warm cache hit went from 4,251 allocations / 1.17 MiB on `origin/main` to 4,060 allocations / 1.15 MiB on this branch. Cold and edited runs remain equivalent, as expected for a cache-key allocation change.

## Verification

- [x] `tools/upstream/sync.sh`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p uf_check`
- [x] `cargo clippy -p uf_check --all-targets --all-features -- -D warnings`
- [x] `cargo test -p uf_check --test cache_hit_allocations -- --nocapture`
- [x] `cargo test -p uf_check`
- [x] `cargo run --example alloc_report -p uf_check -- packages/pm/index.js --cache --batch 64`
- [x] `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791816776&installation_model_id=422833&pr_number=837&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F837&signature=426120a162c737acb3bb9de66bf3ed71ad62fc2ccc4f5741768a7659f36ce339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->