### PR TITLE
test: extend browser startup budget

### DIFF
--- a/packages/test/browser-worker.js
+++ b/packages/test/browser-worker.js
@@ -78,7 +78,7 @@ type Request = {|
  * browser that will not start, with its own output attached — not as a file
  * that timed out, which is a sentence about tests that were never reached.
  */
-const START_TIMEOUT_MS = 20_000;
+const START_TIMEOUT_MS = 25_000;
 
 /**
  * The switches a headless run needs, and what each is for.


### PR DESCRIPTION
## Summary
- extend the browser worker startup handshake from 20s to 25s while staying below the 30s browser file budget
- keep startup failures reported as browser startup failures rather than file timeouts

## Verification
- git diff --check
- npm exec biome -- check packages/test/browser-worker.js

Unblocks browser-host CI flakes seen while validating #845.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791829686&installation_model_id=422833&pr_number=849&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F849&signature=663684aeaa86aaa9fd346c14384231a232731c5514ab01da00205211c34792d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->