### PR TITLE
feat(react-native): expose Metro config helper

### DIFF
--- a/crates/uf_cli/src/commands/build.rs
+++ b/crates/uf_cli/src/commands/build.rs
@@ -1090,6 +1090,10 @@ fn target_contract(target: RouteTarget) -> serde_json::Value {
                 "kind": "metro",
                 "platform": target.as_str(),
                 "sourceExtensions": ["js", "jsx", "mjs", "cjs"],
+                "config": {
+                    "package": "@uniflowed/react-native/metro",
+                    "helper": "withUniflowedMetro"
+                },
                 "reason": "React Native builds still need a Metro/native transformer contract"
             },
         }),
@@ -1432,6 +1436,14 @@ mod tests {
             assert_eq!(
                 contract["transform"]["sourceExtensions"],
                 serde_json::json!(["js", "jsx", "mjs", "cjs"])
+            );
+            assert_eq!(
+                contract["transform"]["config"]["package"],
+                serde_json::json!("@uniflowed/react-native/metro")
+            );
+            assert_eq!(
+                contract["transform"]["config"]["helper"],
+                serde_json::json!("withUniflowedMetro")
             );
         }
     }

--- a/crates/uf_cli/tests/vite.rs
+++ b/crates/uf_cli/tests/vite.rs
@@ -420,6 +420,14 @@ fn a_native_target_manifest_names_the_pending_native_contract() {
         serde_json::json!(["js", "jsx", "mjs", "cjs"])
     );
     assert_eq!(
+        manifest["targetContract"]["transform"]["config"]["package"],
+        serde_json::json!("@uniflowed/react-native/metro")
+    );
+    assert_eq!(
+        manifest["targetContract"]["transform"]["config"]["helper"],
+        serde_json::json!("withUniflowedMetro")
+    );
+    assert_eq!(
         manifest["routes"][0]["page"],
         serde_json::json!("app/$page.native.js"),
         "the build did not consume the native route target:\n{manifest:#}"

--- a/docs/app/reference/packages/$page.mdx
+++ b/docs/app/reference/packages/$page.mdx
@@ -64,7 +64,7 @@ use; and a `// @flow` pragma on every file.
 | `@uniflowed/hooks` | The hook library — the [browser half](/reference/hooks) has a server answer for every one |
 | `@uniflowed/motion` | Animation |
 | `@uniflowed/stylex` | Static styles |
-| `@uniflowed/react-native` | React Native, re-exported as the app's peer runtime |
+| `@uniflowed/react-native` | React Native, re-exported as the app's peer runtime, plus `@uniflowed/react-native/metro` for Metro config |
 | `@uniflowed/tui` | Terminal interfaces — see [the guide](/guide/tui) |
 
 ## Testing

--- a/packages/react-native/metro.js
+++ b/packages/react-native/metro.js
@@ -1,0 +1,61 @@
+// @flow
+//
+// `@uniflowed/react-native/metro`: the Metro half of uf's native target.
+//
+// `uf build --target native` writes the same extension list into the build
+// manifest's target contract. This module gives a React Native application a
+// package subpath it can import from `metro.config.js`, so the contract is not
+// only something a completed build reports after the fact.
+
+export type MetroResolverConfig = {
+  readonly sourceExts?: $ReadOnlyArray<string>,
+  readonly resolverMainFields?: $ReadOnlyArray<string>,
+  readonly [key: string]: mixed,
+};
+
+export type MetroConfig = {
+  readonly resolver?: MetroResolverConfig,
+  readonly [key: string]: mixed,
+};
+
+export const metroSourceExts: $ReadOnlyArray<string> = Object.freeze(["js", "jsx", "mjs", "cjs"]);
+export const metroResolverMainFields: $ReadOnlyArray<string> = Object.freeze([
+  "react-native",
+  "browser",
+  "main",
+]);
+
+/**
+ * Add uf's Flow-first JavaScript extensions to a Metro config.
+ *
+ * Metro already owns platform suffix resolution (`.ios.js`, `.android.js`,
+ * `.native.js`). uf's route scanner and build manifest use the same suffixes,
+ * so this helper only names the source extensions and resolver main fields a
+ * Metro app needs to consume `@uniflowed/*` Flow packages without dropping any
+ * app-specific extensions the project already configured.
+ */
+export function withUniflowedMetro(config?: MetroConfig = {} as MetroConfig): MetroConfig {
+  const resolver = config.resolver ?? {};
+  return {
+    ...config,
+    resolver: {
+      ...resolver,
+      sourceExts: mergeUnique(resolver.sourceExts, metroSourceExts),
+      resolverMainFields: mergeUnique(resolver.resolverMainFields, metroResolverMainFields),
+    },
+  };
+}
+
+function mergeUnique(
+  existing: void | $ReadOnlyArray<string>,
+  required: $ReadOnlyArray<string>,
+): $ReadOnlyArray<string> {
+  const merged: Array<string> = [];
+  const seen: Set<string> = new Set();
+  for (const value of [...(existing ?? []), ...required]) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    merged.push(value);
+  }
+  return merged;
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -11,10 +11,12 @@
     "directory": "packages/react-native"
   },
   "exports": {
-    ".": "./index.js"
+    ".": "./index.js",
+    "./metro": "./metro.js"
   },
   "files": [
     "index.js",
+    "metro.js",
     "!*.test.js"
   ],
   "peerDependencies": {

--- a/packages/react-native/react-native.test.js
+++ b/packages/react-native/react-native.test.js
@@ -1,0 +1,44 @@
+// @flow
+//
+// React Native package integration that does not require the peer runtime.
+//
+// The root package re-exports `react-native`, so importing it would correctly
+// need the app's peer dependency. The Metro helper is different: a
+// `metro.config.js` needs to be able to import it while the app is still being
+// assembled.
+
+import { describe, expect, it } from "@uniflowed/test";
+import {
+  metroResolverMainFields,
+  metroSourceExts,
+  withUniflowedMetro,
+} from "@uniflowed/react-native/metro";
+
+describe("@uniflowed/react-native/metro", () => {
+  it("names the source extensions from the native build contract", () => {
+    expect(metroSourceExts).toEqual(["js", "jsx", "mjs", "cjs"]);
+    expect(metroResolverMainFields).toEqual(["react-native", "browser", "main"]);
+  });
+
+  it("extends a Metro config without dropping project fields", () => {
+    const config = withUniflowedMetro({
+      cacheVersion: "app",
+      resolver: {
+        sourceExts: ["tsx", "js"],
+        resolverMainFields: ["expo", "react-native"],
+        unstable_conditionNames: ["react-native"],
+      },
+      transformer: {
+        minifierPath: "metro-minify-terser",
+      },
+    });
+
+    expect(config.cacheVersion).toBe("app");
+    expect(config.transformer).toEqual({ minifierPath: "metro-minify-terser" });
+    expect(config.resolver).toEqual({
+      sourceExts: ["tsx", "js", "jsx", "mjs", "cjs"],
+      resolverMainFields: ["expo", "react-native", "browser", "main"],
+      unstable_conditionNames: ["react-native"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add `@uniflowed/react-native/metro` with `withUniflowedMetro` for Metro source extensions and resolver main fields
- publish the subpath from `@uniflowed/react-native` and document it in the package reference
- include the helper in the native build target contract so `uf build --target native` points at the consumable Metro config surface

Refs #501.
Refs #488.

## Validation

- `target/debug/uf lint packages/react-native/metro.js packages/react-native/react-native.test.js --color never`
- `target/debug/uf check packages/react-native/metro.js packages/react-native/react-native.test.js --color never`
- `cargo run -p uf_cli --bin uf -- test packages/react-native/react-native.test.js`
- `cargo test -p uf_lib --test package_surface`
- `cargo test -p uf_cli --test vite a_native_target_manifest_names_the_pending_native_contract`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791831278&installation_model_id=422833&pr_number=853&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F853&signature=c930320e6885071000ddeaf444664cf8a80af146abcf95e3925c059bc3b7de9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->