### PR TITLE
feat(ui): add field status live region

### DIFF
--- a/crates/uf_lib/src/ui.rs
+++ b/crates/uf_lib/src/ui.rs
@@ -382,7 +382,7 @@ pub fn ui_components() -> Vec<UiComponent> {
         // anything a new part would render.
         UiComponent::new(
             "Field",
-            &["Root", "Label", "Control", "Description", "Error"],
+            &["Root", "Label", "Control", "Description", "Status", "Error"],
             UiRuntime::Client,
         )
         .styled_by(&["fieldStyles"]),

--- a/packages/form/field.js
+++ b/packages/form/field.js
@@ -148,6 +148,7 @@ export hook useFieldSource<
     // what this module is for.
     required: isRequired(rules ?? {}),
     disabled: registered.disabled === true,
+    busy: state.isSubmitting || state.isValidating || state.isLoading,
     message: error?.message ?? null,
     control,
   };

--- a/packages/ui/field.js
+++ b/packages/ui/field.js
@@ -129,6 +129,7 @@ export type FieldSource = {|
   readonly invalid: boolean,
   readonly required: boolean,
   readonly disabled: boolean,
+  readonly busy: boolean,
   /** What is wrong, or null while the field is valid. */
   readonly message: string | null,
   readonly control: Rest,
@@ -141,14 +142,17 @@ type FieldState = {|
   readonly controlId: string,
   readonly labelId: string,
   readonly descriptionId: string,
+  readonly statusId: string,
   readonly errorId: string,
   readonly invalid: boolean,
   readonly required: boolean,
+  readonly busy: boolean,
   readonly group: boolean,
   readonly message: string | null,
   readonly control: Rest,
   readonly describedBy: string | void,
   readonly registerDescription: (present: boolean) => void,
+  readonly registerStatus: (present: boolean) => void,
   readonly registerError: (present: boolean) => void,
 |};
 
@@ -187,6 +191,7 @@ export component FieldRoot(
   children: React.Node,
   invalid?: boolean = false,
   required?: boolean = false,
+  busy?: boolean = false,
   field?: FieldSource,
   group?: boolean = false,
   render?: RenderProp,
@@ -194,20 +199,24 @@ export component FieldRoot(
 ) {
   const base = useId();
   const [hasDescription, setHasDescription] = useState(false);
+  const [hasStatus, setHasStatus] = useState(false);
   const [hasError, setHasError] = useState(false);
   const sourceInvalid = field?.invalid ?? false;
   const sourceRequired = field?.required ?? false;
+  const sourceBusy = field?.busy ?? false;
   const message = field?.message ?? null;
   const control = field?.control ?? NO_CONTROL;
 
   const state = useMemo(() => {
     const descriptionId = `${base}-description`;
+    const statusId = `${base}-status`;
     const errorId = `${base}-error`;
     const wrong = invalid || sourceInvalid;
     // Only ids that are in the document. `aria-describedby` naming a missing
     // element makes a screen reader announce nothing rather than skipping it.
     const described = [
       hasDescription ? descriptionId : null,
+      hasStatus ? statusId : null,
       wrong && hasError ? errorId : null,
     ].filter(Boolean);
 
@@ -215,14 +224,17 @@ export component FieldRoot(
       controlId: `${base}-control`,
       labelId: `${base}-label`,
       descriptionId,
+      statusId,
       errorId,
       invalid: wrong,
       required: required || sourceRequired,
+      busy: busy || sourceBusy,
       group,
       message,
       control,
       describedBy: described.length === 0 ? undefined : described.join(" "),
       registerDescription: setHasDescription,
+      registerStatus: setHasStatus,
       registerError: setHasError,
     };
   }, [
@@ -231,10 +243,13 @@ export component FieldRoot(
     sourceInvalid,
     required,
     sourceRequired,
+    busy,
+    sourceBusy,
     group,
     message,
     control,
     hasDescription,
+    hasStatus,
     hasError,
   ]);
 
@@ -242,6 +257,7 @@ export component FieldRoot(
     // A group names itself, describes itself and reports its own validity,
     // because there is no one control inside it to carry any of the three.
     // See the module header.
+    "aria-busy": group && state.busy ? "true" : undefined,
     "aria-describedby": group ? state.describedBy : undefined,
     "aria-invalid": group && state.invalid ? "true" : undefined,
     "aria-labelledby": group ? state.labelId : undefined,
@@ -292,6 +308,7 @@ export component FieldControl(render: RenderProp) {
   const own: Rest = field.group
     ? { "aria-required": field.required ? "true" : undefined }
     : {
+        "aria-busy": field.busy ? "true" : undefined,
         id: field.controlId,
         "aria-labelledby": field.labelId,
         "aria-describedby": field.describedBy,
@@ -311,6 +328,30 @@ export component FieldDescription(children: React.Node, render?: RenderProp, ...
   }, [register]);
 
   const props = withProps(rest, { children, id: field.descriptionId });
+  return render != null ? render(props) : <p {...props} />;
+}
+
+/**
+ * Non-error feedback for the field.
+ *
+ * A polite live region has to exist before the text changes. So unlike
+ * `Field.Error`, this part stays in the document even while it is empty; the
+ * control points at it only while the caller rendered the part.
+ */
+export component FieldStatus(children?: React.Node, render?: RenderProp, ...rest: Rest) {
+  const field = useField("Field.Status");
+  const register = field.registerStatus;
+  useEffect(() => {
+    register(true);
+    return () => register(false);
+  }, [register]);
+
+  const props = withProps(rest, {
+    "aria-live": "polite",
+    children: children ?? "",
+    id: field.statusId,
+    role: "status",
+  });
   return render != null ? render(props) : <p {...props} />;
 }
 

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -396,7 +396,14 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "./drawer.js";
-import { FieldControl, FieldDescription, FieldError, FieldLabel, FieldRoot } from "./field.js";
+import {
+  FieldControl,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FieldRoot,
+  FieldStatus,
+} from "./field.js";
 import { HoverCardBody, HoverCardRoot, HoverCardTrigger } from "./hover-card.js";
 import { InputOtpGroup, InputOtpRoot, InputOtpSeparator, InputOtpSlot } from "./input-otp.js";
 import {
@@ -551,14 +558,16 @@ export { dismissAllToasts, dismissToast, toast, updateToast };
  *     <Field.Label>Email</Field.Label>
  *     <Field.Control render={(props) => <input type="email" {...props} />} />
  *     <Field.Description>We will not share it.</Field.Description>
+ *     <Field.Status>{saving ? "Saving…" : ""}</Field.Status>
  *     <Field.Error>{error}</Field.Error>
  *   </Field.Root>
  *
  * Inside a form, `field` replaces the hand-written `invalid`: the form says
  * whether the field is wrong and what the message is, and the field composes
- * every `aria-*` from that in one place. `@uniflowed/form`'s `useFieldSource`
- * is what produces one, and `field.js`'s header says why the hook lives there
- * rather than here.
+ * every `aria-*` from that in one place. It also marks the control busy during
+ * submit, validation, or async default loading. `@uniflowed/form`'s
+ * `useFieldSource` is what produces one, and `field.js`'s header says why the
+ * hook lives there rather than here.
  *
  *   const email = useFieldSource(form, "email", { required: "We need one" });
  *   <Field.Root field={email}>…<Field.Error /></Field.Root>
@@ -573,6 +582,7 @@ export const Field = {
   Label: FieldLabel,
   Control: FieldControl,
   Description: FieldDescription,
+  Status: FieldStatus,
   Error: FieldError,
 };
 

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -30,6 +30,7 @@ import {
   render,
   screen,
   userEvent,
+  waitFor,
   within,
 } from "@uniflowed/react-testing";
 // The clock behind `Temporal.Now`, so that "today" in a calendar is a fact this
@@ -323,6 +324,7 @@ describe("Field", () => {
         <Field.Description render={(props) => <small {...props} />}>
           We will not share it.
         </Field.Description>
+        <Field.Status render={(props) => <output {...props} />}>Checking…</Field.Status>
         <Field.Error render={(props) => <output {...props} />}>
           That is not an email address.
         </Field.Error>
@@ -332,15 +334,51 @@ describe("Field", () => {
     const control = screen.getByRole("textbox", { name: "Email address" });
     const label = screen.getByText("Email address");
     const help = screen.getByText("We will not share it.");
+    const status = screen.getByRole("status");
     const error = screen.getByRole("alert");
     expect(label.tagName).toBe("STRONG");
     expect(help.tagName).toBe("SMALL");
+    expect(status.tagName).toBe("OUTPUT");
     expect(error.tagName).toBe("OUTPUT");
     expect(control.getAttribute("aria-labelledby")).toBe(label.getAttribute("id"));
     const described = control.getAttribute("aria-describedby") ?? "";
     expect(described.split(" ")).toContain(help.getAttribute("id"));
+    expect(described.split(" ")).toContain(status.getAttribute("id"));
     expect(described.split(" ")).toContain(error.getAttribute("id"));
     expect(control).toHaveAttribute("aria-invalid", "true");
+    expect(danglingReferences()).toEqual([]);
+  });
+
+  it("keeps non-error status feedback in a polite region before it changes", async () => {
+    component SavingField() {
+      const [saving, setSaving] = useState(false);
+      return (
+        <div>
+          <Field.Root busy={saving}>
+            <Field.Label>Email address</Field.Label>
+            <Field.Control render={(props) => <input type="email" {...props} />} />
+            <Field.Status>{saving ? "Saving email" : ""}</Field.Status>
+          </Field.Root>
+          <button onClick={() => setSaving(true)} type="button">
+            Save
+          </button>
+        </div>
+      );
+    }
+
+    render(<SavingField />);
+    const control = screen.getByLabelText("Email address");
+    const status = screen.getByRole("status");
+    expect(status.textContent).toBe("");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect((control.getAttribute("aria-describedby") ?? "").split(" ")).toContain(
+      status.getAttribute("id"),
+    );
+    expect(control).not.toHaveAttribute("aria-busy");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByRole("status").textContent).toBe("Saving email");
+    expect(control).toHaveAttribute("aria-busy", "true");
     expect(danglingReferences()).toEqual([]);
   });
 });
@@ -457,6 +495,49 @@ describe("Field: bound to a form", () => {
     await submit();
     expect(screen.getByLabelText("Email address")).not.toHaveAttribute("aria-invalid");
     expect(screen.queryByRole("alert")).toBe(null);
+  });
+
+  it("marks the bound control busy while the form is submitting", async () => {
+    let release: () => void = () => {};
+
+    component SubmittingForm() {
+      const form = useForm<Signup>({ defaultValues: { email: "" } });
+      const email = useFieldSource(form, "email", { required: "We need an email address" });
+      return (
+        <form
+          onSubmit={form.handleSubmit(
+            () =>
+              new Promise<void>((resolve) => {
+                release = () => resolve();
+              }),
+          )}
+        >
+          <Field.Root field={email}>
+            <Field.Label>Email address</Field.Label>
+            <Field.Control render={(props) => <input type="email" {...props} />} />
+            <Field.Status>Saving email</Field.Status>
+            <Field.Error />
+          </Field.Root>
+          <button type="submit">Save</button>
+        </form>
+      );
+    }
+
+    render(<SubmittingForm />);
+    const control = screen.getByLabelText("Email address");
+    await userEvent.type(control, "someone@example.com");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => {
+      expect(control).toHaveAttribute("aria-busy", "true");
+    });
+
+    await act(async () => {
+      release();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(control).not.toHaveAttribute("aria-busy");
+    });
   });
 });
 
@@ -8581,6 +8662,7 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Field.Error",
     "Field.Label",
     "Field.Root",
+    "Field.Status",
     "HoverCard.Trigger",
     "Menu.Body",
     "Menu.CheckboxItem",


### PR DESCRIPTION
## Summary
- add `Field.Status` as a render-prop-capable polite live region for non-error field feedback
- carry form busy state into `FieldSource` so bound controls expose `aria-busy` while submitting, validating, or loading
- register the new Field part in the UI surface and cover headless wiring with tests

Advances #305.
Relates #488.

## Verification
- `cargo fmt --all -- --check`
- `npm exec biome -- check packages/ui/field.js packages/ui/index.js packages/ui/ui.test.js packages/form/field.js`
- `cargo test -p uf_lib --profile ci`
- `cargo build --release --bin uf`
- `./target/release/uf test packages/ui/ui.test.js -t Field`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791828220&installation_model_id=422833&pr_number=847&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F847&signature=a5e83a64a4e1a922585357b9bd7398d09680b77a7252832f30859df0609c38e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->