### PR TITLE
fix: refuse Deno coverage before AOT

### DIFF
--- a/crates/uf_cli/src/commands/test.rs
+++ b/crates/uf_cli/src/commands/test.rs
@@ -33,7 +33,7 @@ use uf_test::{
 use crate::cli::{CoverageReporterArg, ResultReporterArg};
 use crate::commands::builder::uniflowed_package;
 use crate::commands::deno_loader;
-use crate::commands::vite::{find_program, resolve_host};
+use crate::commands::vite::{Host, find_program, resolve_host};
 
 use crate::support::{
     TEST, ignore_deprecation, plural, project_env, quoted_list, render_ignore_deprecation, selects,
@@ -228,9 +228,29 @@ pub(crate) fn test(cwd: &Utf8Path, ui: &mut Ui, args: TestArgs) -> Result<()> {
         );
     }
 
-    let mut host = test_host(&root, &resolved.config, &env, &files, args.browser)?
-        .with_snapshot_updates(args.update_snapshots)
-        .with_axe(resolved.config.accessibility.axe.as_json());
+    let resolved_host = resolve_host(&resolved.config)?;
+    let host_kind = test_host_kind(resolved_host.kind, args.browser);
+    let settings = &resolved.config.test.coverage;
+    if (args.coverage || settings.enabled) && !host_kind_can_collect_coverage(host_kind) {
+        bail!(
+            "`uf test --coverage` needs Node.js: coverage is V8's own count, written out \
+             through `NODE_V8_COVERAGE` and mapped back through the source map the Node \
+             loader attaches. {} provides neither, and reporting zeroes would be worse than \
+             saying so.",
+            host_kind.name()
+        );
+    }
+
+    let mut host = test_host_with_resolved_host(
+        &root,
+        &resolved.config,
+        &env,
+        &files,
+        args.browser,
+        resolved_host,
+    )?
+    .with_snapshot_updates(args.update_snapshots)
+    .with_axe(resolved.config.accessibility.axe.as_json());
 
     // Every JavaScript file the project has, before discovery narrows it to the
     // ones that declare tests: a file no test imports never becomes a script,
@@ -245,17 +265,7 @@ pub(crate) fn test(cwd: &Utf8Path, ui: &mut Ui, args: TestArgs) -> Result<()> {
         .map(|file| file.relative_path.clone())
         .collect();
 
-    let settings = &resolved.config.test.coverage;
     let raw = if args.coverage || settings.enabled {
-        if !host.can_collect_coverage() {
-            bail!(
-                "`uf test --coverage` needs Node.js: coverage is V8's own count, written out \
-                 through `NODE_V8_COVERAGE` and mapped back through the source map the Node \
-                 loader attaches. {} provides neither, and reporting zeroes would be worse than \
-                 saying so.",
-                host.kind.name()
-            );
-        }
         let raw = coverage::RawCoverage::create(&root)?;
         host = host.with_coverage_dir(raw.directory().to_path_buf());
         Some(raw)
@@ -373,6 +383,17 @@ pub(crate) fn test_host(
     browser: bool,
 ) -> Result<HostCommand> {
     let host = resolve_host(config)?;
+    test_host_with_resolved_host(root, config, env, sources, browser, host)
+}
+
+fn test_host_with_resolved_host(
+    root: &Utf8Path,
+    config: &uf_config::UniflowedConfig,
+    env: &ProjectEnv,
+    sources: &[ProjectFile],
+    browser: bool,
+    host: Host,
+) -> Result<HostCommand> {
     // The loader, not the bundler. `uf test` transforms through `uf transform`
     // and runs on a Capability JS Host; nothing in that path is Vite's, and
     // asking for `@uniflowed/vite` made a test run depend on a bundler it never
@@ -395,15 +416,7 @@ pub(crate) fn test_host(
             )
         })?;
 
-    let kind = if browser {
-        HostKind::Browser
-    } else {
-        match host.kind {
-            uf_config::CapabilityJsHost::Node => HostKind::Node,
-            uf_config::CapabilityJsHost::Bun => HostKind::Bun,
-            uf_config::CapabilityJsHost::Deno => HostKind::Deno,
-        }
-    };
+    let kind = test_host_kind(host.kind, browser);
     // The driver of a browser run is Node whatever the project's Capability JS
     // Host is, because the runtime under test is the browser and the driver
     // only shuttles JSON between a pipe and a socket. Found here rather than
@@ -557,6 +570,21 @@ pub(crate) fn test_host(
         );
     }
     Ok(command)
+}
+
+fn test_host_kind(host: uf_config::CapabilityJsHost, browser: bool) -> HostKind {
+    if browser {
+        return HostKind::Browser;
+    }
+    match host {
+        uf_config::CapabilityJsHost::Node => HostKind::Node,
+        uf_config::CapabilityJsHost::Bun => HostKind::Bun,
+        uf_config::CapabilityJsHost::Deno => HostKind::Deno,
+    }
+}
+
+const fn host_kind_can_collect_coverage(kind: HostKind) -> bool {
+    matches!(kind, HostKind::Node)
 }
 
 /// The `uf` every worker in this run transforms its modules through.

--- a/crates/uf_cli/tests/deno_host.rs
+++ b/crates/uf_cli/tests/deno_host.rs
@@ -433,6 +433,45 @@ fn uf_test_watch_on_deno_refuses_rather_than_running_a_stale_tree() {
     assert!(stderr.contains("issues/246"), "stderr:\n{stderr}");
 }
 
+/// Coverage is a Node loader feature, not a Deno AOT feature.
+///
+/// The refusal has to happen before the ahead-of-time pass, or an unsupported
+/// mode can fail while compiling the project and tell the user about their
+/// Flow syntax instead of the mode they asked for. This test gives Deno a file
+/// the pass would reject and asserts the pass never ran.
+#[test]
+fn uf_test_coverage_on_deno_refuses_before_the_aot_pass() {
+    if !deno_ready() {
+        return;
+    }
+    let project = deno_project(&[(
+        "broken.test.js",
+        "// @flow\nimport { it } from \"@uniflowed/test\";\n\n\
+         const value: = 1;\n\
+         it(\"would never parse\", () => {});\n",
+    )]);
+
+    let output = uf()
+        .arg("--cwd")
+        .arg(project.path())
+        .args(["test", "--coverage", "broken.test.js"])
+        .output()
+        .expect("uf runs");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr:\n{stderr}");
+    assert!(stderr.contains("uf test --coverage"), "stderr:\n{stderr}");
+    assert!(stderr.contains("needs Node.js"), "stderr:\n{stderr}");
+    assert!(
+        stderr.contains("Deno provides neither"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        !project.path().join(".uf/deno").exists(),
+        "`uf test --coverage` on Deno must refuse before building the AOT tree"
+    );
+}
+
 /// No `-A` reaches Deno from `uf test`, on a project that declared nothing.
 ///
 /// This is the sentence ubugeeei-prod/uf#246 ends on. `uf test` passed

--- a/crates/uf_test/src/coverage.rs
+++ b/crates/uf_test/src/coverage.rs
@@ -28,8 +28,9 @@
 //!
 //! The cost is stated rather than hidden: this is Node-only. Bun's preload
 //! transforms with `sourceMap: false` and Bun does not implement
-//! `NODE_V8_COVERAGE`; Deno has no Flow loader at all. `uf test --coverage` on
-//! either says so instead of reporting zeroes.
+//! `NODE_V8_COVERAGE`; Deno's ahead-of-time loader has no equivalent coverage
+//! flush or source-map cache to read back. `uf test --coverage` on either says
+//! so instead of reporting zeroes.
 //!
 //! # What is counted, exactly
 //!

--- a/crates/uf_test/src/host.rs
+++ b/crates/uf_test/src/host.rs
@@ -354,9 +354,9 @@ impl HostCommand {
     ///
     /// Node only, and the reason is not a missing feature of uf's: Bun's
     /// preload transforms with `sourceMap: false` and implements no
-    /// `NODE_V8_COVERAGE`, and Deno has no Flow loader in `@uniflowed/host` to
-    /// produce a map with. A caller is expected to say so rather than report a
-    /// run of zeroes.
+    /// `NODE_V8_COVERAGE`, and Deno's ahead-of-time loader has no equivalent
+    /// coverage flush or source-map cache to read back. A caller is expected to
+    /// say so rather than report a run of zeroes.
     ///
     /// The browser is the interesting `false`, because the counters are right
     /// there — V8 is counting in the renderer exactly as it counts in Node. The


### PR DESCRIPTION
## Summary
- refuse `uf test --coverage` on non-Node hosts before constructing the test host
- prevent Deno coverage requests from building the ahead-of-time tree before the unsupported-mode message
- refresh coverage comments for Deno's AOT loader limitation

## Tests
- `mise x deno@1.46.3 -- cargo test -p uf_cli --test deno_host -- --nocapture`
- `cargo test -p uf_cli --test coverage -- --nocapture`
- `cargo test -p uf_test --lib -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Advances #246; does not close it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791825124&installation_model_id=422833&pr_number=842&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F842&signature=b4cfd5e293d3591ab71557d31968eaf8946fe29fefad8052504fcbc9b33afa51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->