### PR TITLE
fix(router): stream root loading fallbacks

### DIFF
--- a/packages/router/internal/runtime.js
+++ b/packages/router/internal/runtime.js
@@ -2209,6 +2209,9 @@ export component RouteView() {
       );
     }
   }
+  if (needsRootStreamFrame(resolved)) {
+    element = <RootStreamFrame>{element}</RootStreamFrame>;
+  }
   return (
     <>
       <Head metadata={resolved.metadata} />
@@ -2221,6 +2224,28 @@ export component RouteView() {
         <BoundaryReporter path={resolved.path} boundaries={marks} />
       ) : null}
     </>
+  );
+}
+
+/**
+ * Whether the outermost route fallback needs one host element above it.
+ *
+ * React can flush a shell whose suspended boundary is inside any host element,
+ * but not one whose boundary is a direct child of the render root. A route with
+ * no layout and a root `$loading.js` is exactly that second tree: every
+ * framework component above it renders no element, so the fallback waits for
+ * the page it was meant to stand in for. A root layout is already the element
+ * that can carry it, and deeper fallbacks sit inside a layout by construction.
+ */
+function needsRootStreamFrame(resolved: ResolvedRoute): boolean {
+  return resolved.layouts.length === 0 && resolved.loading.some((boundary) => boundary.above === 0);
+}
+
+component RootStreamFrame(children: React.Node) {
+  return (
+    <div data-uf-stream-root="" style={{ display: "contents" }}>
+      {children}
+    </div>
   );
 }
 
@@ -2332,10 +2357,8 @@ component AwaitedPage(loader: Promise<mixed>) {
  * rows rather than one each — the boundaries inside it still resolve
  * independently, since each is its own.
  *
- * The same rule catches a route whose `$loading.js` sits above no layout:
- * `RouteView` puts that boundary in the same position, and it does not stream
- * either. That is a bug this file did not introduce and does not fix; it is
- * written down in ubugeeei-prod/uf#519 rather than left to be rediscovered.
+ * The same rule catches a route whose `$loading.js` sits above no layout, so
+ * `RouteView` wraps that specific root shape in `RootStreamFrame`.
  */
 function payloadElements(data: mixed): React.Node {
   if (data === undefined) {

--- a/packages/router/streaming.test.js
+++ b/packages/router/streaming.test.js
@@ -204,6 +204,31 @@ function suspendingTable(waited: Promise<string>, options?: {| readonly loading?
   };
 }
 
+/** The same wait, with the fallback declared at the router root and no layout. */
+function rootSuspendingTable(waited: Promise<string>) {
+  component SlowPage() {
+    return <p>{use(waited)}</p>;
+  }
+  component Loading() {
+    return <p>the root fallback is here</p>;
+  }
+  return {
+    routes: [
+      {
+        path: "/slow",
+        params: [],
+        mdx: false,
+        file: "app/slow/$page.js",
+        page: () => Promise.resolve({ default: SlowPage }),
+        layouts: [],
+        loading: [{ above: 0, module: () => Promise.resolve({ default: Loading }) }],
+      },
+    ],
+    notFound: [],
+    errors: [],
+  };
+}
+
 describe("the `<Suspense>` in the tree", () => {
   it("renders the fallback while the page waits, and the layout around both", async () => {
     const waited = deferred();
@@ -354,6 +379,34 @@ describe("rendering a route that suspends", () => {
       .join("");
     expect(rest).toContain("the page is here");
     expect(chunks.length > 1).toBe(true);
+  });
+
+  it("sends a root fallback before the page resolves even without a layout", async () => {
+    const waited = deferred();
+    const renderer = createRenderer({
+      App: routerView("./app"),
+      ...rootSuspendingTable(waited.promise),
+    });
+
+    let settled = false;
+    setTimeout(() => {
+      settled = true;
+      waited.resolve();
+    }, 120);
+    const result = await renderer.render("/slow", assets);
+
+    expect(settled).toBe(false);
+    const chunks = await chunksOf(result);
+    const shell = chunks[0];
+    expect(shell.text).toContain("the root fallback is here");
+    expect(shell.text).not.toContain("the page is here");
+    expect(shell.at < 120).toBe(true);
+
+    const rest = chunks
+      .slice(1)
+      .map((chunk) => chunk.text)
+      .join("");
+    expect(rest).toContain("the page is here");
   });
 
   it("writes the head before any of the body", async () => {


### PR DESCRIPTION
## Summary
- stream root-level `$loading.js` fallbacks even when a route has no layout by inserting a `display: contents` host frame for that specific shape
- add a regression test that reads the first streamed chunk before the page promise resolves

Advances #519. Does not close it; the element payload and RSC graph split remain open.

## Verification
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo run -p uf_cli --bin uf -- lint packages/router/internal/runtime.js packages/router/streaming.test.js`
- `cargo run -p uf_cli --bin uf -- test packages/router/streaming.test.js`

## Known Existing Failures
- `cargo run -p uf_cli --bin uf -- check packages/router/internal/runtime.js packages/router/streaming.test.js` reports pre-existing Flow checker errors in these files.
- `cargo run -p uf_cli --bin uf -- test packages/router/metadata.test.js` fails on `the render anchor > hands the tree an instant and a seed that a second render reproduces`; reproduced unchanged on `release/alpha-29`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791825054&installation_model_id=422833&pr_number=841&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F841&signature=d48bd78bcd115d9b286f63ee00ea07e2f178ca11f20279ace622ebe3dc83901f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed streaming for routes without layouts that use a root loading state.
  - Loading fallbacks now appear promptly while page content continues resolving.
  - Resolved page content is delivered in subsequent streamed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->