### PR TITLE
test: widen cold browser startup budget

### DIFF
--- a/crates/uf_test/src/options.rs
+++ b/crates/uf_test/src/options.rs
@@ -15,21 +15,21 @@ pub const DEFAULT_FILE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Default wall-clock budget for one test file in a browser.
 ///
-/// Twelve times [`DEFAULT_FILE_TIMEOUT`], and not because a browser is twelve times
-/// slower at running a test. The driver starts the browser while `uf` is
-/// already holding the stopwatch for the run's *first* file, and a cold
-/// Chromium with a cold profile is seven seconds on a laptop and worse in a
-/// container — busy CI runners have taken more than twenty-five seconds just to
-/// reach the first page request. Under the ordinary budget the first file of
-/// every browser run was reported as timed out, and the tests in it never ran at
-/// all.
+/// Twenty-four times [`DEFAULT_FILE_TIMEOUT`], and not because a browser is
+/// twenty-four times slower at running a test. The driver starts the browser
+/// while `uf` is already holding the stopwatch for the run's *first* file, and
+/// a cold Chromium with a cold profile is seven seconds on a laptop and worse
+/// in a container — busy CI runners have taken more than forty-five seconds
+/// just to reach the first page request. Under the ordinary budget the first
+/// file of every browser run was reported as timed out, and the tests in it
+/// never ran at all.
 ///
 /// The alternative was a handshake: a driver that says "the browser is up"
 /// before `uf` starts counting. That is a change to the protocol every host
 /// speaks, for the benefit of one, and it would buy a tighter bound on a
 /// failure — a page that hangs — that a bound already catches. A number with
 /// this paragraph attached is the cheaper honest answer.
-pub const BROWSER_FILE_TIMEOUT: Duration = Duration::from_secs(60);
+pub const BROWSER_FILE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Largest per-file budget that can be requested.
 ///

--- a/packages/test/browser-worker.js
+++ b/packages/test/browser-worker.js
@@ -71,15 +71,15 @@ type Request = {|
  *
  * Generous against a cold Chromium with a cold profile, which is about seven
  * seconds on a laptop and much worse in a busy container, and deliberately
- * *shorter than `uf_test`'s browser file budget* (`BROWSER_FILE_TIMEOUT`, sixty
- * seconds).
+ * *shorter than `uf_test`'s browser file budget* (`BROWSER_FILE_TIMEOUT`, two
+ * minutes).
  * That order is the whole point: `uf` is already holding a stopwatch on the
  * first file while this is happening, and whichever of the two fires first is
  * what the report says. A browser that will not start should be reported as a
  * browser that will not start, with its own output attached — not as a file
  * that timed out, which is a sentence about tests that were never reached.
  */
-const START_TIMEOUT_MS = 45_000;
+const START_TIMEOUT_MS = 90_000;
 
 /**
  * The switches a headless run needs, and what each is for.


### PR DESCRIPTION
## Summary
- raise the browser worker startup refusal budget to 90s after CI still exceeded 45s
- raise the default browser file budget to 120s so startup failures still report as host startup failures instead of file timeouts

## Validation
- git diff --check
- cargo fmt --all -- --check
- npm exec biome -- check packages/test/browser-worker.js

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/uf/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791834627&installation_model_id=422833&pr_number=857&repository=ubugeeei-prod%2Fuf&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fuf%2Fpull%2F857&signature=ddad0b1d5fa59758b9500593ff01e74265b81e964a8dfe86135d04f9e8d77b56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->