### PR TITLE
perf(check): report batch allocation split

### DIFF
--- a/crates/uf_check/examples/alloc_report.rs
+++ b/crates/uf_check/examples/alloc_report.rs
@@ -11,7 +11,10 @@
 //! * **`--batch N`** — the same module N times, which separates the cost paid
 //!   once per *call* (a builtin environment, forced as far as the batch needs
 //!   it) from the cost paid per *module*. Neither is visible on its own: a
-//!   single run reports their sum and says nothing about which is which;
+//!   single run reports their sum and says nothing about which is which. When
+//!   `N` is greater than one, the report measures `1` and `N` in the same
+//!   process and prints the inferred split, so the comparison in #678 is not a
+//!   hand calculation;
 //! * **`--cache`** — the same module through one [`CheckCache`] three times,
 //!   which is the question #678 leaves open. `check_sources_cached` exists for
 //!   the caller that checks one file at a time, and a batch proving cheap says
@@ -99,6 +102,9 @@ fn main() {
         std::hint::black_box(&report);
     });
     print_delta(&delta, runs);
+    if batch > 1 {
+        print_batch_split(&sources[0..1], &delta, batch, runs);
+    }
 
     if phases {
         // A second pass rather than the one above: a span reads the
@@ -219,6 +225,48 @@ fn print_delta(delta: &AllocDelta, runs: u64) {
     println!(
         "peak           {:.2} MiB",
         delta.peak_above_baseline as f64 / (1024.0 * 1024.0)
+    );
+}
+
+/// Estimate the per-call and per-module pieces of a batch report.
+///
+/// The model is deliberately the same one #678 used in the issue body:
+/// `batch_cost = fixed + batch * module`. Measuring a batch of one and the
+/// caller's requested batch in the same process keeps one-time builtin
+/// preparation out of both sides, leaving the split that matters to a cold
+/// `uf check` run.
+fn print_batch_split(single: &[Source<'_>], batch_delta: &AllocDelta, batch: usize, runs: u64) {
+    let single_delta = measure(runs, || {
+        let report = check_sources(single, &[], &CheckLimits::default()).expect("checks");
+        std::hint::black_box(&report);
+    });
+
+    let batch = u64::try_from(batch).expect("batch count fits in u64");
+    let batch_allocations = batch_delta.allocations / runs;
+    let single_allocations = single_delta.allocations / runs;
+    let marginal_allocations =
+        batch_allocations.saturating_sub(single_allocations) / batch.saturating_sub(1);
+    let fixed_allocations = single_allocations.saturating_sub(marginal_allocations);
+
+    let batch_bytes = batch_delta.bytes_allocated / runs;
+    let single_bytes = single_delta.bytes_allocated / runs;
+    let marginal_bytes = batch_bytes.saturating_sub(single_bytes) / batch.saturating_sub(1);
+    let fixed_bytes = single_bytes.saturating_sub(marginal_bytes);
+
+    println!("single allocs  {single_allocations}");
+    println!(
+        "single bytes   {:.2} MiB",
+        single_bytes as f64 / (1024.0 * 1024.0)
+    );
+    println!("fixed allocs   {fixed_allocations}");
+    println!(
+        "fixed bytes    {:.2} MiB",
+        fixed_bytes as f64 / (1024.0 * 1024.0)
+    );
+    println!("module allocs  {marginal_allocations}");
+    println!(
+        "module bytes   {:.2} MiB",
+        marginal_bytes as f64 / (1024.0 * 1024.0)
     );
 }
 


### PR DESCRIPTION
## Summary
- Teach the `uf_check` allocation report to measure a batch of one alongside `--batch N`.
- Print the inferred fixed per-call cost and marginal per-module cost for allocations and bytes.
- Keep the existing headline untouched so old measurements remain comparable.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p uf_check --example alloc_report`
- `cargo run --example alloc_report -p uf_check -- packages/router/internal/runtime.js --batch 2`
- `cargo test -p uf_check --test cache_hit_allocations`

Advances #678.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791830944&installation_model_id=422833&pr_number=852&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F852&signature=ea0a597cda08acb6c670e2df8bec6295d1ea53ff1e89ddb8729472f34b4d3551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->