### PR TITLE
feat(ui): add table and pagination render escape hatches

### DIFF
--- a/packages/ui/pagination.js
+++ b/packages/ui/pagination.js
@@ -44,8 +44,8 @@
 
 import * as React from "@uniflowed/react";
 
-import type { Rest } from "./internal/merge-props.js";
-import { withoutComposed } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import { withProps, withoutComposed } from "./internal/merge-props.js";
 
 /**
  * The pagination, as a named landmark, and the region that announces it.
@@ -62,16 +62,16 @@ export component PaginationRoot(
   page?: number | null = null,
   pageCount?: number | null = null,
   announcePage?: (page: number, pageCount: number) => string,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const message =
     page == null || pageCount == null ? "" : (announcePage ?? defaultAnnouncement)(page, pageCount);
+  const props = withProps(rest, { "aria-label": label, children });
 
   return (
     <>
-      <nav {...rest} aria-label={label}>
-        {children}
-      </nav>
+      {render == null ? <nav {...props} /> : render(withProps(props, { role: "navigation" }))}
       {/*
         Beside the navigation rather than inside it, so a reader walking the
         landmark hears the links and not a sentence about them — and mounted
@@ -93,9 +93,14 @@ export component PaginationRoot(
  */
 export component PaginationContent(
   children: renders* (PaginationItem | PaginationPrevious | PaginationNext),
+  render?: RenderProp,
   ...rest: Rest
 ) {
-  return <ul {...rest}>{children}</ul>;
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(withProps(props, { role: "list" }));
+  }
+  return <ul {...props} />;
 }
 
 /**
@@ -108,10 +113,11 @@ export component PaginationItem(
   children: React.Node,
   current?: boolean = false,
   disabled?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   return (
-    <PageLink current={current} disabled={disabled} rest={rest}>
+    <PageLink current={current} disabled={disabled} render={render} rest={rest}>
       {children}
     </PageLink>
   );
@@ -129,10 +135,11 @@ export component PaginationPrevious(
   children?: React.Node,
   label?: string = "Previous page",
   disabled?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   return (
-    <PageLink disabled={disabled} label={label} rest={rest}>
+    <PageLink disabled={disabled} label={label} render={render} rest={rest}>
       {children}
     </PageLink>
   );
@@ -143,10 +150,11 @@ export component PaginationNext(
   children?: React.Node,
   label?: string = "Next page",
   disabled?: boolean = false,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   return (
-    <PageLink disabled={disabled} label={label} rest={rest}>
+    <PageLink disabled={disabled} label={label} render={render} rest={rest}>
       {children}
     </PageLink>
   );
@@ -174,19 +182,23 @@ component PageLink(
   current?: boolean = false,
   disabled?: boolean = false,
   label?: string,
+  render?: RenderProp,
 ) {
   const passed = withoutComposed(rest, disabled ? ["href"] : []);
+  const props = withProps(passed, {
+    "aria-current": current ? "page" : undefined,
+    "aria-disabled": disabled ? "true" : undefined,
+    "aria-label": label,
+    children,
+  });
+
+  if (render != null) {
+    return <li>{render(withProps(props, { role: disabled ? undefined : "link" }))}</li>;
+  }
 
   return (
     <li>
-      <a
-        {...passed}
-        aria-current={current ? "page" : undefined}
-        aria-disabled={disabled ? "true" : undefined}
-        aria-label={label}
-      >
-        {children}
-      </a>
+      <a {...props} />
     </li>
   );
 }

--- a/packages/ui/table.js
+++ b/packages/ui/table.js
@@ -68,8 +68,13 @@ import { createContext, useContext, useEffect, useId, useMemo, useState } from "
 import { useStableCallback } from "@uniflowed/hooks/lifecycle";
 
 import { Checkbox } from "./checkbox.js";
-import type { Rest } from "./internal/merge-props.js";
-import { composeHandlers, composeRefs, withoutComposed } from "./internal/merge-props.js";
+import type { RenderProp, Rest } from "./internal/merge-props.js";
+import {
+  composeHandlers,
+  composeRefs,
+  withProps,
+  withoutComposed,
+} from "./internal/merge-props.js";
 import { useControlled } from "./internal/controlled-state.js";
 
 /** Which column a table is sorted by, and which way. */
@@ -130,6 +135,7 @@ export component TableRoot(
   rowCount?: number | null = null,
   rowOffset?: number = 0,
   announceSort?: (column: string, direction: "ascending" | "descending") => string,
+  render?: RenderProp,
   ...rest: Rest
 ) {
   const base = useId();
@@ -184,23 +190,15 @@ export component TableRoot(
           labels[current.column] ?? current.column,
           current.direction,
         );
+  const props = withProps(rest, {
+    "aria-labelledby": captioned ? `${base}-caption` : undefined,
+    "aria-rowcount": rowCount == null ? undefined : rowCount + headerRows,
+    children,
+  });
 
   return (
     <TableContext.Provider value={state}>
-      <table
-        {...rest}
-        // The caption is a `<table>`'s accessible name in HTML-AAM already;
-        // naming it again here is what turns "the host will probably do this"
-        // into something this component promises, and it costs nothing because
-        // both point at the same words. Only while a caption is rendered, for
-        // the reason every part of this package repeats.
-        aria-labelledby={captioned ? `${base}-caption` : undefined}
-        // Every row in the table, which is the data plus the header — the
-        // arithmetic a caller should not have to remember.
-        aria-rowcount={rowCount == null ? undefined : rowCount + headerRows}
-      >
-        {children}
-      </table>
+      {render == null ? <table {...props} /> : render(withProps(props, { role: "table" }))}
       {/*
         Beside the table rather than inside it, because a `<table>` may only
         contain a caption, column groups and row groups — and mounted from the
@@ -221,7 +219,7 @@ export component TableRoot(
  * what a screen reader reads when a reader lands on it. A heading above the
  * table looks the same and is not the table's name.
  */
-export component TableCaption(children: React.Node, ...rest: Rest) {
+export component TableCaption(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const table = useTable("Table.Caption");
   const register = table.registerCaption;
 
@@ -230,11 +228,11 @@ export component TableCaption(children: React.Node, ...rest: Rest) {
     return () => register(false);
   }, [register]);
 
-  return (
-    <caption {...rest} id={table.captionId}>
-      {children}
-    </caption>
-  );
+  const props = withProps(rest, { children, id: table.captionId });
+  if (render != null) {
+    return render(withProps(props, { role: "caption" }));
+  }
+  return <caption {...props} />;
 }
 
 /**
@@ -243,7 +241,7 @@ export component TableCaption(children: React.Node, ...rest: Rest) {
  * It tells the root that it exists, because `aria-rowcount` and every row's
  * `aria-rowindex` count header rows and a table without one counts differently.
  */
-export component TableHeader(children: React.Node, ...rest: Rest) {
+export component TableHeader(children: React.Node, render?: RenderProp, ...rest: Rest) {
   const table = useTable("Table.Header");
   const register = table.registerHeader;
 
@@ -252,18 +250,21 @@ export component TableHeader(children: React.Node, ...rest: Rest) {
     return () => register(false);
   }, [register]);
 
+  const props = withProps(rest, { children });
+
   return (
     <HeaderContext.Provider value={true}>
-      <thead {...rest}>{children}</thead>
+      {render == null ? <thead {...props} /> : render(withProps(props, { role: "rowgroup" }))}
     </HeaderContext.Provider>
   );
 }
 
 /** The data rows. */
-export component TableBody(children: React.Node, ...rest: Rest) {
+export component TableBody(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children });
   return (
     <HeaderContext.Provider value={false}>
-      <tbody {...rest}>{children}</tbody>
+      {render == null ? <tbody {...props} /> : render(withProps(props, { role: "rowgroup" }))}
     </HeaderContext.Provider>
   );
 }
@@ -284,7 +285,12 @@ export component TableBody(children: React.Node, ...rest: Rest) {
  * adding them anyway is a second source of truth that can disagree with the
  * document.
  */
-export component TableRow(children: React.Node, index?: number | null = null, ...rest: Rest) {
+export component TableRow(
+  children: React.Node,
+  index?: number | null = null,
+  render?: RenderProp,
+  ...rest: Rest
+) {
   const table = useTable("Table.Row");
   const header = useContext(HeaderContext);
   const counted = table.rowCount != null;
@@ -300,11 +306,11 @@ export component TableRow(children: React.Node, index?: number | null = null, ..
     rowIndex = table.headerRows + table.rowOffset + (index ?? 0) + 1;
   }
 
-  return (
-    <tr {...rest} aria-rowindex={rowIndex}>
-      {children}
-    </tr>
-  );
+  const props = withProps(rest, { "aria-rowindex": rowIndex, children });
+  if (render != null) {
+    return render(withProps(props, { role: "row" }));
+  }
+  return <tr {...props} />;
 }
 
 /**
@@ -320,7 +326,12 @@ export component TableRow(children: React.Node, index?: number | null = null, ..
  * Not `"none"` on the others: eleven headers each announcing "not sorted" is
  * eleven announcements of nothing, on every pass through the table.
  */
-export component TableHead(children: React.Node, column?: string | null = null, ...rest: Rest) {
+export component TableHead(
+  children: React.Node,
+  column?: string | null = null,
+  render?: RenderProp,
+  ...rest: Rest
+) {
   const table = useTable("Table.Head");
   const passed = withoutComposed(rest, column == null ? [] : ["onClick", "ref"]);
   const sorted = column != null && table.sort?.column === column;
@@ -341,41 +352,49 @@ export component TableHead(children: React.Node, column?: string | null = null, 
   });
 
   if (column == null) {
-    return (
-      <th {...rest} scope="col">
-        {children}
-      </th>
-    );
+    const props = withProps(rest, { children, scope: "col" });
+    if (render != null) {
+      return render(withProps(props, { role: "columnheader" }));
+    }
+    return <th {...props} />;
   }
 
-  return (
-    <th
-      {...passed}
-      aria-sort={sorted ? table.sort?.direction : undefined}
-      ref={composeRefs(rest.ref, setElement)}
-      scope="col"
+  const button = (
+    <button
+      onClick={composeHandlers(rest.onClick, () => {
+        // Two states, not three. A sort that cycles back to "unsorted" gives
+        // a reader a third press whose result is a table in an order nobody
+        // asked for.
+        table.setSort({
+          column,
+          direction: sorted && table.sort?.direction === "ascending" ? "descending" : "ascending",
+        });
+      })}
+      type="button"
     >
-      <button
-        onClick={composeHandlers(rest.onClick, () => {
-          // Two states, not three. A sort that cycles back to "unsorted" gives
-          // a reader a third press whose result is a table in an order nobody
-          // asked for.
-          table.setSort({
-            column,
-            direction: sorted && table.sort?.direction === "ascending" ? "descending" : "ascending",
-          });
-        })}
-        type="button"
-      >
-        {children}
-      </button>
-    </th>
+      {children}
+    </button>
   );
+  const props = withProps(passed, {
+    "aria-sort": sorted ? table.sort?.direction : undefined,
+    children: button,
+    ref: composeRefs(rest.ref, setElement),
+    scope: "col",
+  });
+
+  if (render != null) {
+    return render(withProps(props, { role: "columnheader" }));
+  }
+  return <th {...props} />;
 }
 
 /** One cell. */
-export component TableCell(children: React.Node, ...rest: Rest) {
-  return <td {...rest}>{children}</td>;
+export component TableCell(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children });
+  if (render != null) {
+    return render(withProps(props, { role: "cell" }));
+  }
+  return <td {...props} />;
 }
 
 /**
@@ -386,12 +405,12 @@ export component TableCell(children: React.Node, ...rest: Rest) {
  * moves down the year column. A table of records usually has one and almost
  * never marks it.
  */
-export component TableRowHeader(children: React.Node, ...rest: Rest) {
-  return (
-    <th {...rest} scope="row">
-      {children}
-    </th>
-  );
+export component TableRowHeader(children: React.Node, render?: RenderProp, ...rest: Rest) {
+  const props = withProps(rest, { children, scope: "row" });
+  if (render != null) {
+    return render(withProps(props, { role: "rowheader" }));
+  }
+  return <th {...props} />;
 }
 
 /**
@@ -430,6 +449,7 @@ export component TableSelectAll(
   label?: string = "Select all rows",
   className?: string,
   disabled?: boolean = false,
+  render?: RenderProp,
 ) {
   return (
     <Checkbox
@@ -439,6 +459,7 @@ export component TableSelectAll(
       disabled={disabled}
       indeterminate={checked === "mixed"}
       onCheckedChange={onCheckedChange}
+      render={render}
     />
   );
 }
@@ -461,6 +482,7 @@ export component TableRowSelect(
   onCheckedChange: (checked: boolean) => void,
   className?: string,
   disabled?: boolean = false,
+  render?: RenderProp,
 ) {
   return (
     <Checkbox
@@ -469,6 +491,7 @@ export component TableRowSelect(
       className={className}
       disabled={disabled}
       onCheckedChange={onCheckedChange}
+      render={render}
     />
   );
 }

--- a/packages/ui/ui.test.js
+++ b/packages/ui/ui.test.js
@@ -6102,6 +6102,77 @@ describe("Table", () => {
     }
     expect(message).toContain("Table.Head must be rendered inside a Table.Root");
   });
+
+  it("hands the table contract to caller-rendered elements", async () => {
+    component CallerRenderedTable() {
+      const [sort, setSort] = useState(null);
+      return (
+        <Table.Root
+          onSortChange={setSort}
+          render={(props) => <section {...props} data-testid="table" />}
+          rowCount={PEOPLE.length}
+          sort={sort}
+        >
+          <Table.Caption render={(props) => <h2 {...props} />}>People</Table.Caption>
+          <Table.Header render={(props) => <div {...props} data-testid="head" />}>
+            <Table.Row render={(props) => <div {...props} data-testid="header-row" />}>
+              <Table.Head render={(props) => <div {...props} data-testid="select-head" />}>
+                <Table.SelectAll
+                  checked="mixed"
+                  onCheckedChange={() => {}}
+                  render={(props) => <span {...props} data-testid="select-all" tabIndex={0} />}
+                />
+              </Table.Head>
+              <Table.Head
+                column="name"
+                render={(props) => <div {...props} data-testid="name-head" />}
+              >
+                Name
+              </Table.Head>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body render={(props) => <div {...props} data-testid="body" />}>
+            <Table.Row index={0} render={(props) => <div {...props} data-testid="row" />}>
+              <Table.RowHeader render={(props) => <strong {...props} />}>
+                Ada Lovelace
+              </Table.RowHeader>
+              <Table.Cell render={(props) => <span {...props} data-testid="born" />}>
+                1815
+              </Table.Cell>
+              <Table.Cell>
+                <Table.RowSelect
+                  checked={false}
+                  label="Select Ada Lovelace"
+                  onCheckedChange={() => {}}
+                  render={(props) => <span {...props} data-testid="row-select" tabIndex={0} />}
+                />
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Root>
+      );
+    }
+
+    render(<CallerRenderedTable />);
+
+    expect(screen.getByRole("table", { name: "People" })).toHaveAttribute("data-testid", "table");
+    expect(screen.getByTestId("table").tagName).toBe("SECTION");
+    expect(screen.getByTestId("table")).toHaveAttribute("aria-rowcount", "4");
+    expect(screen.getByText("People")).toHaveAttribute("role", "caption");
+    expect(screen.getByTestId("head")).toHaveAttribute("role", "rowgroup");
+    expect(screen.getByTestId("header-row")).toHaveAttribute("role", "row");
+    expect(screen.getByTestId("select-head")).toHaveAttribute("role", "columnheader");
+    expect(screen.getByTestId("select-head")).toHaveAttribute("scope", "col");
+    expect(screen.getByTestId("select-all")).toHaveAttribute("role", "checkbox");
+    expect(screen.getByTestId("select-all")).toHaveAttribute("aria-checked", "mixed");
+    expect(screen.getByRole("rowheader", { name: "Ada Lovelace" })).toHaveAttribute("scope", "row");
+    expect(screen.getByTestId("born")).toHaveAttribute("role", "cell");
+    expect(screen.getByTestId("row-select")).toHaveAttribute("role", "checkbox");
+
+    await userEvent.click(within(screen.getByTestId("name-head")).getByRole("button"));
+    expect(screen.getByTestId("name-head")).toHaveAttribute("aria-sort", "ascending");
+    expect(screen.getByRole("status").textContent).toBe("Sorted by Name, ascending.");
+  });
 });
 
 describe("Pagination", () => {
@@ -6182,6 +6253,53 @@ describe("Pagination", () => {
   it("is a list, so a reader can skip it in one keystroke", () => {
     render(<Example />);
     expect(within(screen.getByRole("navigation")).getAllByRole("listitem").length).toBe(5);
+  });
+
+  it("hands the pagination contract to caller-rendered elements", () => {
+    render(
+      <Pagination.Root
+        label="Pages"
+        page={4}
+        pageCount={25}
+        render={(props) => <section {...props} data-testid="pager" />}
+      >
+        <Pagination.Content render={(props) => <div {...props} data-testid="pages" />}>
+          <Pagination.Previous
+            disabled
+            href="?page=3"
+            render={(props) => <span {...props} data-testid="previous" />}
+          >
+            ‹
+          </Pagination.Previous>
+          <Pagination.Item
+            current
+            href="?page=4"
+            render={(props) => <span {...props} data-testid="current" />}
+          >
+            4
+          </Pagination.Item>
+          <Pagination.Next
+            href="?page=5"
+            render={(props) => <span {...props} data-testid="next" />}
+          >
+            ›
+          </Pagination.Next>
+        </Pagination.Content>
+      </Pagination.Root>,
+    );
+
+    expect(screen.getByRole("navigation", { name: "Pages" })).toHaveAttribute(
+      "data-testid",
+      "pager",
+    );
+    expect(screen.getByTestId("pager").tagName).toBe("SECTION");
+    expect(screen.getByTestId("pages")).toHaveAttribute("role", "list");
+    expect(screen.getByRole("link", { current: "page" }).textContent).toBe("4");
+    expect(screen.getByRole("link", { name: "Next page" })).toHaveAttribute("data-testid", "next");
+    expect(screen.queryByRole("link", { name: "Previous page" })).toBe(null);
+    expect(screen.getByTestId("previous")).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByTestId("previous")).not.toHaveAttribute("href");
+    expect(screen.getByRole("status").textContent).toBe("Page 4 of 25.");
   });
 });
 
@@ -8685,6 +8803,11 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Menubar.Separator",
     "Menubar.SubTrigger",
     "Menubar.Trigger",
+    "Pagination.Content",
+    "Pagination.Item",
+    "Pagination.Next",
+    "Pagination.Previous",
+    "Pagination.Root",
     "Progress",
     "Separator",
     "Sheet.Body",
@@ -8703,6 +8826,16 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Tabs.Panel",
     "Tabs.Root",
     "Tabs.Tab",
+    "Table.Body",
+    "Table.Caption",
+    "Table.Cell",
+    "Table.Head",
+    "Table.Header",
+    "Table.Root",
+    "Table.Row",
+    "Table.RowHeader",
+    "Table.RowSelect",
+    "Table.SelectAll",
     "Toggle",
     "Tooltip.Body",
     "Tooltip.Trigger",
@@ -8728,14 +8861,9 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Menu.Sub",
     "Menubar.Menu",
     "Menubar.Sub",
-    "Pagination.Item",
-    "Pagination.Next",
-    "Pagination.Previous",
     "Popover.Root",
     "Sheet.Root",
     "Sidebar.Root",
-    "Table.RowSelect",
-    "Table.SelectAll",
     "Tooltip.Provider",
     "Tooltip.Root",
   ];
@@ -8771,8 +8899,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "NavigationMenu.List",
     "NavigationMenu.Root",
     "NavigationMenu.Trigger",
-    "Pagination.Content",
-    "Pagination.Root",
     "Popover.Body",
     "Popover.Trigger",
     "RadioGroup.Indicator",
@@ -8801,14 +8927,6 @@ describe("the escape hatch: which part hands its element to the caller", () => {
     "Slider.Root",
     "Slider.Thumb",
     "Slider.Track",
-    "Table.Body",
-    "Table.Caption",
-    "Table.Cell",
-    "Table.Head",
-    "Table.Header",
-    "Table.Root",
-    "Table.Row",
-    "Table.RowHeader",
     "Toast.Action",
     "Toast.Close",
     "Toast.Description",


### PR DESCRIPTION
## Summary
- add `render?: RenderProp` to the remaining Table element parts and forward Table.SelectAll/RowSelect through Checkbox
- add `render?: RenderProp` to Pagination.Root/Content and the page links, preserving disabled links as non-links
- move the covered parts from #303's fixed/no-element lists into RENDER and add behavior tests for caller-rendered table and pagination elements

## Checks
- `/Users/ubugeeei/.local/bin/uf fmt --check packages/ui/pagination.js packages/ui/table.js packages/ui/ui.test.js`
- `/Users/ubugeeei/.local/bin/uf lint packages/ui/pagination.js packages/ui/table.js packages/ui/ui.test.js --json`
- `git diff --check`

Full local `uf test` was not run because this temporary worktree has no `node_modules` and the machine has only about 2.8 GiB free; CI should run the self-built toolchain and full suite.

Refs #303

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791828766&installation_model_id=422833&pr_number=848&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F848&signature=8f2bda9f9f6c1dd25367d56be1226e53cc7bc2d0f3f6530f80fa749d83668b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable rendering for pagination components, allowing callers to provide their own elements while preserving navigation semantics and accessibility attributes.
  - Added customizable rendering for table components, including headers, rows, cells, selection controls, and structural elements.
  - Custom-rendered components continue to support relevant roles, sorting, selection, disabled states, and status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->