### PR TITLE
perf(rsc): cache slot client route checks

### DIFF
--- a/packages/vite/internal/rsc.js
+++ b/packages/vite/internal/rsc.js
@@ -145,6 +145,7 @@ export function clientRouteFilter(manifest, root, boundaries = {}) {
 
   const notFound = boundaries.notFound ?? [];
   const errors = boundaries.errors ?? [];
+  const needsSlot = slotPredicate(needed);
 
   return (route) => {
     if (needed(route.page)) return true;
@@ -156,7 +157,7 @@ export function clientRouteFilter(manifest, root, boundaries = {}) {
     // interactive part is in a slot would be dropped from the client bundle
     // and served as a document — rendered correctly and never hydrated, which
     // is the quietest way a feature can be half-implemented.
-    if (slotNeeds(route.slots ?? [], needed)) return true;
+    if ((route.slots ?? []).some(needsSlot)) return true;
     // A boundary with no module of its own is the record the scan synthesises
     // at the router root, and what renders there is the framework's own page —
     // already in `@uniflowed/router`, reaching nothing this project wrote. It
@@ -187,19 +188,28 @@ export function clientRouteFilter(manifest, root, boundaries = {}) {
  * @param {ReadonlyArray<{
  *   defaultPage: ?string,
  *   routes: ReadonlyArray<{page: string, layouts: ReadonlyArray<string>, slots: ReadonlyArray<*>}>,
- * }>} slots
  * @param {(file: ?string) => boolean} needed
+ * @returns {(slot: *) => boolean}
  */
-function slotNeeds(slots, needed) {
-  for (const slot of slots) {
-    if (slot.defaultPage != null && needed(slot.defaultPage)) return true;
-    for (const route of slot.routes) {
-      if (needed(route.page)) return true;
-      if (route.layouts.some(needed)) return true;
-      if (slotNeeds(route.slots, needed)) return true;
+function slotPredicate(needed) {
+  const cache = new WeakMap();
+  const needsSlot = (slot) => {
+    const cached = cache.get(slot);
+    if (cached !== undefined) return cached;
+    let answer = false;
+    if (slot.defaultPage != null && needed(slot.defaultPage)) {
+      answer = true;
     }
-  }
-  return false;
+    for (const route of slot.routes) {
+      if (answer) break;
+      if (needed(route.page) || route.layouts.some(needed) || route.slots.some(needsSlot)) {
+        answer = true;
+      }
+    }
+    cache.set(slot, answer);
+    return answer;
+  };
+  return needsSlot;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vite/rsc-split.test.js
+++ b/packages/vite/rsc-split.test.js
@@ -123,6 +123,18 @@ function splitProject(): string {
   });
 }
 
+/** A root slot, so its content is part of every route under the root layout. */
+function slottedProject(): string {
+  const page = "// @flow\nexport default function Page() {}\n";
+  return project({
+    "app/$layout.js": page,
+    "app/$page.js": page,
+    "app/docs/$page.js": page,
+    "app/@panel/$default.js": page,
+    "app/@panel/docs/$page.js": page,
+  });
+}
+
 /** The manifest that project's analysis would produce. */
 function splitManifest(version: number = 3) {
   return {
@@ -187,6 +199,74 @@ describe("the client route table", () => {
     // Not the layout: `/counter` keeps it, so it is already in the table as a
     // lazy import, and a second static one would pull it into the entry chunk.
     expect(source).not.toContain(`import ${JSON.stringify(path.join(root, "app/$layout.js"))};`);
+  });
+
+  it("keeps a route whose only client boundary lives in a slot", () => {
+    // A slot renders inside the route that declares it. If the only
+    // interactive module is there, the ordinary page and its layout still have
+    // to ship: the browser hydrates the whole matched tree, not just the slot.
+    const root = slottedProject();
+    const table = scanRoutes(path.join(root, "app"));
+    const manifest = manifestIn(root, {
+      ...splitManifest(),
+      modules: [
+        manifestModule("app/$layout.js", false),
+        manifestModule("app/$page.js", false),
+        manifestModule("app/docs/$page.js", false),
+        manifestModule("app/@panel/$default.js", true),
+        manifestModule("app/@panel/docs/$page.js", false),
+      ],
+    });
+    const shipsPage = clientRouteFilter(manifest, root, table);
+
+    const source = routesModuleSource(table, { shipsPage });
+
+    expect(table.routes.map((route) => [route.path, shipsPage(route)])).toEqual([
+      ["/", true],
+      ["/docs", true],
+    ]);
+    expect(source).toContain(`import(${JSON.stringify(path.join(root, "app/$page.js"))})`);
+    expect(source).toContain(`import(${JSON.stringify(path.join(root, "app/docs/$page.js"))})`);
+    expect(source).toContain(
+      `import(${JSON.stringify(path.join(root, "app/@panel/$default.js"))})`,
+    );
+  });
+
+  it("still imports dropped slot modules for their stylesheets", () => {
+    // The side-effect import rule applies to slots too. A route that needs no
+    // browser JavaScript can still render a slotted subtree whose CSS is part
+    // of the document; dropping that import would make the page correct but
+    // visually broken.
+    const root = slottedProject();
+    const table = scanRoutes(path.join(root, "app"));
+    const manifest = manifestIn(root, {
+      ...splitManifest(),
+      modules: [
+        manifestModule("app/$layout.js", false),
+        manifestModule("app/$page.js", false),
+        manifestModule("app/docs/$page.js", false),
+        manifestModule("app/@panel/$default.js", false),
+        manifestModule("app/@panel/docs/$page.js", false),
+      ],
+    });
+    const shipsPage = clientRouteFilter(manifest, root, table);
+
+    const source = routesModuleSource(table, { shipsPage });
+
+    expect(table.routes.map((route) => [route.path, shipsPage(route)])).toEqual([
+      ["/", false],
+      ["/docs", false],
+    ]);
+    expect(source).toContain(`import ${JSON.stringify(path.join(root, "app/$page.js"))};`);
+    expect(source).toContain(
+      `import ${JSON.stringify(path.join(root, "app/@panel/$default.js"))};`,
+    );
+    expect(source).toContain(
+      `import ${JSON.stringify(path.join(root, "app/@panel/docs/$page.js"))};`,
+    );
+    expect(source).not.toContain(
+      `import(${JSON.stringify(path.join(root, "app/@panel/$default.js"))})`,
+    );
   });
 
   it("ships every page when there is no manifest to read", () => {


### PR DESCRIPTION
## Summary
- memoize repeated slot-tree checks while deciding which routes stay in the client RSC route table
- add coverage for routes whose only client boundary lives in a parallel-route slot
- add coverage that dropped routes still carry slot modules as stylesheet side-effect imports

## Validation
- git diff --check
- uf lint packages/vite/internal/rsc.js packages/vite/rsc-split.test.js tests/library/parallel-routes.test.js
- uf check packages/vite/internal/rsc.js
- uf test packages/vite/rsc-split.test.js
- uf test tests/library/parallel-routes.test.js

Advances #252 and #267. Does not close either issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791834354&installation_model_id=422833&pr_number=856&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F856&signature=17fb10dbc379e80ff359eb33c3b611c55a6443c144540225ca503016f3efb9ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->