### PR TITLE
feat(build): record native Metro platform contract

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -1088,6 +1088,8 @@ fn target_contract(target: RouteTarget) -> serde_json::Value {
             "transform": {
                 "status": "pending",
                 "kind": "metro",
+                "platform": target.as_str(),
+                "sourceExtensions": ["js", "jsx", "mjs", "cjs"],
                 "reason": "React Native builds still need a Metro/native transformer contract"
             },
         }),
@@ -1397,5 +1399,40 @@ mod tests {
         let source = diagnostic_source(&root, module, &[&diagnostic]);
 
         assert_eq!(source, "", "a climbing module path read a file anyway");
+    }
+
+    #[test]
+    fn react_native_alias_is_an_application_target() {
+        assert_eq!(
+            parse_application_target("react-native").unwrap(),
+            RouteTarget::Native
+        );
+    }
+
+    #[test]
+    fn native_target_contract_names_the_metro_platform() {
+        for (target, platform) in [
+            (RouteTarget::Native, "native"),
+            (RouteTarget::Ios, "ios"),
+            (RouteTarget::Android, "android"),
+        ] {
+            let contract = target_contract(target);
+            assert_eq!(contract["runtime"], serde_json::json!("react-native"));
+            assert_eq!(contract["renderer"]["status"], serde_json::json!("pending"));
+            assert_eq!(contract["router"]["kind"], serde_json::json!("navigator"));
+            assert_eq!(
+                contract["transform"]["status"],
+                serde_json::json!("pending")
+            );
+            assert_eq!(contract["transform"]["kind"], serde_json::json!("metro"));
+            assert_eq!(
+                contract["transform"]["platform"],
+                serde_json::json!(platform)
+            );
+            assert_eq!(
+                contract["transform"]["sourceExtensions"],
+                serde_json::json!(["js", "jsx", "mjs", "cjs"])
+            );
+        }
     }
 }

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -412,6 +412,14 @@ fn a_native_target_manifest_names_the_pending_native_contract() {
         serde_json::json!("metro")
     );
     assert_eq!(
+        manifest["targetContract"]["transform"]["platform"],
+        serde_json::json!("native")
+    );
+    assert_eq!(
+        manifest["targetContract"]["transform"]["sourceExtensions"],
+        serde_json::json!(["js", "jsx", "mjs", "cjs"])
+    );
+    assert_eq!(
         manifest["routes"][0]["page"],
         serde_json::json!("app/$page.native.js"),
         "the build did not consume the native route target:\n{manifest:#}"


### PR DESCRIPTION
## Summary
- record the Metro platform and Flow source extensions in native-family build target contracts
- cover the react-native alias plus native, iOS, and Android contract metadata in build-command tests
- assert the real native build manifest writes the Metro contract fields

Refs #501

## Verification
- cargo fmt --all -- --check
- git diff --check
- RUSTC_BOOTSTRAP=1 cargo test -p uf_cli commands::build::tests --ignore-rust-version -j1
- RUSTC_BOOTSTRAP=1 cargo test -p uf_cli --test vite a_native_target_manifest_names_the_pending_native_contract --ignore-rust-version -j1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791825263&installation_model_id=422833&pr_number=843&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F843&signature=dda2309902c60695d10e1829d95e6e6c6ce8a6a53812625ffe5abac1ff9ee191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->